### PR TITLE
FEAT: Support events

### DIFF
--- a/xinference/api/restful_api.py
+++ b/xinference/api/restful_api.py
@@ -55,7 +55,7 @@ from uvicorn import Config, Server
 from xoscar.utils import get_next_port
 
 from ..constants import XINFERENCE_DEFAULT_ENDPOINT_PORT
-from ..core.event import EventCollectorActor, EventType, Event
+from ..core.event import Event, EventCollectorActor, EventType
 from ..core.supervisor import SupervisorActor
 from ..core.utils import json_dumps
 from ..types import (

--- a/xinference/core/event.py
+++ b/xinference/core/event.py
@@ -1,0 +1,56 @@
+# Copyright 2022-2024 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import queue
+from collections import defaultdict
+from enum import Enum
+from typing import Dict, List, TypedDict
+
+import xoscar as xo
+
+MAX_EVENT_COUNT_PER_MODEL = 100
+
+
+class EventType(Enum):
+    INFO = 1
+    WARNING = 2
+    ERROR = 3
+
+
+class Event(TypedDict):
+    event_type: EventType
+    event_ts: int
+    event_content: str
+
+
+class EventCollectorActor(xo.StatelessActor):
+    def __init__(self):
+        super().__init__()
+        self._model_uid_to_events: Dict[str, queue.Queue] = defaultdict(
+            lambda: queue.Queue(maxsize=MAX_EVENT_COUNT_PER_MODEL)
+        )
+
+    @classmethod
+    def uid(cls) -> str:
+        return "event_collector"
+
+    def get_model_events(self, model_uid: str) -> List[Dict]:
+        event_queue = self._model_uid_to_events.get(model_uid)
+        if event_queue is None:
+            return []
+        else:
+            return [dict(e, event_type=e["event_type"].name) for e in event_queue.queue]
+
+    def report_event(self, model_uid: str, event: Event):
+        self._model_uid_to_events[model_uid].put(event)

--- a/xinference/core/supervisor.py
+++ b/xinference/core/supervisor.py
@@ -97,6 +97,14 @@ class SupervisorActor(xo.StatelessActor):
             StatusGuardActor, address=self.address, uid=StatusGuardActor.uid()
         )
 
+        from .event import EventCollectorActor
+
+        self._event_collector_ref: xo.ActorRefType[
+            EventCollectorActor
+        ] = await xo.create_actor(
+            EventCollectorActor, address=self.address, uid=EventCollectorActor.uid()
+        )
+
         from ..model.embedding import (
             CustomEmbeddingModelSpec,
             register_embedding,


### PR DESCRIPTION
- Add a router to the restful api: `/v1/models/{model_uid}/events`
- Example of the query result:

```python
[
  {
    "event_type": "INFO",
    "event_ts": 1705905654,
    "event_content": "Launch model"
  },
  {
    "event_type": "ERROR",
    "event_ts": 1705905669,
    "event_content": "Remote server 127.0.0.1:49371 closed"
  },
  {
    "event_type": "INFO",
    "event_ts": 1705905670,
    "event_content": "Terminate model"
  }
]
```