### PR TITLE
BUG: Fix log level on subprocess

### DIFF
--- a/xinference/deploy/cmdline.py
+++ b/xinference/deploy/cmdline.py
@@ -30,7 +30,7 @@ from ..constants import (
 )
 
 
-def log_level_config(log_level: str) -> str:
+def get_config_string(log_level: str) -> str:
     return f"""
         [loggers]
         keys=root
@@ -84,7 +84,7 @@ def cli(
         from .local import main
 
         logging_conf = configparser.RawConfigParser()
-        logger_config_string = log_level_config(log_level)
+        logger_config_string = get_config_string(log_level)
         logging_conf.read_string(logger_config_string)
         logging.config.fileConfig(logging_conf)  # type: ignore
 
@@ -130,7 +130,7 @@ def worker(log_level: str, endpoint: Optional[str], host: str):
     from ..deploy.worker import main
 
     logging_conf = configparser.RawConfigParser()
-    logger_config_string = log_level_config(log_level)
+    logger_config_string = get_config_string(log_level)
     logging_conf.read_string(logger_config_string)
     logging.config.fileConfig(level=logging.getLevelName(log_level.upper()))  # type: ignore
 

--- a/xinference/deploy/worker.py
+++ b/xinference/deploy/worker.py
@@ -14,7 +14,7 @@
 
 import asyncio
 import logging
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 
 import xoscar as xo
 
@@ -53,7 +53,7 @@ async def _start_worker(
     await pool.join()
 
 
-def main(address: str, supervisor_address: str, logging_conf: Optional[Dict] = None):
+def main(address: str, supervisor_address: str, logging_conf: Any = None):
     loop = asyncio.get_event_loop()
     task = loop.create_task(_start_worker(address, supervisor_address, logging_conf))
 


### PR DESCRIPTION
Now if user specified log-level in their command line, like: xinference --log-level debug(any upper lower case of debug), all the processes, including main and subprocess, will have correct log level corresponding to the log log level input.