### PR TITLE
BUG: Fix the launch bug of OmnilMM 12B.

### DIFF
--- a/xinference/thirdparty/omnilmm/chat.py
+++ b/xinference/thirdparty/omnilmm/chat.py
@@ -207,7 +207,7 @@ class OmniLMM3B:
 
 class OmniLMMChat:
     def __init__(self, model_path, device_map) -> None:
-        if "12B" in model_path:
+        if "12b" in model_path:
             self.model = OmniLMM12B(model_path, device_map)
         else:
             self.model = OmniLMM3B(model_path, device_map)


### PR DESCRIPTION
ValueError: [address=[0.0.0.0:41917](http://0.0.0.0:41917/), pid=2321173] Unrecognized configuration class <class 'xinference.thirdparty.omnilmm.model.omnilmm.OmniLMMConfig'> for this kind of AutoModel: AutoModel.