### PR TITLE
FEAT: add support for qwen1.5 32B chat model

### DIFF
--- a/xinference/model/llm/llm_family.json
+++ b/xinference/model/llm/llm_family.json
@@ -1607,6 +1607,16 @@
       },
       {
         "model_format": "pytorch",
+        "model_size_in_billions": 32,
+        "quantizations": [
+          "4-bit",
+          "8-bit",
+          "none"
+        ],
+        "model_id": "Qwen/Qwen1.5-32B-Chat"
+      },
+      {
+        "model_format": "pytorch",
         "model_size_in_billions": 72,
         "quantizations": [
           "4-bit",
@@ -1662,6 +1672,14 @@
       },
       {
         "model_format": "gptq",
+        "model_size_in_billions": 32,
+        "quantizations": [
+          "Int4"
+        ],
+        "model_id": "Qwen/Qwen1.5-32B-Chat-GPTQ-{quantization}"
+      },
+      {
+        "model_format": "gptq",
         "model_size_in_billions": 72,
         "quantizations": [
           "Int4",
@@ -1708,6 +1726,14 @@
           "Int4"
         ],
         "model_id": "Qwen/Qwen1.5-14B-Chat-AWQ"
+      },
+      {
+        "model_format": "awq",
+        "model_size_in_billions": 32,
+        "quantizations": [
+          "Int4"
+        ],
+        "model_id": "Qwen/Qwen1.5-32B-Chat-AWQ"
       },
       {
         "model_format": "awq",
@@ -1796,6 +1822,22 @@
         ],
         "model_id": "Qwen/Qwen1.5-14B-Chat-GGUF",
         "model_file_name_template": "qwen1_5-14b-chat-{quantization}.gguf"
+      },
+      {
+        "model_format": "ggufv2",
+        "model_size_in_billions": 32,
+        "quantizations": [
+          "q2_k",
+          "q3_k_m",
+          "q4_0",
+          "q4_k_m",
+          "q5_0",
+          "q5_k_m",
+          "q6_k",
+          "q8_0"
+        ],
+        "model_id": "Qwen/Qwen1.5-32B-Chat-GGUF",
+        "model_file_name_template": "qwen1_5-32b-chat-{quantization}.gguf"
       },
       {
         "model_format": "ggufv2",

--- a/xinference/model/llm/llm_family_modelscope.json
+++ b/xinference/model/llm/llm_family_modelscope.json
@@ -1827,6 +1827,17 @@
       },
       {
         "model_format": "pytorch",
+        "model_size_in_billions": 32,
+        "quantizations": [
+          "4-bit",
+          "8-bit",
+          "none"
+        ],
+        "model_id": "qwen/Qwen1.5-32B-Chat",
+        "model_hub": "modelscope"
+      },
+      {
+        "model_format": "pytorch",
         "model_size_in_billions": 72,
         "quantizations": [
           "4-bit",
@@ -1888,6 +1899,15 @@
       },
       {
         "model_format": "gptq",
+        "model_size_in_billions": 32,
+        "quantizations": [
+          "Int4"
+        ],
+        "model_id": "qwen/Qwen1.5-32B-Chat-GPTQ-{quantization}",
+        "model_hub": "modelscope"
+      },
+      {
+        "model_format": "gptq",
         "model_size_in_billions": 72,
         "quantizations": [
           "Int4",
@@ -1939,6 +1959,15 @@
           "Int4"
         ],
         "model_id": "qwen/Qwen1.5-14B-Chat-AWQ",
+        "model_hub": "modelscope"
+      },
+      {
+        "model_format": "awq",
+        "model_size_in_billions": 32,
+        "quantizations": [
+          "Int4"
+        ],
+        "model_id": "qwen/Qwen1.5-32B-Chat-AWQ",
         "model_hub": "modelscope"
       },
       {
@@ -2034,6 +2063,23 @@
         "model_id": "qwen/Qwen1.5-14B-Chat-GGUF",
         "model_hub": "modelscope",
         "model_file_name_template": "qwen1_5-14b-chat-{quantization}.gguf"
+      },
+      {
+        "model_format": "ggufv2",
+        "model_size_in_billions": 32,
+        "quantizations": [
+          "q2_k",
+          "q3_k_m",
+          "q4_0",
+          "q4_k_m",
+          "q5_0",
+          "q5_k_m",
+          "q6_k",
+          "q8_0"
+        ],
+        "model_id": "qwen/Qwen1.5-32B-Chat-GGUF",
+        "model_hub": "modelscope",
+        "model_file_name_template": "qwen1_5-32b-chat-{quantization}.gguf"
       },
       {
         "model_format": "ggufv2",


### PR DESCRIPTION
Both HF and modelscope config files have been added.