### PR TITLE
BUG: Set default values for the input and voice parameters in ChatTTSModel.speech

### DIFF
--- a/xinference/model/audio/chattts.py
+++ b/xinference/model/audio/chattts.py
@@ -48,7 +48,7 @@ class ChatTTSModel:
         self._model.load(source="custom", custom_path=self._model_path, compile=True)
 
     def speech(
-        self, input: str, voice: str, response_format: str = "mp3", speed: float = 1.0
+        self, input: str = "Hello world!", voice: str = "echo", response_format: str = "mp3", speed: float = 1.0
     ):
         import ChatTTS
         import numpy as np


### PR DESCRIPTION
To avoid `NoneType` errors, set default values for the `input` and `voice` parameters in the `speech` method of the `ChatTTSModel`.