### PR TITLE
FEAT: Add --model-uid to launch sub command

### DIFF
--- a/xinference/client/restful/restful_client.py
+++ b/xinference/client/restful/restful_client.py
@@ -315,6 +315,7 @@ class Client:
         self,
         model_name: str,
         model_type: str = "LLM",
+        model_uid: str = None,
         model_size_in_billions: Optional[int] = None,
         model_format: Optional[str] = None,
         quantization: Optional[str] = None,
@@ -331,6 +332,8 @@ class Client:
             The name of model.
         model_type: str
             type of model.
+        model_uid: str
+            UID of model, auto generate a UUID if is None.
         model_size_in_billions: Optional[int]
             The size (in billions) of the model.
         model_format: Optional[str]
@@ -354,7 +357,8 @@ class Client:
 
         url = f"{self.base_url}/v1/models"
 
-        model_uid = self._gen_model_uid()
+        if model_uid is None:
+            model_uid = self._gen_model_uid()
 
         payload = {
             "model_uid": model_uid,

--- a/xinference/core/restful_api.py
+++ b/xinference/core/restful_api.py
@@ -34,6 +34,7 @@ from uvicorn import Config, Server
 
 from ..types import ChatCompletion, Completion, Embedding
 from .supervisor import SupervisorActor
+from .utils import is_valid_model_uid
 
 logger = logging.getLogger(__name__)
 
@@ -398,6 +399,11 @@ class RESTfulAPIActor(xo.Actor):
             raise HTTPException(
                 status_code=400,
                 detail="Invalid input. Please specify the model UID and the model name",
+            )
+        if not is_valid_model_uid(model_uid):
+            raise HTTPException(
+                status_code=400,
+                detail="The model UID is invalid. Please specify the model UID by a-z or A-Z and 0 < length <= 100.",
             )
 
         try:

--- a/xinference/core/tests/test_utils.py
+++ b/xinference/core/tests/test_utils.py
@@ -14,6 +14,7 @@
 
 from ..utils import (
     build_replica_model_uid,
+    is_valid_model_uid,
     iter_replica_model_uid,
     parse_replica_model_uid,
 )
@@ -29,3 +30,18 @@ def test_replica_model_uid():
         all_gen_ids.append(replica_model_uid)
     assert len(all_gen_ids) == 5
     assert len(set(all_gen_ids)) == 5
+
+
+def test_is_valid_model_uid():
+    from ...client.restful.restful_client import Client
+
+    assert is_valid_model_uid("foo")
+    assert is_valid_model_uid("foo-bar")
+    assert is_valid_model_uid("foo_bar")
+    assert is_valid_model_uid("123")
+    assert not is_valid_model_uid("foo@bar")
+    assert not is_valid_model_uid("foo bar")
+    assert not is_valid_model_uid("_foo")
+    assert not is_valid_model_uid("-foo")
+    for _ in range(10):
+        assert is_valid_model_uid(Client._gen_model_uid())

--- a/xinference/core/utils.py
+++ b/xinference/core/utils.py
@@ -82,3 +82,12 @@ def parse_replica_model_uid(replica_model_uid: str) -> Tuple[str, int, int]:
     replica = int(parts.pop())
     model_uid = "-".join(parts)
     return model_uid, replica, rep_id
+
+
+def is_valid_model_uid(model_uid: str) -> bool:
+    if not model_uid or len(model_uid) > 100:
+        return False
+
+    import re
+
+    return re.match(r"^[A-Za-z0-9][A-Za-z0-9_\-]*$", model_uid) is not None

--- a/xinference/deploy/cmdline.py
+++ b/xinference/deploy/cmdline.py
@@ -350,6 +350,13 @@ def list_model_registrations(
     help="Specify type of model, LLM as default.",
 )
 @click.option(
+    "--model-uid",
+    "-u",
+    type=str,
+    default=None,
+    help="Specify UID of model, default is None.",
+)
+@click.option(
     "--size-in-billions",
     "-s",
     default=None,
@@ -393,6 +400,7 @@ def model_launch(
     endpoint: Optional[str],
     model_name: str,
     model_type: str,
+    model_uid: str,
     size_in_billions: int,
     model_format: str,
     quantization: str,
@@ -413,6 +421,7 @@ def model_launch(
     model_uid = client.launch_model(
         model_name=model_name,
         model_type=model_type,
+        model_uid=model_uid,
         model_size_in_billions=size_in_billions,
         model_format=model_format,
         quantization=quantization,

--- a/xinference/deploy/test/test_cmdline.py
+++ b/xinference/deploy/test/test_cmdline.py
@@ -31,7 +31,8 @@ from ..cmdline import (
 
 
 @pytest.mark.parametrize("stream", [True, False])
-def test_cmdline(setup, stream):
+@pytest.mark.parametrize("model_uid", [None, "my_model_uid"])
+def test_cmdline(setup, stream, model_uid):
     endpoint, _ = setup
     runner = CliRunner()
 
@@ -62,12 +63,16 @@ def test_cmdline(setup, stream):
     client = Client(endpoint)
     # Windows CI has limited resources, use replica 1
     replica = 1 if os.name == "nt" else 2
+    original_model_uid = model_uid
     model_uid = client.launch_model(
         model_name="orca",
+        model_uid=model_uid,
         model_size_in_billions=3,
         quantization="q4_0",
         replica=replica,
     )
+    if original_model_uid == "my_model_uid":
+        assert model_uid == "my_model_uid"
     assert len(model_uid) != 0
 
     # list model


### PR DESCRIPTION
- In order to use xinference more flexibly, provide `--model-uid` for launch sub command. e.g. specify a fixed model uid for continue integration.