### PR TITLE
BLD: add autoawq in setup

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -95,6 +95,7 @@ all =
     controlnet_aux
     orjson
     auto-gptq ; sys_platform!='darwin'
+    autoawq
     optimum
     sglang[all] ; sys_platform=='linux'
 intel =
@@ -115,6 +116,7 @@ transformers =
     einops
     tiktoken
     auto-gptq
+    autoawq
     optimum
     peft
 vllm =

--- a/setup.cfg
+++ b/setup.cfg
@@ -95,7 +95,7 @@ all =
     controlnet_aux
     orjson
     auto-gptq ; sys_platform!='darwin'
-    autoawq
+    autoawq ; sys_platform!='darwin'
     optimum
     sglang[all] ; sys_platform=='linux'
 intel =


### PR DESCRIPTION
Support autoawq.
Otherwise, when inferring the AWQ quantization model, it will error that dependencies are missing.
