### PR TITLE
FEAT: Support Launching Model with Uid

### DIFF
--- a/xinference/client.py
+++ b/xinference/client.py
@@ -641,6 +641,7 @@ class RESTfulClient:
         model_size_in_billions: Optional[int] = None,
         model_format: Optional[str] = None,
         quantization: Optional[str] = None,
+        model_uid: Optional[str] = None,
         **kwargs,
     ) -> str:
         """
@@ -656,6 +657,8 @@ class RESTfulClient:
             The format of the model.
         quantization: Optional[str]
             The quantization of model.
+        model_uid: Optional[str]
+            The assigned model_uid of model.
         **kwargs:
             Any other parameters been specified.
 
@@ -668,7 +671,7 @@ class RESTfulClient:
 
         url = f"{self.base_url}/v1/models"
 
-        model_uid = self._gen_model_uid()
+        model_uid = self._gen_model_uid() if model_uid is None else model_uid
 
         payload = {
             "model_uid": model_uid,
@@ -689,6 +692,7 @@ class RESTfulClient:
 
         response_data = response.json()
         model_uid = response_data["model_uid"]
+        assert model_uid is not None
         return model_uid
 
     def terminate_model(self, model_uid: str):

--- a/xinference/core/restful_api.py
+++ b/xinference/core/restful_api.py
@@ -320,7 +320,7 @@ class RESTfulAPIActor(xo.Actor):
             key: value for key, value in payload.items() if key not in exclude_keys
         }
 
-        if model_uid is None or model_uid is None:
+        if model_uid is None or model_name is None:
             raise HTTPException(
                 status_code=400,
                 detail="Invalid input. Please specify the model UID and the model name",

--- a/xinference/deploy/cmdline.py
+++ b/xinference/deploy/cmdline.py
@@ -157,12 +157,14 @@ def worker(log_level: str, endpoint: Optional[str], host: str):
 @click.option("--size-in-billions", "-s", default=None, type=int)
 @click.option("--model-format", "-f", default=None, type=str)
 @click.option("--quantization", "-q", default=None, type=str)
+@click.option("--model-uid", "-i", default=None, type=str)
 def model_launch(
     endpoint: Optional[str],
     model_name: str,
     size_in_billions: int,
     model_format: str,
     quantization: str,
+    model_uid: str,
 ):
     endpoint = get_endpoint(endpoint)
 
@@ -172,6 +174,7 @@ def model_launch(
         model_size_in_billions=size_in_billions,
         model_format=model_format,
         quantization=quantization,
+        model_uid=model_uid,
     )
 
     print(f"Model uid: {model_uid}", file=sys.stderr)


### PR DESCRIPTION
Add `--model-uid -i` in the terminal as an optional argument that overrides the default randomly generated uid.

Resolves #254 

example: Run the following two commands in two separate terminal windows.
1. `xinference`
2. `xinference launch --model-name chatglm --model-uid chatglm`