### PR TITLE
BUG: fix flexible model register in worker

### DIFF
--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -226,6 +226,7 @@ class WorkerActor(xo.StatelessActor):
         )
         from ..model.flexible import (
             FlexibleModelSpec,
+            generate_flexible_model_description,
             get_flexible_model_descriptions,
             register_flexible_model,
             unregister_flexible_model,
@@ -287,6 +288,7 @@ class WorkerActor(xo.StatelessActor):
                 FlexibleModelSpec,
                 register_flexible_model,
                 unregister_flexible_model,
+                generate_flexible_model_description,
             ),
         }
 


### PR DESCRIPTION
Bug trigger only on non-local mode:

call `register_model(model_type=flexible)` on worker will raise Exception

    File "/opt/inference/xinference/core/worker.py", line 573, in register_model
    ValueError: [address=XXXX pid=7] not enough values to unpack (expected 4, got 3)

introduced from
```
commit 9bb548a6d98a7bf145cdbff76ae032aa9ccf9db1
Author: Wang Shenggong [wangshenggong@gmail.com](mailto:wangshenggong@gmail.com)
Date:   Fri Jul 12 11:43:08 2024 +0800

    FEAT: Add support for Flexible Model (#1671)
```