### PR TITLE
ENH: add `print-error` option in benchmark

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -38,3 +38,10 @@ python benchmark/benchmark_long.py --context-length ${context_length} --tokenize
 							--model-uid ${model_uid} \
 							--num-prompts 32 -c 16
 ```
+
+## Common Options for Benchmarking Tools
+- `--stream`. You can enable streaming responses by using the option, which is useful for real-time data processing and receiving incremental data without waiting for the entire dataset to be processed. 
+
+- `--print-error`. For troubleshooting and more detailed output, the option can be used to print detailed error messages if any errors are encountered during the execution. 
+
+These options are available for use in all benchmarking tools provided in this suite, enhancing flexibility and providing essential debugging information.

--- a/benchmark/benchmark_latency.py
+++ b/benchmark/benchmark_latency.py
@@ -59,6 +59,7 @@ def main(args: argparse.Namespace):
         input_requests,
         args.stream,
         args.api_key,
+        args.print_error,
     )
     asyncio.run(benchmark.run())
 
@@ -96,6 +97,10 @@ if __name__ == "__main__":
         default=None,
         help="Authorization api key",
     )
-
+    parser.add_argument(
+        "--print-error",
+        action="store_true",
+        help="Print detailed error messages if any errors encountered."
+    )
     args = parser.parse_args()
     main(args)

--- a/benchmark/benchmark_long.py
+++ b/benchmark/benchmark_long.py
@@ -79,6 +79,7 @@ def main(args: argparse.Namespace):
         args.stream,
         concurrency=args.concurrency,
         api_key=args.api_key,
+        print_error=args.print_error,
     )
     asyncio.run(benchmark.run())
 
@@ -119,6 +120,11 @@ if __name__ == "__main__":
     parser.add_argument("--seed", type=int, default=0)
     parser.add_argument(
         "--stream", action="store_true", help="Enable streaming responses."
+    )
+    parser.add_argument(
+        "--print-error",
+        action="store_true",
+        help="Print detailed error messages if any errors encountered."
     )
     args = parser.parse_args()
     main(args)

--- a/benchmark/benchmark_rerank.py
+++ b/benchmark/benchmark_rerank.py
@@ -38,6 +38,7 @@ class RerankBenchmarkRunner(ConcurrentBenchmarkRunner):
         top_n: int,
         concurrency: int,
         api_key: Optional[str] = None,
+        print_error: bool = False,
     ):
         super().__init__(
             api_url,
@@ -46,6 +47,7 @@ class RerankBenchmarkRunner(ConcurrentBenchmarkRunner):
             stream,
             concurrency,
             api_key,
+            print_error,
         )
         self.top_n = top_n
 
@@ -127,6 +129,7 @@ def main(args: argparse.Namespace):
         top_n=args.top_n,
         concurrency=args.concurrency,
         api_key=args.api_key,
+        print_error=args.print_error,
     )
     asyncio.run(benchmark.run())
 
@@ -181,6 +184,11 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--api-key", type=str, default=None, help="Authorization api key",
+    )
+    parser.add_argument(
+        "--print-error",
+        action="store_true",
+        help="Print detailed error messages if any errors encountered."
     )
     args = parser.parse_args()
     main(args)

--- a/benchmark/benchmark_serving.py
+++ b/benchmark/benchmark_serving.py
@@ -38,6 +38,7 @@ class ServingBenchmarkRunner(ConcurrentBenchmarkRunner):
         concurrency: int,
         request_rate: float,
         api_key: Optional[str] = None,
+        print_error: bool = False,
     ):
         super().__init__(
             api_url,
@@ -46,6 +47,7 @@ class ServingBenchmarkRunner(ConcurrentBenchmarkRunner):
             stream,
             concurrency,
             api_key,
+            print_error,
         )
         self.request_rate = request_rate
         self.queue = None  # delay the creation of the queue
@@ -118,6 +120,7 @@ def main(args: argparse.Namespace):
         request_rate=args.request_rate,
         concurrency=args.concurrency,
         api_key=args.api_key,
+        print_error=args.print_error,
     )
     asyncio.run(benchmark.run())
 
@@ -173,6 +176,11 @@ if __name__ == "__main__":
     parser.add_argument("--model-uid", type=str, help="Xinference model UID.")
     parser.add_argument(
         "--stream", action="store_true", help="Enable streaming responses."
+    )
+    parser.add_argument(
+        "--print-error",
+        action="store_true",
+        help="Print detailed error messages if any errors encountered."
     )
     args = parser.parse_args()
     main(args)


### PR DESCRIPTION
1. Added the `--print-error` option to benchmarking tools to improve error diagnostics:
- If an error occurs, the system prompts:`INFO:benchmark_runner: Errors were encountered. Use --print-error for details.`.

![1](https://github.com/user-attachments/assets/74aaa203-ba73-47ea-b5dc-94c4d474796a)

- When used, --print-error provides a detailed traceback for errors: `INFO:benchmark_runner: Error for prompt length 182: xxx`.

![微信截图_20240911172603](https://github.com/user-attachments/assets/4390ad84-ea30-4096-87df-76d8dfde7a8a)

2. Updated README.md.
