### PR TITLE
FEAT: telechat model

### DIFF
--- a/doc/source/models/builtin/llm/index.rst
+++ b/doc/source/models/builtin/llm/index.rst
@@ -411,6 +411,11 @@ The following is a list of built-in LLM in Xinference:
      - 4096
      - We introduce Starling-7B, an open large language model (LLM) trained by Reinforcement Learning from AI Feedback (RLAIF). The model harnesses the power of our new GPT-4 labeled ranking dataset
 
+   * - :ref:`telechat <models_llm_telechat>`
+     - chat
+     - 8192
+     - The TeleChat is a large language model developed and trained by China Telecom Artificial Intelligence Technology Co., LTD. The 7B model base is trained with 1.5 trillion Tokens and 3 trillion Tokens and Chinese high-quality corpus.
+
    * - :ref:`tiny-llama <models_llm_tiny-llama>`
      - generate
      - 2048
@@ -663,6 +668,8 @@ The following is a list of built-in LLM in Xinference:
    starcoderplus
   
    starling-lm
+  
+   telechat
   
    tiny-llama
   

--- a/doc/source/models/builtin/llm/telechat.rst
+++ b/doc/source/models/builtin/llm/telechat.rst
@@ -1,0 +1,95 @@
+.. _models_llm_telechat:
+
+========================================
+telechat
+========================================
+
+- **Context Length:** 8192
+- **Model Name:** telechat
+- **Languages:** en, zh
+- **Abilities:** chat
+- **Description:** The TeleChat is a large language model developed and trained by China Telecom Artificial Intelligence Technology Co., LTD. The 7B model base is trained with 1.5 trillion Tokens and 3 trillion Tokens and Chinese high-quality corpus.
+
+Specifications
+^^^^^^^^^^^^^^
+
+
+Model Spec 1 (pytorch, 7 Billion)
+++++++++++++++++++++++++++++++++++++++++
+
+- **Model Format:** pytorch
+- **Model Size (in billions):** 7
+- **Quantizations:** 4-bit, 8-bit, none
+- **Engines**: Transformers
+- **Model ID:** Tele-AI/telechat-7B
+- **Model Hubs**:  `Hugging Face <https://huggingface.co/Tele-AI/telechat-7B>`__, `ModelScope <https://modelscope.cn/models/TeleAI/telechat-7B>`__
+
+Execute the following command to launch the model, remember to replace ``${quantization}`` with your
+chosen quantization method from the options listed above::
+
+   xinference launch --model-engine ${engine} --model-name telechat --size-in-billions 7 --model-format pytorch --quantization ${quantization}
+
+
+Model Spec 2 (gptq, 7 Billion)
+++++++++++++++++++++++++++++++++++++++++
+
+- **Model Format:** gptq
+- **Model Size (in billions):** 7
+- **Quantizations:** int4, int8
+- **Engines**: Transformers
+- **Model ID:** Tele-AI/telechat-7B-{quantization}
+- **Model Hubs**:  `Hugging Face <https://huggingface.co/Tele-AI/telechat-7B-{quantization}>`__, `ModelScope <https://modelscope.cn/models/TeleAI/telechat-7B-{quantization}>`__
+
+Execute the following command to launch the model, remember to replace ``${quantization}`` with your
+chosen quantization method from the options listed above::
+
+   xinference launch --model-engine ${engine} --model-name telechat --size-in-billions 7 --model-format gptq --quantization ${quantization}
+
+
+Model Spec 3 (pytorch, 12 Billion)
+++++++++++++++++++++++++++++++++++++++++
+
+- **Model Format:** pytorch
+- **Model Size (in billions):** 12
+- **Quantizations:** 4-bit, 8-bit, none
+- **Engines**: Transformers
+- **Model ID:** Tele-AI/TeleChat-12B
+- **Model Hubs**:  `Hugging Face <https://huggingface.co/Tele-AI/TeleChat-12B>`__, `ModelScope <https://modelscope.cn/models/Tele-AI/TeleChat-12B>`__
+
+Execute the following command to launch the model, remember to replace ``${quantization}`` with your
+chosen quantization method from the options listed above::
+
+   xinference launch --model-engine ${engine} --model-name telechat --size-in-billions 12 --model-format pytorch --quantization ${quantization}
+
+
+Model Spec 4 (gptq, 12 Billion)
+++++++++++++++++++++++++++++++++++++++++
+
+- **Model Format:** gptq
+- **Model Size (in billions):** 12
+- **Quantizations:** int4, int8
+- **Engines**: Transformers
+- **Model ID:** Tele-AI/TeleChat-12B-{quantization}
+- **Model Hubs**:  `Hugging Face <https://huggingface.co/Tele-AI/TeleChat-12B-{quantization}>`__, `ModelScope <https://modelscope.cn/models/Tele-AI/TeleChat-12B-{quantization}>`__
+
+Execute the following command to launch the model, remember to replace ``${quantization}`` with your
+chosen quantization method from the options listed above::
+
+   xinference launch --model-engine ${engine} --model-name telechat --size-in-billions 12 --model-format gptq --quantization ${quantization}
+
+
+Model Spec 5 (pytorch, 52 Billion)
+++++++++++++++++++++++++++++++++++++++++
+
+- **Model Format:** pytorch
+- **Model Size (in billions):** 52
+- **Quantizations:** 4-bit, 8-bit, none
+- **Engines**: Transformers
+- **Model ID:** Tele-AI/TeleChat-52B
+- **Model Hubs**:  `Hugging Face <https://huggingface.co/Tele-AI/TeleChat-52B>`__, `ModelScope <https://modelscope.cn/models/Tele-AI/TeleChat-52B>`__
+
+Execute the following command to launch the model, remember to replace ``${quantization}`` with your
+chosen quantization method from the options listed above::
+
+   xinference launch --model-engine ${engine} --model-name telechat --size-in-billions 52 --model-format pytorch --quantization ${quantization}
+

--- a/xinference/model/llm/llm_family.json
+++ b/xinference/model/llm/llm_family.json
@@ -6205,31 +6205,31 @@
     "model_description": "InternVL 1.5 is an open-source multimodal large language model (MLLM) to bridge the capability gap between open-source and proprietary commercial models in multimodal understanding. ",
     "model_specs": [
       {
-            "model_format": "pytorch",
-            "model_size_in_billions": 2,
-            "quantizations": [
-                "none"
-            ],
-            "model_id": "OpenGVLab/Mini-InternVL-Chat-2B-V1-5",
-            "model_revision": "ce3f67acff17281bacbf4b156f402a0580fb9605"
+          "model_format": "pytorch",
+          "model_size_in_billions": 2,
+          "quantizations": [
+              "none"
+          ],
+          "model_id": "OpenGVLab/Mini-InternVL-Chat-2B-V1-5",
+          "model_revision": "ce3f67acff17281bacbf4b156f402a0580fb9605"
         },
         {
-            "model_format": "pytorch",
-            "model_size_in_billions": 26,
-            "quantizations": [
-                "none"
-            ],
-            "model_id": "OpenGVLab/InternVL-Chat-V1-5",
-            "model_revision": "e822119e5806946ce128043023a73d715ecabf8d"
+          "model_format": "pytorch",
+          "model_size_in_billions": 26,
+          "quantizations": [
+              "none"
+          ],
+          "model_id": "OpenGVLab/InternVL-Chat-V1-5",
+          "model_revision": "e822119e5806946ce128043023a73d715ecabf8d"
         },
         {
-            "model_format": "pytorch",
-            "model_size_in_billions": 26,
-            "quantizations": [
-                "Int8"
-            ],
-            "model_id": "OpenGVLab/InternVL-Chat-V1-5-{quantization}",
-            "model_revision": "acaaed06937c603ab04f084216ecb0268160f538"
+          "model_format": "pytorch",
+          "model_size_in_billions": 26,
+          "quantizations": [
+              "Int8"
+          ],
+          "model_id": "OpenGVLab/InternVL-Chat-V1-5-{quantization}",
+          "model_revision": "acaaed06937c603ab04f084216ecb0268160f538"
         }
     ],
     "prompt_style": {
@@ -6247,7 +6247,7 @@
             "<|im_end|>"
         ]
     }
-},
+  },
   {
     "version": 1,
     "context_length": 8192,
@@ -6262,24 +6262,24 @@
     ],
     "model_description": "CogVLM2 have achieved good results in many lists compared to the previous generation of CogVLM open source models. Its excellent performance can compete with some non-open source models.",
     "model_specs": [
-        {
-            "model_format": "pytorch",
-            "model_size_in_billions": 20,
-            "quantizations": [
-                "none"
-            ],
-            "model_id": "THUDM/cogvlm2-llama3-chinese-chat-19B",
-            "model_revision": "d88b352bce5ee58a289b1ac8328553eb31efa2ef"
-        },
       {
-            "model_format": "pytorch",
-            "model_size_in_billions": 20,
-            "quantizations": [
-                "int4"
-            ],
-            "model_id": "THUDM/cogvlm2-llama3-chinese-chat-19B-{quantizations}",
-            "model_revision": "7863e362174f4718c2fe9cba4befd0b580a3194f"
-        }
+        "model_format": "pytorch",
+        "model_size_in_billions": 20,
+        "quantizations": [
+          "none"
+        ],
+        "model_id": "THUDM/cogvlm2-llama3-chinese-chat-19B",
+        "model_revision": "d88b352bce5ee58a289b1ac8328553eb31efa2ef"
+      },
+      {
+        "model_format": "pytorch",
+        "model_size_in_billions": 20,
+        "quantizations": [
+          "int4"
+        ],
+        "model_id": "THUDM/cogvlm2-llama3-chinese-chat-19B-{quantizations}",
+        "model_revision": "7863e362174f4718c2fe9cba4befd0b580a3194f"
+      }
     ],
     "prompt_style": {
       "style_name": "LLAMA3",
@@ -6299,8 +6299,8 @@
         "<|eot_id|>"
       ]
     }
-},
-    {
+  },
+  {
     "version": 1,
     "context_length": 8192,
     "model_name": "telechat",

--- a/xinference/model/llm/llm_family.json
+++ b/xinference/model/llm/llm_family.json
@@ -6299,5 +6299,86 @@
         "<|eot_id|>"
       ]
     }
-}
+},
+    {
+    "version": 1,
+    "context_length": 8192,
+    "model_name": "telechat",
+    "model_lang": [
+      "en",
+      "zh"
+    ],
+    "model_ability": [
+      "chat"
+    ],
+    "model_description": "The TeleChat is a large language model developed and trained by China Telecom Artificial Intelligence Technology Co., LTD. The 7B model base is trained with 1.5 trillion Tokens and 3 trillion Tokens and Chinese high-quality corpus.",
+    "model_specs": [
+      {
+        "model_format": "pytorch",
+        "model_size_in_billions": 7,
+        "quantizations": [
+          "4-bit",
+          "8-bit",
+          "none"
+        ],
+        "model_id": "Tele-AI/telechat-7B"
+      },
+      {
+        "model_format": "gptq",
+        "model_size_in_billions": 7,
+        "quantizations": [
+          "int4",
+          "int8"
+        ],
+        "model_id": "Tele-AI/telechat-7B-{quantization}"
+      },
+      {
+        "model_format": "pytorch",
+        "model_size_in_billions": 12,
+        "quantizations": [
+          "4-bit",
+          "8-bit",
+          "none"
+        ],
+        "model_id": "Tele-AI/TeleChat-12B"
+      },
+      {
+        "model_format": "gptq",
+        "model_size_in_billions": 12,
+        "quantizations": [
+          "int4",
+          "int8"
+        ],
+        "model_id": "Tele-AI/TeleChat-12B-{quantization}"
+      },
+      {
+        "model_format": "pytorch",
+        "model_size_in_billions": 52,
+        "quantizations": [
+          "4-bit",
+          "8-bit",
+          "none"
+        ],
+        "model_id": "Tele-AI/TeleChat-52B"
+      }
+    ],
+    "prompt_style": {
+      "style_name": "NO_COLON_TWO",
+      "system_prompt": "You are a helpful assistant.",
+      "roles": [
+        "<_user>",
+        "<_bot>"
+      ],
+      "intra_message_sep": "",
+      "inter_message_sep": "",
+      "stop": [
+        "<_end>",
+        "<_start>"
+      ],
+      "stop_token_ids": [
+        160133,
+        160132
+      ]
+    }
+  }
 ]

--- a/xinference/model/llm/llm_family_modelscope.json
+++ b/xinference/model/llm/llm_family_modelscope.json
@@ -3959,7 +3959,7 @@
           "8-bit",
           "none"
         ],
-        "model_id": "Tele-AI/TeleChat-12B",
+        "model_id": "TeleAI/TeleChat-12B",
         "model_hub": "modelscope",
         "model_revision": "master"
       },
@@ -3970,7 +3970,7 @@
           "int4",
           "int8"
         ],
-        "model_id": "Tele-AI/TeleChat-12B-{quantization}",
+        "model_id": "TeleAI/TeleChat-12B-{quantization}",
         "model_hub": "modelscope",
         "model_revision": "master"
       },
@@ -3982,7 +3982,7 @@
           "8-bit",
           "none"
         ],
-        "model_id": "Tele-AI/TeleChat-52B",
+        "model_id": "TeleAI/TeleChat-52B",
         "model_hub": "modelscope",
         "model_revision": "master"
       }

--- a/xinference/model/llm/llm_family_modelscope.json
+++ b/xinference/model/llm/llm_family_modelscope.json
@@ -3875,27 +3875,26 @@
     ],
     "model_description": "CogVLM2 have achieved good results in many lists compared to the previous generation of CogVLM open source models. Its excellent performance can compete with some non-open source models.",
     "model_specs": [
-        {
-            "model_format": "pytorch",
-            "model_size_in_billions": 20,
-            "quantizations": [
-                "none"
-            ],
-          "model_hub": "modelscope",
-
-            "model_id": "ZhipuAI/cogvlm2-llama3-chinese-chat-19B",
-            "model_revision": "master"
-        },
       {
-            "model_format": "pytorch",
-            "model_size_in_billions": 20,
-            "quantizations": [
-                "int4"
-            ],
-          "model_hub": "modelscope",
-            "model_id": "ZhipuAI/cogvlm2-llama3-chinese-chat-19B-{quantization}",
-            "model_revision": "master"
-        }
+        "model_format": "pytorch",
+        "model_size_in_billions": 20,
+        "quantizations": [
+          "none"
+        ],
+        "model_hub": "modelscope",
+        "model_id": "ZhipuAI/cogvlm2-llama3-chinese-chat-19B",
+        "model_revision": "master"
+      },
+      {
+        "model_format": "pytorch",
+        "model_size_in_billions": 20,
+        "quantizations": [
+          "int4"
+        ],
+        "model_hub": "modelscope",
+        "model_id": "ZhipuAI/cogvlm2-llama3-chinese-chat-19B-{quantization}",
+        "model_revision": "master"
+      }
     ],
     "prompt_style": {
       "style_name": "LLAMA3",
@@ -3915,7 +3914,8 @@
         "<|eot_id|>"
       ]
     }
-},{
+  },
+  {
     "version": 1,
     "context_length": 8192,
     "model_name": "telechat",
@@ -3936,7 +3936,9 @@
           "8-bit",
           "none"
         ],
-        "model_id": "Tele-AI/telechat-7B"
+        "model_id": "TeleAI/telechat-7B",
+        "model_hub": "modelscope",
+        "model_revision": "master"
       },
       {
         "model_format": "gptq",
@@ -3945,7 +3947,9 @@
           "int4",
           "int8"
         ],
-        "model_id": "Tele-AI/telechat-7B-{quantization}"
+        "model_id": "TeleAI/telechat-7B-{quantization}",
+        "model_hub": "modelscope",
+        "model_revision": "master"
       },
       {
         "model_format": "pytorch",
@@ -3955,7 +3959,9 @@
           "8-bit",
           "none"
         ],
-        "model_id": "Tele-AI/TeleChat-12B"
+        "model_id": "Tele-AI/TeleChat-12B",
+        "model_hub": "modelscope",
+        "model_revision": "master"
       },
       {
         "model_format": "gptq",
@@ -3964,7 +3970,9 @@
           "int4",
           "int8"
         ],
-        "model_id": "Tele-AI/TeleChat-12B-{quantization}"
+        "model_id": "Tele-AI/TeleChat-12B-{quantization}",
+        "model_hub": "modelscope",
+        "model_revision": "master"
       },
       {
         "model_format": "pytorch",
@@ -3974,7 +3982,9 @@
           "8-bit",
           "none"
         ],
-        "model_id": "Tele-AI/TeleChat-52B"
+        "model_id": "Tele-AI/TeleChat-52B",
+        "model_hub": "modelscope",
+        "model_revision": "master"
       }
     ],
     "prompt_style": {

--- a/xinference/model/llm/llm_family_modelscope.json
+++ b/xinference/model/llm/llm_family_modelscope.json
@@ -3915,5 +3915,85 @@
         "<|eot_id|>"
       ]
     }
-}
+},{
+    "version": 1,
+    "context_length": 8192,
+    "model_name": "telechat",
+    "model_lang": [
+      "en",
+      "zh"
+    ],
+    "model_ability": [
+      "chat"
+    ],
+    "model_description": "The TeleChat is a large language model developed and trained by China Telecom Artificial Intelligence Technology Co., LTD. The 7B model base is trained with 1.5 trillion Tokens and 3 trillion Tokens and Chinese high-quality corpus.",
+    "model_specs": [
+      {
+        "model_format": "pytorch",
+        "model_size_in_billions": 7,
+        "quantizations": [
+          "4-bit",
+          "8-bit",
+          "none"
+        ],
+        "model_id": "Tele-AI/telechat-7B"
+      },
+      {
+        "model_format": "gptq",
+        "model_size_in_billions": 7,
+        "quantizations": [
+          "int4",
+          "int8"
+        ],
+        "model_id": "Tele-AI/telechat-7B-{quantization}"
+      },
+      {
+        "model_format": "pytorch",
+        "model_size_in_billions": 12,
+        "quantizations": [
+          "4-bit",
+          "8-bit",
+          "none"
+        ],
+        "model_id": "Tele-AI/TeleChat-12B"
+      },
+      {
+        "model_format": "gptq",
+        "model_size_in_billions": 12,
+        "quantizations": [
+          "int4",
+          "int8"
+        ],
+        "model_id": "Tele-AI/TeleChat-12B-{quantization}"
+      },
+      {
+        "model_format": "pytorch",
+        "model_size_in_billions": 52,
+        "quantizations": [
+          "4-bit",
+          "8-bit",
+          "none"
+        ],
+        "model_id": "Tele-AI/TeleChat-52B"
+      }
+    ],
+    "prompt_style": {
+      "style_name": "NO_COLON_TWO",
+      "system_prompt": "You are a helpful assistant.",
+      "roles": [
+        "<_user>",
+        "<_bot>"
+      ],
+      "intra_message_sep": "",
+      "inter_message_sep": "",
+      "stop": [
+        "<_end>",
+        "<_start>"
+      ],
+      "stop_token_ids": [
+        160133,
+        160132
+      ]
+    }
+  }
 ]


### PR DESCRIPTION
新增中国电信Telecaht大模型，参数量为7B，12B，52B。
其中包含7B和12B的gptq量化模型，int4和int8。