### PR TITLE
FEAT: Support grammar-based sampling for ggml models

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ potential of cutting-edge AI models.
 
 ## 🔥 Hot Topics
 ### Framework Enhancements
+- Support grammar-based sampling for ggml models: [#525](https://github.com/xorbitsai/inference/pull/525)
 - Incorporate vLLM: [#445](https://github.com/xorbitsai/inference/pull/445)
 - Embedding model support: [#418](https://github.com/xorbitsai/inference/pull/418)
 - LoRA support: [#271](https://github.com/xorbitsai/inference/issues/271)

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -23,6 +23,7 @@ Xorbits Inference（Xinference）是一个性能强大且功能全面的分布�
 
 ## 🔥 近期热点
 ### 框架增强
+- 支持指定 grammar 输出: [#525](https://github.com/xorbitsai/inference/pull/525)
 - 引入 vLLM: [#445](https://github.com/xorbitsai/inference/pull/445)
 - Embedding 模型支持: [#418](https://github.com/xorbitsai/inference/pull/418)
 - LoRA 支持: [#271](https://github.com/xorbitsai/inference/issues/271)

--- a/xinference/core/restful_api.py
+++ b/xinference/core/restful_api.py
@@ -147,6 +147,7 @@ class CreateCompletionRequest(BaseModel):
     top_k: int = top_k_field
     repetition_penalty: float = repetition_penalty_field
     logit_bias_type: Optional[Literal["input_ids", "tokens"]] = Field(None)
+    grammar: Optional[str] = Field(None)
 
     class Config:
         schema_extra = {
@@ -209,6 +210,7 @@ class CreateChatCompletionRequest(BaseModel):
     top_k: int = top_k_field
     repetition_penalty: float = repetition_penalty_field
     logit_bias_type: Optional[Literal["input_ids", "tokens"]] = Field(None)
+    grammar: Optional[str] = Field(None)
 
     class Config:
         schema_extra = {

--- a/xinference/model/llm/ggml/llamacpp.py
+++ b/xinference/model/llm/ggml/llamacpp.py
@@ -15,7 +15,7 @@
 import datetime
 import logging
 import os
-from typing import TYPE_CHECKING, Any, Iterator, List, Optional, TypedDict, Union
+from typing import Iterator, List, Optional, Union
 
 from ....types import (
     ChatCompletion,
@@ -33,51 +33,6 @@ from ..utils import ChatModelMixin
 from .ctransformers import CTRANSFORMERS_SUPPORTED_MODEL
 
 logger = logging.getLogger(__name__)
-
-
-class LlamaCppGenerateConfig(TypedDict, total=False):
-    suffix: Optional[str]
-    max_tokens: int
-    temperature: float
-    top_p: float
-    logprobs: Optional[int]
-    echo: bool
-    stop: Optional[Union[str, List[str]]]
-    frequency_penalty: float
-    presence_penalty: float
-    repetition_penalty: float
-    top_k: int
-    stream: bool
-    tfs_z: float
-    mirostat_mode: int
-    mirostat_tau: float
-    mirostat_eta: float
-    model: Optional[str]
-    grammar: Optional[Any]
-    stopping_criteria: Optional["StoppingCriteriaList"]
-    logits_processor: Optional["LogitsProcessorList"]
-
-
-class LlamaCppModelConfig(TypedDict, total=False):
-    n_ctx: int
-    n_parts: int
-    n_gpu_layers: int
-    seed: int
-    f16_kv: bool
-    logits_all: bool
-    vocab_only: bool
-    use_mmap: bool
-    use_mlock: bool
-    embedding: bool
-    n_threads: Optional[int]
-    n_batch: int
-    last_n_tokens_size: int
-    lora_base: Optional[str]
-    lora_path: Optional[str]
-    low_vram: bool
-    n_gqa: Optional[int]  # (TEMPORARY) must be 8 for llama2 70b
-    rms_norm_eps: Optional[float]  # (TEMPORARY)
-    verbose: bool
 
 
 SIZE_TO_GPU_LAYERS = {

--- a/xinference/model/llm/ggml/tests/test_gguf.py
+++ b/xinference/model/llm/ggml/tests/test_gguf.py
@@ -31,6 +31,22 @@ def test_load_ggmlv3(setup):
     assert "content" in completion["choices"][0]["message"]
     assert len(completion["choices"][0]["message"]["content"]) != 0
 
+    # test grammar
+    grammar = r"""
+    root ::= answer
+    answer ::= ("Apple" | "Banana" | "Orange")
+    """
+    completion = model.chat(
+        "Tell me a random fruit name.",
+        generate_config={"max_tokens": 10, "grammar": grammar},
+    )
+    assert "content" in completion["choices"][0]["message"]
+    assert completion["choices"][0]["message"]["content"] in [
+        "Apple",
+        "Banana",
+        "Orange",
+    ]
+
 
 def test_gguf(setup):
     endpoint, _ = setup

--- a/xinference/types.py
+++ b/xinference/types.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 
 from typing_extensions import Literal, NotRequired, TypedDict
 
@@ -169,6 +169,7 @@ class LlamaCppGenerateConfig(TypedDict, total=False):
     mirostat_tau: float
     mirostat_eta: float
     model: Optional[str]
+    grammar: Optional[Any]
     stopping_criteria: Optional["StoppingCriteriaList"]
     logits_processor: Optional["LogitsProcessorList"]
 


### PR DESCRIPTION
Example for passing grammar:
```Python
grammar = r"""
root ::= answer
answer ::= ("Apple" | "Banana" | "Orange")
"""
completion = model.chat(
    "Tell me a random fruit name.",
    generate_config={"max_tokens": 10, "grammar": grammar},
)
```