### PR TITLE
ENH: Update System Prompt for llama-2-chat

### DIFF
--- a/xinference/model/llm/llm_family.json
+++ b/xinference/model/llm/llm_family.json
@@ -540,7 +540,7 @@
     ],
     "prompt_style": {
       "style_name": "LLAMA2",
-      "system_prompt": "<s>[INST] <<SYS>>\nYou are a helpful, respectful and honest assistant. Always answer as helpfully as possible, while being safe. Your answers should not include any harmful, unethical, racist, sexist, toxic, dangerous, or illegal content. Please ensure that your responses are socially unbiased and positive in nature.\n\nIf a question does not make any sense, or is not factually coherent, explain why instead of answering something not correct. If you don't know the answer to a question, please don't share false information.\n<</SYS>>\n\n",
+      "system_prompt": "<s>[INST] <<SYS>>\nYou are a helpful AI assistant.\n<</SYS>>\n\n",
       "roles": [
         "[INST]",
         "[/INST]"


### PR DESCRIPTION
Resolve #327 

I did not remove the prompt entirely, but maintained a generic `You are a helpful AI assistant` as a placeholder so the chat history format is the exact same.

That being said, I did run some tests with the same settings to make sure the new system prompt is working.

Left image uses the new system prompt while the right image uses the old.

<p align="center">
  <img width="45%"src="https://github.com/xorbitsai/inference/assets/102875484/dd724625-5868-4558-8a3d-7e8505c21c5a"> 
  &nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp;
  <img width="45%" src="https://github.com/xorbitsai/inference/assets/102875484/86dd433c-e952-4350-ba57-ecc9e8154544">
</p>