### PR TITLE
FEAT: Support Mistral & Mistral-Instruct

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -79,7 +79,7 @@ ggml =
     llama-cpp-python>=0.2.0
     ctransformers
 pytorch =
-    transformers>=4.31.0
+    transformers>=4.34.0
     torch
     accelerate>=0.20.3
     sentencepiece

--- a/xinference/model/llm/ggml/ctransformers.py
+++ b/xinference/model/llm/ggml/ctransformers.py
@@ -42,11 +42,10 @@ MODEL_TYPE_FOR_CTRANSFORMERS = {
     "starcoder": "starcoder",
     "starchat": "starcoder",
     "falcon": "falcon",
-    "mistral-v0.1": "mistral",
 }
 
 # these two constants subjects to change for future development and ctransformers updates.
-CTRANSFORMERS_SUPPORTED_MODEL = ["starcoder", "gpt-2", "mistral-v0.1"]
+CTRANSFORMERS_SUPPORTED_MODEL = ["starcoder", "gpt-2"]
 
 CTRANSFORMERS_GPU_SUPPORT = ["llama", "llama-2", "mpt", "falcon"]
 

--- a/xinference/model/llm/ggml/ctransformers.py
+++ b/xinference/model/llm/ggml/ctransformers.py
@@ -42,10 +42,11 @@ MODEL_TYPE_FOR_CTRANSFORMERS = {
     "starcoder": "starcoder",
     "starchat": "starcoder",
     "falcon": "falcon",
+    "mistral-v0.1": "mistral",
 }
 
 # these two constants subjects to change for future development and ctransformers updates.
-CTRANSFORMERS_SUPPORTED_MODEL = ["starcoder", "gpt-2"]
+CTRANSFORMERS_SUPPORTED_MODEL = ["starcoder", "gpt-2", "mistral-v0.1"]
 
 CTRANSFORMERS_GPU_SUPPORT = ["llama", "llama-2", "mpt", "falcon"]
 
@@ -190,7 +191,7 @@ class CtransformersModel(LLM):
     def match(
         cls, llm_family: LLMFamilyV1, llm_spec: LLMSpecV1, quantization: str
     ) -> bool:
-        if llm_spec.model_format != "ggmlv3":
+        if llm_spec.model_format != "ggmlv3" and llm_spec.model_format != "ggufv2":
             return False
         if llm_family.model_name not in CTRANSFORMERS_SUPPORTED_MODEL:
             return False

--- a/xinference/model/llm/llm_family.json
+++ b/xinference/model/llm/llm_family.json
@@ -1732,6 +1732,109 @@
   },
   {
     "version": 1,
+    "context_length": 8192,
+    "model_name": "mistral-v0.1",
+    "model_lang": [
+      "en"
+    ],
+    "model_ability": [
+      "generate"
+    ],
+    "model_description": "Mistral-7B is a unmoderated Transformer based LLM claiming to outperform Llama on all benchmarks.",
+    "model_specs": [
+      {
+        "model_format": "pytorch",
+        "model_size_in_billions": 7,
+        "quantizations": [
+          "4-bit",
+          "8-bit",
+          "none"
+        ],
+        "model_id": "mistralai/Mistral-7B-v0.1",
+        "model_revision": "ae9d75c6b4eb39515def78c685fb4d71d49fc2cf"
+      },
+      {
+        "model_format": "ggufv2",
+        "model_size_in_billions": 7,
+        "quantizations": [
+          "Q2_K",
+          "Q3_K_S",
+          "Q3_K_M",
+          "Q3_K_L",
+          "Q4_0",
+          "Q4_K_S",
+          "Q4_K_M",
+          "Q5_0",
+          "Q5_K_S",
+          "Q5_K_M",
+          "Q6_K",
+          "Q8_0"
+        ],
+        "model_id": "TheBloke/Mistral-7B-v0.1-GGUF",
+        "model_file_name_template": "mistral-7b-v0.1.{quantization}.gguf"
+      }
+    ]
+  },
+  {
+    "version": 1,
+    "context_length": 8192,
+    "model_name": "mistral-instruct-v0.1",
+    "model_lang": [
+      "en"
+    ],
+    "model_ability": [
+      "chat"
+    ],
+    "model_description": "Mistral-7B-Instruct is a fine-tuned version of the Mistral-7B LLM on public datasets, specializing in chatting.",
+    "model_specs": [
+      {
+        "model_format": "pytorch",
+        "model_size_in_billions": 7,
+        "quantizations": [
+          "4-bit",
+          "8-bit",
+          "none"
+        ],
+        "model_id": "mistralai/Mistral-7B-Instruct-v0.1",
+        "model_revision": "54766df6d50e4d3d7ccd66758e5341ba105a6d36"
+      },
+      {
+        "model_format": "ggufv2",
+        "model_size_in_billions": 7,
+        "quantizations": [
+          "Q2_K",
+          "Q3_K_S",
+          "Q3_K_M",
+          "Q3_K_L",
+          "Q4_0",
+          "Q4_K_S",
+          "Q4_K_M",
+          "Q5_0",
+          "Q5_K_S",
+          "Q5_K_M",
+          "Q6_K",
+          "Q8_0"
+        ],
+        "model_id": "TheBloke/Mistral-7B-Instruct-v0.1-GGUF",
+        "model_file_name_template": "mistral-7b-instruct-v0.1.{quantization}.gguf"
+      }
+    ],
+    "prompt_style": {
+      "style_name": "NO_COLON_TWO",
+      "system_prompt": "<s>[INST] <<SYS>>\nAn informative and inspiring conversation\n<</SYS>>\n\n",
+      "roles": [
+        "[INST]",
+        "[/INST]"
+      ],
+      "intra_message_sep": " ",
+      "inter_message_sep": " </s><s>",
+      "stop_token_ids": [
+        2
+      ]
+    }
+  },
+  {
+    "version": 1,
     "context_length": 2048,
     "model_name": "tiny-llama",
     "model_lang": [

--- a/xinference/model/llm/llm_family.json
+++ b/xinference/model/llm/llm_family.json
@@ -1740,7 +1740,7 @@
     "model_ability": [
       "generate"
     ],
-    "model_description": "Mistral-7B is a unmoderated Transformer based LLM claiming to outperform Llama on all benchmarks.",
+    "model_description": "Mistral-7B is a unmoderated Transformer based LLM claiming to outperform Llama2 on all benchmarks.",
     "model_specs": [
       {
         "model_format": "pytorch",


### PR DESCRIPTION
Resolve #508

Adding Mistral-7B-v0.1 and Mistral-Instruct-7B-v0.1, with both GGML and PyTorch support.

GGUFv2 models has been tested locally on my computer and works properly. However, PyTorch models are a bit too big to run on my computer. I've documented the PyTorch model specifics in their families, but I'd appreciate a hand pulling this and checking if everything's functioning. Thanks!