### PR TITLE
FEAT: support minicpm-reranker model

### DIFF
--- a/xinference/model/rerank/model_spec.json
+++ b/xinference/model/rerank/model_spec.json
@@ -54,5 +54,13 @@
     "max_tokens": 1024,
     "model_id": "jinaai/jina-reranker-v2-base-multilingual",
     "model_revision": "298e48cada4a9318650d7fbd795f63827f884087"
+  },
+  {
+    "model_name": "minicpm-reranker",
+    "type": "normal",
+    "language": ["en", "zh"],
+    "max_tokens": 1024,
+    "model_id": "openbmb/MiniCPM-Reranker",
+    "model_revision": "5d2fd7345b6444c89d4c0fa59c92272888f3f2d0"
   }
 ]

--- a/xinference/model/rerank/model_spec_modelscope.json
+++ b/xinference/model/rerank/model_spec_modelscope.json
@@ -49,5 +49,13 @@
     "max_tokens": 2048,
     "model_id": "mirror013/bge-reranker-v2-minicpm-layerwise",
     "model_hub": "modelscope"
+  },
+  {
+    "model_name": "minicpm-reranker",
+    "type": "normal",
+    "language": ["en", "zh"],
+    "max_tokens": 1024,
+    "model_id": "OpenBMB/MiniCPM-Reranker",
+    "model_hub": "modelscope"
   }
 ]


### PR DESCRIPTION
This pr support for minicpm-reranker model.

![image](https://github.com/user-attachments/assets/ea962d32-6378-4e77-a3e5-342a6de796ce)

![image](https://github.com/user-attachments/assets/840d5856-1320-446a-867d-e08a9cf53600)

![image](https://github.com/user-attachments/assets/703525d2-ac10-4518-9859-9d16775359f4)

![image](https://github.com/user-attachments/assets/12f6581d-56b5-47a6-92e5-847379ed8234)
