### PR TITLE
FEAT: Add Rerank model token input/output usage

### DIFF
--- a/xinference/api/restful_api.py
+++ b/xinference/api/restful_api.py
@@ -109,6 +109,7 @@ class RerankRequest(BaseModel):
     documents: List[str]
     top_n: Optional[int] = None
     return_documents: Optional[bool] = False
+    return_len: Optional[bool] = False
     max_chunks_per_doc: Optional[int] = None
 
 
@@ -1112,6 +1113,7 @@ class RESTfulAPI:
                 top_n=body.top_n,
                 max_chunks_per_doc=body.max_chunks_per_doc,
                 return_documents=body.return_documents,
+                return_len=body.return_len,
                 **kwargs,
             )
             return Response(scores, media_type="application/json")

--- a/xinference/client/restful/restful_client.py
+++ b/xinference/client/restful/restful_client.py
@@ -135,6 +135,7 @@ class RESTfulRerankModelHandle(RESTfulModelHandle):
         top_n: Optional[int] = None,
         max_chunks_per_doc: Optional[int] = None,
         return_documents: Optional[bool] = None,
+        return_len: Optional[bool] = None,
         **kwargs,
     ):
         """
@@ -152,6 +153,8 @@ class RESTfulRerankModelHandle(RESTfulModelHandle):
             The maximum number of chunks derived from a document
         return_documents: bool
             if return documents
+        return_len: bool
+            if return tokens len
         Returns
         -------
         Scores
@@ -170,6 +173,7 @@ class RESTfulRerankModelHandle(RESTfulModelHandle):
             "top_n": top_n,
             "max_chunks_per_doc": max_chunks_per_doc,
             "return_documents": return_documents,
+            "return_len": return_len,
         }
         request_body.update(kwargs)
         response = requests.post(url, json=request_body, headers=self.auth_headers)

--- a/xinference/core/model.py
+++ b/xinference/core/model.py
@@ -540,6 +540,7 @@ class ModelActor(xo.StatelessActor):
         top_n: Optional[int],
         max_chunks_per_doc: Optional[int],
         return_documents: Optional[bool],
+        return_len: Optional[bool],
         *args,
         **kwargs,
     ):
@@ -551,6 +552,7 @@ class ModelActor(xo.StatelessActor):
                 top_n,
                 max_chunks_per_doc,
                 return_documents,
+                return_len,
                 *args,
                 **kwargs,
             )

--- a/xinference/model/rerank/tests/test_rerank.py
+++ b/xinference/model/rerank/tests/test_rerank.py
@@ -54,6 +54,12 @@ def test_restful_api(model_name, setup):
     assert scores["results"][0]["index"] == 0
     assert scores["results"][0]["document"] == corpus[0]
 
+    scores = model.rerank(corpus, query)
+    assert (
+        scores["meta"]["tokens"]["input_tokens"]
+        == scores["meta"]["tokens"]["output_tokens"]
+    )
+
     kwargs = {
         "invalid": "invalid",
     }

--- a/xinference/model/rerank/tests/test_rerank.py
+++ b/xinference/model/rerank/tests/test_rerank.py
@@ -60,6 +60,8 @@ def test_restful_api(model_name, setup):
         == scores["meta"]["tokens"]["output_tokens"]
     )
 
+    print(scores)
+
     kwargs = {
         "invalid": "invalid",
     }

--- a/xinference/model/rerank/tests/test_rerank.py
+++ b/xinference/model/rerank/tests/test_rerank.py
@@ -54,11 +54,16 @@ def test_restful_api(model_name, setup):
     assert scores["results"][0]["index"] == 0
     assert scores["results"][0]["document"] == corpus[0]
 
-    scores = model.rerank(corpus, query)
+    scores = model.rerank(corpus, query, return_len=True)
     assert (
         scores["meta"]["tokens"]["input_tokens"]
         == scores["meta"]["tokens"]["output_tokens"]
     )
+
+    print(scores)
+
+    scores = model.rerank(corpus, query)
+    assert scores["meta"]["tokens"] == None
 
     print(scores)
 

--- a/xinference/types.py
+++ b/xinference/types.py
@@ -80,9 +80,37 @@ class DocumentObj(TypedDict):
     document: Optional[Document]
 
 
+# Cohere API compatibility
+class ApiVersion(TypedDict):
+    version: str
+    is_deprecated: bool
+    is_experimental: bool
+
+
+# Cohere API compatibility
+class BilledUnit(TypedDict):
+    input_tokens: int
+    output_tokens: int
+    search_units: int
+    classifications: int
+
+
+class RerankTokens(TypedDict):
+    input_tokens: int
+    output_tokens: int
+
+
+class Meta(TypedDict):
+    api_version: Optional[ApiVersion]
+    billed_units: Optional[BilledUnit]
+    tokens: RerankTokens
+    warnings: Optional[List[str]]
+
+
 class Rerank(TypedDict):
     id: str
     results: List[DocumentObj]
+    meta: Meta
 
 
 class CompletionLogprobs(TypedDict):


### PR DESCRIPTION
Added Rerank model token input/output usage with Cohere API compatibility.
Example output:
```
{
  "id": "string",
  "results": [
    {
      "document": {
        "text": "string"
      },
      "index": 0,
      "relevance_score": 0
    }
  ],
  "meta": {
    "api_version": None,
    "billed_units": None,
    "tokens": {
      "input_tokens": 0,
      "output_tokens": 0
    },
    "warnings": None
  }
}
```