### PR TITLE
ENH: [UI] Error can be shown on web UI directly via Snackbar

### DIFF
--- a/xinference/web/ui/src/components/apiContext.js
+++ b/xinference/web/ui/src/components/apiContext.js
@@ -5,6 +5,7 @@ export const ApiContext = createContext()
 export const ApiContextProvider = ({ children }) => {
   const [isCallingApi, setIsCallingApi] = useState(false)
   const [isUpdatingModel, setIsUpdatingModel] = useState(false)
+  const [errorMsg, setErrorMsg] = useState('')
   let endPoint = ''
   if (!process.env.NODE_ENV || process.env.NODE_ENV === 'development') {
     endPoint = 'http://127.0.0.1:9997'
@@ -21,6 +22,8 @@ export const ApiContextProvider = ({ children }) => {
         isUpdatingModel,
         setIsUpdatingModel,
         endPoint,
+        errorMsg,
+        setErrorMsg,
       }}
     >
       {children}

--- a/xinference/web/ui/src/components/errorMessageSnackBar.js
+++ b/xinference/web/ui/src/components/errorMessageSnackBar.js
@@ -1,0 +1,30 @@
+import Snackbar from "@mui/material/Snackbar";
+import React, {useContext} from "react";
+import {ApiContext} from "./apiContext";
+import MuiAlert from '@mui/material/Alert';
+
+const Alert = React.forwardRef(function Alert(props, ref) {
+  return <MuiAlert elevation={6} ref={ref} variant="filled" {...props} />;
+});
+
+const ErrorMessageSnackBar = () => {
+  const {errorMsg, setErrorMsg} = useContext(ApiContext);
+
+  const handleClose = (event, reason) => {
+    if (reason === 'clickaway') {
+      return;
+    }
+    setErrorMsg("");
+  };
+
+  return (
+    <Snackbar open={errorMsg !== ""} autoHideDuration={10000}
+              anchorOrigin={{vertical: 'top', horizontal: 'center'}} onClose={handleClose}>
+      <Alert severity="error" onClose={handleClose} sx={{width: '100%'}}>
+        {errorMsg}
+      </Alert>
+    </Snackbar>
+  );
+}
+
+export default ErrorMessageSnackBar;

--- a/xinference/web/ui/src/components/errorMessageSnackBar.js
+++ b/xinference/web/ui/src/components/errorMessageSnackBar.js
@@ -1,30 +1,35 @@
-import Snackbar from "@mui/material/Snackbar";
-import React, {useContext} from "react";
-import {ApiContext} from "./apiContext";
-import MuiAlert from '@mui/material/Alert';
+import MuiAlert from '@mui/material/Alert'
+import Snackbar from '@mui/material/Snackbar'
+import React, { useContext } from 'react'
+
+import { ApiContext } from './apiContext'
 
 const Alert = React.forwardRef(function Alert(props, ref) {
-  return <MuiAlert elevation={6} ref={ref} variant="filled" {...props} />;
-});
+  return <MuiAlert elevation={6} ref={ref} variant="filled" {...props} />
+})
 
 const ErrorMessageSnackBar = () => {
-  const {errorMsg, setErrorMsg} = useContext(ApiContext);
+  const { errorMsg, setErrorMsg } = useContext(ApiContext)
 
   const handleClose = (event, reason) => {
     if (reason === 'clickaway') {
-      return;
+      return
     }
-    setErrorMsg("");
-  };
+    setErrorMsg('')
+  }
 
   return (
-    <Snackbar open={errorMsg !== ""} autoHideDuration={10000}
-              anchorOrigin={{vertical: 'top', horizontal: 'center'}} onClose={handleClose}>
-      <Alert severity="error" onClose={handleClose} sx={{width: '100%'}}>
+    <Snackbar
+      open={errorMsg !== ''}
+      autoHideDuration={10000}
+      anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+      onClose={handleClose}
+    >
+      <Alert severity="error" onClose={handleClose} sx={{ width: '100%' }}>
         {errorMsg}
       </Alert>
     </Snackbar>
-  );
+  )
 }
 
-export default ErrorMessageSnackBar;
+export default ErrorMessageSnackBar

--- a/xinference/web/ui/src/scenes/launch_model/embeddingCard.js
+++ b/xinference/web/ui/src/scenes/launch_model/embeddingCard.js
@@ -13,11 +13,10 @@ const EmbeddingCard = ({ url, modelData }) => {
   const [selected, setSelected] = useState(false)
   const { isCallingApi, setIsCallingApi } = useContext(ApiContext)
   const { isUpdatingModel } = useContext(ApiContext)
+  const { setErrorMsg } = useContext(ApiContext)
 
   // UseEffects for parameter selection, change options based on previous selections
-  useEffect(() => {
-    return
-  }, [modelData])
+  useEffect(() => {}, [modelData])
 
   const launchModel = (url) => {
     if (isCallingApi || isUpdatingModel) {
@@ -41,7 +40,20 @@ const EmbeddingCard = ({ url, modelData }) => {
       },
       body: JSON.stringify(modelDataWithID),
     })
-      .then(() => {
+      .then((res) => {
+        if (!res.ok) {
+          res
+            .json()
+            .then((errData) =>
+              setErrorMsg(
+                `Server error: ${res.status} - ${
+                  errData.detail || 'Unknown error'
+                }`
+              )
+            )
+        } else {
+          window.open(url + '/ui/#/running_models', '_blank', 'noreferrer')
+        }
         setIsCallingApi(false)
       })
       .catch((error) => {

--- a/xinference/web/ui/src/scenes/launch_model/index.js
+++ b/xinference/web/ui/src/scenes/launch_model/index.js
@@ -6,6 +6,7 @@ import ErrorMessageSnackBar from '../../components/errorMessageSnackBar'
 import Title from '../../components/Title'
 import LaunchEmbedding from './launchEmbedding'
 import LaunchLLM from './launchLLM'
+import LaunchRerank from './launchRerank'
 
 const LaunchModel = () => {
   const [value, setValue] = React.useState('1')

--- a/xinference/web/ui/src/scenes/launch_model/index.js
+++ b/xinference/web/ui/src/scenes/launch_model/index.js
@@ -2,10 +2,10 @@ import { TabContext, TabList, TabPanel } from '@mui/lab'
 import { Box, Tab } from '@mui/material'
 import React from 'react'
 
+import ErrorMessageSnackBar from '../../components/errorMessageSnackBar'
 import Title from '../../components/Title'
 import LaunchEmbedding from './launchEmbedding'
 import LaunchLLM from './launchLLM'
-import LaunchRerank from './launchRerank'
 
 const LaunchModel = () => {
   const [value, setValue] = React.useState('1')
@@ -17,6 +17,7 @@ const LaunchModel = () => {
   return (
     <Box m="20px">
       <Title title="Launch Model" />
+      <ErrorMessageSnackBar />
       <TabContext value={value}>
         <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
           <TabList value={value} onChange={handleTabChange} aria-label="tabs">

--- a/xinference/web/ui/src/scenes/launch_model/modelCard.js
+++ b/xinference/web/ui/src/scenes/launch_model/modelCard.js
@@ -27,6 +27,7 @@ const ModelCard = ({ url, modelData }) => {
   const [selected, setSelected] = useState(false)
   const { isCallingApi, setIsCallingApi } = useContext(ApiContext)
   const { isUpdatingModel } = useContext(ApiContext)
+  const { setErrorMsg } = useContext(ApiContext)
 
   // Model parameter selections
   const [modelFormat, setModelFormat] = useState('')
@@ -113,18 +114,16 @@ const ModelCard = ({ url, modelData }) => {
       .then((response) => {
         if (!response.ok) {
           // Assuming the server returns error details in JSON format
-          return response.json().then((errorData) => {
-            throw new Error(
+          response.json().then((errorData) => {
+            setErrorMsg(
               `Server error: ${response.status} - ${
                 errorData.detail || 'Unknown error'
               }`
             )
           })
+        } else {
+          window.open(url + '/ui/#/running_models', '_blank', 'noreferrer')
         }
-        return response.json() // Also return the promise from response.json() for successful responses
-      })
-      .then(() => {
-        window.open(url + '/ui/#/running_models', '_blank', 'noreferrer')
         setIsCallingApi(false)
       })
       .catch((error) => {


### PR DESCRIPTION
Previsouly, when some error happens, we have to open the `F12`  tool page to find the error, which is not easy.
Now, some key errors would just be shown on Web UI via Snackbar.
For example:
<img width="1507" alt="image" src="https://github.com/xorbitsai/inference/assets/109656400/ac7954e1-1948-4b4d-b84b-b6ade6d20654">

Additionally, fix a issue that web will keep sending requests to backend to get builtin promot styles.
