### PR TITLE
BUG: remove `best_of` from benchmark

### DIFF
--- a/benchmark/benchmark_latency.py
+++ b/benchmark/benchmark_latency.py
@@ -32,12 +32,11 @@ async def benchmark(
     api_url: str,
     model_uid: str,
     input_requests: List[Tuple[str, int, int]],
-    best_of: int,
 ) -> None:
     for request in input_requests:
         prompt, prompt_len, output_len = request
         await send_request(
-            api_url, model_uid, prompt, prompt_len, output_len, best_of, REQUEST_LATENCY
+            api_url, model_uid, prompt, prompt_len, output_len, REQUEST_LATENCY
         )
 
 
@@ -61,7 +60,6 @@ def main(args: argparse.Namespace):
             api_url,
             model_uid,
             input_requests,
-            args.best_of,
         )
     )
 
@@ -97,12 +95,6 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--tokenizer", type=str, required=True, help="Name or path of the tokenizer."
-    )
-    parser.add_argument(
-        "--best-of",
-        type=int,
-        default=1,
-        help="Generates `best_of` sequences per prompt and " "returns the best one.",
     )
     parser.add_argument(
         "--num-prompts", type=int, default=100, help="Number of prompts to process."

--- a/benchmark/benchmark_serving.py
+++ b/benchmark/benchmark_serving.py
@@ -52,7 +52,6 @@ async def benchmark(
     api_url: str,
     model_uid: str,
     input_requests: List[Tuple[str, int, int]],
-    best_of: int,
     request_rate: float,
 ) -> None:
     tasks: List[asyncio.Task] = []
@@ -65,7 +64,6 @@ async def benchmark(
                 prompt,
                 prompt_len,
                 output_len,
-                best_of,
                 REQUEST_LATENCY,
             )
         )
@@ -92,7 +90,6 @@ def main(args: argparse.Namespace):
             api_url,
             model_uid,
             input_requests,
-            args.best_of,
             args.request_rate,
         )
     )
@@ -132,12 +129,6 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--tokenizer", type=str, required=True, help="Name or path of the tokenizer."
-    )
-    parser.add_argument(
-        "--best-of",
-        type=int,
-        default=1,
-        help="Generates `best_of` sequences per prompt and " "returns the best one.",
     )
     parser.add_argument(
         "--num-prompts", type=int, default=100, help="Number of prompts to process."

--- a/benchmark/utils.py
+++ b/benchmark/utils.py
@@ -144,7 +144,6 @@ async def send_request(
     prompt: str,
     prompt_len: int,
     output_len: int,
-    best_of: int,
     stats: List[Tuple[int, int, float]],  # output.
 ) -> None:
     request_start_time = time.time()
@@ -152,7 +151,6 @@ async def send_request(
     pload = {
         "model": model_uid,
         "n": 1,
-        "best_of": best_of,
         "temperature": 1.0,
         "top_p": 1.0,
         "max_tokens": output_len,


### PR DESCRIPTION
`best_of` is supported in OpenAI legacy API [Create Completion](https://platform.openai.com/docs/api-reference/completions/create) and not in [Create Chat Completion](https://platform.openai.com/docs/api-reference/chat/create). So remove it from benchmark.