### PR TITLE
ENH: support multi gpus for qwen-vl and yi-vl

### DIFF
--- a/xinference/model/llm/pytorch/qwen_vl.py
+++ b/xinference/model/llm/pytorch/qwen_vl.py
@@ -53,6 +53,8 @@ class QwenVLChatModel(PytorchChatModel):
 
         device = self._pytorch_model_config.get("device", "auto")
         device = select_device(device)
+        # for multiple GPU, set back to auto to make multiple devices work
+        device = "auto" if device == "cuda" else device
 
         self._tokenizer = AutoTokenizer.from_pretrained(
             self.model_path,

--- a/xinference/model/llm/pytorch/yi_vl.py
+++ b/xinference/model/llm/pytorch/yi_vl.py
@@ -186,14 +186,13 @@ class YiVLChatModel(PytorchChatModel):
         state.append_message(state.roles[1], None)
 
         prompt = state.get_prompt()
-        device = 'cuda' if self._device == 'auto' else self._device
 
         input_ids = (
             tokenizer_image_token(
                 prompt, self._tokenizer, IMAGE_TOKEN_INDEX, return_tensors="pt"
             )
             .unsqueeze(0)
-            .to(device)
+            .to(self._model.device)
         )
 
         images = state.get_images(return_pil=True)
@@ -218,7 +217,7 @@ class YiVLChatModel(PytorchChatModel):
             "input_ids": input_ids,
             "images": image_tensor.unsqueeze(0)
             .to(dtype=torch.bfloat16)
-            .to(device),
+            .to(self._model.device),
             "streamer": streamer,
             "do_sample": True,
             "top_p": float(top_p),


### PR DESCRIPTION
qwen-vl and yi-vl are tested on multiple cards.

deepseek-vl and omniLMM used third party implementation, the multi gpus support is non-trivial, will support at a right point in the future.