### PR TITLE
BUG: baichuan-chat and baichuan-base don't support MacOS

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -91,7 +91,6 @@ jobs:
           pip install accelerate
           pip install sentencepiece
           pip install transformers_stream_generator
-          pip install cpm_kernels
           pip install -e ".[dev]"
         working-directory: .
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,7 +65,7 @@ all =
     accelerate
     sentencepiece
     transformers_stream_generator
-    cpm_kernels
+    cpm_kernels; platform_system != "Darwin"
 doc =
     ipython>=6.5.0
     sphinx>=3.0.0,<5.0.0

--- a/xinference/core/service.py
+++ b/xinference/core/service.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import asyncio
+import platform
 import time
 from dataclasses import dataclass
 from logging import getLogger
@@ -246,6 +247,13 @@ class WorkerActor(xo.Actor):
 
         raise RuntimeError("No available slot found")
 
+    def _check_model_is_valid(self, model_name):
+        # baichuan-base and baichuan-chat depend on `cpm_kernels` module,
+        # but `cpm_kernels` cannot run on Darwin system.
+        if platform.system() == "Darwin":
+            if model_name in ["baichuan-base", "baichuan-chat"]:
+                raise RuntimeError(f"{model_name} model can't run on Darwin system.")
+
     @log
     async def launch_builtin_model(
         self,
@@ -257,6 +265,7 @@ class WorkerActor(xo.Actor):
         **kwargs,
     ) -> xo.ActorRefType["ModelActor"]:
         assert model_uid not in self._model_uid_to_model
+        self._check_model_is_valid(model_name)
 
         from ..model import MODEL_FAMILIES
 

--- a/xinference/core/service.py
+++ b/xinference/core/service.py
@@ -252,7 +252,7 @@ class WorkerActor(xo.Actor):
         # but `cpm_kernels` cannot run on Darwin system.
         if platform.system() == "Darwin":
             if model_name in ["baichuan-base", "baichuan-chat"]:
-                raise RuntimeError(f"{model_name} model can't run on Darwin system.")
+                raise ValueError(f"{model_name} model can't run on Darwin system.")
 
     @log
     async def launch_builtin_model(


### PR DESCRIPTION
`baichuan-base` and `baichuan-chat` depend on `cpm_kernels` module, but `cpm_kernels` cannot run on Darwin system.