### PR TITLE
BUG: add quantization to valid file name

### DIFF
--- a/xinference/model/llm/ggml/llamacpp.py
+++ b/xinference/model/llm/ggml/llamacpp.py
@@ -124,7 +124,7 @@ class LlamaCppModel(LLM):
             "{}.{}.ggufv2".format(self.model_family.model_name, self.quantization),
         )
         # trick for validation, use a mark file to make sure the gguf file is converted
-        mark_file = os.path.join(gguf_dir, "__valid")
+        mark_file = os.path.join(gguf_dir, f"__valid_{self.quantization}")
         if os.path.exists(mark_file):
             return gguf_path
         else:


### PR DESCRIPTION
Bug description:

In the function `_convert_ggml_to_gguf`, when one model was converted and the `__valid` file was created to mark this job was done. However, when another quantization model tries to convert from ggml to gguf, it could be skipped due to the `__valid` file exists, and this error `Model path does not exist: /path/.xinference/cache/llama-2-chat-ggufv2-13b/llama-2-chat.q4_0.ggufv2` could come up

Solution:

Add quantization to valid file name of valid file