### PR TITLE
CHORE: Use python3.10 to build and release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.x"
+          python-version: "3.10"
       - uses: actions/checkout@v3
       - name: Install pypa/build
         run: >-


### PR DESCRIPTION
https://github.com/aresnow1/inference/actions/runs/6688050241/job/18169539702