### PR TITLE
Correct ModelActor import path in worker & supervisor

### DIFF
--- a/xinference/core/__init__.py
+++ b/xinference/core/__init__.py
@@ -11,5 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from .model import ModelActor

--- a/xinference/core/supervisor.py
+++ b/xinference/core/supervisor.py
@@ -28,7 +28,7 @@ from ..constants import (
     XINFERENCE_HEALTH_CHECK_INTERVAL,
     XINFERENCE_HEALTH_CHECK_TIMEOUT,
 )
-from ..core import ModelActor
+from ..core.model import ModelActor
 from ..core.status_guard import InstanceInfo, LaunchStatus
 from ..types import PeftModelConfig
 from .metrics import record_metrics

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -32,7 +32,7 @@ from ..constants import (
     XINFERENCE_DISABLE_HEALTH_CHECK,
     XINFERENCE_HEALTH_CHECK_INTERVAL,
 )
-from ..core import ModelActor
+from ..core.model import ModelActor
 from ..core.status_guard import LaunchStatus
 from ..device_utils import get_available_device_env_name, gpu_count
 from ..model.core import ModelDescription, create_model_instance


### PR DESCRIPTION
It seems not necessary to install ModelActor in xinference.core, 
using original path core.model.ModelActor instead.