### PR TITLE
FEAT: support sdapi/sd-models and sdapi/samplers

### DIFF
--- a/xinference/core/image_interface.py
+++ b/xinference/core/image_interface.py
@@ -73,6 +73,8 @@ class ImageInterface:
         return interface
 
     def text2image_interface(self) -> "gr.Blocks":
+        from ..model.image.stable_diffusion.core import SAMPLING_METHODS
+
         def text_generate_image(
             prompt: str,
             n: int,
@@ -81,6 +83,7 @@ class ImageInterface:
             guidance_scale: int,
             num_inference_steps: int,
             negative_prompt: Optional[str] = None,
+            sampler_name: Optional[str] = None,
         ) -> PIL.Image.Image:
             from ..client import RESTfulClient
 
@@ -94,6 +97,7 @@ class ImageInterface:
             num_inference_steps = (
                 None if num_inference_steps == -1 else num_inference_steps  # type: ignore
             )
+            sampler_name = None if sampler_name == "default" else sampler_name
 
             response = model.text_to_image(
                 prompt=prompt,
@@ -102,6 +106,7 @@ class ImageInterface:
                 num_inference_steps=num_inference_steps,
                 guidance_scale=guidance_scale,
                 negative_prompt=negative_prompt,
+                sampler_name=sampler_name,
                 response_format="b64_json",
             )
 
@@ -140,6 +145,11 @@ class ImageInterface:
                     num_inference_steps = gr.Number(
                         label="Inference Step Number", value=-1
                     )
+                    sampler_name = gr.Dropdown(
+                        choices=SAMPLING_METHODS,
+                        value="default",
+                        label="Sampling method",
+                    )
 
                 with gr.Column():
                     image_output = gr.Gallery()
@@ -154,6 +164,7 @@ class ImageInterface:
                     guidance_scale,
                     num_inference_steps,
                     negative_prompt,
+                    sampler_name,
                 ],
                 outputs=image_output,
             )
@@ -161,6 +172,8 @@ class ImageInterface:
         return text2image_vl_interface
 
     def image2image_interface(self) -> "gr.Blocks":
+        from ..model.image.stable_diffusion.core import SAMPLING_METHODS
+
         def image_generate_image(
             prompt: str,
             negative_prompt: str,
@@ -170,6 +183,7 @@ class ImageInterface:
             size_height: int,
             num_inference_steps: int,
             padding_image_to_multiple: int,
+            sampler_name: Optional[str] = None,
         ) -> PIL.Image.Image:
             from ..client import RESTfulClient
 
@@ -186,6 +200,7 @@ class ImageInterface:
                 None if num_inference_steps == -1 else num_inference_steps  # type: ignore
             )
             padding_image_to_multiple = None if padding_image_to_multiple == -1 else padding_image_to_multiple  # type: ignore
+            sampler_name = None if sampler_name == "default" else sampler_name
 
             bio = io.BytesIO()
             image.save(bio, format="png")
@@ -199,6 +214,7 @@ class ImageInterface:
                 response_format="b64_json",
                 num_inference_steps=num_inference_steps,
                 padding_image_to_multiple=padding_image_to_multiple,
+                sampler_name=sampler_name,
             )
 
             images = []
@@ -239,6 +255,11 @@ class ImageInterface:
                     padding_image_to_multiple = gr.Number(
                         label="Padding image to multiple", value=-1
                     )
+                    sampler_name = gr.Dropdown(
+                        choices=SAMPLING_METHODS,
+                        value="default",
+                        label="Sampling method",
+                    )
 
                 with gr.Row():
                     with gr.Column(scale=1):
@@ -257,6 +278,7 @@ class ImageInterface:
                     size_height,
                     num_inference_steps,
                     padding_image_to_multiple,
+                    sampler_name,
                 ],
                 outputs=output_gallery,
             )

--- a/xinference/model/image/stable_diffusion/core.py
+++ b/xinference/model/image/stable_diffusion/core.py
@@ -39,6 +39,25 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+SAMPLING_METHODS = [
+    "default",
+    "DPM++ 2M",
+    "DPM++ 2M Karras",
+    "DPM++ 2M SDE",
+    "DPM++ 2M SDE Karras",
+    "DPM++ SDE",
+    "DPM++ SDE Karras",
+    "DPM2",
+    "DPM2 Karras",
+    "DPM2 a",
+    "DPM2 a Karras",
+    "Euler",
+    "Euler a",
+    "Heun",
+    "LMS",
+    "LMS Karras",
+]
+
 
 class DiffusionModel(SDAPIDiffusionModelMixin):
     def __init__(
@@ -262,10 +281,6 @@ class DiffusionModel(SDAPIDiffusionModelMixin):
 
         from ....device_utils import empty_cache
 
-        logger.debug(
-            "stable diffusion args: %s",
-            kwargs,
-        )
         model = model if model is not None else self._model
         is_padded = kwargs.pop("is_padded", None)
         origin_size = kwargs.pop("origin_size", None)
@@ -277,6 +292,10 @@ class DiffusionModel(SDAPIDiffusionModelMixin):
         sampler_name = kwargs.pop("sampler_name", None)
         assert callable(model)
         with self._reset_when_done(sampler_name):
+            logger.debug(
+                "stable diffusion args: %s",
+                kwargs,
+            )
             images = model(**kwargs).images
 
         # revert padding if padded


### PR DESCRIPTION
`/sdapi/sd-models` and `sdapi/samplers` are used in dify stable diffusion tool thus we add the API first.