### PR TITLE
ENH: vLLM latest models support

### DIFF
--- a/doc/source/user_guide/backends.rst
+++ b/doc/source/user_guide/backends.rst
@@ -35,6 +35,7 @@ vLLM
 vLLM is a fast and easy-to-use library for LLM inference and serving.
 
 vLLM is fast with:
+
 - State-of-the-art serving throughput
 - Efficient management of attention key and value memory with PagedAttention
 - Continuous batching of incoming requests
@@ -59,3 +60,5 @@ Currently, supported model includes:
 - ``code-llama``, ``code-llama-python``, ``code-llama-instruct``
 - ``mistral-v0.1``, ``mistral-instruct-v0.1``, ``mistral-instruct-v0.2``, ``mixtral-instruct-v0.1``
 - ``chatglm3``
+- ``gemma-it``
+- ``orion-chat``, ``orion-chat-rag``

--- a/xinference/model/llm/vllm/core.py
+++ b/xinference/model/llm/vllm/core.py
@@ -107,7 +107,7 @@ if VLLM_INSTALLED and vllm.__version__ >= "0.3.2":
     VLLM_SUPPORTED_CHAT_MODELS.append("gemma-it")
 
 if VLLM_INSTALLED and vllm.__version__ >= "0.3.3":
-    VLLM_SUPPORTED_CHAT_MODELS.append("orion-chat")   
+    VLLM_SUPPORTED_CHAT_MODELS.append("orion-chat")
     VLLM_SUPPORTED_CHAT_MODELS.append("orion-chat-rag")
 
 class VLLMModel(LLM):

--- a/xinference/model/llm/vllm/core.py
+++ b/xinference/model/llm/vllm/core.py
@@ -110,6 +110,7 @@ if VLLM_INSTALLED and vllm.__version__ >= "0.3.3":
     VLLM_SUPPORTED_CHAT_MODELS.append("orion-chat")
     VLLM_SUPPORTED_CHAT_MODELS.append("orion-chat-rag")
 
+
 class VLLMModel(LLM):
     def __init__(
         self,

--- a/xinference/model/llm/vllm/core.py
+++ b/xinference/model/llm/vllm/core.py
@@ -103,6 +103,12 @@ VLLM_SUPPORTED_CHAT_MODELS = [
 if VLLM_INSTALLED and vllm.__version__ >= "0.3.0":
     VLLM_SUPPORTED_CHAT_MODELS.append("qwen1.5-chat")
 
+if VLLM_INSTALLED and vllm.__version__ >= "0.3.2":
+    VLLM_SUPPORTED_CHAT_MODELS.append("gemma-it")
+
+if VLLM_INSTALLED and vllm.__version__ >= "0.3.3":
+    VLLM_SUPPORTED_CHAT_MODELS.append("orion-chat")   
+    VLLM_SUPPORTED_CHAT_MODELS.append("orion-chat-rag")
 
 class VLLMModel(LLM):
     def __init__(


### PR DESCRIPTION
add vLLM latest models ``gemma-it``, ``orion-chat``, ``orion-chat-rag``.
FIX https://github.com/xorbitsai/inference/issues/1154