### PR TITLE
BUG: fix embedding model gte-Qwen2 dimensions

### DIFF
--- a/doc/source/models/builtin/embedding/gte-qwen2.rst
+++ b/doc/source/models/builtin/embedding/gte-qwen2.rst
@@ -11,7 +11,7 @@ gte-Qwen2
 Specifications
 ^^^^^^^^^^^^^^
 
-- **Dimensions:** 3584
+- **Dimensions:** 4096
 - **Max Tokens:** 32000
 - **Model ID:** Alibaba-NLP/gte-Qwen2-7B-instruct
 - **Model Hubs**: `Hugging Face <https://huggingface.co/Alibaba-NLP/gte-Qwen2-7B-instruct>`__, `ModelScope <https://modelscope.cn/models/iic/gte_Qwen2-7B-instruct>`__

--- a/xinference/model/embedding/model_spec.json
+++ b/xinference/model/embedding/model_spec.json
@@ -233,7 +233,7 @@
   },
   {
     "model_name": "gte-Qwen2",
-    "dimensions": 3584,
+    "dimensions": 4096,
     "max_tokens": 32000,
     "language": ["zh", "en"],
     "model_id": "Alibaba-NLP/gte-Qwen2-7B-instruct",


### PR DESCRIPTION
Fixes #2471 
fix embedding model gte-Qwen2 dimensions

> wrong dimensions：
> 
> https://github.com/xorbitsai/inference/blob/48a07e8af3d015908c8a55f91c7baea3afbbb809/xinference/model/embedding/model_spec.json#L236C1-L237C1
> 
> correct dimensions：
> 
> https://github.com/xorbitsai/inference/blob/48a07e8af3d015908c8a55f91c7baea3afbbb809/xinference/model/embedding/model_spec_modelscope.json#L238


base on the right message：
https://huggingface.co/Alibaba-NLP/gte-Qwen1.5-7B-instruct
https://modelscope.cn/models/iic/gte_Qwen1.5-7B-instruct/summary