### PR TITLE
BUG: Fix early truncation due to `max_token` being default to `16` instead of `1024`

### DIFF
--- a/xinference/api/restful_api.py
+++ b/xinference/api/restful_api.py
@@ -1137,7 +1137,7 @@ class RESTfulAPI:
         }
         kwargs = body.dict(exclude_unset=True, exclude=exclude)
 
-        # TODO: Decide if this default value overide is necessary #1061
+        # TODO: Decide if this default value override is necessary #1061
         if body.max_tokens is None:
             kwargs["max_tokens"] = max_tokens_field.default
 

--- a/xinference/api/restful_api.py
+++ b/xinference/api/restful_api.py
@@ -63,6 +63,7 @@ from ..types import (
     CreateChatCompletion,
     CreateCompletion,
     ImageList,
+    max_tokens_field,
 )
 from .oauth2.auth_service import AuthService
 from .oauth2.types import LoginUserForm
@@ -844,6 +845,10 @@ class RESTfulAPI:
         }
         kwargs = body.dict(exclude_unset=True, exclude=exclude)
 
+        # TODO: Decide if this default value overide is necessary #1061
+        if body.max_tokens is None:
+            kwargs["max_tokens"] = max_tokens_field.default
+
         if body.logit_bias is not None:
             raise HTTPException(status_code=501, detail="Not implemented")
 
@@ -1131,6 +1136,10 @@ class RESTfulAPI:
             "user",
         }
         kwargs = body.dict(exclude_unset=True, exclude=exclude)
+
+        # TODO: Decide if this default value overide is necessary #1061
+        if body.max_tokens is None:
+            kwargs["max_tokens"] = max_tokens_field.default
 
         if body.logit_bias is not None:
             raise HTTPException(status_code=501, detail="Not implemented")

--- a/xinference/api/restful_api.py
+++ b/xinference/api/restful_api.py
@@ -63,7 +63,6 @@ from ..types import (
     CreateChatCompletion,
     CreateCompletion,
     ImageList,
-    max_tokens_field,
 )
 from .oauth2.auth_service import AuthService
 from .oauth2.types import LoginUserForm
@@ -845,9 +844,6 @@ class RESTfulAPI:
         }
         kwargs = body.dict(exclude_unset=True, exclude=exclude)
 
-        if body.max_tokens is None:
-            kwargs["max_tokens"] = max_tokens_field.default
-
         if body.logit_bias is not None:
             raise HTTPException(status_code=501, detail="Not implemented")
 
@@ -1135,9 +1131,6 @@ class RESTfulAPI:
             "user",
         }
         kwargs = body.dict(exclude_unset=True, exclude=exclude)
-
-        if body.max_tokens is None:
-            kwargs["max_tokens"] = max_tokens_field.default
 
         if body.logit_bias is not None:
             raise HTTPException(status_code=501, detail="Not implemented")

--- a/xinference/api/restful_api.py
+++ b/xinference/api/restful_api.py
@@ -845,7 +845,7 @@ class RESTfulAPI:
         }
         kwargs = body.dict(exclude_unset=True, exclude=exclude)
 
-        # TODO: Decide if this default value overide is necessary #1061
+        # TODO: Decide if this default value override is necessary #1061
         if body.max_tokens is None:
             kwargs["max_tokens"] = max_tokens_field.default
 

--- a/xinference/types.py
+++ b/xinference/types.py
@@ -346,8 +346,8 @@ try:
 
     CreateCompletionLlamaCpp = get_pydantic_model_from_method(
         Llama.create_completion,
-        exclude_fields=["model", "prompt", "grammar"],
-        include_fields={"grammar": (Optional[Any], None)},
+        exclude_fields=["model", "prompt", "grammar", "max_tokens"],
+        include_fields={"grammar": (Optional[Any], None), "max_tokens": (Optional[Any], None)},
     )
 except ImportError:
     CreateCompletionLlamaCpp = create_model("CreateCompletionLlamaCpp")

--- a/xinference/types.py
+++ b/xinference/types.py
@@ -349,7 +349,7 @@ try:
         exclude_fields=["model", "prompt", "grammar", "max_tokens"],
         include_fields={
             "grammar": (Optional[Any], None),
-            "max_tokens": (Optional[Any], None),
+            "max_tokens": (Optional[int], max_tokens_field),
         },
     )
 except ImportError:

--- a/xinference/types.py
+++ b/xinference/types.py
@@ -347,7 +347,10 @@ try:
     CreateCompletionLlamaCpp = get_pydantic_model_from_method(
         Llama.create_completion,
         exclude_fields=["model", "prompt", "grammar", "max_tokens"],
-        include_fields={"grammar": (Optional[Any], None), "max_tokens": (Optional[Any], None)},
+        include_fields={
+            "grammar": (Optional[Any], None),
+            "max_tokens": (Optional[Any], None),
+        },
     )
 except ImportError:
     CreateCompletionLlamaCpp = create_model("CreateCompletionLlamaCpp")


### PR DESCRIPTION
The `CreateCompletionLlamaCpp` model inherits from the signature of  [`llama_cpp.llama.create_completion`](https://github.com/abetlen/llama-cpp-python/blob/8c71725d5345b2ba325e6d28209875057c5873e6/llama_cpp/llama.py#L1384) which sets `max_tokens` to `16` by default. This invalidates the default value set in [`restful_api.py`](https://github.com/xorbitsai/inference/blob/d53c80a6a82ded81231d22984ff4d02eb3935ae5/xinference/api/restful_api.py#L848) which expects `max_tokens` to be `None` if not set in the request.