### PR TITLE
ENH: Supports request limits for the model

### DIFF
--- a/xinference/api/restful_api.py
+++ b/xinference/api/restful_api.py
@@ -256,6 +256,11 @@ class RESTfulAPI:
         self._router = APIRouter()
         self._app = FastAPI()
 
+    @staticmethod
+    def handle_request_limit_error(e: Exception):
+        if "Rate limit reached" in str(e):
+            raise HTTPException(status_code=429, detail=str(e))
+
     async def _get_supervisor_ref(self) -> xo.ActorRefType[SupervisorActor]:
         if self._supervisor_ref is None:
             self._supervisor_ref = await xo.actor_ref(
@@ -464,6 +469,7 @@ class RESTfulAPI:
         model_type = payload.get("model_type")
         replica = payload.get("replica", 1)
         n_gpu = payload.get("n_gpu", "auto")
+        request_limits = payload.get("request_limits", None)
 
         exclude_keys = {
             "model_uid",
@@ -474,6 +480,7 @@ class RESTfulAPI:
             "model_type",
             "replica",
             "n_gpu",
+            "request_limits",
         }
 
         kwargs = {
@@ -496,6 +503,7 @@ class RESTfulAPI:
                 model_type=model_type,
                 replica=replica,
                 n_gpu=n_gpu,
+                request_limits=request_limits,
                 **kwargs,
             )
 
@@ -617,7 +625,10 @@ class RESTfulAPI:
             async def stream_results():
                 iterator = None
                 try:
-                    iterator = await model.generate(body.prompt, kwargs)
+                    try:
+                        iterator = await model.generate(body.prompt, kwargs)
+                    except RuntimeError as re:
+                        self.handle_request_limit_error(re)
                     async for item in iterator:
                         yield dict(data=json.dumps(item))
                 except Exception as ex:
@@ -633,6 +644,7 @@ class RESTfulAPI:
                 return await model.generate(body.prompt, kwargs)
             except Exception as e:
                 logger.error(e, exc_info=True)
+                self.handle_request_limit_error(e)
                 raise HTTPException(status_code=500, detail=str(e))
 
     async def create_embedding(self, request: CreateEmbeddingRequest):
@@ -652,6 +664,7 @@ class RESTfulAPI:
             return embedding
         except RuntimeError as re:
             logger.error(re, exc_info=True)
+            self.handle_request_limit_error(re)
             raise HTTPException(status_code=400, detail=str(re))
         except Exception as e:
             logger.error(e, exc_info=True)
@@ -675,6 +688,7 @@ class RESTfulAPI:
             return image_list
         except RuntimeError as re:
             logger.error(re, exc_info=True)
+            self.handle_request_limit_error(re)
             raise HTTPException(status_code=400, detail=str(re))
         except Exception as e:
             logger.error(e, exc_info=True)
@@ -807,12 +821,15 @@ class RESTfulAPI:
             async def stream_results():
                 iterator = None
                 try:
-                    if is_chatglm_ggml:
-                        iterator = await model.chat(prompt, chat_history, kwargs)
-                    else:
-                        iterator = await model.chat(
-                            prompt, system_prompt, chat_history, kwargs
-                        )
+                    try:
+                        if is_chatglm_ggml:
+                            iterator = await model.chat(prompt, chat_history, kwargs)
+                        else:
+                            iterator = await model.chat(
+                                prompt, system_prompt, chat_history, kwargs
+                            )
+                    except RuntimeError as re:
+                        self.handle_request_limit_error(re)
                     async for item in iterator:
                         yield dict(data=json.dumps(item))
                 except Exception as ex:
@@ -831,6 +848,7 @@ class RESTfulAPI:
                     return await model.chat(prompt, system_prompt, chat_history, kwargs)
             except Exception as e:
                 logger.error(e, exc_info=True)
+                self.handle_request_limit_error(e)
                 raise HTTPException(status_code=500, detail=str(e))
 
     async def register_model(self, model_type: str, request: RegisterModelRequest):

--- a/xinference/client/oscar/actor_client.py
+++ b/xinference/client/oscar/actor_client.py
@@ -351,6 +351,7 @@ class ActorClient:
         quantization: Optional[str] = None,
         replica: int = 1,
         n_gpu: Optional[Union[int, str]] = "auto",
+        request_limits: Optional[int] = None,
         **kwargs,
     ) -> str:
         """
@@ -373,6 +374,9 @@ class ActorClient:
         n_gpu: Optional[Union[int, str]],
             The number of GPUs used by the model, default is "auto".
             ``n_gpu=None`` means cpu only, ``n_gpu=auto`` lets the system automatically determine the best number of GPUs to use.
+        request_limits: Optional[int]
+            The number of request limits for this model， default is None.
+            ``request_limits=None`` means no limits for this model.
         **kwargs:
             Any other parameters been specified.
 
@@ -393,6 +397,7 @@ class ActorClient:
             quantization=quantization,
             replica=replica,
             n_gpu=n_gpu,
+            request_limits=request_limits,
             **kwargs,
         )
 

--- a/xinference/client/restful/restful_client.py
+++ b/xinference/client/restful/restful_client.py
@@ -478,6 +478,7 @@ class Client:
         quantization: Optional[str] = None,
         replica: int = 1,
         n_gpu: Optional[Union[int, str]] = "auto",
+        request_limits: Optional[int] = None,
         **kwargs,
     ) -> str:
         """
@@ -502,6 +503,9 @@ class Client:
         n_gpu: Optional[Union[int, str]],
             The number of GPUs used by the model, default is "auto".
             ``n_gpu=None`` means cpu only, ``n_gpu=auto`` lets the system automatically determine the best number of GPUs to use.
+        request_limits: Optional[int]
+            The number of request limits for this model， default is None.
+            ``request_limits=None`` means no limits for this model.
         **kwargs:
             Any other parameters been specified.
 
@@ -526,6 +530,7 @@ class Client:
             "quantization": quantization,
             "replica": replica,
             "n_gpu": n_gpu,
+            "request_limits": request_limits,
         }
 
         for key, value in kwargs.items():

--- a/xinference/core/model.py
+++ b/xinference/core/model.py
@@ -45,6 +45,33 @@ from .utils import log_async
 T = TypeVar("T")
 
 
+def request_limit(fn):
+    async def wrapped_func(self, *args, **kwargs):
+        logger.debug(
+            f"Request {fn.__name__}, current serve request count: {self._serve_count}, request limit: {self._request_limits} for the model {self.model_uid()}"
+        )
+        if self._request_limits is not None:
+            async with self._limit_lock:
+                if 1 + self._serve_count <= self._request_limits:
+                    self._serve_count += 1
+                else:
+                    raise RuntimeError(
+                        f"Rate limit reached for the model. Request limit {self._request_limits} for the model: {self.model_uid()}"
+                    )
+        try:
+            ret = await fn(self, *args, **kwargs)
+        finally:
+            if self._request_limits is not None:
+                async with self._limit_lock:
+                    self._serve_count -= 1
+            logger.debug(
+                f"After request {fn.__name__}, current serve request count: {self._serve_count} for the model {self.model_uid()}"
+            )
+        return ret
+
+    return wrapped_func
+
+
 class IteratorWrapper(Generic[T]):
     def __init__(self, uid: str, model_actor_addr: str, model_actor_uid: str):
         self._uid = uid
@@ -109,13 +136,14 @@ class ModelActor(xo.StatelessActor):
             gc.collect()
             torch.cuda.empty_cache()
 
-    def __init__(self, model: "LLM"):
+    def __init__(self, model: "LLM", request_limits: Optional[int] = None):
         super().__init__()
         from ..model.llm.pytorch.core import PytorchModel
         from ..model.llm.pytorch.spec_model import SpeculativeModel
         from ..model.llm.vllm.core import VLLMModel
 
         self._model = model
+        self._request_limits = request_limits
 
         self._generators: Dict[str, Union[Iterator, AsyncGenerator]] = {}
         self._lock = (
@@ -123,9 +151,18 @@ class ModelActor(xo.StatelessActor):
             if isinstance(self._model, (PytorchModel, SpeculativeModel, VLLMModel))
             else asyncio.locks.Lock()
         )
+        self._serve_count = 0
+        self._limit_lock = asyncio.locks.Lock()
 
     def load(self):
         self._model.load()
+
+    def model_uid(self):
+        return (
+            self._model.model_uid
+            if hasattr(self._model, "model_uid")
+            else self._model._model_uid
+        )
 
     async def _wrap_generator(self, ret: Any):
         if inspect.isgenerator(ret) or inspect.isasyncgen(ret):
@@ -153,6 +190,7 @@ class ModelActor(xo.StatelessActor):
         return await asyncio.create_task(_wrapper())
 
     @log_async(logger=logger)
+    @request_limit
     async def generate(self, prompt: str, *args, **kwargs):
         if not hasattr(self._model, "generate") and not hasattr(
             self._model, "async_generate"
@@ -176,6 +214,7 @@ class ModelActor(xo.StatelessActor):
             return await self._call_async_wrapper(_async_wrapper)
 
     @log_async(logger=logger)
+    @request_limit
     async def chat(self, prompt: str, *args, **kwargs):
         if not hasattr(self._model, "chat") and not hasattr(self._model, "async_chat"):
             raise AttributeError(f"Model {self._model.model_spec} is not for chat.")
@@ -196,6 +235,8 @@ class ModelActor(xo.StatelessActor):
         else:
             return await self._call_wrapper(_wrapper)
 
+    @log_async(logger=logger)
+    @request_limit
     async def create_embedding(self, input: Union[str, List[str]], *args, **kwargs):
         if not hasattr(self._model, "create_embedding"):
             raise AttributeError(
@@ -207,6 +248,8 @@ class ModelActor(xo.StatelessActor):
 
         return await self._call_wrapper(_wrapper)
 
+    @log_async(logger=logger)
+    @request_limit
     async def text_to_image(
         self,
         prompt: str,
@@ -274,7 +317,7 @@ class ModelActor(xo.StatelessActor):
 
         async def _async_wrapper():
             try:
-                return await anext(gen)
+                return await anext(gen)  # noqa: F821
             except StopAsyncIteration:
                 return stop
 

--- a/xinference/core/model.py
+++ b/xinference/core/model.py
@@ -161,7 +161,11 @@ class ModelActor(xo.StatelessActor):
         return (
             self._model.model_uid
             if hasattr(self._model, "model_uid")
-            else self._model._model_uid
+            else (
+                self._model._model_uid
+                if hasattr(self._model, "_model_uid")
+                else None  # return None for UT
+            )
         )
 
     async def _wrap_generator(self, ret: Any):

--- a/xinference/core/supervisor.py
+++ b/xinference/core/supervisor.py
@@ -273,6 +273,7 @@ class SupervisorActor(xo.StatelessActor):
         model_type: Optional[str],
         replica: int = 1,
         n_gpu: Optional[Union[int, str]] = "auto",
+        request_limits: Optional[int] = None,
         **kwargs,
     ) -> str:
         logger.debug(
@@ -306,6 +307,7 @@ class SupervisorActor(xo.StatelessActor):
                 quantization=quantization,
                 model_type=model_type,
                 n_gpu=n_gpu,
+                request_limits=request_limits,
                 **kwargs,
             )
             self._replica_model_uid_to_worker[_replica_model_uid] = worker_ref
@@ -313,6 +315,11 @@ class SupervisorActor(xo.StatelessActor):
         if not is_valid_model_uid(model_uid):
             raise ValueError(
                 "The model UID is invalid. Please specify the model UID by a-z or A-Z, 0 < length <= 100."
+            )
+
+        if request_limits is not None and request_limits < 0:
+            raise ValueError(
+                "The `request_limits` parameter must be greater or equal than 0."
             )
 
         if model_uid in self._model_uid_to_replica_info:

--- a/xinference/core/tests/test_restful_api.py
+++ b/xinference/core/tests/test_restful_api.py
@@ -377,6 +377,66 @@ def test_restful_api_for_embedding(setup):
     assert len(response_data) == 0
 
 
+def test_restful_api_with_request_limits(setup):
+    model_name = "gte-base"
+
+    endpoint, _ = setup
+    url = f"{endpoint}/v1/models"
+
+    # test embedding
+    # launch
+    payload = {
+        "model_uid": "test_embedding",
+        "model_name": model_name,
+        "model_type": "embedding",
+        "request_limits": 0,
+    }
+
+    response = requests.post(url, json=payload)
+    response_data = response.json()
+    model_uid_res = response_data["model_uid"]
+    assert model_uid_res == "test_embedding"
+
+    # test embedding
+    url = f"{endpoint}/v1/embeddings"
+    payload = {
+        "model": "test_embedding",
+        "input": "The food was delicious and the waiter...",
+    }
+    response = requests.post(url, json=payload)
+    assert response.status_code == 429
+    assert "Rate limit reached" in response.json()["detail"]
+
+    # delete model
+    url = f"{endpoint}/v1/models/test_embedding"
+    response = requests.delete(url)
+    assert response.status_code == 200
+
+    # test llm
+    url = f"{endpoint}/v1/models"
+    payload = {
+        "model_uid": "test_restful_api",
+        "model_name": "orca",
+        "quantization": "q4_0",
+        "request_limits": 0,
+    }
+
+    response = requests.post(url, json=payload)
+    response_data = response.json()
+    model_uid_res = response_data["model_uid"]
+    assert model_uid_res == "test_restful_api"
+
+    # generate
+    url = f"{endpoint}/v1/completions"
+    payload = {
+        "model": model_uid_res,
+        "prompt": "Once upon a time, there was a very old computer.",
+    }
+    response = requests.post(url, json=payload)
+    assert response.status_code == 429
+    assert "Rate limit reached" in response.json()["detail"]
+
+
 @pytest.mark.asyncio
 @pytest.mark.skipif(
     sys.platform == "win32", reason="Window CI hangs after run this case."

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -215,6 +215,7 @@ class WorkerActor(xo.StatelessActor):
         quantization: Optional[str],
         model_type: str = "LLM",
         n_gpu: Optional[Union[int, str]] = "auto",
+        request_limits: Optional[int] = None,
         **kwargs,
     ) -> xo.ActorRefType["ModelActor"]:
         if n_gpu is not None:
@@ -246,7 +247,11 @@ class WorkerActor(xo.StatelessActor):
         subpool_address, devices = await self._create_subpool(model_uid, n_gpu=n_gpu)
         try:
             model_ref = await xo.create_actor(
-                ModelActor, address=subpool_address, uid=model_uid, model=model
+                ModelActor,
+                address=subpool_address,
+                uid=model_uid,
+                model=model,
+                request_limits=request_limits,
             )
             await model_ref.load()
         except:


### PR DESCRIPTION
Add a new parameter `request_limits` to `launch_model` interface to control the visit count on a single model instance at the same time.