### PR TITLE
BUG: fix issue with model launch failing when .safetensors file is missing (#2094)

### DIFF
--- a/xinference/model/audio/whisper.py
+++ b/xinference/model/audio/whisper.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
+import os
+from glob import glob
 from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
 from ...device_utils import (
@@ -56,12 +58,13 @@ class WhisperModel:
                 raise ValueError(f"Device {self._device} is not available!")
 
         torch_dtype = get_device_preferred_dtype(self._device)
+        use_safetensors = any(glob(os.path.join(self._model_path, "*.safetensors")))
 
         model = AutoModelForSpeechSeq2Seq.from_pretrained(
             self._model_path,
             torch_dtype=torch_dtype,
             low_cpu_mem_usage=True,
-            use_safetensors=True,
+            use_safetensors=use_safetensors,
         )
         model.to(self._device)
 


### PR DESCRIPTION
**Reason:**
The `openai/whisper` model provides weights in the `.safetensors` format, but the `xinference`-supported `BELLE-2/Belle-whisper-large-v3-zh` model only provides weights in the `pytorch_model.bin` format. Setting `use_safetensors=True` causes errors when running the `Belle-whisper-large-v3-zh` model.

**Solution:**
Added a check to determine if `.safetensors` files are present in the model directory.

**Effect:**
Both `whisper` and `Belle-whisper` models now launch and inference correctly on our company's private server.