### PR TITLE
BUG: fix transformers compatibility

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -66,7 +66,7 @@ dev =
 all =
     ctransformers
     llama-cpp-python>=0.2.0
-    transformers<=4.33.1
+    transformers>=4.34.1
     torch
     accelerate>=0.20.3
     sentencepiece
@@ -82,7 +82,7 @@ ggml =
     llama-cpp-python>=0.2.0
     ctransformers
 transformers =
-    transformers<=4.33.1
+    transformers>=4.34.1
     torch
     accelerate>=0.20.3
     sentencepiece

--- a/xinference/model/llm/llm_family.json
+++ b/xinference/model/llm/llm_family.json
@@ -433,7 +433,7 @@
           "none"
         ],
         "model_id": "THUDM/chatglm2-6b",
-        "model_revision": "b1502f4f75c71499a3d566b14463edd62620ce9f"
+        "model_revision": "7fabe56db91e085c9c027f56f1c654d137bdba40"
       }
     ],
     "prompt_style": {
@@ -468,7 +468,7 @@
           "none"
         ],
         "model_id": "THUDM/chatglm2-6b-32k",
-        "model_revision": "455746d4706479a1cbbd07179db39eb2741dc692"
+        "model_revision": "a2065f5dc8253f036a209e642d7220a942d92765"
       }
     ],
     "prompt_style": {
@@ -1089,7 +1089,7 @@
           "none"
         ],
         "model_id": "internlm/internlm-7b",
-        "model_revision": "ab8633378889e2d7b7720703cc72caf52e1c9c44"
+        "model_revision": "592b0efc83be3eb1cba8990c4caf41ce604b958c"
       }
     ]
   },
@@ -1115,7 +1115,7 @@
           "none"
         ],
         "model_id": "internlm/internlm-chat-7b",
-        "model_revision": "ed5e35564ac836710817c51e8e8d0a5d4ff03102"
+        "model_revision": "d4fa2dbcbd2fa4edfa6735aa2ba0f0577fed6a62"
       }
     ],
     "prompt_style": {
@@ -1158,7 +1158,7 @@
           "none"
         ],
         "model_id": "internlm/internlm-20b",
-        "model_revision": "f0433b0db933a9adfa169f756ab8547f67ccef1d"
+        "model_revision": "c56a72957239b490ea206ea857e86611b3f65f3a"
       }
     ]
   },
@@ -1184,7 +1184,7 @@
           "none"
         ],
         "model_id": "internlm/internlm-chat-20b",
-        "model_revision": "84969e0447c3807207e9acdd92c9302309ec64fc"
+        "model_revision": "c67e80e42c4950ebae18a955c9fe138c5ceb5b10"
       }
     ],
     "prompt_style": {

--- a/xinference/model/llm/llm_family_modelscope.json
+++ b/xinference/model/llm/llm_family_modelscope.json
@@ -132,7 +132,7 @@
         ],
         "model_id": "baichuan-inc/Baichuan2-7B-Chat",
         "model_hub": "modelscope",
-        "model_revision": "v1.0.1"
+        "model_revision": "v1.0.4"
       },
       {
         "model_format": "pytorch",
@@ -142,9 +142,9 @@
           "8-bit",
           "none"
         ],
-        "model_id": "baichuan-inc/Baichuan2-7B-Chat",
+        "model_id": "baichuan-inc/Baichuan2-13B-Chat",
         "model_hub": "modelscope",
-        "model_revision": "v1.0.1"
+        "model_revision": "v1.0.3"
       }
     ],
     "prompt_style": {
@@ -184,7 +184,7 @@
           "none"
         ],
         "model_id": "baichuan-inc/Baichuan2-7B-Base",
-        "model_revision": "v1.0.1",
+        "model_revision": "v1.0.2",
         "model_hub": "modelscope"
       },
       {
@@ -196,7 +196,7 @@
           "none"
         ],
         "model_id": "baichuan-inc/Baichuan2-13B-Base",
-        "model_revision": "v1.0.1",
+        "model_revision": "v1.0.3",
         "model_hub": "modelscope"
       }
     ]
@@ -224,7 +224,7 @@
         ],
         "model_hub": "modelscope",
         "model_id": "ZhipuAI/chatglm2-6b",
-        "model_revision": "v1.0.11"
+        "model_revision": "v1.0.12"
       }
     ],
     "prompt_style": {
@@ -260,7 +260,7 @@
         ],
         "model_hub": "modelscope",
         "model_id": "ZhipuAI/chatglm2-6b-32k",
-        "model_revision": "v1.0.1"
+        "model_revision": "v1.0.2"
       }
     ],
     "prompt_style": {
@@ -366,7 +366,7 @@
         ],
         "model_id": "Shanghai_AI_Laboratory/internlm-7b",
         "model_hub": "modelscope",
-        "model_revision": "v1.0.0"
+        "model_revision": "v1.0.1"
       }
     ]
   },
@@ -393,7 +393,7 @@
         ],
         "model_id": "Shanghai_AI_Laboratory/internlm-chat-7b",
         "model_hub": "modelscope",
-        "model_revision": "v1.0.0"
+        "model_revision": "v1.0.1"
       }
     ],
     "prompt_style": {
@@ -437,7 +437,7 @@
         ],
         "model_id": "Shanghai_AI_Laboratory/internlm-20b",
         "model_hub": "modelscope",
-        "model_revision": "v1.0.0"
+        "model_revision": "v1.0.1"
       }
     ]
   },
@@ -464,7 +464,7 @@
         ],
         "model_id": "Shanghai_AI_Laboratory/internlm-chat-20b",
         "model_hub": "modelscope",
-        "model_revision": "v1.0.0"
+        "model_revision": "v1.0.1"
       }
     ],
     "prompt_style": {


### PR DESCRIPTION
Models such as Zephyr require version v0.34.0 or higher of transformers. However, existing models, particularly Chinese models, would fail due to an incompatible change introduced in v4.34.0. Therefore, we locked the version to v4.33.1.

Recently, the model providers have addressed this issue. As a result, I have updated the model's revision and removed the version lock.