### PR TITLE
Remove duplicated call of model_install

### DIFF
--- a/xinference/deploy/supervisor.py
+++ b/xinference/deploy/supervisor.py
@@ -31,10 +31,6 @@ from .utils import health_check
 
 logger = logging.getLogger(__name__)
 
-from ..model import _install as install_model
-
-install_model()
-
 
 async def _start_supervisor(address: str, logging_conf: Optional[Dict] = None):
     logging.config.dictConfig(logging_conf)  # type: ignore


### PR DESCRIPTION
由于有反馈说 xinference-local 变慢。
在 PR #2443 修改了 model install 的方式, 没注意到  deploy/supervisor.py 里面有一个显式的重复调用，现在移除。

实测确认无论改还是不改，实际 xinference/model/__init__.py 的 _install 方法都只会执行一次,  即使把PR #2443 revert, xinference-local的启动速度也并无明显差别。

Fixes #2460 .