### PR TITLE
ENH: Make GET /v1/models compatible with OpenAI API.

### DIFF
--- a/xinference/api/restful_api.py
+++ b/xinference/api/restful_api.py
@@ -584,8 +584,22 @@ class RESTfulAPI:
 
     async def list_models(self) -> JSONResponse:
         try:
-            data = await (await self._get_supervisor_ref()).list_models()
-            return JSONResponse(content=data)
+            models = await (await self._get_supervisor_ref()).list_models()
+
+            model_list = []
+            for model_id, model_info in models.items():
+                model_list.append(
+                    {
+                        "id": model_id,
+                        "object": "model",
+                        "created": 0,
+                        "owned_by": "xinference",
+                        **model_info,
+                    }
+                )
+            response = {"object": "list", "data": model_list}
+
+            return JSONResponse(content=response)
         except Exception as e:
             logger.error(e, exc_info=True)
             raise HTTPException(status_code=500, detail=str(e))

--- a/xinference/client/restful/restful_client.py
+++ b/xinference/client/restful/restful_client.py
@@ -732,7 +732,8 @@ class Client:
             )
 
         response_data = response.json()
-        return response_data
+        model_list = response_data["data"]
+        return {item["id"]: item for item in model_list}
 
     def launch_speculative_llm(
         self,

--- a/xinference/core/tests/test_restful_api.py
+++ b/xinference/core/tests/test_restful_api.py
@@ -34,7 +34,7 @@ async def test_restful_api(setup):
     # list
     response = requests.get(url)
     response_data = response.json()
-    assert len(response_data) == 0
+    assert len(response_data["data"]) == 0
 
     # launch
     payload = {
@@ -70,7 +70,7 @@ async def test_restful_api(setup):
     # list
     response = requests.get(url)
     response_data = response.json()
-    assert len(response_data) == 1
+    assert len(response_data["data"]) == 1
 
     # describe
     response = requests.get(f"{endpoint}/v1/models/test_restful_api")
@@ -188,7 +188,7 @@ async def test_restful_api(setup):
     # list
     response = requests.get(f"{endpoint}/v1/models")
     response_data = response.json()
-    assert len(response_data) == 0
+    assert len(response_data["data"]) == 0
 
     # delete again
     url = f"{endpoint}/v1/models/test_restful_api"
@@ -307,7 +307,7 @@ def test_restful_api_for_embedding(setup):
     # list
     response = requests.get(url)
     response_data = response.json()
-    assert len(response_data) == 0
+    assert len(response_data["data"]) == 0
 
     # launch
     payload = {
@@ -323,7 +323,7 @@ def test_restful_api_for_embedding(setup):
 
     response = requests.get(url)
     response_data = response.json()
-    assert len(response_data) == 1
+    assert len(response_data["data"]) == 1
 
     # test embedding
     url = f"{endpoint}/v1/embeddings"
@@ -361,7 +361,7 @@ def test_restful_api_for_embedding(setup):
 
     response = requests.get(f"{endpoint}/v1/models")
     response_data = response.json()
-    assert len(response_data) == 0
+    assert len(response_data["data"]) == 0
 
 
 def _check_invalid_tool_calls(endpoint, model_uid_res):
@@ -423,7 +423,7 @@ def test_restful_api_for_tool_calls(setup, model_format, quantization):
     # list
     response = requests.get(url)
     response_data = response.json()
-    assert len(response_data) == 0
+    assert len(response_data["data"]) == 0
 
     # launch
     payload = {
@@ -441,7 +441,7 @@ def test_restful_api_for_tool_calls(setup, model_format, quantization):
 
     response = requests.get(url)
     response_data = response.json()
-    assert len(response_data) == 1
+    assert len(response_data["data"]) == 1
 
     # tool
     tools = [
@@ -570,7 +570,7 @@ def test_restful_api_for_gorilla_openfunctions_tool_calls(
     # list
     response = requests.get(url)
     response_data = response.json()
-    assert len(response_data) == 0
+    assert len(response_data["data"]) == 0
 
     # launch
     payload = {
@@ -588,7 +588,7 @@ def test_restful_api_for_gorilla_openfunctions_tool_calls(
 
     response = requests.get(url)
     response_data = response.json()
-    assert len(response_data) == 1
+    assert len(response_data["data"]) == 1
 
     # tool
     tools = [
@@ -669,7 +669,7 @@ def test_restful_api_for_qwen_tool_calls(setup, model_format, quantization):
     # list
     response = requests.get(url)
     response_data = response.json()
-    assert len(response_data) == 0
+    assert len(response_data["data"]) == 0
 
     # launch
     payload = {
@@ -687,7 +687,7 @@ def test_restful_api_for_qwen_tool_calls(setup, model_format, quantization):
 
     response = requests.get(url)
     response_data = response.json()
-    assert len(response_data) == 1
+    assert len(response_data["data"]) == 1
 
     # tool
     tools = [
@@ -885,7 +885,7 @@ async def test_openai(setup):
     # list
     response = requests.get(url)
     response_data = response.json()
-    assert len(response_data) == 0
+    assert len(response_data["data"]) == 0
 
     # launch
     payload = {
@@ -943,7 +943,7 @@ def test_lang_chain(setup):
     # list
     response = requests.get(url)
     response_data = response.json()
-    assert len(response_data) == 0
+    assert len(response_data["data"]) == 0
 
     # launch
     payload = {

--- a/xinference/web/ui/src/scenes/running_models/index.js
+++ b/xinference/web/ui/src/scenes/running_models/index.js
@@ -63,16 +63,16 @@ const RunningModels = () => {
               )
             })
           } else {
-            response.json().then((data) => {
+            response.json().then((response) => {
               const newLlmData = []
               const newEmbeddingModelData = []
               const newImageModelData = []
               const newRerankModelData = []
-              Object.entries(data).forEach(([key, value]) => {
+              response.data.forEach((model) => {
                 let newValue = {
-                  ...value,
-                  id: key,
-                  url: key,
+                  ...model,
+                  id: model.id,
+                  url: model.id,
                 }
                 if (newValue.model_type === 'LLM') {
                   newLlmData.push(newValue)


### PR DESCRIPTION
This PR add some fields according to https://platform.openai.com/docs/api-reference/models/list while retaining its original fields. Now I'm able to use xinference with https://github.com/open-webui/open-webui