### PR TITLE
ENH: make the size param of *_to_image more compatible

### DIFF
--- a/xinference/model/image/stable_diffusion/core.py
+++ b/xinference/model/image/stable_diffusion/core.py
@@ -15,6 +15,7 @@
 import base64
 import logging
 import os
+import re
 import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor
@@ -120,7 +121,7 @@ class DiffusionModel:
     ):
         # References:
         # https://huggingface.co/docs/diffusers/main/en/api/pipelines/controlnet_sdxl
-        width, height = map(int, size.split("*"))
+        width, height = map(int, re.split(r"[^\d]+", size))
         return self._call_model(
             prompt=prompt,
             height=height,
@@ -140,7 +141,7 @@ class DiffusionModel:
         response_format: str = "url",
         **kwargs,
     ):
-        width, height = map(int, size.split("*"))
+        width, height = map(int, re.split(r"[^\d]+", size))
         return self._call_model(
             image=image,
             prompt=prompt,


### PR DESCRIPTION
the `size` param use '*' as seperator only. it should be better to support other characters such as 'x' or any other non-integers. 