### PR TITLE
FEAT: Support rerank models

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -102,6 +102,7 @@ jobs:
           pip install s3fs
           pip install modelscope
           pip install diffusers
+          pip install protobuf
           pip install -e ".[dev]"
           pip install "jinja2==3.1.2"
         working-directory: .

--- a/doc/source/models/builtin/bge-reranker-base.rst
+++ b/doc/source/models/builtin/bge-reranker-base.rst
@@ -1,0 +1,19 @@
+.. _models_builtin_bge_rerank_base:
+
+=================
+bge-reranker-base
+=================
+
+- **Model Name:** bge-reranker-base
+- **Languages:** [zh, en]
+- **Abilities:** rerank
+
+Specifications
+^^^^^^^^^^^^^^
+
+- **Model ID:** BAAI/bge-reranker-base
+
+Execute the following command to launch the model::
+
+   xinference launch --model-name bge-reranker-base --model-type rerank
+

--- a/doc/source/models/builtin/bge-reranker-large
+++ b/doc/source/models/builtin/bge-reranker-large
@@ -1,0 +1,19 @@
+.. _models_builtin_bge_rerank_large:
+
+=================
+bge-reranker-large
+=================
+
+- **Model Name:** bge-reranker-large
+- **Languages:** [zh, en]
+- **Abilities:** rerank
+
+Specifications
+^^^^^^^^^^^^^^
+
+- **Model ID:** BAAI/bge-reranker-large
+
+Execute the following command to launch the model::
+
+   xinference launch --model-name bge-reranker-large --model-type rerank
+

--- a/doc/source/models/builtin/index.rst
+++ b/doc/source/models/builtin/index.rst
@@ -156,3 +156,10 @@ Language: Chinese
    multilingual-e5-large
    bge-small-zh
    bge-small-zh-v1.5
+
+
+Rerank Models
+++++++++++++++++++++++
+- :ref:`bge_rerank_base <models_builtin_bge_rerank_base>`
+- :ref:`bge_rerank_large <models_builtin_bge_rerank_large>`
+

--- a/doc/source/user_guide/client_api.rst
+++ b/doc/source/user_guide/client_api.rst
@@ -142,3 +142,35 @@ Output:
     {'created': 1697536913,
      'data': [{'url': '/home/admin/.xinference/image/605d2f545ac74142b8031455af31ee33.jpg',
      'b64_json': None}]}
+
+Rerank
+~~~~~~
+To launch a rerank model and compute the similarity scores:
+.. code-block::
+
+    from xinference.client import Client
+
+    client = Client("http://localhost:9997")
+    model_uid = client.launch_model(model_name="bge-reranker-base", model_type="rerank")
+    model = client.get_model(model_uid)
+
+    query = "A man is eating pasta."
+    corpus = [
+        "A man is eating food.",
+        "A man is eating a piece of bread.",
+        "The girl is carrying a baby.",
+        "A man is riding a horse.",
+        "A woman is playing violin."
+    ]
+    print(model.rerank(corpus, query))
+
+Output:
+
+.. code-block::
+
+    {'id': '480dca92-8910-11ee-b76a-c2c8e4cad3f5', 'results': [{'index': 0, 'relevance_score': 0.9999247789382935,
+     'document': 'A man is eating food.'}, {'index': 1, 'relevance_score': 0.2564932405948639,
+     'document': 'A man is eating a piece of bread.'}, {'index': 3, 'relevance_score': 3.955026841140352e-05,
+     'document': 'A man is riding a horse.'}, {'index': 2, 'relevance_score': 3.742107219295576e-05,
+     'document': 'The girl is carrying a baby.'}, {'index': 4, 'relevance_score': 3.739788007806055e-05,
+     'document': 'A woman is playing violin.'}]}

--- a/xinference/core/model.py
+++ b/xinference/core/model.py
@@ -267,6 +267,37 @@ class ModelActor(xo.StatelessActor):
 
     @log_async(logger=logger)
     @request_limit
+    async def rerank(
+        self,
+        documents: List[str],
+        query: str,
+        top_n: Optional[int],
+        max_chunks_per_doc: Optional[int],
+        return_documents: Optional[bool],
+        *args,
+        **kwargs,
+    ):
+        if not hasattr(self._model, "rerank"):
+            raise AttributeError(
+                f"Model {self._model.model_spec} is not for reranking."
+            )
+
+        def _wrapper():
+            data = getattr(self._model, "rerank")(
+                documents,
+                query,
+                top_n,
+                max_chunks_per_doc,
+                return_documents,
+                *args,
+                **kwargs,
+            )
+            return json_dumps(data)
+
+        return await self._call_wrapper(_wrapper)
+
+    @log_async(logger=logger)
+    @request_limit
     async def text_to_image(
         self,
         prompt: str,

--- a/xinference/model/core.py
+++ b/xinference/model/core.py
@@ -44,6 +44,7 @@ def create_model_instance(
     from .embedding.core import create_embedding_model_instance
     from .image.core import create_image_model_instance
     from .llm.core import create_llm_model_instance
+    from .rerank.core import create_rerank_model_instance
 
     if model_type == "LLM":
         return create_llm_model_instance(
@@ -66,6 +67,11 @@ def create_model_instance(
     elif model_type == "image":
         kwargs.pop("trust_remote_code", None)
         return create_image_model_instance(
+            subpool_addr, devices, model_uid, model_name, **kwargs
+        )
+    elif model_type == "rerank":
+        kwargs.pop("trust_remote_code", None)
+        return create_rerank_model_instance(
             subpool_addr, devices, model_uid, model_name, **kwargs
         )
     else:

--- a/xinference/model/embedding/core.py
+++ b/xinference/model/embedding/core.py
@@ -198,8 +198,6 @@ def get_cache_status(
     cache_dir = os.path.realpath(
         os.path.join(XINFERENCE_CACHE_DIR, model_spec.model_name)
     )
-    if not os.path.exists(cache_dir):
-        os.makedirs(cache_dir, exist_ok=True)
     meta_path = os.path.join(cache_dir, "__valid_download")
     return valid_model_revision(meta_path, model_spec.model_revision)
 

--- a/xinference/model/image/core.py
+++ b/xinference/model/image/core.py
@@ -119,8 +119,6 @@ def get_cache_status(
     cache_dir = os.path.realpath(
         os.path.join(XINFERENCE_CACHE_DIR, model_spec.model_name)
     )
-    if not os.path.exists(cache_dir):
-        os.makedirs(cache_dir, exist_ok=True)
     meta_path = os.path.join(cache_dir, "__valid_download")
     return valid_model_revision(meta_path, model_spec.model_revision)
 

--- a/xinference/model/rerank/__init__.py
+++ b/xinference/model/rerank/__init__.py
@@ -1,0 +1,36 @@
+# Copyright 2022-2023 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import codecs
+import json
+import os
+
+from .core import RerankModelSpec, get_cache_status
+
+_model_spec_json = os.path.join(os.path.dirname(__file__), "model_spec.json")
+_model_spec_modelscope_json = os.path.join(
+    os.path.dirname(__file__), "model_spec_modelscope.json"
+)
+BUILTIN_RERANK_MODELS = dict(
+    (spec["model_name"], RerankModelSpec(**spec))
+    for spec in json.load(codecs.open(_model_spec_json, "r", encoding="utf-8"))
+)
+MODELSCOPE_RERANK_MODELS = dict(
+    (spec["model_name"], RerankModelSpec(**spec))
+    for spec in json.load(
+        codecs.open(_model_spec_modelscope_json, "r", encoding="utf-8")
+    )
+)
+del _model_spec_json
+del _model_spec_modelscope_json

--- a/xinference/model/rerank/core.py
+++ b/xinference/model/rerank/core.py
@@ -152,6 +152,9 @@ def cache(model_spec: RerankModelSpec):
         return cache_dir
 
     if model_spec.model_hub == "modelscope":
+        logger.info(
+            f"Download {model_spec.model_name} from modelscope {model_spec.model_id}"
+        )
         download_dir = retry_download(
             ms_download,
             model_spec.model_name,
@@ -164,6 +167,9 @@ def cache(model_spec: RerankModelSpec):
                 relpath = os.path.relpath(os.path.join(subdir, file), download_dir)
                 symlink_local_file(os.path.join(subdir, file), cache_dir, relpath)
     else:
+        logger.info(
+            f"Download {model_spec.model_name} from huggingface {model_spec.model_id}"
+        )
         retry_download(
             hf_download,
             model_spec.model_name,

--- a/xinference/model/rerank/core.py
+++ b/xinference/model/rerank/core.py
@@ -1,0 +1,218 @@
+# Copyright 2022-2023 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import os
+import uuid
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+from pydantic import BaseModel
+
+from ...constants import XINFERENCE_CACHE_DIR
+from ...types import Document, DocumentObj, Rerank
+from ..core import ModelDescription
+from ..utils import valid_model_revision
+
+logger = logging.getLogger(__name__)
+
+
+class RerankModelSpec(BaseModel):
+    model_name: str
+    language: List[str]
+    model_id: str
+    model_revision: str
+    model_hub: str = "huggingface"
+
+
+class RerankModelDescription(ModelDescription):
+    def __init__(
+        self,
+        address: Optional[str],
+        devices: Optional[List[str]],
+        model_spec: RerankModelSpec,
+    ):
+        super().__init__(address, devices)
+        self._model_spec = model_spec
+
+    def to_dict(self):
+        return {
+            "model_type": "rerank",
+            "address": self.address,
+            "accelerators": self.devices,
+            "model_name": self._model_spec.model_name,
+            "language": self._model_spec.language,
+            "model_revision": self._model_spec.model_revision,
+        }
+
+
+class RerankModel:
+    def __init__(
+        self,
+        model_uid: str,
+        model_path: str,
+        device: Optional[str] = None,
+        model_config: Optional[Dict] = None,
+    ):
+        self._model_uid = model_uid
+        self._model_path = model_path
+        self._device = device
+        self._model_config = model_config or dict()
+        self._model = None
+
+    def load(self):
+        try:
+            from sentence_transformers.cross_encoder import CrossEncoder
+        except ImportError:
+            error_message = "Failed to import module 'SentenceTransformer'"
+            installation_guide = [
+                "Please make sure 'sentence-transformers' is installed. ",
+                "You can install it by `pip install sentence-transformers`\n",
+            ]
+
+            raise ImportError(f"{error_message}\n\n{''.join(installation_guide)}")
+        self._model = CrossEncoder(
+            self._model_path, device=self._device, **self._model_config
+        )
+
+    def rerank(
+        self,
+        documents: List[str],
+        query: str,
+        top_n: Optional[int],
+        max_chunks_per_doc: Optional[int],
+        return_documents: Optional[bool],
+    ) -> Rerank:
+        assert self._model is not None
+        if max_chunks_per_doc is not None:
+            raise ValueError("rerank hasn't support `max_chunks_per_doc` parameter.")
+        sentence_combinations = [[query, doc] for doc in documents]
+        similarity_scores = self._model.predict(sentence_combinations)
+        sim_scores_argsort = list(reversed(np.argsort(similarity_scores)))
+        if top_n is not None:
+            sim_scores_argsort = sim_scores_argsort[:top_n]
+        if return_documents:
+            docs = [
+                DocumentObj(
+                    index=int(arg),
+                    relevance_score=float(similarity_scores[arg]),
+                    document=Document(text=documents[arg]),
+                )
+                for arg in sim_scores_argsort
+            ]
+        else:
+            docs = [
+                DocumentObj(
+                    index=int(arg),
+                    relevance_score=float(similarity_scores[arg]),
+                    document=None,
+                )
+                for arg in sim_scores_argsort
+            ]
+        return Rerank(id=str(uuid.uuid1()), results=docs)
+
+
+def get_cache_status(
+    model_spec: RerankModelSpec,
+) -> bool:
+    cache_dir = os.path.realpath(
+        os.path.join(XINFERENCE_CACHE_DIR, model_spec.model_name)
+    )
+    if not os.path.exists(cache_dir):
+        os.makedirs(cache_dir, exist_ok=True)
+    meta_path = os.path.join(cache_dir, "__valid_download")
+    return valid_model_revision(meta_path, model_spec.model_revision)
+
+
+def cache(model_spec: RerankModelSpec):
+    # TODO: cache from uri
+    from huggingface_hub import snapshot_download as hf_download
+    from modelscope.hub.snapshot_download import snapshot_download as ms_download
+
+    from ..utils import retry_download, symlink_local_file
+
+    cache_dir = os.path.realpath(
+        os.path.join(XINFERENCE_CACHE_DIR, model_spec.model_name)
+    )
+    if not os.path.exists(cache_dir):
+        os.makedirs(cache_dir, exist_ok=True)
+    meta_path = os.path.join(cache_dir, "__valid_download")
+    if valid_model_revision(meta_path, model_spec.model_revision):
+        return cache_dir
+
+    if model_spec.model_hub == "modelscope":
+        download_dir = retry_download(
+            ms_download,
+            model_spec.model_name,
+            None,
+            model_spec.model_id,
+            revision=model_spec.model_revision,
+        )
+        for subdir, dirs, files in os.walk(download_dir):
+            for file in files:
+                relpath = os.path.relpath(os.path.join(subdir, file), download_dir)
+                symlink_local_file(os.path.join(subdir, file), cache_dir, relpath)
+    else:
+        retry_download(
+            hf_download,
+            model_spec.model_name,
+            None,
+            model_spec.model_id,
+            revision=model_spec.model_revision,
+            local_dir=cache_dir,
+            local_dir_use_symlinks=True,
+        )
+    with open(meta_path, "w") as f:
+        import json
+
+        desc = RerankModelDescription(None, None, model_spec)
+        json.dump(desc.to_dict(), f)
+    return cache_dir
+
+
+def create_rerank_model_instance(
+    subpool_addr: str, devices: List[str], model_uid: str, model_name: str, **kwargs
+) -> Tuple[RerankModel, RerankModelDescription]:
+    from ..utils import download_from_modelscope
+    from . import BUILTIN_RERANK_MODELS, MODELSCOPE_RERANK_MODELS
+
+    if download_from_modelscope():
+        if model_name in MODELSCOPE_RERANK_MODELS:
+            logger.debug(f"Rerank model {model_name} found in ModelScope.")
+            model_spec = MODELSCOPE_RERANK_MODELS[model_name]
+        else:
+            logger.debug(
+                f"Rerank model {model_name} not found in ModelScope, "
+                f"now try to download from huggingface."
+            )
+            if model_name in BUILTIN_RERANK_MODELS:
+                model_spec = BUILTIN_RERANK_MODELS[model_name]
+            else:
+                raise ValueError(
+                    f"Rerank model {model_name} not found, available"
+                    f"model list: {BUILTIN_RERANK_MODELS.keys()}"
+                )
+    else:
+        if model_name in BUILTIN_RERANK_MODELS:
+            model_spec = BUILTIN_RERANK_MODELS[model_name]
+        else:
+            raise ValueError(
+                f"Rerank model {model_name} not found, available"
+                f"model list: {BUILTIN_RERANK_MODELS.keys()}"
+            )
+
+    model_path = cache(model_spec)
+    model = RerankModel(model_uid, model_path, **kwargs)
+    model_description = RerankModelDescription(subpool_addr, devices, model_spec)
+    return model, model_description

--- a/xinference/model/rerank/core.py
+++ b/xinference/model/rerank/core.py
@@ -129,8 +129,6 @@ def get_cache_status(
     cache_dir = os.path.realpath(
         os.path.join(XINFERENCE_CACHE_DIR, model_spec.model_name)
     )
-    if not os.path.exists(cache_dir):
-        os.makedirs(cache_dir, exist_ok=True)
     meta_path = os.path.join(cache_dir, "__valid_download")
     return valid_model_revision(meta_path, model_spec.model_revision)
 

--- a/xinference/model/rerank/model_spec.json
+++ b/xinference/model/rerank/model_spec.json
@@ -1,0 +1,14 @@
+[
+  {
+    "model_name": "bge-reranker-large",
+    "language": ["en", "zh"],
+    "model_id": "BAAI/bge-large-en",
+    "model_revision": "27c9168d479987529781de8474dff94d69beca11"
+  },
+  {
+    "model_name": "bge-reranker-base",
+    "language": ["en", "zh"],
+    "model_id": "BAAI/bge-reranker-base",
+    "model_revision": "465b4b7ddf2be0a020c8ad6e525b9bb1dbb708ae"
+  }
+]

--- a/xinference/model/rerank/model_spec.json
+++ b/xinference/model/rerank/model_spec.json
@@ -2,7 +2,7 @@
   {
     "model_name": "bge-reranker-large",
     "language": ["en", "zh"],
-    "model_id": "BAAI/bge-large-en",
+    "model_id": "BAAI/bge-reranker-large",
     "model_revision": "27c9168d479987529781de8474dff94d69beca11"
   },
   {

--- a/xinference/model/rerank/model_spec_modelscope.json
+++ b/xinference/model/rerank/model_spec_modelscope.json
@@ -1,6 +1,6 @@
 [
   {
-    "model_name": "bge-reranker-large",
+    "model_name": "bge-reranker-base",
     "language": ["en", "zh"],
     "model_id": "hekaisheng/bge-reranker-base",
     "model_revision": "v0.0.1",

--- a/xinference/model/rerank/model_spec_modelscope.json
+++ b/xinference/model/rerank/model_spec_modelscope.json
@@ -1,0 +1,9 @@
+[
+  {
+    "model_name": "bge-reranker-large",
+    "language": ["en", "zh"],
+    "model_id": "hekaisheng/bge-reranker-base",
+    "model_revision": "v0.0.1",
+    "model_hub": "modelscope"
+  }
+]

--- a/xinference/model/rerank/model_spec_modelscope.json
+++ b/xinference/model/rerank/model_spec_modelscope.json
@@ -2,7 +2,14 @@
   {
     "model_name": "bge-reranker-base",
     "language": ["en", "zh"],
-    "model_id": "hekaisheng/bge-reranker-base",
+    "model_id": "Xorbits/bge-reranker-base",
+    "model_revision": "v0.0.1",
+    "model_hub": "modelscope"
+  },
+  {
+    "model_name": "bge-reranker-large",
+    "language": ["en", "zh"],
+    "model_id": "Xorbits/bge-reranker-large",
     "model_revision": "v0.0.1",
     "model_hub": "modelscope"
   }

--- a/xinference/model/rerank/tests/__init__.py
+++ b/xinference/model/rerank/tests/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2022-2023 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/xinference/model/rerank/tests/test_rerank.py
+++ b/xinference/model/rerank/tests/test_rerank.py
@@ -19,9 +19,7 @@ def test_oscar_api(setup):
     endpoint, _ = setup
     client = Client(endpoint)
 
-    model_uid = client.launch_model(
-        model_name="bge-reranker-large", model_type="rerank"
-    )
+    model_uid = client.launch_model(model_name="bge-reranker-base", model_type="rerank")
     assert len(client.list_models()) == 1
     model = client.get_model(model_uid)
     # We want to compute the similarity between the query sentence

--- a/xinference/model/rerank/tests/test_rerank.py
+++ b/xinference/model/rerank/tests/test_rerank.py
@@ -15,7 +15,7 @@
 from ....client import Client
 
 
-def test_oscar_api(setup):
+def test_restful_api(setup):
     endpoint, _ = setup
     client = Client(endpoint)
 

--- a/xinference/model/rerank/tests/test_rerank.py
+++ b/xinference/model/rerank/tests/test_rerank.py
@@ -1,0 +1,50 @@
+# Copyright 2022-2023 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ....client import Client
+
+
+def test_oscar_api(setup):
+    endpoint, _ = setup
+    client = Client(endpoint)
+
+    model_uid = client.launch_model(
+        model_name="bge-reranker-large", model_type="rerank"
+    )
+    assert len(client.list_models()) == 1
+    model = client.get_model(model_uid)
+    # We want to compute the similarity between the query sentence
+    query = "A man is eating pasta."
+
+    # With all sentences in the corpus
+    corpus = [
+        "A man is eating food.",
+        "A man is eating a piece of bread.",
+        "The girl is carrying a baby.",
+        "A man is riding a horse.",
+        "A woman is playing violin.",
+        "Two men pushed carts through the woods.",
+        "A man is riding a white horse on an enclosed ground.",
+        "A monkey is playing drums.",
+        "A cheetah is running behind its prey.",
+    ]
+
+    scores = model.rerank(corpus, query)
+    assert scores["results"][0]["index"] == 0
+    assert scores["results"][0]["document"] == corpus[0]
+
+    scores = model.rerank(corpus, query, top_n=3)
+    assert len(scores["results"]) == 3
+    assert scores["results"][0]["index"] == 0
+    assert scores["results"][0]["document"] == corpus[0]

--- a/xinference/types.py
+++ b/xinference/types.py
@@ -67,6 +67,21 @@ class Embedding(TypedDict):
     usage: EmbeddingUsage
 
 
+class Document(TypedDict):
+    text: str
+
+
+class DocumentObj(TypedDict):
+    index: int
+    relevance_score: float
+    document: Optional[Document]
+
+
+class Rerank(TypedDict):
+    id: str
+    results: List[DocumentObj]
+
+
 class CompletionLogprobs(TypedDict):
     text_offset: List[int]
     token_logprobs: List[Optional[float]]


### PR DESCRIPTION
- [x] Add rerank type
- [x] Compatible with cohere rerank APIs
- [x] Support bge-reranker-large and bge-reranker-base
- [x] Support downloading from modelscope
- [x] Documentation

example for launching rerank model:
```Python
model_uid = client.launch_model(
        model_name="bge-reranker-large", model_type="rerank"
    )
model = client.get_model(model_uid)
query = "A man is eating pasta."
corpus = [
    "A man is eating food.",
    "A man is eating a piece of bread.",
    "The girl is carrying a baby.",
    "A man is riding a horse.",
    "A woman is playing violin.",
    "Two men pushed carts through the woods.",
    "A man is riding a white horse on an enclosed ground.",
    "A monkey is playing drums.",
    "A cheetah is running behind its prey.",
]
print(model.rerank(corpus, query))
```
