### PR TITLE
BUG: [UI] Cannot get engine for custom models

### DIFF
--- a/xinference/web/ui/src/scenes/launch_model/modelCard.js
+++ b/xinference/web/ui/src/scenes/launch_model/modelCard.js
@@ -743,7 +743,7 @@ const ModelCard = ({
             if (arr.length) setIsHistory(true)
             setSelected(true)
             if (modelType === 'LLM') {
-              getModelEngine(modelData.model_name)
+              getModelEngine(modelData.model_family || modelData.model_name)
             } else {
               handleOtherHistory()
             }
@@ -1208,9 +1208,9 @@ const ModelCard = ({
                         const spec = specs.find((s) => {
                           return s.quantizations.includes(quant)
                         })
-                        const cached = Array.isArray(spec.cache_status)
+                        const cached = spec && Array.isArray(spec.cache_status)
                           ? spec.cache_status[spec.quantizations.indexOf(quant)]
-                          : spec.cache_status
+                          : spec ? spec.cache_status : false;
 
                         const displayedQuant = cached
                           ? quant + ' (cached)'

--- a/xinference/web/ui/src/scenes/launch_model/modelCard.js
+++ b/xinference/web/ui/src/scenes/launch_model/modelCard.js
@@ -1208,9 +1208,14 @@ const ModelCard = ({
                         const spec = specs.find((s) => {
                           return s.quantizations.includes(quant)
                         })
-                        const cached = spec && Array.isArray(spec.cache_status)
-                          ? spec.cache_status[spec.quantizations.indexOf(quant)]
-                          : spec ? spec.cache_status : false;
+                        const cached =
+                          spec && Array.isArray(spec.cache_status)
+                            ? spec.cache_status[
+                                spec.quantizations.indexOf(quant)
+                              ]
+                            : spec
+                            ? spec.cache_status
+                            : false
 
                         const displayedQuant = cached
                           ? quant + ' (cached)'


### PR DESCRIPTION
1、注册模型无法选择模型引擎问题解决方案
这是由于注册模型的名字不在model family中，搜索不到关联的 model engine 列表
现在优先根据model family查询 支持的model engine，若没有model family 再根据model name查询
2、切换model format 白屏问题解决方案
字段非空异常导致的白屏，增加异常判断