### PR TITLE
BUG: Chatglm max_length doesn't work

### DIFF
--- a/xinference/model/llm/ggml/chatglm.py
+++ b/xinference/model/llm/ggml/chatglm.py
@@ -184,7 +184,8 @@ class ChatglmCppChatModel(LLM):
 
         generate_config = self._sanitize_generate_config(generate_config)
         params = dict(generate_config)
-        params["max_length"] = params.pop("max_tokens")
+        if "max_tokens" in params:
+            params["max_length"] = params.pop("max_tokens")
 
         assert self._llm is not None
 

--- a/xinference/model/llm/ggml/chatglm.py
+++ b/xinference/model/llm/ggml/chatglm.py
@@ -183,18 +183,22 @@ class ChatglmCppChatModel(LLM):
         logger.debug("Full conversation history:\n%s", str(chat_history_list))
 
         generate_config = self._sanitize_generate_config(generate_config)
+        params = dict(generate_config)
+        params["max_length"] = params.pop("max_tokens")
 
         assert self._llm is not None
 
-        if generate_config.get("stream", False):
+        if params.pop("stream", False):
             it = self._llm.stream_chat(
                 chat_history_list,
+                **params,
             )
             assert not isinstance(it, str)
             return self._convert_raw_text_chunks_to_chat(it, self.model_uid)
         else:
             c = self._llm.chat(
                 chat_history_list,
+                **params,
             )
             assert not isinstance(c, Iterator)
             return self._convert_raw_text_completion_to_chat(c, self.model_uid)


### PR DESCRIPTION
resolves #163 

Although the parameters are successfully passed to the model, ChatGLM often generates nothing if the max_length is set to small values (~40 tokens) when I was testing it locally. It seems the model is simply not trained on short-sentence snippets and therefore is incapable of chatting in them.