### PR TITLE
BUG: fix loading multiple gguf parts

### DIFF
--- a/xinference/model/llm/ggml/llamacpp.py
+++ b/xinference/model/llm/ggml/llamacpp.py
@@ -155,11 +155,13 @@ class LlamaCppModel(LLM):
             raise ImportError(f"{error_message}\n\n{''.join(installation_guide)}")
 
         # handle legacy cache.
-        model_path = os.path.join(
-            self.model_path,
-            self.model_spec.model_file_name_template.format(
-                quantization=self.quantization
-            ),
+        model_path = os.path.realpath(
+            os.path.join(
+                self.model_path,
+                self.model_spec.model_file_name_template.format(
+                    quantization=self.quantization
+                ),
+            )
         )
         legacy_model_file_path = os.path.join(self.model_path, "model.bin")
         if os.path.exists(legacy_model_file_path):

--- a/xinference/model/llm/llm_family.py
+++ b/xinference/model/llm/llm_family.py
@@ -699,12 +699,12 @@ def _generate_model_file_names(
 def _merge_cached_files(
     cache_dir: str, input_file_names: List[str], output_file_name: str
 ):
-    with open(os.path.join(cache_dir, output_file_name), "wb") as output_file:
-        for file_name in input_file_names:
-            logger.info(f"Merging file {file_name} into {output_file_name} ...")
-
-            with open(os.path.join(cache_dir, file_name), "rb") as input_file:
-                shutil.copyfileobj(input_file, output_file)
+    # now llama.cpp can find the gguf parts automatically
+    # we only need to provide the first part
+    # thus we create the symlink to the first part
+    symlink_local_file(
+        os.path.join(cache_dir, input_file_names[0]), cache_dir, output_file_name
+    )
 
     logger.info(f"Merge complete.")
 


### PR DESCRIPTION
#1075 introduced multiple gguf parts, in that PR, the gguf parts were merged into one file, but now llama.cpp will fail to load this file, instead, the llama.cpp could recognize the whole files with given the first part, thus, in this PR, we just symlink the gguf file to the first part, then when loading, we tell llama.cpp the realpath.

Fixes #1912 
