### PR TITLE
ENH: lock transformers version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -65,7 +65,7 @@ dev =
 all =
     ctransformers
     llama-cpp-python>=0.2.0
-    transformers>=4.31.0
+    transformers<=4.33.1
     torch
     accelerate>=0.20.3
     sentencepiece
@@ -81,7 +81,7 @@ ggml =
     llama-cpp-python>=0.2.0
     ctransformers
 transformers =
-    transformers>=4.34.0
+    transformers<=4.33.1
     torch
     accelerate>=0.20.3
     sentencepiece


### PR DESCRIPTION
To address recent incompatible changes in `transformers`, like #505.