### PR TITLE
BUG: when terminating worker by `ctrl+C`, supervisor does not remove worker information

### DIFF
--- a/xinference/core/supervisor.py
+++ b/xinference/core/supervisor.py
@@ -600,6 +600,16 @@ class SupervisorActor(xo.StatelessActor):
         self._worker_address_to_worker[worker_address] = worker_ref
         logger.debug("Worker %s has been added successfully", worker_address)
 
+    @log_async(logger=logger)
+    async def remove_worker(self, worker_address: str):
+        if worker_address in self._worker_address_to_worker:
+            del self._worker_address_to_worker[worker_address]
+            logger.debug("Worker %s has been removed successfully", worker_address)
+        else:
+            logger.warning(
+                f"Worker {worker_address} cannot be removed since it is not registered to supervisor."
+            )
+
     async def report_worker_status(
         self, worker_address: str, status: Dict[str, ResourceStatus]
     ):

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -15,6 +15,7 @@
 import asyncio
 import os
 import platform
+import signal
 from collections import defaultdict
 from logging import getLogger
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
@@ -104,6 +105,15 @@ class WorkerActor(xo.StatelessActor):
                 unregister_embedding,
             ),
         }
+
+        async def singal_handler():
+            await self._supervisor_ref.remove_worker(self.address)
+            os._exit(0)
+
+        loop = asyncio.get_running_loop()
+        loop.add_signal_handler(
+            signal.SIGINT, lambda: asyncio.create_task(singal_handler())
+        )
 
     async def __pre_destroy__(self):
         self._upload_task.cancel()


### PR DESCRIPTION
Fixes #768 