### PR TITLE
BUG: UI Crash on Search when `model_format` and `model_size` have been selected

### DIFF
--- a/xinference/web/ui/src/scenes/launch_model/modelCard.js
+++ b/xinference/web/ui/src/scenes/launch_model/modelCard.js
@@ -496,10 +496,8 @@ const ModelCard = ({ url, modelData, gpuAvailable, is_custom = false }) => {
 
                     const cached =
                       modelFormat === 'pytorch'
-                        ? specs[0].cache_status &&
-                          specs[0].cache_status === true
-                        : specs[0].cache_status &&
-                          specs[0].cache_status[index] === true
+                        ? specs[0]?.cache_status ?? false === true
+                        : specs[0]?.cache_status?.[index] ?? false === true
                     const displayedQuant = cached ? quant + ' (cached)' : quant
 
                     return (


### PR DESCRIPTION
Fix #765 

The bug is caused by how the `cache_status` property was accessed in our code. This fix should help us avoid the unexpected crashes. Here is a quick break down of the change.

**The Issue:**
We were directly accessing `cache_status` on the `specs[0]` object. If `specs[0]` or `cache_status` does not exist (in this case the card is filtered out by the search), the code would throw an error.

**The Fix:**
I've introduced optional chaining (`?.`) and the nullish coalescing operator (`??`)to address the nonexistent property issue:

Before:
```javascript
const cached = modelFormat === 'pytorch'
    ? specs[0].cache_status &&
      specs[0].cache_status === true
    : specs[0].cache_status &&
      specs[0].cache_status[index] === true
```
After:
```javascript
const cached = modelFormat === 'pytorch'
    ? specs[0]?.cache_status ?? false === true
    : specs[0]?.cache_status?.[index] ?? false === true;
```

**Brief Explaination**
- **Optional Chaining (`?.`):** This is like asking, "Hey, do you have this property? If not, it's cool, just be `undefined`." It stops JavaScript from freaking out and throwing errors when it doesn't find something.
- **Nullish Coalescing Operator (`??`):** This one's like a safety net. It catches `undefined` or `null` and replaces them with a default value, which in our case is `false`.

I have tested the updates locally and the UI is not crashing anymore. Please let me know if there are any additional errors that are not fixed.