### PR TITLE
ENH: Remove quantization limits for Apple METAL device when running model via `llama-cpp-python`

### DIFF
--- a/xinference/model/llm/ggml/llamacpp.py
+++ b/xinference/model/llm/ggml/llamacpp.py
@@ -52,9 +52,6 @@ class LlamaCppModel(LLM):
         )
         self._llm = None
 
-    def _can_apply_metal(self):
-        return self.quantization.lower() in ["q4_0", "q4_1", "q4_k_s", "q4_k_m"]
-
     def _can_apply_cublas(self):
         # TODO: figure out the quantizations supported.
         return True
@@ -78,8 +75,7 @@ class LlamaCppModel(LLM):
             llamacpp_model_config["use_mlock"] = False
             llamacpp_model_config["n_gqa"] = 8
 
-        if self._is_darwin_and_apple_silicon() and self._can_apply_metal():
-            # TODO: platform.processor() is not safe, need to be replaced to other method.
+        if self._is_darwin_and_apple_silicon():
             llamacpp_model_config.setdefault("n_gpu_layers", -1)
         elif self._is_linux() and self._can_apply_cublas():
             llamacpp_model_config.setdefault("n_gpu_layers", -1)


### PR DESCRIPTION
For example, I tried `q3_k_m` quantization of `qwen1.5-chat` on Apple M1 MAX:
<img width="1719" alt="image" src="https://github.com/xorbitsai/inference/assets/109656400/a23b4a9a-6176-43d7-a10a-5640d3fee4d7">
<img width="1519" alt="image" src="https://github.com/xorbitsai/inference/assets/109656400/f419a614-18ec-432f-803f-6545cefff8d1">
