### PR TITLE
FEAT: qwen 1.8b gptq

### DIFF
--- a/xinference/core/model.py
+++ b/xinference/core/model.py
@@ -203,13 +203,13 @@ class ModelActor(xo.StatelessActor):
     @oom_check
     async def _call_wrapper(self, fn: Callable, *args, **kwargs):
         if self._lock is None:
-            if inspect.isgeneratorfunction(fn):
+            if inspect.iscoroutinefunction(fn):
                 ret = await fn(*args, **kwargs)
             else:
                 ret = await asyncio.to_thread(fn, *args, **kwargs)
         else:
             async with self._lock:
-                if inspect.isgeneratorfunction(fn):
+                if inspect.iscoroutinefunction(fn):
                     ret = await fn(*args, **kwargs)
                 else:
                     ret = await asyncio.to_thread(fn, *args, **kwargs)

--- a/xinference/model/llm/llm_family.json
+++ b/xinference/model/llm/llm_family.json
@@ -1206,12 +1206,21 @@
       },
       {
         "model_format": "gptq",
-        "model_size_in_billions": 7,
+        "model_size_in_billions": "1_8",
         "quantizations": [
           "Int4",
           "Int8"
         ],
         "model_id": "Qwen/Qwen-7B-Chat-{quantization}"
+      },
+      {
+        "model_format": "gptq",
+        "model_size_in_billions": 7,
+        "quantizations": [
+          "Int4",
+          "Int8"
+        ],
+        "model_id": "Qwen/Qwen-1_8B-Chat-{quantization}"
       },
       {
         "model_format": "gptq",

--- a/xinference/model/llm/llm_family_modelscope.json
+++ b/xinference/model/llm/llm_family_modelscope.json
@@ -1527,6 +1527,17 @@
       },
       {
         "model_format": "gptq",
+        "model_size_in_billions": "1_8",
+        "quantizations": [
+          "Int4",
+          "Int8"
+        ],
+        "model_id": "qwen/Qwen-1_8B-Chat-{quantization}",
+        "model_hub": "modelscope",
+        "model_revision": "master"
+      },
+      {
+        "model_format": "gptq",
         "model_size_in_billions": 7,
         "quantizations": [
           "Int4",


### PR DESCRIPTION
- Add gptq quanization for qwen 1.8b.
- Known issue: https://modelscope.cn/models/qwen/Qwen-1_8B-Chat-Int4 has bugs, it can't works with vLLM.

```python
2024-01-08 08:03:57,300 xinference.core.worker 129598 ERROR    Failed to load model qwen-chat-1-0
Traceback (most recent call last):
  File "/home/codingl2k1/inference/xinference/core/worker.py", line 381, in launch_builtin_model
    await model_ref.load()
  File "/home/codingl2k1/.pyenv/versions/3.9.18/lib/python3.9/site-packages/xoscar/backends/context.py", line 227, in send
    return self._process_result_message(result)
  File "/home/codingl2k1/.pyenv/versions/3.9.18/lib/python3.9/site-packages/xoscar/backends/context.py", line 102, in _process_result_message
    raise message.as_instanceof_cause()
  File "/home/codingl2k1/.pyenv/versions/3.9.18/lib/python3.9/site-packages/xoscar/backends/pool.py", line 657, in send
    result = await self._run_coro(message.message_id, coro)
  File "/home/codingl2k1/.pyenv/versions/3.9.18/lib/python3.9/site-packages/xoscar/backends/pool.py", line 368, in _run_coro
    return await coro
  File "/home/codingl2k1/.pyenv/versions/3.9.18/lib/python3.9/site-packages/xoscar/api.py", line 384, in __on_receive__
    return await super().__on_receive__(message)  # type: ignore
  File "xoscar/core.pyx", line 558, in __on_receive__
    raise ex
  File "xoscar/core.pyx", line 520, in xoscar.core._BaseActor.__on_receive__
    async with self._lock:
  File "xoscar/core.pyx", line 521, in xoscar.core._BaseActor.__on_receive__
    with debug_async_timeout('actor_lock_timeout',
  File "xoscar/core.pyx", line 524, in xoscar.core._BaseActor.__on_receive__
    result = func(*args, **kwargs)
  File "/home/codingl2k1/inference/xinference/core/model.py", line 167, in load
    self._model.load()
  File "/home/codingl2k1/inference/xinference/model/llm/vllm/core.py", line 134, in load
    self._engine = AsyncLLMEngine.from_engine_args(engine_args)
  File "/home/codingl2k1/.pyenv/versions/3.9.18/lib/python3.9/site-packages/vllm/engine/async_llm_engine.py", line 496, in from_engine_args
    engine = cls(parallel_config.worker_use_ray,
  File "/home/codingl2k1/.pyenv/versions/3.9.18/lib/python3.9/site-packages/vllm/engine/async_llm_engine.py", line 269, in __init__
    self.engine = self._init_engine(*args, **kwargs)
  File "/home/codingl2k1/.pyenv/versions/3.9.18/lib/python3.9/site-packages/vllm/engine/async_llm_engine.py", line 314, in _init_engine
    return engine_class(*args, **kwargs)
  File "/home/codingl2k1/.pyenv/versions/3.9.18/lib/python3.9/site-packages/vllm/engine/llm_engine.py", line 110, in __init__
    self._init_workers(distributed_init_method)
  File "/home/codingl2k1/.pyenv/versions/3.9.18/lib/python3.9/site-packages/vllm/engine/llm_engine.py", line 146, in _init_workers
    self._run_workers(
  File "/home/codingl2k1/.pyenv/versions/3.9.18/lib/python3.9/site-packages/vllm/engine/llm_engine.py", line 755, in _run_workers
    self._run_workers_in_batch(workers, method, *args, **kwargs))
  File "/home/codingl2k1/.pyenv/versions/3.9.18/lib/python3.9/site-packages/vllm/engine/llm_engine.py", line 729, in _run_workers_in_batch
    output = executor(*args, **kwargs)
  File "/home/codingl2k1/.pyenv/versions/3.9.18/lib/python3.9/site-packages/vllm/worker/worker.py", line 79, in load_model
    self.model_runner.load_model()
  File "/home/codingl2k1/.pyenv/versions/3.9.18/lib/python3.9/site-packages/vllm/worker/model_runner.py", line 57, in load_model
    self.model = get_model(self.model_config)
  File "/home/codingl2k1/.pyenv/versions/3.9.18/lib/python3.9/site-packages/vllm/model_executor/model_loader.py", line 72, in get_model
    model.load_weights(model_config.model, model_config.download_dir,
  File "/home/codingl2k1/.pyenv/versions/3.9.18/lib/python3.9/site-packages/vllm/model_executor/models/qwen.py", line 288, in load_weights
    weight_loader(param, loaded_weight)
  File "/home/codingl2k1/.pyenv/versions/3.9.18/lib/python3.9/site-packages/vllm/model_executor/layers/linear.py", line 382, in weight_loader
    assert param_data.shape == loaded_weight.shape
AssertionError: [address=0.0.0.0:42627, pid=129882]
```