### PR TITLE
BUG: launch method exception (#807)

### DIFF
--- a/xinference/deploy/cmdline.py
+++ b/xinference/deploy/cmdline.py
@@ -498,7 +498,9 @@ def model_launch(
 
     endpoint = get_endpoint(endpoint)
     model_size: Optional[Union[str, int]] = (
-        size_in_billions if size_in_billions is None or "_" in size_in_billions else int(size_in_billions)
+        size_in_billions
+        if size_in_billions is None or "_" in size_in_billions
+        else int(size_in_billions)
     )
 
     client = RESTfulClient(base_url=endpoint)

--- a/xinference/deploy/cmdline.py
+++ b/xinference/deploy/cmdline.py
@@ -498,7 +498,7 @@ def model_launch(
 
     endpoint = get_endpoint(endpoint)
     model_size: Union[str, int] = (
-        size_in_billions if "_" in size_in_billions else int(size_in_billions)
+        size_in_billions if size_in_billions is None or "_" in size_in_billions else int(size_in_billions)
     )
 
     client = RESTfulClient(base_url=endpoint)

--- a/xinference/deploy/cmdline.py
+++ b/xinference/deploy/cmdline.py
@@ -497,7 +497,7 @@ def model_launch(
         _n_gpu = int(n_gpu)
 
     endpoint = get_endpoint(endpoint)
-    model_size: Union[str, int] = (
+    model_size: Optional[Union[str, int]] = (
         size_in_billions if size_in_billions is None or "_" in size_in_billions else int(size_in_billions)
     )
 


### PR DESCRIPTION
When `model_size_in_billions` is not provided, the operation involving this field should be ignored.
Fixes #807 