### PR TITLE
BUG: use `default_uid` to replace `uid` of actors which may override the xoscar actor's uid property

### DIFF
--- a/xinference/api/restful_api.py
+++ b/xinference/api/restful_api.py
@@ -199,7 +199,7 @@ class RESTfulAPI:
     async def _get_supervisor_ref(self) -> xo.ActorRefType[SupervisorActor]:
         if self._supervisor_ref is None:
             self._supervisor_ref = await xo.actor_ref(
-                address=self._supervisor_address, uid=SupervisorActor.uid()
+                address=self._supervisor_address, uid=SupervisorActor.default_uid()
             )
         return self._supervisor_ref
 

--- a/xinference/api/restful_api.py
+++ b/xinference/api/restful_api.py
@@ -206,7 +206,7 @@ class RESTfulAPI:
     async def _get_event_collector_ref(self) -> xo.ActorRefType[EventCollectorActor]:
         if self._event_collector_ref is None:
             self._event_collector_ref = await xo.actor_ref(
-                address=self._supervisor_address, uid=EventCollectorActor.uid()
+                address=self._supervisor_address, uid=EventCollectorActor.default_uid()
             )
         return self._event_collector_ref
 

--- a/xinference/conftest.py
+++ b/xinference/conftest.py
@@ -144,7 +144,7 @@ async def _start_test_cluster(
             address=f"test://{address}", logging_conf=logging_conf
         )
         await xo.create_actor(
-            SupervisorActor, address=address, uid=SupervisorActor.uid()
+            SupervisorActor, address=address, uid=SupervisorActor.default_uid()
         )
         await start_worker_components(
             address=address,

--- a/xinference/core/cache_tracker.py
+++ b/xinference/core/cache_tracker.py
@@ -25,7 +25,7 @@ class CacheTrackerActor(xo.Actor):
         self._model_name_to_version_info: Dict[str, List[Dict]] = {}  # type: ignore
 
     @classmethod
-    def uid(cls) -> str:
+    def default_uid(cls) -> str:
         return "cache_tracker"
 
     @staticmethod

--- a/xinference/core/event.py
+++ b/xinference/core/event.py
@@ -41,7 +41,7 @@ class EventCollectorActor(xo.StatelessActor):
         )
 
     @classmethod
-    def uid(cls) -> str:
+    def default_uid(cls) -> str:
         return "event_collector"
 
     def get_model_events(self, model_uid: str) -> List[Dict]:

--- a/xinference/core/model.py
+++ b/xinference/core/model.py
@@ -265,7 +265,7 @@ class ModelActor(xo.StatelessActor):
 
         if self._worker_ref is None:
             self._worker_ref = await xo.actor_ref(
-                address=self._worker_address, uid=WorkerActor.uid()
+                address=self._worker_address, uid=WorkerActor.default_uid()
             )
         return self._worker_ref
 

--- a/xinference/core/status_guard.py
+++ b/xinference/core/status_guard.py
@@ -51,7 +51,7 @@ class StatusGuardActor(xo.StatelessActor):
         self._model_uid_to_info: Dict[str, InstanceInfo] = {}  # type: ignore
 
     @classmethod
-    def uid(cls) -> str:
+    def default_uid(cls) -> str:
         return "status_guard"
 
     @staticmethod

--- a/xinference/core/supervisor.py
+++ b/xinference/core/supervisor.py
@@ -105,7 +105,7 @@ class SupervisorActor(xo.StatelessActor):
         self._lock = asyncio.Lock()
 
     @classmethod
-    def uid(cls) -> str:
+    def default_uid(cls) -> str:
         return "supervisor"
 
     def _get_worker_ref_by_ip(
@@ -1233,7 +1233,9 @@ class SupervisorActor(xo.StatelessActor):
             worker_address not in self._worker_address_to_worker
         ), f"Worker {worker_address} exists"
 
-        worker_ref = await xo.actor_ref(address=worker_address, uid=WorkerActor.uid())
+        worker_ref = await xo.actor_ref(
+            address=worker_address, uid=WorkerActor.default_uid()
+        )
         self._worker_address_to_worker[worker_address] = worker_ref
         logger.debug("Worker %s has been added successfully", worker_address)
 

--- a/xinference/core/supervisor.py
+++ b/xinference/core/supervisor.py
@@ -135,12 +135,12 @@ class SupervisorActor(xo.StatelessActor):
         self._status_guard_ref: xo.ActorRefType[  # type: ignore
             "StatusGuardActor"
         ] = await xo.create_actor(
-            StatusGuardActor, address=self.address, uid=StatusGuardActor.uid()
+            StatusGuardActor, address=self.address, uid=StatusGuardActor.default_uid()
         )
         self._cache_tracker_ref: xo.ActorRefType[  # type: ignore
             "CacheTrackerActor"
         ] = await xo.create_actor(
-            CacheTrackerActor, address=self.address, uid=CacheTrackerActor.uid()
+            CacheTrackerActor, address=self.address, uid=CacheTrackerActor.default_uid()
         )
 
         from .event import EventCollectorActor
@@ -148,7 +148,9 @@ class SupervisorActor(xo.StatelessActor):
         self._event_collector_ref: xo.ActorRefType[  # type: ignore
             EventCollectorActor
         ] = await xo.create_actor(
-            EventCollectorActor, address=self.address, uid=EventCollectorActor.uid()
+            EventCollectorActor,
+            address=self.address,
+            uid=EventCollectorActor.default_uid(),
         )
 
         from ..model.audio import (

--- a/xinference/core/tests/test_metrics.py
+++ b/xinference/core/tests/test_metrics.py
@@ -72,7 +72,9 @@ async def test_metrics_exporter_server(setup_cluster):
     )
 
     # Check the supervisor metrics collected the RESTful API.
-    supervisor_ref = await xo.actor_ref(supervisor_address, SupervisorActor.uid())
+    supervisor_ref = await xo.actor_ref(
+        supervisor_address, SupervisorActor.default_uid()
+    )
     response = requests.get(f"{endpoint}/metrics")
     assert response.ok
     assert "/v1/models" in response.text

--- a/xinference/core/tests/test_worker.py
+++ b/xinference/core/tests/test_worker.py
@@ -97,7 +97,7 @@ async def test_allocate_cuda_devices(setup_pool):
     worker: xo.ActorRefType["MockWorkerActor"] = await xo.create_actor(  # type: ignore
         MockWorkerActor,
         address=addr,
-        uid=WorkerActor.uid(),
+        uid=WorkerActor.default_uid(),
         supervisor_address="test",
         main_pool=pool,
         cuda_devices=[i for i in range(8)],
@@ -124,7 +124,7 @@ async def test_terminate_model_flag(setup_pool):
     worker: xo.ActorRefType["MockWorkerActor"] = await xo.create_actor(  # type: ignore
         MockWorkerActor,
         address=addr,
-        uid=WorkerActor.uid(),
+        uid=WorkerActor.default_uid(),
         supervisor_address="test",
         main_pool=pool,
         cuda_devices=[i for i in range(8)],
@@ -174,7 +174,7 @@ async def test_launch_embedding_model(setup_pool):
     worker: xo.ActorRefType["MockWorkerActor"] = await xo.create_actor(  # type: ignore
         MockWorkerActor,
         address=addr,
-        uid=WorkerActor.uid(),
+        uid=WorkerActor.default_uid(),
         supervisor_address="test",
         main_pool=pool,
         cuda_devices=[i for i in range(4)],
@@ -270,11 +270,12 @@ async def test_launch_model_with_gpu_idx(setup_pool):
     worker: xo.ActorRefType["MockWorkerActor"] = await xo.create_actor(  # type: ignore
         MockWorkerActor,
         address=addr,
-        uid=WorkerActor.uid(),
+        uid=WorkerActor.default_uid(),
         supervisor_address="test",
         main_pool=pool,
         cuda_devices=[i for i in range(4)],
     )
+    assert (await xo.actor_ref(addr, WorkerActor.default_uid())).uid == b"worker"
 
     # test normal model
     await worker.launch_builtin_model(

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -185,7 +185,7 @@ class WorkerActor(xo.StatelessActor):
                 break
 
     @classmethod
-    def uid(cls) -> str:
+    def default_uid(cls) -> str:
         return "worker"
 
     async def __post_create__(self):
@@ -270,9 +270,9 @@ class WorkerActor(xo.StatelessActor):
 
         try:
             await self.get_supervisor_ref(add_worker=True)
-        except Exception as e:
+        except Exception:
             # Do not crash the worker if supervisor is down, auto re-connect later
-            logger.error(f"cannot connect to supervisor {e}")
+            logger.error(f"cannot connect to supervisor", exc_info=True)
 
         if not XINFERENCE_DISABLE_HEALTH_CHECK:
             from ..isolation import Isolation
@@ -324,7 +324,7 @@ class WorkerActor(xo.StatelessActor):
         if self._supervisor_ref is not None:
             return self._supervisor_ref
         supervisor_ref = await xo.actor_ref(  # type: ignore
-            address=self._supervisor_address, uid=SupervisorActor.uid()
+            address=self._supervisor_address, uid=SupervisorActor.default_uid()
         )
         # Prevent concurrent operations leads to double initialization, check again.
         if self._supervisor_ref is not None:
@@ -814,7 +814,7 @@ class WorkerActor(xo.StatelessActor):
                 )
         except Exception as e:
             # Report callback error can be log and ignore, should not interrupt the Process
-            logger.error("report_event error: %s" % (e))
+            logger.error("report_event error: %s" % (e), exc_info=True)
 
         if gpu_idx is not None:
             logger.info(

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -336,13 +336,13 @@ class WorkerActor(xo.StatelessActor):
             logger.info("Connected to supervisor as a fresh worker")
 
         self._status_guard_ref = await xo.actor_ref(
-            address=self._supervisor_address, uid=StatusGuardActor.uid()
+            address=self._supervisor_address, uid=StatusGuardActor.default_uid()
         )
         self._event_collector_ref = await xo.actor_ref(
-            address=self._supervisor_address, uid=EventCollectorActor.uid()
+            address=self._supervisor_address, uid=EventCollectorActor.default_uid()
         )
         self._cache_tracker_ref = await xo.actor_ref(
-            address=self._supervisor_address, uid=CacheTrackerActor.uid()
+            address=self._supervisor_address, uid=CacheTrackerActor.default_uid()
         )
         # cache_tracker is on supervisor
         from ..model.audio import get_audio_model_descriptions

--- a/xinference/deploy/local.py
+++ b/xinference/deploy/local.py
@@ -49,7 +49,7 @@ async def _start_local_cluster(
             address=address, logging_conf=logging_conf
         )
         await xo.create_actor(
-            SupervisorActor, address=address, uid=SupervisorActor.uid()
+            SupervisorActor, address=address, uid=SupervisorActor.default_uid()
         )
         await start_worker_components(
             address=address,

--- a/xinference/deploy/supervisor.py
+++ b/xinference/deploy/supervisor.py
@@ -41,7 +41,7 @@ async def _start_supervisor(address: str, logging_conf: Optional[Dict] = None):
             address=address, n_process=0, logging_conf={"dict": logging_conf}
         )
         await xo.create_actor(
-            SupervisorActor, address=address, uid=SupervisorActor.uid()
+            SupervisorActor, address=address, uid=SupervisorActor.default_uid()
         )
         await pool.join()
     except asyncio.exceptions.CancelledError:

--- a/xinference/deploy/utils.py
+++ b/xinference/deploy/utils.py
@@ -167,7 +167,7 @@ def health_check(address: str, max_attempts: int, sleep_interval: int = 3) -> bo
                 from ..core.supervisor import SupervisorActor
 
                 supervisor_ref: xo.ActorRefType[SupervisorActor] = await xo.actor_ref(  # type: ignore
-                    address=address, uid=SupervisorActor.uid()
+                    address=address, uid=SupervisorActor.default_uid()
                 )
 
                 await supervisor_ref.get_status()

--- a/xinference/deploy/worker.py
+++ b/xinference/deploy/worker.py
@@ -43,7 +43,7 @@ async def start_worker_components(
     await xo.create_actor(
         WorkerActor,
         address=address,
-        uid=WorkerActor.uid(),
+        uid=WorkerActor.default_uid(),
         supervisor_address=supervisor_address,
         main_pool=main_pool,
         gpu_devices=gpu_device_indices,


### PR DESCRIPTION
Fixes https://github.com/xorbitsai/xoscar/issues/103

The reason is because these actors use `uid()` to generate default uid, which override the `xoscar.Actor`'s `uid` property, hence change them to `default_uid()`.