### PR TITLE
ENH: Speed up cli interaction

### DIFF
--- a/xinference/__init__.py
+++ b/xinference/__init__.py
@@ -26,12 +26,8 @@ except:
 def _install():
     from xoscar.backends.router import Router
 
-    from .model import _install as install_model
-
     default_router = Router.get_instance_or_empty()
     Router.set_instance(default_router)
-
-    install_model()
 
 
 _install()

--- a/xinference/deploy/supervisor.py
+++ b/xinference/deploy/supervisor.py
@@ -31,6 +31,10 @@ from .utils import health_check
 
 logger = logging.getLogger(__name__)
 
+from ..model import _install as install_model
+
+install_model()
+
 
 async def _start_supervisor(address: str, logging_conf: Optional[Dict] = None):
     logging.config.dictConfig(logging_conf)  # type: ignore

--- a/xinference/model/__init__.py
+++ b/xinference/model/__init__.py
@@ -29,3 +29,7 @@ def _install():
     image_install()
     rerank_install()
     video_install()
+
+
+_install()
+del _install

--- a/xinference/utils.py
+++ b/xinference/utils.py
@@ -13,9 +13,8 @@
 # limitations under the License.
 
 
-import torch
-
-
 def cuda_count():
+    import torch
+
     # even if install torch cpu, this interface would return 0.
     return torch.cuda.device_count()


### PR DESCRIPTION
Avoid installing model in app level

This will speed up cli and simplify dependency for distributed deployment

Move install model from xinference/__init__.py to to xinference/model/__init__.py

cli 在import xinference 的时候默认会运行 models/__init__.py 中的 install,  导致加载 torch 然后遍历所有 model，花时间很多, 但实际对于命令行并不需要. 

修改前：
```
time xinference list

real    0m6.322s
user    0m6.187s
sys     0m0.769s
```
修改后:
```
# time xinference list

real    0m0.793s
user    0m1.164s
sys     0m0.268s
```
已经测试过模型启动一切正常, 聊天也正常