### PR TITLE
FEAT: Refactor device related code and add initial Intel GPU support

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -95,6 +95,9 @@ all =
     orjson
     auto-gptq ; sys_platform!='darwin'
     optimum
+intel =
+    torch==2.1.0a0
+    intel_extension_for_pytorch==2.1.10+xpu
 ggml =
     llama-cpp-python>=0.2.25
     ctransformers

--- a/xinference/__init__.py
+++ b/xinference/__init__.py
@@ -18,6 +18,12 @@ from . import _version
 __version__ = _version.get_versions()["version"]
 
 
+try:
+    import intel_extension_for_pytorch  # noqa: F401
+except:
+    pass
+
+
 def _install():
     from xoscar.backends.router import Router
 

--- a/xinference/api/restful_api.py
+++ b/xinference/api/restful_api.py
@@ -231,9 +231,11 @@ class RESTfulAPI:
             "/v1/ui/{model_uid}",
             self.build_gradio_interface,
             methods=["POST"],
-            dependencies=[Security(self._auth_service, scopes=["models:read"])]
-            if self.is_authenticated()
-            else None,
+            dependencies=(
+                [Security(self._auth_service, scopes=["models:read"])]
+                if self.is_authenticated()
+                else None
+            ),
         )
         self._router.add_api_route(
             "/token", self.login_for_access_token, methods=["POST"]
@@ -246,142 +248,176 @@ class RESTfulAPI:
             "/v1/models/instances",
             self.get_instance_info,
             methods=["GET"],
-            dependencies=[Security(self._auth_service, scopes=["models:list"])]
-            if self.is_authenticated()
-            else None,
+            dependencies=(
+                [Security(self._auth_service, scopes=["models:list"])]
+                if self.is_authenticated()
+                else None
+            ),
         )
         self._router.add_api_route(
             "/v1/models/{model_type}/{model_name}/versions",
             self.get_model_versions,
             methods=["GET"],
-            dependencies=[Security(self._auth_service, scopes=["models:list"])]
-            if self.is_authenticated()
-            else None,
+            dependencies=(
+                [Security(self._auth_service, scopes=["models:list"])]
+                if self.is_authenticated()
+                else None
+            ),
         )
         self._router.add_api_route(
             "/v1/models",
             self.list_models,
             methods=["GET"],
-            dependencies=[Security(self._auth_service, scopes=["models:list"])]
-            if self.is_authenticated()
-            else None,
+            dependencies=(
+                [Security(self._auth_service, scopes=["models:list"])]
+                if self.is_authenticated()
+                else None
+            ),
         )
 
         self._router.add_api_route(
             "/v1/models/{model_uid}",
             self.describe_model,
             methods=["GET"],
-            dependencies=[Security(self._auth_service, scopes=["models:list"])]
-            if self.is_authenticated()
-            else None,
+            dependencies=(
+                [Security(self._auth_service, scopes=["models:list"])]
+                if self.is_authenticated()
+                else None
+            ),
         )
         self._router.add_api_route(
             "/v1/models/{model_uid}/events",
             self.get_model_events,
             methods=["GET"],
-            dependencies=[Security(self._auth_service, scopes=["models:read"])]
-            if self.is_authenticated()
-            else None,
+            dependencies=(
+                [Security(self._auth_service, scopes=["models:read"])]
+                if self.is_authenticated()
+                else None
+            ),
         )
         self._router.add_api_route(
             "/v1/models/instance",
             self.launch_model_by_version,
             methods=["POST"],
-            dependencies=[Security(self._auth_service, scopes=["models:start"])]
-            if self.is_authenticated()
-            else None,
+            dependencies=(
+                [Security(self._auth_service, scopes=["models:start"])]
+                if self.is_authenticated()
+                else None
+            ),
         )
         self._router.add_api_route(
             "/v1/models",
             self.launch_model,
             methods=["POST"],
-            dependencies=[Security(self._auth_service, scopes=["models:start"])]
-            if self.is_authenticated()
-            else None,
+            dependencies=(
+                [Security(self._auth_service, scopes=["models:start"])]
+                if self.is_authenticated()
+                else None
+            ),
         )
         self._router.add_api_route(
             "/experimental/speculative_llms",
             self.launch_speculative_llm,
             methods=["POST"],
-            dependencies=[Security(self._auth_service, scopes=["models:start"])]
-            if self.is_authenticated()
-            else None,
+            dependencies=(
+                [Security(self._auth_service, scopes=["models:start"])]
+                if self.is_authenticated()
+                else None
+            ),
         )
         self._router.add_api_route(
             "/v1/models/{model_uid}",
             self.terminate_model,
             methods=["DELETE"],
-            dependencies=[Security(self._auth_service, scopes=["models:stop"])]
-            if self.is_authenticated()
-            else None,
+            dependencies=(
+                [Security(self._auth_service, scopes=["models:stop"])]
+                if self.is_authenticated()
+                else None
+            ),
         )
         self._router.add_api_route(
             "/v1/completions",
             self.create_completion,
             methods=["POST"],
             response_model=Completion,
-            dependencies=[Security(self._auth_service, scopes=["models:read"])]
-            if self.is_authenticated()
-            else None,
+            dependencies=(
+                [Security(self._auth_service, scopes=["models:read"])]
+                if self.is_authenticated()
+                else None
+            ),
         )
         self._router.add_api_route(
             "/v1/embeddings",
             self.create_embedding,
             methods=["POST"],
-            dependencies=[Security(self._auth_service, scopes=["models:read"])]
-            if self.is_authenticated()
-            else None,
+            dependencies=(
+                [Security(self._auth_service, scopes=["models:read"])]
+                if self.is_authenticated()
+                else None
+            ),
         )
         self._router.add_api_route(
             "/v1/rerank",
             self.rerank,
             methods=["POST"],
-            dependencies=[Security(self._auth_service, scopes=["models:read"])]
-            if self.is_authenticated()
-            else None,
+            dependencies=(
+                [Security(self._auth_service, scopes=["models:read"])]
+                if self.is_authenticated()
+                else None
+            ),
         )
         self._router.add_api_route(
             "/v1/audio/transcriptions",
             self.create_transcriptions,
             methods=["POST"],
-            dependencies=[Security(self._auth_service, scopes=["models:read"])]
-            if self.is_authenticated()
-            else None,
+            dependencies=(
+                [Security(self._auth_service, scopes=["models:read"])]
+                if self.is_authenticated()
+                else None
+            ),
         )
         self._router.add_api_route(
             "/v1/audio/translations",
             self.create_translations,
             methods=["POST"],
-            dependencies=[Security(self._auth_service, scopes=["models:read"])]
-            if self.is_authenticated()
-            else None,
+            dependencies=(
+                [Security(self._auth_service, scopes=["models:read"])]
+                if self.is_authenticated()
+                else None
+            ),
         )
         self._router.add_api_route(
             "/v1/images/generations",
             self.create_images,
             methods=["POST"],
             response_model=ImageList,
-            dependencies=[Security(self._auth_service, scopes=["models:read"])]
-            if self.is_authenticated()
-            else None,
+            dependencies=(
+                [Security(self._auth_service, scopes=["models:read"])]
+                if self.is_authenticated()
+                else None
+            ),
         )
         self._router.add_api_route(
             "/v1/images/variations",
             self.create_variations,
             methods=["POST"],
             response_model=ImageList,
-            dependencies=[Security(self._auth_service, scopes=["models:read"])]
-            if self.is_authenticated()
-            else None,
+            dependencies=(
+                [Security(self._auth_service, scopes=["models:read"])]
+                if self.is_authenticated()
+                else None
+            ),
         )
         self._router.add_api_route(
             "/v1/chat/completions",
             self.create_chat_completion,
             methods=["POST"],
             response_model=ChatCompletion,
-            dependencies=[Security(self._auth_service, scopes=["models:read"])]
-            if self.is_authenticated()
-            else None,
+            dependencies=(
+                [Security(self._auth_service, scopes=["models:read"])]
+                if self.is_authenticated()
+                else None
+            ),
         )
 
         # for custom models
@@ -389,33 +425,41 @@ class RESTfulAPI:
             "/v1/model_registrations/{model_type}",
             self.register_model,
             methods=["POST"],
-            dependencies=[Security(self._auth_service, scopes=["models:register"])]
-            if self.is_authenticated()
-            else None,
+            dependencies=(
+                [Security(self._auth_service, scopes=["models:register"])]
+                if self.is_authenticated()
+                else None
+            ),
         )
         self._router.add_api_route(
             "/v1/model_registrations/{model_type}/{model_name}",
             self.unregister_model,
             methods=["DELETE"],
-            dependencies=[Security(self._auth_service, scopes=["models:unregister"])]
-            if self.is_authenticated()
-            else None,
+            dependencies=(
+                [Security(self._auth_service, scopes=["models:unregister"])]
+                if self.is_authenticated()
+                else None
+            ),
         )
         self._router.add_api_route(
             "/v1/model_registrations/{model_type}",
             self.list_model_registrations,
             methods=["GET"],
-            dependencies=[Security(self._auth_service, scopes=["models:list"])]
-            if self.is_authenticated()
-            else None,
+            dependencies=(
+                [Security(self._auth_service, scopes=["models:list"])]
+                if self.is_authenticated()
+                else None
+            ),
         )
         self._router.add_api_route(
             "/v1/model_registrations/{model_type}/{model_name}",
             self.get_model_registrations,
             methods=["GET"],
-            dependencies=[Security(self._auth_service, scopes=["models:list"])]
-            if self.is_authenticated()
-            else None,
+            dependencies=(
+                [Security(self._auth_service, scopes=["models:list"])]
+                if self.is_authenticated()
+                else None
+            ),
         )
 
         # Clear the global Registry for the MetricsMiddleware, or

--- a/xinference/core/model.py
+++ b/xinference/core/model.py
@@ -45,6 +45,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 from .utils import json_dumps, log_async
+from ..device_utils import empty_cache
 
 try:
     from torch.cuda import OutOfMemoryError
@@ -130,7 +131,7 @@ class ModelActor(xo.StatelessActor):
             try:
                 import gc
 
-                import torch
+                import torch # noqa: F401
             except ImportError:
                 error_message = "Failed to import module 'torch'"
                 installation_guide = [
@@ -141,7 +142,7 @@ class ModelActor(xo.StatelessActor):
 
             del self._model
             gc.collect()
-            torch.cuda.empty_cache()
+            empty_cache()
 
     def __init__(
         self,

--- a/xinference/core/model.py
+++ b/xinference/core/model.py
@@ -44,8 +44,8 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-from .utils import json_dumps, log_async
 from ..device_utils import empty_cache
+from .utils import json_dumps, log_async
 
 try:
     from torch.cuda import OutOfMemoryError
@@ -131,7 +131,7 @@ class ModelActor(xo.StatelessActor):
             try:
                 import gc
 
-                import torch # noqa: F401
+                import torch  # noqa: F401
             except ImportError:
                 error_message = "Failed to import module 'torch'"
                 installation_guide = [

--- a/xinference/core/supervisor.py
+++ b/xinference/core/supervisor.py
@@ -227,11 +227,11 @@ class SupervisorActor(xo.StatelessActor):
         }
 
     async def get_devices_count(self) -> int:
-        from ..utils import cuda_count
+        from ..device_utils import gpu_count
 
         if self.is_local_deployment():
-            return cuda_count()
-        # distributed deployment, choose a worker and return its cuda_count.
+            return gpu_count()
+        # distributed deployment, choose a worker and return its device_count.
         # Assume that each worker has the same count of cards.
         worker_ref = await self._choose_worker()
         return await worker_ref.get_devices_count()

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -30,8 +30,8 @@ from xoscar import MainActorPoolType
 from ..constants import XINFERENCE_CACHE_DIR
 from ..core import ModelActor
 from ..core.status_guard import LaunchStatus
-from ..model.core import ModelDescription, create_model_instance
 from ..device_utils import gpu_count
+from ..model.core import ModelDescription, create_model_instance
 from .event import Event, EventCollectorActor, EventType
 from .metrics import launch_metrics_export_server, record_metrics
 from .resource import gather_node_info

--- a/xinference/deploy/worker.py
+++ b/xinference/deploy/worker.py
@@ -21,7 +21,7 @@ import xoscar as xo
 from xoscar import MainActorPoolType
 
 from ..core.worker import WorkerActor
-from ..utils import cuda_count
+from ..device_utils import gpu_count
 
 logger = logging.getLogger(__name__)
 
@@ -33,12 +33,12 @@ async def start_worker_components(
     metrics_exporter_host: Optional[str],
     metrics_exporter_port: Optional[int],
 ):
-    cuda_device_indices = []
-    cuda_visible_devices = os.environ.get("CUDA_VISIBLE_DEVICES")
-    if cuda_visible_devices:
-        cuda_device_indices.extend([int(i) for i in cuda_visible_devices.split(",")])
+    gpu_device_indices = []
+    cuda_visible_devices = os.environ.get("CUDA_VISIBLE_DEVICES", None)
+    if cuda_visible_devices is not None and cuda_visible_devices != "-1":
+        gpu_device_indices.extend([int(i) for i in cuda_visible_devices.split(",")])
     else:
-        cuda_device_indices = list(range(cuda_count()))
+        gpu_device_indices = list(range(gpu_count()))
 
     await xo.create_actor(
         WorkerActor,
@@ -46,7 +46,7 @@ async def start_worker_components(
         uid=WorkerActor.uid(),
         supervisor_address=supervisor_address,
         main_pool=main_pool,
-        cuda_devices=cuda_device_indices,
+        gpu_devices=gpu_device_indices,
         metrics_exporter_host=metrics_exporter_host,
         metrics_exporter_port=metrics_exporter_port,
     )

--- a/xinference/device_utils.py
+++ b/xinference/device_utils.py
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 import os
-from typing_extensions import Literal, Union
 
 import torch
+from typing_extensions import Literal, Union
 
 try:
-    import intel_extension_for_pytorch # noqa: F401
+    import intel_extension_for_pytorch  # noqa: F401
 except:
     pass
 

--- a/xinference/device_utils.py
+++ b/xinference/device_utils.py
@@ -17,11 +17,6 @@ import os
 import torch
 from typing_extensions import Literal, Union
 
-try:
-    import intel_extension_for_pytorch  # noqa: F401
-except:
-    pass
-
 
 DeviceType = Literal["cuda", "mps", "xpu", "cpu"]
 

--- a/xinference/device_utils.py
+++ b/xinference/device_utils.py
@@ -17,7 +17,6 @@ import os
 import torch
 from typing_extensions import Literal, Union
 
-
 DeviceType = Literal["cuda", "mps", "xpu", "cpu"]
 
 

--- a/xinference/device_utils.py
+++ b/xinference/device_utils.py
@@ -1,0 +1,106 @@
+# Copyright 2022-2023 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from typing_extensions import Literal, Union
+
+import torch
+
+try:
+    import intel_extension_for_pytorch # noqa: F401
+except:
+    pass
+
+
+DeviceType = Literal["cuda", "mps", "xpu", "cpu"]
+
+
+def is_xpu_available() -> bool:
+    return hasattr(torch, "xpu") and torch.xpu.is_available()
+
+
+def get_available_device() -> DeviceType:
+    if torch.cuda.is_available():
+        return "cuda"
+    elif torch.backends.mps.is_available():
+        return "mps"
+    elif is_xpu_available():
+        return "xpu"
+    return "cpu"
+
+
+def is_device_available(device: str) -> bool:
+    if device == "cuda":
+        return torch.cuda.is_available()
+    elif device == "mps":
+        return torch.backends.mps.is_available()
+    elif device == "xpu":
+        return is_xpu_available()
+    elif device == "cpu":
+        return True
+
+    return False
+
+
+def move_model_to_available_device(model):
+    device = get_available_device()
+
+    if device == "cpu":
+        return model
+
+    return model.to(device)
+
+
+def get_device_preferred_dtype(device: str) -> Union[torch.dtype, None]:
+    if device == "cpu":
+        return torch.float32
+    elif device == "cuda" or device == "mps":
+        return torch.float16
+    elif device == "xpu":
+        return torch.bfloat16
+
+    return None
+
+
+def is_hf_accelerate_supported(device: str) -> bool:
+    return device == "cuda" or device == "xpu"
+
+
+def empty_cache():
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+    if torch.backends.mps.is_available():
+        torch.mps.empty_cache()
+    if is_xpu_available():
+        torch.xpu.empty_cache()
+
+
+def gpu_count():
+    if torch.cuda.is_available():
+        cuda_visible_devices_env = os.getenv("CUDA_VISIBLE_DEVICES", None)
+
+        if cuda_visible_devices_env is None:
+            return torch.cuda.device_count()
+
+        cuda_visible_devices = (
+            cuda_visible_devices_env.split(",") if cuda_visible_devices_env else []
+        )
+
+        return min(torch.cuda.device_count(), len(cuda_visible_devices))
+    elif torch.backends.mps.is_available():
+        return 1
+    elif is_xpu_available():
+        return torch.xpu.device_count()
+    else:
+        return 0

--- a/xinference/model/audio/whisper.py
+++ b/xinference/model/audio/whisper.py
@@ -14,7 +14,11 @@
 import logging
 from typing import TYPE_CHECKING, Dict, Optional
 
-from xinference.device_utils import get_available_device, is_device_available, get_device_preferred_dtype
+from xinference.device_utils import (
+    get_available_device,
+    get_device_preferred_dtype,
+    is_device_available,
+)
 
 if TYPE_CHECKING:
     from .core import AudioModelFamilyV1
@@ -105,9 +109,11 @@ class WhisperModel:
             )
         return self._call_model(
             audio=audio,
-            generate_kwargs={"language": language, "task": "transcribe"}
-            if language is not None
-            else {"task": "transcribe"},
+            generate_kwargs=(
+                {"language": language, "task": "transcribe"}
+                if language is not None
+                else {"task": "transcribe"}
+            ),
             response_format=response_format,
         )
 

--- a/xinference/model/image/stable_diffusion/core.py
+++ b/xinference/model/image/stable_diffusion/core.py
@@ -23,8 +23,8 @@ from functools import partial
 from io import BytesIO
 from typing import List, Optional, Union
 
-from ....device_utils import move_model_to_available_device
 from ....constants import XINFERENCE_IMAGE_DIR
+from ....device_utils import move_model_to_available_device
 from ....types import Image, ImageList
 
 logger = logging.getLogger(__name__)

--- a/xinference/model/image/stable_diffusion/core.py
+++ b/xinference/model/image/stable_diffusion/core.py
@@ -23,6 +23,7 @@ from functools import partial
 from io import BytesIO
 from typing import List, Optional, Union
 
+from ....device_utils import move_model_to_available_device
 from ....constants import XINFERENCE_IMAGE_DIR
 from ....types import Image, ImageList
 
@@ -40,7 +41,7 @@ class DiffusionModel:
         self._kwargs = kwargs
 
     def load(self):
-        import torch
+        # import torch
         from diffusers import AutoPipelineForText2Image
 
         controlnet = self._kwargs.get("controlnet")
@@ -57,10 +58,7 @@ class DiffusionModel:
             # torch_dtype=torch.float16,
             # use_safetensors=True,
         )
-        if torch.cuda.is_available():
-            self._model = self._model.to("cuda")
-        elif torch.backends.mps.is_available():
-            self._model = self._model.to("mps")
+        self._model = move_model_to_available_device(self._model)
         # Recommended if your computer has < 64 GB of RAM
         self._model.enable_attention_slicing()
 

--- a/xinference/model/llm/pytorch/compression.py
+++ b/xinference/model/llm/pytorch/compression.py
@@ -25,6 +25,8 @@ from torch.nn import functional as F
 from tqdm import tqdm
 from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
 
+from ....device_utils import empty_cache
+
 
 @dataclasses.dataclass
 class CompressionConfig:
@@ -153,7 +155,7 @@ def load_compress_model(
             tmp_state_dict[name] = None
             tensor = None
             gc.collect()
-            torch.cuda.empty_cache()
+            empty_cache()
 
     for name in model.state_dict():
         if name not in linear_weights:

--- a/xinference/model/llm/pytorch/core.py
+++ b/xinference/model/llm/pytorch/core.py
@@ -12,11 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import logging
 import os
-import json
 from typing import Iterable, Iterator, List, Optional, Union
 
+from ....device_utils import (
+    get_device_preferred_dtype,
+    gpu_count,
+    is_hf_accelerate_supported,
+)
 from ....types import (
     ChatCompletion,
     ChatCompletionChunk,
@@ -30,7 +35,6 @@ from ....types import (
     PytorchGenerateConfig,
     PytorchModelConfig,
 )
-from ....device_utils import gpu_count, get_device_preferred_dtype, is_hf_accelerate_supported
 from ...utils import select_device
 from ..core import LLM
 from ..llm_family import LLMFamilyV1, LLMSpecV1
@@ -149,7 +153,9 @@ class PytorchModel(LLM):
 
         if max_memory_env is not None:
             max_memory_raw = json.loads(max_memory_env)
-            max_memory = {int(k) if k.isdigit() else k : max_memory_raw[k] for k in max_memory_raw}
+            max_memory = {
+                int(k) if k.isdigit() else k: max_memory_raw[k] for k in max_memory_raw
+            }
             kwargs["max_memory"] = max_memory
 
         if quantization != "none" and model_format == "pytorch":

--- a/xinference/model/llm/pytorch/qwen_vl.py
+++ b/xinference/model/llm/pytorch/qwen_vl.py
@@ -95,9 +95,11 @@ class QwenVLChatModel(PytorchChatModel):
         if not isinstance(content, str):
             # TODO(codingl2k1): Optimize _ensure_url
             content = [
-                {"image": _ensure_url(c["image_url"]["url"]), "type": "image"}
-                if c.get("type") == "image_url"
-                else c
+                (
+                    {"image": _ensure_url(c["image_url"]["url"]), "type": "image"}
+                    if c.get("type") == "image_url"
+                    else c
+                )
                 for c in content
             ]
             content = sorted(content, key=operator.itemgetter("type"))

--- a/xinference/model/llm/pytorch/spec_decoding_utils.py
+++ b/xinference/model/llm/pytorch/spec_decoding_utils.py
@@ -17,6 +17,8 @@ import time
 import uuid
 from typing import Any, Dict, Iterable, Iterator, List, Optional, Tuple
 
+from ....device_utils import empty_cache
+
 try:
     import torch
     from torch.nn import functional as F
@@ -526,4 +528,4 @@ def speculative_generate_stream(
     del kv_cache
     del draft_kv_cache
     gc.collect()
-    torch.cuda.empty_cache()
+    empty_cache()

--- a/xinference/model/llm/pytorch/spec_model.py
+++ b/xinference/model/llm/pytorch/spec_model.py
@@ -15,8 +15,12 @@
 import logging
 from typing import Iterator, List, Optional, Union
 
+from ....device_utils import (
+    get_device_preferred_dtype,
+    gpu_count,
+    is_hf_accelerate_supported,
+)
 from ....types import Completion, CompletionChunk, Embedding
-from ....device_utils import gpu_count, get_device_preferred_dtype, is_hf_accelerate_supported
 from ...utils import select_device
 from .. import LLMFamilyV1, LLMSpecV1
 from .core import PytorchChatModel, PytorchGenerateConfig, PytorchModelConfig
@@ -73,7 +77,7 @@ class SpeculativeModel(PytorchChatModel):
 
     def load(self):
         try:
-            import torch # noqa: F401
+            import torch  # noqa: F401
         except ImportError:
             raise ImportError(
                 f"Failed to import module 'torch'. Please make sure 'torch' is installed.\n\n"

--- a/xinference/model/llm/pytorch/utils.py
+++ b/xinference/model/llm/pytorch/utils.py
@@ -29,6 +29,7 @@ from transformers.generation.logits_process import (
     TopPLogitsWarper,
 )
 
+from ....device_utils import empty_cache
 from ....types import (
     CompletionChoice,
     CompletionChunk,
@@ -335,7 +336,7 @@ def generate_stream(
     # clean
     del past_key_values, out
     gc.collect()
-    torch.cuda.empty_cache()
+    empty_cache()
 
 
 @torch.inference_mode()
@@ -489,4 +490,4 @@ def generate_stream_falcon(
 
     # clean
     gc.collect()
-    torch.cuda.empty_cache()
+    empty_cache()

--- a/xinference/model/llm/pytorch/yi_vl.py
+++ b/xinference/model/llm/pytorch/yi_vl.py
@@ -24,6 +24,7 @@ import requests
 import torch
 from PIL import Image
 
+from ....model.utils import select_device
 from ....types import (
     ChatCompletion,
     ChatCompletionChoice,

--- a/xinference/model/llm/pytorch/yi_vl.py
+++ b/xinference/model/llm/pytorch/yi_vl.py
@@ -211,7 +211,9 @@ class YiVLChatModel(PytorchChatModel):
         max_new_tokens = generate_config.get("max_tokens", 512)
         generate_kwargs = {
             "input_ids": input_ids,
-            "images": image_tensor.unsqueeze(0).to(dtype=torch.bfloat16).to(self._device),
+            "images": image_tensor.unsqueeze(0)
+            .to(dtype=torch.bfloat16)
+            .to(self._device),
             "streamer": streamer,
             "do_sample": True,
             "top_p": float(top_p),

--- a/xinference/model/utils.py
+++ b/xinference/model/utils.py
@@ -21,9 +21,8 @@ from typing import Any, Callable, Dict, Optional, Tuple
 
 from fsspec import AbstractFileSystem
 
-from ..device_utils import get_available_device, is_device_available
-
 from ..constants import XINFERENCE_CACHE_DIR, XINFERENCE_ENV_MODEL_SRC
+from ..device_utils import get_available_device, is_device_available
 from .core import CacheableModelSpec
 
 logger = logging.getLogger(__name__)
@@ -403,7 +402,7 @@ def patch_trust_remote_code():
 
 def select_device(device):
     try:
-        import torch # noqa: F401
+        import torch  # noqa: F401
     except ImportError:
         raise ImportError(
             f"Failed to import module 'torch'. Please make sure 'torch' is installed.\n\n"

--- a/xinference/model/utils.py
+++ b/xinference/model/utils.py
@@ -21,6 +21,8 @@ from typing import Any, Callable, Dict, Optional, Tuple
 
 from fsspec import AbstractFileSystem
 
+from ..device_utils import get_available_device, is_device_available
+
 from ..constants import XINFERENCE_CACHE_DIR, XINFERENCE_ENV_MODEL_SRC
 from .core import CacheableModelSpec
 
@@ -401,27 +403,16 @@ def patch_trust_remote_code():
 
 def select_device(device):
     try:
-        import torch
+        import torch # noqa: F401
     except ImportError:
         raise ImportError(
             f"Failed to import module 'torch'. Please make sure 'torch' is installed.\n\n"
         )
 
     if device == "auto":
-        # When env CUDA_VISIBLE_DEVICES=-1, torch.cuda.is_available() return False
-        if torch.cuda.is_available():
-            return "cuda"
-        elif torch.backends.mps.is_available():
-            return "mps"
-        return "cpu"
-    elif device == "cuda":
-        if not torch.cuda.is_available():
-            raise ValueError("cuda is unavailable in your environment")
-    elif device == "mps":
-        if not torch.backends.mps.is_available():
-            raise ValueError("mps is unavailable in your environment")
-    elif device == "cpu":
-        pass
+        return get_available_device()
     else:
-        raise ValueError(f"Device {device} is not supported in temporary")
+        if not is_device_available(device):
+            raise ValueError(f"{device} is unavailable in your environment")
+
     return device

--- a/xinference/thirdparty/llava/mm_utils.py
+++ b/xinference/thirdparty/llava/mm_utils.py
@@ -85,7 +85,7 @@ def load_pretrained_model(
 
     if not vision_tower.is_loaded:
         vision_tower.load_model()
-    vision_tower.to(device="cuda", dtype=torch.bfloat16)
+    vision_tower.to(device=model.device, dtype=torch.bfloat16)
     image_processor = vision_tower.image_processor
 
     if hasattr(model.config, "max_sequence_length"):


### PR DESCRIPTION
Refactors most device related code into `device_utils` (only `pytorch` backend, `vllm` and `ctransformers` are unsupported, `8bit` and `4bit` are also unsupported), and adds initial Intel GPU support.

You will need `intel-extension-for-pytorch` to run it: https://intel.github.io/intel-extension-for-pytorch/xpu/latest/tutorials/installation.html

Tested on Llama2-chat and ChatGlm3.

(for `device_map`, requires https://github.com/huggingface/accelerate/pull/2383)