### PR TITLE
BUG: Fix default value of max_model_len for vLLM backend.

### DIFF
--- a/xinference/model/llm/vllm/core.py
+++ b/xinference/model/llm/vllm/core.py
@@ -304,7 +304,7 @@ class VLLMModel(LLM):
         model_config.setdefault("gpu_memory_utilization", 0.90)
         model_config.setdefault("max_num_seqs", 256)
         model_config.setdefault("quantization", None)
-        model_config.setdefault("max_model_len", 4096)
+        model_config.setdefault("max_model_len", None)
 
         return model_config
 


### PR DESCRIPTION
When I launch the LLM Qwen2.5-Instruct with vLLM backend on xinference,  through built-in model or just create another custom model, and try it on a relative long context, from the log on standard output, the backend says:
> Input prompt (xxxx tokens) is too long and exceeds limit of 4096

and the it just returns an empty response to the request from OpenAI API. 

However, when serving the model directly with vLLM, using default engine arguments, it just works fine.

For the argument max-model-len, referencing https://docs.vllm.ai/en/latest/models/engine_args.html:
>  If unspecified, will be automatically derived from the model config.

The current version of xinference code use a specific default value 4096 for argument max-model-len passed to vLLM backend, and override the auto-selected value by vLLM itself from model's config.json when this argument not set explicitly from xinference. This will lead to an unexpected inference behavior for LLM models with context-length larger than 4096.

From https://github.com/vllm-project/vllm/blob/main/vllm/engine/arg_utils.py#L97:
When max-model-len is not specified, its default value is None.

B.T.W. This current default value setting 4096 may be ralated to issue #2357.
It's also highly recommended that, description of how to pass argument to vLLM backend should be added into the documentation.