### PR TITLE
ENH: fix the max length of codeqwen-7B-chat

### DIFF
--- a/xinference/model/llm/llm_family.json
+++ b/xinference/model/llm/llm_family.json
@@ -2074,7 +2074,7 @@
   },
   {
     "version": 1,
-    "context_length": 65536,
+    "context_length": 32768,
     "model_name": "codeqwen1.5-chat",
     "model_lang": [
       "en",

--- a/xinference/model/llm/llm_family_modelscope.json
+++ b/xinference/model/llm/llm_family_modelscope.json
@@ -2267,7 +2267,7 @@
   },
   {
     "version": 1,
-    "context_length": 65536,
+    "context_length": 32768,
     "model_name": "codeqwen1.5-chat",
     "model_lang": [
       "en",


### PR DESCRIPTION
Although both in the official document and config.json, the max length is stated as 65536, however, it is 32768 after actual testing