### PR TITLE
BUG: chat_completion not response while error appears more than 100

### DIFF
--- a/xinference/core/event.py
+++ b/xinference/core/event.py
@@ -60,7 +60,9 @@ class EventCollectorActor(xo.StatelessActor):
         if event_queue is None:
             return []
         else:
-            return [dict(e, event_type=e["event_type"].name) for e in event_queue._queue]
+            return [
+                dict(e, event_type=e["event_type"].name) for e in event_queue._queue
+            ]
 
     async def report_event(self, model_uid: str, event: Event):
         await self._model_uid_to_events[model_uid].put(event)

--- a/xinference/core/event.py
+++ b/xinference/core/event.py
@@ -49,9 +49,7 @@ class EventCollectorActor(xo.StatelessActor):
         if event_queue is None:
             return []
         else:
-            return [
-                dict(e, event_type=e["event_type"].name) for e in iter(event_queue)
-            ]
+            return [dict(e, event_type=e["event_type"].name) for e in iter(event_queue)]
 
     def report_event(self, model_uid: str, event: Event):
         self._model_uid_to_events[model_uid].append(event)

--- a/xinference/core/event.py
+++ b/xinference/core/event.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import asyncio
-import queue
 from collections import defaultdict
 from enum import Enum
 from typing import Dict, List, TypedDict

--- a/xinference/core/event.py
+++ b/xinference/core/event.py
@@ -61,7 +61,7 @@ class EventCollectorActor(xo.StatelessActor):
             return []
         else:
             return [
-                dict(e, event_type=e["event_type"].name) for e in event_queue._queue
+                dict(e, event_type=e["event_type"].name) for e in event_queue._queue  # type: ignore[attr-defined]
             ]
 
     async def report_event(self, model_uid: str, event: Event):

--- a/xinference/core/event.py
+++ b/xinference/core/event.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
 import queue
 from collections import defaultdict
 from enum import Enum
@@ -34,11 +35,21 @@ class Event(TypedDict):
     event_content: str
 
 
+class FIFOQueue(asyncio.Queue):
+    def __init__(self, maxsize=0):
+        super().__init__(maxsize)
+
+    async def put(self, item):
+        if self.full():
+            await self.get()  # 丢弃最旧的项目
+        await super().put(item)
+
+
 class EventCollectorActor(xo.StatelessActor):
     def __init__(self):
         super().__init__()
-        self._model_uid_to_events: Dict[str, queue.Queue] = defaultdict(  # type: ignore
-            lambda: queue.Queue(maxsize=MAX_EVENT_COUNT_PER_MODEL)
+        self._model_uid_to_events: Dict[str, asyncio.Queue] = defaultdict(  # type: ignore
+            lambda: FIFOQueue(maxsize=MAX_EVENT_COUNT_PER_MODEL)
         )
 
     @classmethod
@@ -50,7 +61,7 @@ class EventCollectorActor(xo.StatelessActor):
         if event_queue is None:
             return []
         else:
-            return [dict(e, event_type=e["event_type"].name) for e in event_queue.queue]
+            return [dict(e, event_type=e["event_type"].name) for e in event_queue._queue]
 
-    def report_event(self, model_uid: str, event: Event):
-        self._model_uid_to_events[model_uid].put(event)
+    async def report_event(self, model_uid: str, event: Event):
+        await self._model_uid_to_events[model_uid].put(event)


### PR DESCRIPTION
chat_completion not response while error appears more than 100 count

## how to replay
```bash
for i in {1..100}
do
  curl -i http://localhost:80/v1/chat/completions \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $OPENAI_API_KEY" \
    -d '{
      "model": "gpt-4",
	  "max_tokens": "8192",
      "messages": [
        {"role": "user", "content": "hello"}
      ]
    }'
done

# extra request would got blocked.
curl -i http://localhost:80/v1/chat/completions \
    -H "Content-Type: application/json" \
    -H "Authorization: Bearer $OPENAI_API_KEY" \
    -d '{
      "model": "gpt-4",
	  "max_tokens": "8192",
      "messages": [
        {"role": "user", "content": "hello"}
      ]
    }'
```
Note that model must not exists in xinference, and you can use `http://localhost:80/v1/models/gpt-4/events` to see error events.

Fixes #1424 .
