### PR TITLE
BUG: fix vl-model img path error

### DIFF
--- a/xinference/core/chat_interface.py
+++ b/xinference/core/chat_interface.py
@@ -217,7 +217,12 @@ class GradioInterface:
                     "role": "user",
                     "content": [
                         {"type": "text", "text": text},
-                        {"type": "image_url", "image_url": {"url": image}},
+                        {
+                            "type": "image_url",
+                            "image_url": {
+                                "url": f"data:image/png;base64,{img_b64_str}"
+                            },
+                        },
                     ],
                 }
             else:


### PR DESCRIPTION
<img width="1260" alt="image" src="https://github.com/xorbitsai/inference/assets/128140880/4a2916cf-4b3e-4b25-8793-ebe47afe5468">
<img width="1391" alt="image" src="https://github.com/xorbitsai/inference/assets/128140880/3a6f2d23-a0b0-4e09-8c6c-3244b55e22a4">

use base64 encoded images