### PR TITLE
BLD: adapt to langchain 0.2.x, which has breaking changes

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -77,6 +77,7 @@ dev =
     openai>1
     opencv-contrib-python
     langchain
+    langchain-community
     orjson
     sphinx-tabs
     sphinx-design


### PR DESCRIPTION
langchain-community need to be installed separately.