### PR TITLE
ENH: running model location & accelerators

### DIFF
--- a/xinference/client/tests/test_client.py
+++ b/xinference/client/tests/test_client.py
@@ -125,6 +125,8 @@ def test_replica_model(setup):
 
     client2 = RESTfulClient(endpoint)
     info = client2.describe_model(model_uid=model_uid)
+    assert "address" in info
+    assert "accelerators" in info
     assert info["replica"] == replica
 
     client.terminate_model(model_uid=model_uid)

--- a/xinference/core/tests/test_worker.py
+++ b/xinference/core/tests/test_worker.py
@@ -65,7 +65,7 @@ class MockWorkerActor(WorkerActor):
         self._model_uid_to_addr[model_uid] = subpool_address
 
     async def terminate_model(self, model_uid: str):
-        await self.release_devices(model_uid)
+        self.release_devices(model_uid)
 
         sub_pool_addr = self._model_uid_to_addr[model_uid]
         await self._main_pool.remove_sub_pool(sub_pool_addr)

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -335,7 +335,7 @@ class WorkerActor(xo.StatelessActor):
         del self._model_uid_to_model[model_uid]
         del self._model_uid_to_model_spec[model_uid]
 
-        await self.release_devices(model_uid)
+        self.release_devices(model_uid)
 
         subpool_address = self._model_uid_to_addr[model_uid]
         await self._main_pool.remove_sub_pool(subpool_address)

--- a/xinference/model/core.py
+++ b/xinference/model/core.py
@@ -13,18 +13,25 @@
 # limitations under the License.
 
 from abc import ABC
-from typing import Any, Optional, Tuple
+from typing import Any, List, Optional, Tuple
 
 
 class ModelDescription(ABC):
+    def __init__(self, address: Optional[str], devices: Optional[List[str]]):
+        self.address = address
+        self.devices = devices
+
     def to_dict(self):
         """
         Return a dict to describe some information about model.
         :return:
         """
+        raise NotImplementedError
 
 
 def create_model_instance(
+    subpool_addr: str,
+    devices: List[str],
     model_uid: str,
     model_type: str,
     model_name: str,
@@ -40,6 +47,8 @@ def create_model_instance(
 
     if model_type == "LLM":
         return create_llm_model_instance(
+            subpool_addr,
+            devices,
             model_uid,
             model_name,
             model_format,
@@ -51,9 +60,13 @@ def create_model_instance(
     elif model_type == "embedding":
         # embedding model doesn't accept trust_remote_code
         kwargs.pop("trust_remote_code", None)
-        return create_embedding_model_instance(model_uid, model_name, **kwargs)
+        return create_embedding_model_instance(
+            subpool_addr, devices, model_uid, model_name, **kwargs
+        )
     elif model_type == "image":
         kwargs.pop("trust_remote_code", None)
-        return create_image_model_instance(model_uid, model_name, **kwargs)
+        return create_image_model_instance(
+            subpool_addr, devices, model_uid, model_name, **kwargs
+        )
     else:
         raise ValueError(f"Unsupported model type: {model_type}.")

--- a/xinference/model/embedding/core.py
+++ b/xinference/model/embedding/core.py
@@ -37,12 +37,20 @@ class EmbeddingModelSpec(BaseModel):
 
 
 class EmbeddingModelDescription(ModelDescription):
-    def __init__(self, model_spec: EmbeddingModelSpec):
+    def __init__(
+        self,
+        address: Optional[str],
+        devices: Optional[List[str]],
+        model_spec: EmbeddingModelSpec,
+    ):
+        super().__init__(address, devices)
         self._model_spec = model_spec
 
     def to_dict(self):
         return {
             "model_type": "embedding",
+            "address": self.address,
+            "accelerators": self.devices,
             "model_name": self._model_spec.model_name,
             "dimensions": self._model_spec.dimensions,
             "max_tokens": self._model_spec.max_tokens,
@@ -93,7 +101,7 @@ def cache(model_spec: EmbeddingModelSpec):
     with open(meta_path, "w") as f:
         import json
 
-        desc = EmbeddingModelDescription(model_spec)
+        desc = EmbeddingModelDescription(None, None, model_spec)
         json.dump(desc.to_dict(), f)
     return cache_dir
 
@@ -314,10 +322,10 @@ def match_embedding(model_name: str) -> EmbeddingModelSpec:
 
 
 def create_embedding_model_instance(
-    model_uid: str, model_name: str, **kwargs
+    subpool_addr: str, devices: List[str], model_uid: str, model_name: str, **kwargs
 ) -> Tuple[EmbeddingModel, EmbeddingModelDescription]:
     model_spec = match_embedding(model_name)
     model_path = cache(model_spec)
     model = EmbeddingModel(model_uid, model_path, **kwargs)
-    model_description = EmbeddingModelDescription(model_spec)
+    model_description = EmbeddingModelDescription(subpool_addr, devices, model_spec)
     return model, model_description

--- a/xinference/model/image/core.py
+++ b/xinference/model/image/core.py
@@ -107,7 +107,7 @@ def cache(model_spec: ImageModelFamilyV1):
     with open(meta_path, "w") as f:
         import json
 
-        desc = ImageModelDescription(model_spec)
+        desc = ImageModelDescription(None, None, model_spec)
         json.dump(desc.to_dict(), f)
 
     return cache_dir

--- a/xinference/model/image/core.py
+++ b/xinference/model/image/core.py
@@ -37,12 +37,20 @@ class ImageModelFamilyV1(BaseModel):
 
 
 class ImageModelDescription(ModelDescription):
-    def __init__(self, model_spec: ImageModelFamilyV1):
+    def __init__(
+        self,
+        address: Optional[str],
+        devices: Optional[List[str]],
+        model_spec: ImageModelFamilyV1,
+    ):
+        super().__init__(address, devices)
         self._model_spec = model_spec
 
     def to_dict(self):
         return {
             "model_type": "image",
+            "address": self.address,
+            "accelerators": self.devices,
             "model_name": self._model_spec.model_name,
             "model_family": self._model_spec.model_family,
             "model_revision": self._model_spec.model_revision,
@@ -118,7 +126,7 @@ def get_cache_status(
 
 
 def create_image_model_instance(
-    model_uid: str, model_name: str, **kwargs
+    subpool_addr: str, devices: List[str], model_uid: str, model_name: str, **kwargs
 ) -> Tuple[DiffusionModel, ImageModelDescription]:
     model_spec = match_diffusion(model_name)
     controlnet = kwargs.get("controlnet")
@@ -151,5 +159,5 @@ def create_image_model_instance(
             kwargs["controlnet"] = controlnet_model_paths
     model_path = cache(model_spec)
     model = DiffusionModel(model_uid, model_path, **kwargs)
-    model_description = ImageModelDescription(model_spec)
+    model_description = ImageModelDescription(subpool_addr, devices, model_spec)
     return model, model_description

--- a/xinference/model/llm/llm_family.py
+++ b/xinference/model/llm/llm_family.py
@@ -453,7 +453,7 @@ def _generate_meta_file(
 
         from .core import LLMDescription
 
-        desc = LLMDescription(llm_family, llm_spec, quantization)
+        desc = LLMDescription(None, None, llm_family, llm_spec, quantization)
         json.dump(desc.to_dict(), f)
 
 

--- a/xinference/web/ui/src/scenes/running_models/index.js
+++ b/xinference/web/ui/src/scenes/running_models/index.js
@@ -85,7 +85,7 @@ const RunningModels = () => {
     },
     {
       field: "accelerators",
-      headerName: "Accelerators",
+      headerName: "GPU Indexes",
       flex: 1,
     },
     {
@@ -274,7 +274,7 @@ const RunningModels = () => {
     },
     {
       field: "accelerators",
-      headerName: "Accelerators",
+      headerName: "GPU Indexes",
       flex: 1,
     },
     {

--- a/xinference/web/ui/src/scenes/running_models/index.js
+++ b/xinference/web/ui/src/scenes/running_models/index.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useContext } from "react";
-import { Box, Stack } from "@mui/material";
+import { Box, Stack, Typography } from "@mui/material";
 import { ApiContext } from "../../components/apiContext";
 import { DataGrid } from "@mui/x-data-grid";
 import Title from "../../components/Title";
@@ -7,33 +7,51 @@ import OpenInBrowserOutlinedIcon from "@mui/icons-material/OpenInBrowserOutlined
 import DeleteOutlineOutlinedIcon from "@mui/icons-material/DeleteOutlineOutlined";
 
 const RunningModels = () => {
-  const [modelData, setModelData] = useState([]);
+  const [llmData, setLlmData] = useState([]);
+  const [embeddingModelData, setEmbeddingModelData] = useState([]);
+  const [imageModelData, setImageModelData] = useState([]);
   const { isCallingApi, setIsCallingApi } = useContext(ApiContext);
   const { isUpdatingModel, setIsUpdatingModel } = useContext(ApiContext);
   const endPoint = useContext(ApiContext).endPoint;
 
   const update = (isCallingApi) => {
     if (isCallingApi) {
-      setModelData([
+      setLlmData([
+        { id: "Loading, do not refresh page...", url: "IS_LOADING" },
+      ]);
+      setEmbeddingModelData([
+        { id: "Loading, do not refresh page...", url: "IS_LOADING" },
+      ]);
+      setImageModelData([
         { id: "Loading, do not refresh page...", url: "IS_LOADING" },
       ]);
     } else {
       setIsUpdatingModel(true);
-      fetch(`${endPoint}/v1/models`, {
+      fetch(`${endPoint}/v1/models/`, {
         method: "GET",
       })
         .then((response) => response.json())
         .then((data) => {
-          const newModelData = [];
+          const newLlmData = [];
+          const newEmbeddingModelData = [];
+          const newImageModelData = [];
           Object.entries(data).forEach(([key, value]) => {
             let newValue = {
               ...value,
               id: key,
               url: key,
             };
-            newModelData.push(newValue);
+            if (newValue.model_type === "LLM") {
+              newLlmData.push(newValue);
+            } else if (newValue.model_type === "embedding") {
+              newEmbeddingModelData.push(newValue);
+            } else if (newValue.model_type === "image") {
+              newImageModelData.push(newValue);
+            }
           });
-          setModelData(newModelData);
+          setLlmData(newLlmData);
+          setEmbeddingModelData(newEmbeddingModelData);
+          setImageModelData(newImageModelData);
           setIsUpdatingModel(false);
         })
         .catch((error) => {
@@ -48,7 +66,7 @@ const RunningModels = () => {
     // eslint-disable-next-line
   }, [isCallingApi]);
 
-  const columns = [
+  const llmColumns = [
     {
       field: "id",
       headerName: "ID",
@@ -58,6 +76,16 @@ const RunningModels = () => {
     {
       field: "model_name",
       headerName: "Name",
+      flex: 1,
+    },
+    {
+      field: "address",
+      headerName: "Address",
+      flex: 1,
+    },
+    {
+      field: "accelerators",
+      headerName: "Accelerators",
       flex: 1,
     },
     {
@@ -227,13 +255,217 @@ const RunningModels = () => {
     },
   ];
 
+  const embeddingModelColumns = [
+    {
+      field: "id",
+      headerName: "ID",
+      flex: 1,
+      minWidth: 250,
+    },
+    {
+      field: "model_name",
+      headerName: "Name",
+      flex: 1,
+    },
+    {
+      field: "address",
+      headerName: "Address",
+      flex: 1,
+    },
+    {
+      field: "accelerators",
+      headerName: "Accelerators",
+      flex: 1,
+    },
+    {
+      field: "url",
+      headerName: "Actions",
+      flex: 1,
+      minWidth: 200,
+      sortable: false,
+      filterable: false,
+      disableColumnMenu: true,
+      renderCell: ({ row }) => {
+        const url = row.url;
+        const closeUrl = `${endPoint}/v1/models/` + url;
+
+        if (url === "IS_LOADING") {
+          return <div></div>;
+        }
+
+        return (
+          <Box
+            style={{
+              width: "100%",
+              display: "flex",
+              justifyContent: "left",
+              alignItems: "left",
+            }}
+          >
+            <button
+              title="Terminate Model"
+              style={{
+                borderWidth: "0px",
+                backgroundColor: "transparent",
+                paddingLeft: "0px",
+                paddingRight: "10px",
+              }}
+              onClick={() => {
+                if (isCallingApi || isUpdatingModel) {
+                  return;
+                }
+                setIsCallingApi(true);
+                fetch(closeUrl, {
+                  method: "DELETE",
+                })
+                  .then((response) => {
+                    response.json();
+                  })
+                  .then((data) => {
+                    setIsCallingApi(false);
+                  })
+                  .catch((error) => {
+                    console.error("Error:", error);
+                    setIsCallingApi(false);
+                  });
+              }}
+            >
+              <Box
+                width="40px"
+                m="0 auto"
+                p="5px"
+                display="flex"
+                justifyContent="center"
+                borderRadius="4px"
+                style={{
+                  border: "1px solid #e5e7eb",
+                  borderWidth: "1px",
+                  borderColor: "#e5e7eb",
+                }}
+              >
+                <DeleteOutlineOutlinedIcon />
+              </Box>
+            </button>
+          </Box>
+        );
+      },
+    },
+  ];
+
+  const imageModelColumns = embeddingModelColumns;
+
   return (
     <Box m="20px">
       <Title title="Running Models" />
-      <Box m="40px 0 0 0" height="75vh">
+      <Box m="40px 0 0 0" height="30vh">
+        <Typography variant="h5" gutterBottom>
+          Language Models
+        </Typography>
         <DataGrid
-          rows={modelData}
-          columns={columns}
+          rows={llmData}
+          columns={llmColumns}
+          sx={{
+            "& .MuiDataGrid-main": {
+              width: "95% !important",
+              overflow: "visible",
+            },
+            "& .MuiDataGrid-row": {
+              background: "white",
+              margin: "10px 0px",
+            },
+            "& .MuiDataGrid-cell": {
+              borderBottom: "none",
+            },
+            "& .CustomWide-cell": {
+              minWidth: "250px !important",
+            },
+            "& .MuiDataGrid-columnHeaders": {
+              borderBottom: "none",
+            },
+            "& .MuiDataGrid-columnHeaderTitle": {
+              fontWeight: "bold",
+            },
+            "& .MuiDataGrid-virtualScroller": {
+              overflowX: "visible !important",
+              overflow: "visible",
+            },
+            "& .MuiDataGrid-footerContainer": {
+              borderTop: "none",
+            },
+            "border-width": "0px",
+          }}
+          slots={{
+            noRowsOverlay: () => (
+              <Stack height="100%" alignItems="center" justifyContent="center">
+                No Running Models
+              </Stack>
+            ),
+            noResultsOverlay: () => (
+              <Stack height="100%" alignItems="center" justifyContent="center">
+                No Running Models Matches
+              </Stack>
+            ),
+          }}
+        />
+      </Box>
+      <Box m="40px 0 0 0" height="30vh">
+        <Typography variant="h5" gutterBottom>
+          Embedding models
+        </Typography>
+        <DataGrid
+          rows={embeddingModelData}
+          columns={embeddingModelColumns}
+          sx={{
+            "& .MuiDataGrid-main": {
+              width: "95% !important",
+              overflow: "visible",
+            },
+            "& .MuiDataGrid-row": {
+              background: "white",
+              margin: "10px 0px",
+            },
+            "& .MuiDataGrid-cell": {
+              borderBottom: "none",
+            },
+            "& .CustomWide-cell": {
+              minWidth: "250px !important",
+            },
+            "& .MuiDataGrid-columnHeaders": {
+              borderBottom: "none",
+            },
+            "& .MuiDataGrid-columnHeaderTitle": {
+              fontWeight: "bold",
+            },
+            "& .MuiDataGrid-virtualScroller": {
+              overflowX: "visible !important",
+              overflow: "visible",
+            },
+            "& .MuiDataGrid-footerContainer": {
+              borderTop: "none",
+            },
+            "border-width": "0px",
+          }}
+          slots={{
+            noRowsOverlay: () => (
+              <Stack height="100%" alignItems="center" justifyContent="center">
+                No Running Models
+              </Stack>
+            ),
+            noResultsOverlay: () => (
+              <Stack height="100%" alignItems="center" justifyContent="center">
+                No Running Models Matches
+              </Stack>
+            ),
+          }}
+        />
+      </Box>
+      <Box m="40px 0 0 0" height="30vh">
+        <Typography variant="h5" gutterBottom>
+          Image models
+        </Typography>
+        <DataGrid
+          rows={imageModelData}
+          columns={imageModelColumns}
           sx={{
             "& .MuiDataGrid-main": {
               width: "95% !important",


### PR DESCRIPTION
The `list models` and `desc model` APIs have been updated to include the model address and the accelerators in use. Corresponding updates have been made to the frontend. The columns and actions now vary depending on the model type.

![image](https://github.com/xorbitsai/inference/assets/109661872/a2f4f91d-4bcc-42f4-8f36-dcd32c6dccfb)
