### PR TITLE
BUG: fix asyncio.Queue error in benchmark

### DIFF
--- a/benchmark/benchmark_runner.py
+++ b/benchmark/benchmark_runner.py
@@ -231,7 +231,7 @@ class BenchmarkRunner:
             p99_itl = np.percentile(itls, 99) * 1000 if itls else 0
 
             # Print benchmark results
-            print("{s:{c}^{n}}".format(s=" Serving Benchmark Result ", n=50, c="="))
+            print("{s:{c}^{n}}".format(s=" Benchmark Result ", n=50, c="="))
             print("{:<40} {:<10}".format("Successful requests:", completed))
             print("{:<40} {:<10.2f}".format("Benchmark duration (s):", total_time))
             print("{:<40} {:<10}".format("Total input tokens:", total_input))

--- a/benchmark/benchmark_serving.py
+++ b/benchmark/benchmark_serving.py
@@ -48,7 +48,7 @@ class ServingBenchmarkRunner(ConcurrentBenchmarkRunner):
             api_key,
         )
         self.request_rate = request_rate
-        self.queue = asyncio.Queue(len(input_requests))
+        self.queue = None  # delay the creation of the queue
 
     async def _run(self):
         tasks = []
@@ -59,6 +59,9 @@ class ServingBenchmarkRunner(ConcurrentBenchmarkRunner):
         await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
 
     async def warm_up(self, num_requests: int = 5):
+        if self.queue is None:
+            self.queue = asyncio.Queue(len(self.input_requests))
+
         logger.info(f"Enqueuing {len(self.input_requests)} requests.")
         for req in iter(self.input_requests):
             await self.queue.put(req)


### PR DESCRIPTION
- fix https://github.com/xorbitsai/inference/issues/2111
- Previously, `asyncio.Queue` was created in the `__init__` method rather than in the `run()` function. In lower versions of Python (e.g., 3.9), this could cause the queue to be attached to an incorrect event loop. 
- To address this issue, the creation of the queue has been moved to the warm_up method.
- Additionally, a minor error in a log message has been corrected.
