### PR TITLE
BUG: check llm model cache correctly

### DIFF
--- a/xinference/model/llm/llm_family.py
+++ b/xinference/model/llm/llm_family.py
@@ -251,7 +251,11 @@ def cache(
         llm_spec.model_size_in_billions,
         quantization,
     )
-    if os.path.exists(legacy_cache_path):
+    cache_dir = _get_cache_dir(llm_family, llm_spec, create_if_not_exist=False)
+    if os.path.exists(cache_dir):
+        logger.info("Cache path exists: %s", cache_dir)
+        return cache_dir
+    elif os.path.exists(legacy_cache_path):
         logger.info("Legacy cache path exists: %s", legacy_cache_path)
         return os.path.dirname(legacy_cache_path)
     elif download_from_self_hosted_storage() and is_self_hosted(llm_family, llm_spec):


### PR DESCRIPTION
The `xinference.model.llm.llm_family.cache` function checks legacy cache dir only, which in form of `qwen1.5-chat-pytorch-4b-{quant}`. But `cache_from_*` functions use cache dir name from `_get_cache_dir` which in form of `qwen1.5-chat-pytorch-4b` without quantization suffix.

So `cache` cannot recognize existed cache dir created by `cache_from_*` functions and continue to download.
