### PR TITLE
ENH: Enable streaming on Ctransformer

### DIFF
--- a/xinference/types.py
+++ b/xinference/types.py
@@ -355,7 +355,10 @@ try:
     CreateCompletionCTransformers = get_pydantic_model_from_method(
         LLM.generate,
         exclude_fields=["tokens"],
-        include_fields={"max_tokens": (Optional[int], max_tokens_field)},
+        include_fields={
+            "max_tokens": (Optional[int], max_tokens_field),
+            "stream": (Optional[bool], stream_field),
+        },
     )
 except ImportError:
     CreateCompletionCTransformers = create_model("CreateCompletionCTransformers")


### PR DESCRIPTION
Fix #783 

Seems like the `CreateCompletionCTransformers` function is not taking in "streaming" as a keyword when creating the config. I added it and that fixes the error encountered when streaming GPT-2.

Now we should be able to stream response with the CTransformers library.