### PR TITLE
ENH: Continuous batching supports all the models with `transformers` backend

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -109,7 +109,7 @@ jobs:
             sudo rm -rf "/usr/local/share/boost"
             sudo rm -rf "$AGENT_TOOLSDIRECTORY"
           fi
-          pip install "llama-cpp-python>=0.2.23,!=0.2.58"
+          pip install "llama-cpp-python>=0.2.23,!=0.2.58" --extra-index-url https://abetlen.github.io/llama-cpp-python/whl/cpu
           pip install transformers
           pip install attrdict
           pip install "timm>=0.9.16"

--- a/xinference/api/restful_api.py
+++ b/xinference/api/restful_api.py
@@ -981,7 +981,8 @@ class RESTfulAPI:
         return JSONResponse(content=self._supervisor_address)
 
     async def create_completion(self, request: Request) -> Response:
-        body = CreateCompletionRequest.parse_obj(await request.json())
+        raw_body = await request.json()
+        body = CreateCompletionRequest.parse_obj(raw_body)
         exclude = {
             "prompt",
             "model",
@@ -991,6 +992,7 @@ class RESTfulAPI:
             "logit_bias_type",
             "user",
         }
+        raw_kwargs = {k: v for k, v in raw_body.items() if k not in exclude}
         kwargs = body.dict(exclude_unset=True, exclude=exclude)
 
         # TODO: Decide if this default value override is necessary #1061
@@ -1020,7 +1022,9 @@ class RESTfulAPI:
                 iterator = None
                 try:
                     try:
-                        iterator = await model.generate(body.prompt, kwargs)
+                        iterator = await model.generate(
+                            body.prompt, kwargs, raw_params=raw_kwargs
+                        )
                     except RuntimeError as re:
                         self.handle_request_limit_error(re)
                     async for item in iterator:
@@ -1040,7 +1044,7 @@ class RESTfulAPI:
             return EventSourceResponse(stream_results())
         else:
             try:
-                data = await model.generate(body.prompt, kwargs)
+                data = await model.generate(body.prompt, kwargs, raw_params=raw_kwargs)
                 return Response(data, media_type="application/json")
             except Exception as e:
                 logger.error(e, exc_info=True)
@@ -1341,7 +1345,8 @@ class RESTfulAPI:
             raise HTTPException(status_code=500, detail=str(e))
 
     async def create_chat_completion(self, request: Request) -> Response:
-        body = CreateChatCompletion.parse_obj(await request.json())
+        raw_body = await request.json()
+        body = CreateChatCompletion.parse_obj(raw_body)
         exclude = {
             "prompt",
             "model",
@@ -1351,6 +1356,7 @@ class RESTfulAPI:
             "logit_bias_type",
             "user",
         }
+        raw_kwargs = {k: v for k, v in raw_body.items() if k not in exclude}
         kwargs = body.dict(exclude_unset=True, exclude=exclude)
 
         # TODO: Decide if this default value override is necessary #1061
@@ -1469,10 +1475,16 @@ class RESTfulAPI:
                 try:
                     try:
                         if is_qwen:
-                            iterator = await model.chat(prompt, chat_history, kwargs)
+                            iterator = await model.chat(
+                                prompt, chat_history, kwargs, raw_params=raw_kwargs
+                            )
                         else:
                             iterator = await model.chat(
-                                prompt, system_prompt, chat_history, kwargs
+                                prompt,
+                                system_prompt,
+                                chat_history,
+                                kwargs,
+                                raw_params=raw_kwargs,
                             )
                     except RuntimeError as re:
                         await self._report_error_event(model_uid, str(re))
@@ -1502,9 +1514,17 @@ class RESTfulAPI:
         else:
             try:
                 if is_qwen:
-                    data = await model.chat(prompt, chat_history, kwargs)
+                    data = await model.chat(
+                        prompt, chat_history, kwargs, raw_params=raw_kwargs
+                    )
                 else:
-                    data = await model.chat(prompt, system_prompt, chat_history, kwargs)
+                    data = await model.chat(
+                        prompt,
+                        system_prompt,
+                        chat_history,
+                        kwargs,
+                        raw_params=raw_kwargs,
+                    )
                 return Response(content=data, media_type="application/json")
             except Exception as e:
                 logger.error(e, exc_info=True)

--- a/xinference/core/model.py
+++ b/xinference/core/model.py
@@ -400,6 +400,7 @@ class ModelActor(xo.StatelessActor):
                 prompt, "generate", *args, **kwargs
             )
         else:
+            kwargs.pop("raw_params", None)
             if hasattr(self._model, "generate"):
                 return await self._call_wrapper(
                     self._model.generate, prompt, *args, **kwargs
@@ -482,6 +483,7 @@ class ModelActor(xo.StatelessActor):
                     prompt, "chat", *args, **kwargs
                 )
             else:
+                kwargs.pop("raw_params", None)
                 if hasattr(self._model, "chat"):
                     response = await self._call_wrapper(
                         self._model.chat, prompt, *args, **kwargs

--- a/xinference/core/model.py
+++ b/xinference/core/model.py
@@ -264,13 +264,10 @@ class ModelActor(xo.StatelessActor):
         return isinstance(self._model, VLLMModel)
 
     def allow_batching(self) -> bool:
-        from ..model.llm.pytorch.core import PytorchChatModel, PytorchModel
+        from ..model.llm.pytorch.core import PytorchModel
 
-        return (
-            XINFERENCE_TRANSFORMERS_ENABLE_BATCHING
-            and isinstance(self._model, PytorchModel)
-            and self._model.__class__.__name__
-            in (PytorchChatModel.__name__, PytorchModel.__name__)
+        return XINFERENCE_TRANSFORMERS_ENABLE_BATCHING and isinstance(
+            self._model, PytorchModel
         )
 
     async def load(self):

--- a/xinference/core/model.py
+++ b/xinference/core/model.py
@@ -266,8 +266,12 @@ class ModelActor(xo.StatelessActor):
     def allow_batching(self) -> bool:
         from ..model.llm.pytorch.core import PytorchModel
 
-        return XINFERENCE_TRANSFORMERS_ENABLE_BATCHING and isinstance(
-            self._model, PytorchModel
+        model_ability = self._model_description.get("model_ability", [])
+
+        return (
+            XINFERENCE_TRANSFORMERS_ENABLE_BATCHING
+            and isinstance(self._model, PytorchModel)
+            and "vision" not in model_ability
         )
 
     async def load(self):

--- a/xinference/core/scheduler.py
+++ b/xinference/core/scheduler.py
@@ -67,6 +67,8 @@ class InferenceRequest:
         self._sanitized_generate_config = None
         # Chunk id for results. In stream mode, all the chunk ids should be same.
         self._stream_chunk_id = str(uuid.uuid4())
+        # For calculate attention mask if needed
+        self.padding_len = 0
         # Use in stream mode
         self.last_output_length = 0
         # inference results,

--- a/xinference/core/scheduler.py
+++ b/xinference/core/scheduler.py
@@ -18,7 +18,7 @@ import logging
 import uuid
 from collections import deque
 from enum import Enum
-from typing import List, Optional, Set
+from typing import List, Optional, Set, Tuple
 
 import xoscar as xo
 
@@ -53,7 +53,8 @@ class InferenceRequest:
         self._kv_cache = None
         # use passed args from upstream interface
         self._inference_args = args
-        # use passed kwargs from upstream interface, basically not used for now
+        # use passed kwargs from upstream interface, currently for getting raw generate config from upstream,
+        # which is useful for some special models
         self._inference_kwargs = kwargs
         # should this request be stopped
         self._stopped = False
@@ -173,6 +174,10 @@ class InferenceRequest:
         self._sanitized_generate_config = value
 
     @property
+    def inference_kwargs(self):
+        return self._inference_kwargs
+
+    @property
     def stopped(self):
         return self._stopped
 
@@ -231,7 +236,9 @@ class InferenceRequest:
         )
 
     @functools.lru_cache
-    def get_generate_configs(self, eos_token_id: int):
+    def get_generate_configs(
+        self, eos_token_id: int, builtin_stop_token_ids: Optional[Tuple[int]] = None
+    ):
         from ..types import max_tokens_field
 
         max_new_tokens = int(
@@ -245,6 +252,7 @@ class InferenceRequest:
         )
         stop_token_ids = set(stop_token_ids)
         stop_token_ids.add(eos_token_id)
+        stop_token_ids.update(builtin_stop_token_ids or [])
         temperature = float(self.sanitized_generate_config.get("temperature", 1.0))
         repetition_penalty = float(
             self.sanitized_generate_config.get("repetition_penalty", 1.0)

--- a/xinference/core/tests/test_continuous_batching.py
+++ b/xinference/core/tests/test_continuous_batching.py
@@ -114,6 +114,8 @@ class AbortThread(BaseThread):
 @pytest.fixture
 def enable_batch():
     os.environ["XINFERENCE_TRANSFORMERS_ENABLE_BATCHING"] = "1"
+    yield
+    os.environ["XINFERENCE_TRANSFORMERS_ENABLE_BATCHING"] = "0"
 
 
 @pytest.mark.skipif(

--- a/xinference/deploy/docker/cpu.Dockerfile
+++ b/xinference/deploy/docker/cpu.Dockerfile
@@ -63,7 +63,7 @@ RUN python -m pip install --upgrade -i "$PIP_INDEX" pip && \
       timm \
       opencv-contrib-python-headless && \
     pip install -i "$PIP_INDEX" -U chatglm-cpp && \
-    pip install -i "$PIP_INDEX" "llama-cpp-python>=0.2.25,!=0.2.58" && \
+    pip install "llama-cpp-python>=0.2.25,!=0.2.58" --extra-index-url https://abetlen.github.io/llama-cpp-python/whl/cpu && \
     cd /opt/inference && \
     python setup.py build_web && \
     git restore . && \

--- a/xinference/model/llm/llm_family.json
+++ b/xinference/model/llm/llm_family.json
@@ -5677,9 +5677,11 @@
       ],
       "intra_message_sep": "<|im_end|>",
       "stop_token_ids": [
+        2,
         92542
       ],
       "stop": [
+        "</s>",
         "<|im_end|>"
       ]
     }

--- a/xinference/model/llm/llm_family_modelscope.json
+++ b/xinference/model/llm/llm_family_modelscope.json
@@ -3352,9 +3352,11 @@
       ],
       "intra_message_sep": "<|im_end|>",
       "stop_token_ids": [
+        2,
         92542
       ],
       "stop": [
+        "</s>",
         "<|im_end|>"
       ]
     }

--- a/xinference/model/llm/pytorch/chatglm.py
+++ b/xinference/model/llm/pytorch/chatglm.py
@@ -15,6 +15,7 @@ import time
 import uuid
 from typing import Any, Dict, Iterator, List, Optional, Union
 
+from ....core.scheduler import InferenceRequest
 from ....types import (
     SPECIAL_TOOL_PROMPT,
     ChatCompletion,
@@ -244,3 +245,25 @@ class ChatglmPytorchChatModel(PytorchChatModel):
                         prompt_tokens=-1, completion_tokens=-1, total_tokens=-1
                     ),
                 )
+
+    @staticmethod
+    def require_attention_mask():
+        """
+        GLM4 needs to use attention mask and position ids during inference.
+        Otherwise, the inference result would be not available.
+        """
+        return True
+
+    def prepare_sanitize_generate_config(self, req: InferenceRequest):
+        """
+        Set temperature and top_p to 0.8 by default
+        """
+        raw_config = req.inference_kwargs.get("raw_params", {})
+        temperature = raw_config.get("temperature", None)
+        if temperature is None:
+            raw_config["temperature"] = 0.8
+        top_p = raw_config.get("top_p", None)
+        if top_p is None:
+            raw_config["top_p"] = 0.8
+
+        return raw_config

--- a/xinference/model/llm/pytorch/core.py
+++ b/xinference/model/llm/pytorch/core.py
@@ -343,6 +343,10 @@ class PytorchModel(LLM):
         else:
             return generator_wrapper(prompt, generate_config)
 
+    @staticmethod
+    def require_attention_mask():
+        return False
+
     @lru_cache
     def get_context_len(self):
         return get_context_length(self._model.config)
@@ -434,6 +438,7 @@ class PytorchModel(LLM):
             self._device,
             context_len,
             self._get_builtin_stop_token_ids(),
+            require_attention_mask=self.require_attention_mask(),
         )
         self.handle_batch_inference_results(req_list)
 

--- a/xinference/model/llm/pytorch/core.py
+++ b/xinference/model/llm/pytorch/core.py
@@ -283,35 +283,21 @@ class PytorchModel(LLM):
     def generate(
         self, prompt: str, generate_config: Optional[PytorchGenerateConfig] = None
     ) -> Union[Completion, Iterator[CompletionChunk]]:
-        from .utils import generate_stream, generate_stream_falcon
-
-        model_family_name = self.model_family.model_name.lower()
+        from .utils import generate_stream
 
         def generator_wrapper(
             prompt: str, generate_config: PytorchGenerateConfig
         ) -> Iterator[CompletionChunk]:
-            if "falcon" in model_family_name:
-                for completion_chunk, completion_usage in generate_stream_falcon(
-                    self.model_uid,
-                    self._model,
-                    self._tokenizer,
-                    prompt,
-                    self._device,
-                    generate_config,
-                ):
-                    completion_chunk["usage"] = completion_usage
-                    yield completion_chunk
-            else:
-                for completion_chunk, completion_usage in generate_stream(
-                    self.model_uid,
-                    self._model,
-                    self._tokenizer,
-                    prompt,
-                    self._device,
-                    generate_config,
-                ):
-                    completion_chunk["usage"] = completion_usage
-                    yield completion_chunk
+            for completion_chunk, completion_usage in generate_stream(
+                self.model_uid,
+                self._model,
+                self._tokenizer,
+                prompt,
+                self._device,
+                generate_config,
+            ):
+                completion_chunk["usage"] = completion_usage
+                yield completion_chunk
 
         logger.debug(
             "Enter generate, prompt: %s, generate config: %s", prompt, generate_config
@@ -336,26 +322,15 @@ class PytorchModel(LLM):
 
         stream = generate_config.get("stream", False)
         if not stream:
-            if "falcon" in model_family_name:
-                for completion_chunk, completion_usage in generate_stream_falcon(
-                    self.model_uid,
-                    self._model,
-                    self._tokenizer,
-                    prompt,
-                    self._device,
-                    generate_config,
-                ):
-                    pass
-            else:
-                for completion_chunk, completion_usage in generate_stream(
-                    self.model_uid,
-                    self._model,
-                    self._tokenizer,
-                    prompt,
-                    self._device,
-                    generate_config,
-                ):
-                    pass
+            for completion_chunk, completion_usage in generate_stream(
+                self.model_uid,
+                self._model,
+                self._tokenizer,
+                prompt,
+                self._device,
+                generate_config,
+            ):
+                pass
             completion = Completion(
                 id=completion_chunk["id"],
                 object=completion_chunk["object"],

--- a/xinference/model/llm/pytorch/core.py
+++ b/xinference/model/llm/pytorch/core.py
@@ -381,7 +381,7 @@ class PytorchModel(LLM):
                     r.error_msg = "Invalid `stop` field type"
                     continue
 
-    def _get_builtin_stop_token_ids(self) -> Tuple[int]:
+    def _get_builtin_stop_token_ids(self) -> Tuple:
         return (
             tuple(self.model_family.prompt_style.stop_token_ids)
             if self.model_family.prompt_style

--- a/xinference/model/llm/pytorch/internlm2.py
+++ b/xinference/model/llm/pytorch/internlm2.py
@@ -15,6 +15,7 @@ import time
 import uuid
 from typing import Any, Dict, Iterator, List, Optional, Union
 
+from ....core.scheduler import InferenceRequest
 from ....types import (
     ChatCompletion,
     ChatCompletionChoice,
@@ -87,6 +88,20 @@ class Internlm2PytorchChatModel(PytorchChatModel):
         if "chat" not in llm_family.model_ability:
             return False
         return True
+
+    def prepare_sanitize_generate_config(self, req: InferenceRequest):
+        """
+        Overwrite this func for this special model.
+        Cannot use the default configuration, which works poorly on this model.
+        """
+        raw_config = req.inference_kwargs.get("raw_params", {})
+        temperature = raw_config.get("temperature", None)
+        if temperature is None:
+            raw_config["temperature"] = 0.8
+        top_p = raw_config.get("top_p", None)
+        if top_p is None:
+            raw_config["top_p"] = 0.8
+        return raw_config
 
     def chat(
         self,

--- a/xinference/model/llm/pytorch/utils.py
+++ b/xinference/model/llm/pytorch/utils.py
@@ -515,8 +515,11 @@ def _get_attention_mask_and_position_ids(kv, reqs: List[InferenceRequest]):
         kv[0][0].shape[2],
         kv[0][0].device,
     )
+    seq_length = seq_length + 1
     position_ids = torch.as_tensor([[seq_length - 1]], dtype=torch.long, device=device)
-    attention_mask = torch.ones((batch_size, seq_length), dtype=torch.long)
+    attention_mask = torch.ones(
+        (batch_size, seq_length), dtype=torch.long, device=device
+    )
     padding_lens = torch.as_tensor([r.padding_len for r in reqs])
     mask = torch.arange(seq_length).expand(
         batch_size, seq_length

--- a/xinference/model/llm/pytorch/utils.py
+++ b/xinference/model/llm/pytorch/utils.py
@@ -610,17 +610,18 @@ def _batch_inference_one_step_internal(
     # here, only decode phase, just run some rounds
     for _i in range(decode_round):
         decode_tokens: List[List[int]] = [[r.new_tokens[-1]] for r in valid_req_list]
-        attention_mask, position_ids = (
-            _get_attention_mask_and_position_ids(past_key_values, valid_req_list)
-            if require_attention_mask
-            else (None, None)
-        )
+        inf_kws = {}
+        if require_attention_mask:
+            attention_mask, position_ids = _get_attention_mask_and_position_ids(
+                past_key_values, valid_req_list
+            )
+            inf_kws["position_ids"] = position_ids
+            inf_kws["attention_mask"] = attention_mask
         out = model(
             input_ids=torch.as_tensor(decode_tokens, device=device),
             use_cache=True,
             past_key_values=past_key_values,
-            position_ids=position_ids,
-            attention_mask=attention_mask,
+            **inf_kws,
         )
         logits = out.logits
         past_key_values = out.past_key_values

--- a/xinference/model/llm/pytorch/utils.py
+++ b/xinference/model/llm/pytorch/utils.py
@@ -689,6 +689,7 @@ def _batch_inference_one_step_internal(
     tokenizer,
     device,
     context_len: int,
+    stop_tokens: Tuple[int],
     decode_round: int = 16,
     bos_flag: str = "<bos_stream>",
     eos_flag: str = "<eos_stream>",
@@ -699,7 +700,8 @@ def _batch_inference_one_step_internal(
     if not valid_req_list:
         return
     generate_config_mapping: Dict[InferenceRequest, Tuple] = {
-        r: r.get_generate_configs(tokenizer.eos_token_id) for r in valid_req_list
+        r: r.get_generate_configs(tokenizer.eos_token_id, stop_tokens)
+        for r in valid_req_list
     }
     s_time = time.time()
 
@@ -903,12 +905,13 @@ def batch_inference_one_step(
     tokenizer,
     device,
     context_len: int,
+    stop_token_ids: Tuple[int],
 ):
     from ....core.model import OutOfMemoryError
 
     try:
         _batch_inference_one_step_internal(
-            req_list, model_uid, model, tokenizer, device, context_len
+            req_list, model_uid, model, tokenizer, device, context_len, stop_token_ids
         )
     except OutOfMemoryError:
         logger.exception(

--- a/xinference/model/llm/pytorch/utils.py
+++ b/xinference/model/llm/pytorch/utils.py
@@ -17,11 +17,9 @@ import logging
 import os
 import time
 import uuid
-from threading import Thread
 from typing import Dict, Iterable, Iterator, List, Optional, Tuple
 
 import torch
-from transformers import GenerationConfig, TextIteratorStreamer
 from transformers.cache_utils import DynamicCache
 from transformers.generation.logits_process import (
     LogitsProcessorList,
@@ -363,179 +361,6 @@ def generate_stream(
     empty_cache()
 
 
-@torch.inference_mode()
-def generate_stream_falcon(
-    model_uid,
-    model,
-    tokenizer,
-    prompt,
-    device,
-    generate_config,
-    judge_sent_end=False,
-) -> Iterator[Tuple[CompletionChunk, CompletionUsage]]:
-    context_len = get_context_length(model.config)
-    stream_interval = generate_config.get("stream_interval", 2)
-    stream = generate_config.get("stream", False)
-    stream_options = generate_config.pop("stream_options", None)
-    include_usage = (
-        stream_options["include_usage"] if isinstance(stream_options, dict) else False
-    )
-    len_prompt = len(prompt)
-
-    temperature = float(generate_config.get("temperature", 1.0))
-    repetition_penalty = float(generate_config.get("repetition_penalty", 1.0))
-    top_p = float(generate_config.get("top_p", 1.0))
-    top_k = int(generate_config.get("top_k", 50))  # -1 means disable
-    max_new_tokens = int(generate_config.get("max_tokens", max_tokens_field.default))
-    echo = bool(generate_config.get("echo", False))
-    stop_str = generate_config.get("stop", None)
-    stop_token_ids = generate_config.get("stop_token_ids", None) or []
-    stop_token_ids.append(tokenizer.eos_token_id)
-    chunk_id = str(uuid.uuid4())
-
-    inputs = tokenizer(prompt, return_tensors="pt").to(model.device)
-    input_ids = inputs["input_ids"]
-    attention_mask = inputs["attention_mask"]
-
-    max_src_len = context_len - max_new_tokens - 8
-
-    input_ids = input_ids[-max_src_len:]  # truncate from the left
-    attention_mask = attention_mask[-max_src_len:]  # truncate from the left
-    input_echo_len = len(input_ids)
-
-    decode_config = dict(skip_special_tokens=True, clean_up_tokenization_spaces=True)
-    streamer = TextIteratorStreamer(tokenizer, skip_prompt=True, **decode_config)
-
-    generation_config = GenerationConfig(
-        max_new_tokens=max_new_tokens,
-        do_sample=temperature >= 1e-5,
-        temperature=temperature,
-        repetition_penalty=repetition_penalty,
-        no_repeat_ngram_size=10,
-        top_p=top_p,
-        top_k=top_k,
-        eos_token_id=stop_token_ids,
-    )
-
-    generation_kwargs = dict(
-        inputs=input_ids,
-        attention_mask=attention_mask,
-        streamer=streamer,
-        generation_config=generation_config,
-    )
-
-    thread = Thread(target=model.generate, kwargs=generation_kwargs)
-    thread.start()
-
-    if echo:
-        # means keep the prompt
-        output = prompt
-    else:
-        output = ""
-
-    last_output_length = 0
-    for i, new_text in enumerate(streamer):
-        output += new_text
-        if i % stream_interval == 0:
-            if echo:
-                rfind_start = len_prompt
-            else:
-                rfind_start = 0
-
-            partially_stopped = False
-            if stop_str:
-                if isinstance(stop_str, str):
-                    pos = output.rfind(stop_str, rfind_start)
-                    if pos != -1:
-                        output = output[:pos]
-                    else:
-                        partially_stopped = is_partial_stop(output, stop_str)
-                elif isinstance(stop_str, Iterable):
-                    for each_stop in stop_str:
-                        pos = output.rfind(each_stop, rfind_start)
-                        if pos != -1:
-                            output = output[:pos]
-                            break
-                        else:
-                            partially_stopped = is_partial_stop(output, each_stop)
-                            if partially_stopped:
-                                break
-                else:
-                    raise ValueError("Invalid stop field type.")
-
-            if stream:
-                output = output.strip("�")
-                tmp_output_length = len(output)
-                output = output[last_output_length:]
-                last_output_length = tmp_output_length
-
-            # prevent yielding partial stop sequence
-            if not partially_stopped:
-                completion_choice = CompletionChoice(
-                    text=output, index=0, logprobs=None, finish_reason=None
-                )
-                completion_chunk = CompletionChunk(
-                    id=chunk_id,
-                    object="text_completion",
-                    created=int(time.time()),
-                    model=model_uid,
-                    choices=[completion_choice],
-                )
-                completion_usage = CompletionUsage(
-                    prompt_tokens=input_echo_len,
-                    completion_tokens=i,
-                    total_tokens=(input_echo_len + i),
-                )
-
-                yield completion_chunk, completion_usage
-    output = output.strip()
-
-    # finish stream event, which contains finish reason
-    if i == max_new_tokens - 1:
-        finish_reason = "length"
-    elif partially_stopped:
-        finish_reason = None
-    else:
-        finish_reason = "stop"
-
-    completion_choice = CompletionChoice(
-        text=output, index=0, logprobs=None, finish_reason=finish_reason
-    )
-    completion_chunk = CompletionChunk(
-        id=chunk_id,
-        object="text_completion",
-        created=int(time.time()),
-        model=model_uid,
-        choices=[completion_choice],
-    )
-    completion_usage = CompletionUsage(
-        prompt_tokens=input_echo_len,
-        completion_tokens=i,
-        total_tokens=(input_echo_len + i),
-    )
-
-    yield completion_chunk, completion_usage
-
-    if include_usage:
-        completion_chunk = CompletionChunk(
-            id=chunk_id,
-            object="text_completion",
-            created=int(time.time()),
-            model=model_uid,
-            choices=[],
-        )
-        completion_usage = CompletionUsage(
-            prompt_tokens=input_echo_len,
-            completion_tokens=i,
-            total_tokens=(input_echo_len + i),
-        )
-        yield completion_chunk, completion_usage
-
-    # clean
-    gc.collect()
-    empty_cache()
-
-
 def _get_token_from_logits(
     req: InferenceRequest, i: int, logits, temperature, repetition_penalty, top_p, top_k
 ):
@@ -562,6 +387,19 @@ def _get_token_from_logits(
         probs = torch.softmax(last_token_logits, dim=-1)
         indices = torch.multinomial(probs, num_samples=2)
     token = indices[0].int().item()
+
+    # next_token_logits = logits[i : i + 1, -1, :]
+    #
+    # # pre-process distribution
+    # input_ids = torch.as_tensor([req.prompt_tokens + req.new_tokens], device=logits.device)
+    # next_token_scores = logits_processor(input_ids, next_token_logits)
+    # # next_token_scores = logits_warper(input_ids, next_token_scores)
+    #
+    # # sample
+    # probs = torch.nn.functional.softmax(next_token_scores, dim=-1)
+    # next_tokens = torch.multinomial(probs, num_samples=1).squeeze(1)
+    # # print(next_tokens, next_tokens.shape)
+    # # raise ValueError("111")
     return token
 
 
@@ -694,6 +532,7 @@ def _batch_inference_one_step_internal(
     bos_flag: str = "<bos_stream>",
     eos_flag: str = "<eos_stream>",
 ):
+    print(f"=====Enter !!! {type(model), type(tokenizer)}")
     # need to judge stopped here,
     # since some requests state may change to stopped due to invalid parameters, e.g. max_src_len
     valid_req_list = [r for r in req_list if not r.stopped]
@@ -741,6 +580,9 @@ def _batch_inference_one_step_internal(
                 top_p,
                 top_k,
             ) = generate_config_mapping[r]
+            print(
+                f"========Config: {generate_config_mapping[r]}， prompt: {r.full_prompt}"
+            )
 
             token = _get_token_from_logits(
                 r, i, logits, temperature, repetition_penalty, top_p, top_k
@@ -791,6 +633,7 @@ def _batch_inference_one_step_internal(
             )
             r.kv_cache = past_key_values
             r.append_new_token(token)
+            print(f"========output token: {token}")
 
             output = None
             if not r.stopped:


### PR DESCRIPTION
Currently, three models are implemented separately for inference:
- internlm2-chat
- glm
- falcon

1. For falcon, after testing, there is no need to write a single function to handle its inference process. So I delete them.
2. For internlm2-chat, this model is sensitive to the inference parameters like `temperature`, `top_p`, `top_k`. We cannot set them by default if use does not pass these.
3. For glm4,  the inference process lacks the processing of `attention_mask` and `position_ids`, which are very important in glm4 inference. ~~However, glm4's batch inference seems to be problematical. See https://github.com/THUDM/GLM-4/issues/25~~
4. Currently, the `chatglm` series may have issues with duplicate outputs.