### PR TITLE
CHORE: lock llama-cpp-python version

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -85,7 +85,7 @@ jobs:
         env:
           MODULE: ${{ matrix.module }}
         run: |
-          pip install llama-cpp-python
+          pip install llama-cpp-python==0.1.77
           pip install transformers
           pip install torch
           pip install accelerate

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,7 +63,7 @@ dev =
     black
 all =
     ctransformers
-    llama-cpp-python>=0.1.77
+    llama-cpp-python==0.1.77
     transformers>=4.31.0
     torch
     accelerate>=0.20.3
@@ -74,7 +74,7 @@ all =
     einops
     tiktoken
 ggml =
-    llama-cpp-python>=0.1.77
+    llama-cpp-python==0.1.77
     ctransformers
 pytorch =
     transformers>=4.31.0


### PR DESCRIPTION
As of version 0.1.79, the llama-cpp-python no longer supports ggmlv3. Therefore, it is necessary to lock its version until we transition the built-in ggmlv3 models to gguf.