### PR TITLE
FEAT: add whisper.small and belle distilwhisper model, fix parameter in rerank

### DIFF
--- a/xinference/model/audio/model_spec.json
+++ b/xinference/model/audio/model_spec.json
@@ -28,6 +28,20 @@
     "multilingual": false
   },
   {
+    "model_name": "whisper-small",
+    "model_family": "whisper",
+    "model_id": "openai/whisper-small",
+    "model_revision": "998cb1a777c20db53d6033a61b977ed4c3792cac",
+    "multilingual": true
+  },
+  {
+    "model_name": "whisper-small.en",
+    "model_family": "whisper",
+    "model_id": "openai/whisper-small.en",
+    "model_revision": "e8727524f962ee844a7319d92be39ac1bd25655a",
+    "multilingual": false
+  },
+  {
     "model_name": "whisper-medium",
     "model_family": "whisper",
     "model_id": "openai/whisper-medium",
@@ -47,5 +61,19 @@
     "model_id": "openai/whisper-large-v3",
     "model_revision": "6cdf07a7e3ec3806e5d55f787915b85d4cd020b1",
     "multilingual": true
+  },
+  {
+    "model_name": "Belle-distilwhisper-large-v2-zh",
+    "model_family": "whisper",
+    "model_id": "BELLE-2/Belle-distilwhisper-large-v2-zh",
+    "model_revision": "ed25d13498fa5bac758b2fc479435b698532dfe8",
+    "multilingual": false
+  },
+  {
+    "model_name": "Belle-whisper-large-v2-zh",
+    "model_family": "whisper",
+    "model_id": "BELLE-2/Belle-whisper-large-v2-zh",
+    "model_revision": "ec5bd5d78598545b7585814edde86dac2002b5b9",
+    "multilingual": false
   }
 ]

--- a/xinference/model/rerank/core.py
+++ b/xinference/model/rerank/core.py
@@ -128,7 +128,7 @@ class RerankModel:
 
             raise ImportError(f"{error_message}\n\n{''.join(installation_guide)}")
         self._model = CrossEncoder(
-            self._model_path, device=self._device, automodel_args=self._model_config
+            self._model_path, device=self._device, **self._model_config
         )
         if self._use_fp16:
             self._model.model.half()


### PR DESCRIPTION
- 增加了 whisper.small 和 belle distil whisper zh 系列模型，其中后者不支持 translations
- 修复了rerank模型启动时不能正常给cross encoder传参的问题
