### PR TITLE
BUG: Fix validation errors when define a custom baichuan-chat LLM model

### DIFF
--- a/xinference/model/llm/pytorch/baichuan.py
+++ b/xinference/model/llm/pytorch/baichuan.py
@@ -73,7 +73,8 @@ class BaichuanPytorchChatModel(PytorchChatModel):
     ) -> bool:
         if llm_spec.model_format != "pytorch":
             return False
-        if llm_family.model_name not in ["baichuan-chat", "baichuan-2-chat"]:
+        if all(baichuan_chat_name not in llm_family.model_name for baichuan_chat_name in
+               ["baichuan-chat", "baichuan-2-chat"]):
             return False
         if "chat" not in llm_family.model_ability:
             return False


### PR DESCRIPTION
注册基于baichuan-chat自定义模型时（model_famliy为baichuan-chat），inference在[做校验时](https://github.com/xorbitsai/inference/blob/f7e088dde46c641a0323e619954c385966af176f/xinference/model/llm/pytorch/baichuan.py#L76)，逻辑应该是反了？
