### PR TITLE
BUG: Fix listing embedding models

### DIFF
--- a/xinference/core/supervisor.py
+++ b/xinference/core/supervisor.py
@@ -101,6 +101,10 @@ class SupervisorActor(xo.Actor):
 
     @log_sync(logger=logger)
     def list_model_registrations(self, model_type: str) -> List[Dict[str, Any]]:
+        def sort_helper(item):
+            assert isinstance(item["model_name"], str)
+            return item.get("model_name").lower()
+
         if model_type == "LLM":
             from ..model.llm import BUILTIN_LLM_FAMILIES, get_user_defined_llm_families
 
@@ -116,10 +120,6 @@ class SupervisorActor(xo.Actor):
                 ]
             )
 
-            def sort_helper(item):
-                assert isinstance(item["model_name"], str)
-                return item.get("model_name").lower()
-
             ret.sort(key=sort_helper)
 
             return ret
@@ -127,10 +127,10 @@ class SupervisorActor(xo.Actor):
             from ..model.embedding import BUILTIN_EMBEDDING_MODELS
 
             ret = [
-                {"model_name": f.model_name, "is_builtin": True}
-                for f in BUILTIN_EMBEDDING_MODELS.values()
+                {"model_name": model_name, "is_builtin": True}
+                for model_name in BUILTIN_EMBEDDING_MODELS
             ]
-            ret.sort(key=lambda x: x["model_name"].lower())
+            ret.sort(key=sort_helper)
             return ret
         else:
             raise ValueError(f"Unsupported model type: {model_type}")

--- a/xinference/core/supervisor.py
+++ b/xinference/core/supervisor.py
@@ -123,6 +123,15 @@ class SupervisorActor(xo.Actor):
             ret.sort(key=sort_helper)
 
             return ret
+        elif model_type == "embedding":
+            from ..model.embedding import BUILTIN_EMBEDDING_MODELS
+
+            ret = [
+                {"model_name": f.model_name, "is_builtin": True}
+                for f in BUILTIN_EMBEDDING_MODELS.values()
+            ]
+            ret.sort(key=lambda x: x["model_name"].lower())
+            return ret
         else:
             raise ValueError(f"Unsupported model type: {model_type}")
 
@@ -137,6 +146,13 @@ class SupervisorActor(xo.Actor):
                 if f.model_name == model_name:
                     return f
 
+            raise ValueError(f"Model {model_name} not found")
+        if model_type == "embedding":
+            from ..model.embedding import BUILTIN_EMBEDDING_MODELS
+
+            for f in BUILTIN_EMBEDDING_MODELS.values():
+                if f.model_name == model_name:
+                    return f
             raise ValueError(f"Model {model_name} not found")
         else:
             raise ValueError(f"Unsupported model type: {model_type}")

--- a/xinference/deploy/cmdline.py
+++ b/xinference/deploy/cmdline.py
@@ -307,22 +307,44 @@ def list_model_registrations(
     registrations = client.list_model_registrations(model_type=model_type)
 
     table = []
-    for registration in registrations:
-        model_name = registration["model_name"]
-        model_family = client.get_model_registration(model_type, model_name)
-        table.append(
-            [
-                model_type,
-                model_family["model_name"],
-                model_family["model_lang"],
-                model_family["model_ability"],
-                registration["is_builtin"],
-            ]
+    if model_type == "LLM":
+        for registration in registrations:
+            model_name = registration["model_name"]
+            model_family = client.get_model_registration(model_type, model_name)
+            table.append(
+                [
+                    model_type,
+                    model_family["model_name"],
+                    model_family["model_lang"],
+                    model_family["model_ability"],
+                    registration["is_builtin"],
+                ]
+            )
+        print(
+            tabulate(
+                table, headers=["Type", "Name", "Language", "Ability", "Is-built-in"]
+            ),
+            file=sys.stderr,
         )
-    print(
-        tabulate(table, headers=["Type", "Name", "Language", "Ability", "Is-built-in"]),
-        file=sys.stderr,
-    )
+    elif model_type == "embedding":
+        for registration in registrations:
+            model_name = registration["model_name"]
+            model_family = client.get_model_registration(model_type, model_name)
+            table.append(
+                [
+                    model_type,
+                    model_family["model_name"],
+                    model_family["language"],
+                    model_family["dimensions"],
+                    registration["is_builtin"],
+                ]
+            )
+        print(
+            tabulate(
+                table, headers=["Type", "Name", "Language", "Dimensions", "Is-built-in"]
+            ),
+            file=sys.stderr,
+        )
 
 
 @cli.command(

--- a/xinference/model/core.py
+++ b/xinference/model/core.py
@@ -37,7 +37,10 @@ def create_model_instance(
     from .embedding.core import create_embedding_model_instance
     from .llm.core import create_llm_model_instance
 
+    # embedding model doesn't accept trust_remote_code
+    trust_remote_code = kwargs.pop("trust_remote_code", None)
     if model_type == "LLM":
+        kwargs["trust_remote_code"] = trust_remote_code
         return create_llm_model_instance(
             model_uid,
             model_name,

--- a/xinference/model/core.py
+++ b/xinference/model/core.py
@@ -37,10 +37,7 @@ def create_model_instance(
     from .embedding.core import create_embedding_model_instance
     from .llm.core import create_llm_model_instance
 
-    # embedding model doesn't accept trust_remote_code
-    trust_remote_code = kwargs.pop("trust_remote_code", None)
     if model_type == "LLM":
-        kwargs["trust_remote_code"] = trust_remote_code
         return create_llm_model_instance(
             model_uid,
             model_name,
@@ -51,6 +48,8 @@ def create_model_instance(
             **kwargs,
         )
     elif model_type == "embedding":
+        # embedding model doesn't accept trust_remote_code
+        kwargs.pop("trust_remote_code", None)
         return create_embedding_model_instance(model_uid, model_name, **kwargs)
     else:
         raise ValueError(f"Unsupported model type: {model_type}.")


### PR DESCRIPTION
Users now can use `xinference registrations --model-type=embedding` to list available embedding models.

Resolves #511 