### PR TITLE
BUG: remove "generate" ability from Baichuan-2-chat json config

### DIFF
--- a/xinference/model/llm/llm_family.json
+++ b/xinference/model/llm/llm_family.json
@@ -1649,7 +1649,6 @@
     ],
     "model_ability": [
       "embed",
-      "generate",
       "chat"
     ],
     "model_description": "Baichuan2-chat is a fine-tuned version of the Baichuan LLM, specializing in chatting.",

--- a/xinference/model/llm/llm_family_modelscope.json
+++ b/xinference/model/llm/llm_family_modelscope.json
@@ -120,7 +120,6 @@
     ],
     "model_ability": [
       "embed",
-      "generate",
       "chat"
     ],
     "model_description": "Baichuan2-chat is a fine-tuned version of the Baichuan LLM, specializing in chatting.",


### PR DESCRIPTION
In document, it says:  ability of model baichuan-2-chat is ['embed', 'chat'], but in llm_family.json that is "model_ability": [      "embed",  "generate",  "chat"   ]