### PR TITLE
BUG: `No slot available` error for embedding and LLM model on one card

### DIFF
--- a/xinference/core/model.py
+++ b/xinference/core/model.py
@@ -124,6 +124,11 @@ class ModelActor(xo.StatelessActor):
             else asyncio.locks.Lock()
         )
 
+    def is_vllm_backend(self) -> bool:
+        from ..model.llm.vllm.core import VLLMModel
+
+        return isinstance(self._model, VLLMModel)
+
     def load(self):
         self._model.load()
 
@@ -274,7 +279,7 @@ class ModelActor(xo.StatelessActor):
 
         async def _async_wrapper():
             try:
-                return await anext(gen)
+                return await anext(gen)  # noqa: F821
             except StopAsyncIteration:
                 return stop
 

--- a/xinference/core/tests/test_worker.py
+++ b/xinference/core/tests/test_worker.py
@@ -39,6 +39,15 @@ class MockWorkerActor(WorkerActor):
     def get_gpu_to_model_uid(self):
         return self._gpu_to_model_uid
 
+    def get_gpu_to_embedding_model_uids(self):
+        return self._gpu_to_embedding_model_uids
+
+    async def is_model_vllm_backend(self, model_uid):
+        for _dev in self._gpu_to_model_uid:
+            if model_uid == self._gpu_to_model_uid[_dev]:
+                return True
+        return False
+
     async def launch_builtin_model(
         self,
         model_uid: str,
@@ -50,13 +59,13 @@ class MockWorkerActor(WorkerActor):
         n_gpu: Optional[int] = None,
         **kwargs,
     ):
-        subpool_address, devices = await self._create_subpool(model_uid, n_gpu=n_gpu)
+        subpool_address, devices = await self._create_subpool(
+            model_uid, model_type, n_gpu=n_gpu
+        )
         self._model_uid_to_addr[model_uid] = subpool_address
 
     async def terminate_model(self, model_uid: str):
-        devs = [dev for dev, uid in self._gpu_to_model_uid.items() if uid == model_uid]
-        for dev in devs:
-            del self._gpu_to_model_uid[dev]
+        await self.release_devices(model_uid)
 
         sub_pool_addr = self._model_uid_to_addr[model_uid]
         await self._main_pool.remove_sub_pool(sub_pool_addr)
@@ -147,3 +156,85 @@ async def test_terminate_model_flag(setup_pool):
     gpu_to_model_id = await worker.get_gpu_to_model_uid()
     for dev in devices:
         assert dev not in gpu_to_model_id
+
+
+@pytest.mark.asyncio
+async def test_launch_embedding_model(setup_pool):
+    pool = setup_pool
+    addr = pool.external_address
+
+    worker: xo.ActorRefType["MockWorkerActor"] = await xo.create_actor(
+        MockWorkerActor,
+        address=addr,
+        uid=WorkerActor.uid(),
+        supervisor_address="test",
+        main_pool=pool,
+        cuda_devices=[i for i in range(4)],
+    )
+
+    # test embedding device candidates 1
+    await worker.launch_builtin_model(
+        "model_model_1", "mock_model_name", None, None, None, n_gpu=3
+    )
+
+    await worker.launch_builtin_model(
+        "model_model_2", "mock_model_name", None, None, None, "embedding", n_gpu=1
+    )
+
+    embedding_info = await worker.get_gpu_to_embedding_model_uids()
+    assert 3 in embedding_info
+    assert len(embedding_info[3]) == 1
+    assert "model_model_2" in embedding_info[3]
+
+    await worker.terminate_model("model_model_2")
+    assert len(embedding_info[3]) == 0
+    await worker.terminate_model("model_model_1")
+
+    # test embedding device candidates 2
+    await worker.launch_builtin_model(
+        "model_model_1", "mock_model_name", None, None, None, n_gpu=2
+    )
+
+    await worker.launch_builtin_model(
+        "model_model_2", "mock_model_name", None, None, None, "embedding", n_gpu=1
+    )
+
+    await worker.launch_builtin_model(
+        "model_model_3", "mock_model_name", None, None, None, "embedding", n_gpu=1
+    )
+    assert 2 in embedding_info
+    assert 3 in embedding_info
+    assert len(embedding_info[2]) == 1
+    assert len(embedding_info[3]) == 1
+    assert "model_model_2" in embedding_info[2]
+    assert "model_model_3" in embedding_info[3]
+
+    await worker.launch_builtin_model(
+        "model_model_4", "mock_model_name", None, None, None, "embedding", n_gpu=1
+    )
+    assert len(embedding_info[2]) == 2
+    assert len(embedding_info[3]) == 1
+    assert "model_model_2" in embedding_info[2]
+    assert "model_model_4" in embedding_info[2]
+    assert "model_model_3" in embedding_info[3]
+
+    for i in range(1, 5):
+        await worker.terminate_model(f"model_model_{i}")
+    assert len(embedding_info[2]) == 0
+    assert len(embedding_info[3]) == 0
+
+    # test no slots
+    for i in range(1, 5):
+        await worker.launch_builtin_model(
+            f"model_model_{i}", "mock_model_name", None, None, None, n_gpu=1
+        )
+    with pytest.raises(RuntimeError):
+        await worker.launch_builtin_model(
+            "model_model_5", "mock_model_name", None, None, None, "embedding", n_gpu=1
+        )
+    # launch CPU would work
+    await worker.launch_builtin_model(
+        "model_model_5", "mock_model_name", None, None, None, "embedding", n_gpu=None
+    )
+    for i in range(1, 6):
+        await worker.terminate_model(f"model_model_{i}")

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -149,7 +149,6 @@ class WorkerActor(xo.StatelessActor):
         model_type: Optional[str] = None,
         n_gpu: Optional[Union[int, str]] = "auto",
     ) -> Tuple[str, List[str]]:
-        logger.debug(f"Enter _create_subpool: {model_uid}")
         env = {}
         devices = []
         if isinstance(n_gpu, int) or (n_gpu == "auto" and cuda_count() > 0):

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -107,6 +107,8 @@ class WorkerActor(xo.StatelessActor):
         # Pick the device with the fewest existing models among all the candidate devices.
         for _dev in candidates:
             existing_cnt = len(self._gpu_to_embedding_model_uids[_dev])
+            if _dev in self._gpu_to_model_uid:
+                existing_cnt += 1
             if chosen_one[1] == -1 or existing_cnt < chosen_one[1]:
                 chosen_one[0], chosen_one[1] = _dev, existing_cnt
 

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -104,16 +104,15 @@ class WorkerActor(xo.StatelessActor):
                 "We recommend to launch the embedding model first, and then launch the LLM models."
             )
 
-        chosen_one = [-1, -1]  # dev, count
+        device, min_cnt = -1, -1
         # Pick the device with the fewest existing models among all the candidate devices.
         for _dev in candidates:
             existing_cnt = len(self._gpu_to_embedding_model_uids[_dev])
             if _dev in self._gpu_to_model_uid:
                 existing_cnt += 1
-            if chosen_one[1] == -1 or existing_cnt < chosen_one[1]:
-                chosen_one[0], chosen_one[1] = _dev, existing_cnt
+            if min_cnt == -1 or existing_cnt < min_cnt:
+                device, min_cnt = _dev, existing_cnt
 
-        device = chosen_one[0]
         self._gpu_to_embedding_model_uids[device].add(model_uid)
         return device
 

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -26,7 +26,7 @@ from xoscar import MainActorPoolType
 from ..core import ModelActor
 from ..model.core import ModelDescription, create_model_instance
 from .resource import gather_node_info
-from .utils import log_async, log_sync
+from .utils import log_async, log_sync, parse_replica_model_uid
 
 logger = getLogger(__name__)
 
@@ -80,7 +80,8 @@ class WorkerActor(xo.StatelessActor):
 
     async def is_model_vllm_backend(self, model_uid: str) -> bool:
         assert self._supervisor_ref is not None
-        model_ref = await self._supervisor_ref.get_model(model_uid)
+        _model_uid, _, _ = parse_replica_model_uid(model_uid)
+        model_ref = await self._supervisor_ref.get_model(_model_uid)
         return await model_ref.is_vllm_backend()
 
     async def allocate_devices_for_embedding(self, model_uid: str) -> int:

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -148,6 +148,7 @@ class WorkerActor(xo.StatelessActor):
         model_type: Optional[str] = None,
         n_gpu: Optional[Union[int, str]] = "auto",
     ) -> Tuple[str, List[str]]:
+        logger.debug(f"Enter _create_subpool: {model_uid}")
         env = {}
         devices = []
         if isinstance(n_gpu, int) or (n_gpu == "auto" and cuda_count() > 0):


### PR DESCRIPTION
When there are only one GPU available and user launches vLLM-backend models first, then launches embedding models to GPU, `No slot available` error would be raised.
Here' the changes:
- Embedding models use their own slots, no relation with LLM models.
- The embedding model will first avoid the card where the LLM model is located, and if there is no slot, the user will be prompted to launch the embedding model first.
- After finding the cards where the embedding models can be placed, try to equalize the load (number of models) between the cards.