### PR TITLE
BUG: RuntimeError when launching model using kwargs whose value is of type int

### DIFF
--- a/xinference/client.py
+++ b/xinference/client.py
@@ -364,7 +364,7 @@ class RESTfulClient:
         }
 
         for key, value in kwargs.items():
-            payload[str(key)] = str(value)
+            payload[str(key)] = value
 
         response = requests.post(url, json=payload)
         if response.status_code != 200:


### PR DESCRIPTION
RuntimeError: Failed to launch model, detail: [address=[0.0.0.0:53237](http://0.0.0.0:53237/), pid=1870] 'str' object cannot be interpreted as an integer