### PR TITLE
BUG:Add some install requires to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -47,6 +47,8 @@ install_requires =
     async-timeout
     peft
     timm
+    vllm
+    llama-cpp-python
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
Hi there! I'm trying to run the test_cmdline.py in xinference/deploy/test.Then I found that it needs some extra requirements to be installed but they are not in the setup.cfg file.That is why I submit this pr.