### PR TITLE
BUG: fix libcuda.so.1: cannot open shared object file

### DIFF
--- a/xinference/deploy/docker/Dockerfile
+++ b/xinference/deploy/docker/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get -y update \
   && apt-get -yq clean
 
 ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
-ENV LD_LIBRARY_PATH /usr/local/cuda/compat
+ENV LD_LIBRARY_PATH /usr/local/cuda/compat:$LD_LIBRARY_PATH
 
 ARG PIP_INDEX=https://pypi.org/simple
 RUN python -m pip install --upgrade -i "$PIP_INDEX" pip && \

--- a/xinference/deploy/docker/Dockerfile
+++ b/xinference/deploy/docker/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get -y update \
   && apt-get -yq clean
 
 ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
+ENV LD_LIBRARY_PATH /usr/local/cuda/compat
 
 ARG PIP_INDEX=https://pypi.org/simple
 RUN python -m pip install --upgrade -i "$PIP_INDEX" pip && \


### PR DESCRIPTION
xinference在k8s环境中以pod的形式启动，出现报错：

`ImportError: libcuda.so.1: cannot open shared object file: No such file or directory`

需要找到libcuda.so.1的路径

`sudo find /usr/ -name 'libcuda.so.*'`

添加环境路径环境变量，如我的路径是:/usr/local/cuda-12.1/compat, 添加环境变量

`export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda-12.1/compat`