### PR TITLE
ENH: add normalize to rerank model

### DIFF
--- a/xinference/api/restful_api.py
+++ b/xinference/api/restful_api.py
@@ -1316,11 +1316,6 @@ class RESTfulAPI(CancelMixin):
         payload = await request.json()
         body = RerankRequest.parse_obj(payload)
         model_uid = body.model
-        kwargs = {
-            key: value
-            for key, value in payload.items()
-            if key not in RerankRequest.__annotations__.keys()
-        }
 
         try:
             model = await (await self._get_supervisor_ref()).get_model(model_uid)

--- a/xinference/api/restful_api.py
+++ b/xinference/api/restful_api.py
@@ -115,7 +115,7 @@ class RerankRequest(BaseModel):
     return_documents: Optional[bool] = False
     return_len: Optional[bool] = False
     max_chunks_per_doc: Optional[int] = None
-    always_normalize: Optional[bool] = False
+    kwargs: Optional[str] = None
 
 
 class TextToImageRequest(BaseModel):
@@ -1334,6 +1334,10 @@ class RESTfulAPI(CancelMixin):
             raise HTTPException(status_code=500, detail=str(e))
 
         try:
+            if body.kwargs is not None:
+                parsed_kwargs = json.loads(body.kwargs)
+            else:
+                parsed_kwargs = {}
             scores = await model.rerank(
                 body.documents,
                 body.query,
@@ -1341,8 +1345,7 @@ class RESTfulAPI(CancelMixin):
                 max_chunks_per_doc=body.max_chunks_per_doc,
                 return_documents=body.return_documents,
                 return_len=body.return_len,
-                always_normalize=body.always_normalize,
-                **kwargs,
+                **parsed_kwargs,
             )
             return Response(scores, media_type="application/json")
         except RuntimeError as re:

--- a/xinference/api/restful_api.py
+++ b/xinference/api/restful_api.py
@@ -115,6 +115,7 @@ class RerankRequest(BaseModel):
     return_documents: Optional[bool] = False
     return_len: Optional[bool] = False
     max_chunks_per_doc: Optional[int] = None
+    always_normalize: Optional[bool] = False
 
 
 class TextToImageRequest(BaseModel):
@@ -1340,6 +1341,7 @@ class RESTfulAPI(CancelMixin):
                 max_chunks_per_doc=body.max_chunks_per_doc,
                 return_documents=body.return_documents,
                 return_len=body.return_len,
+                always_normalize=body.always_normalize,
                 **kwargs,
             )
             return Response(scores, media_type="application/json")

--- a/xinference/client/restful/restful_client.py
+++ b/xinference/client/restful/restful_client.py
@@ -174,6 +174,7 @@ class RESTfulRerankModelHandle(RESTfulModelHandle):
             "max_chunks_per_doc": max_chunks_per_doc,
             "return_documents": return_documents,
             "return_len": return_len,
+            "kwargs": json.dumps(kwargs),
         }
         request_body.update(kwargs)
         response = requests.post(url, json=request_body, headers=self.auth_headers)

--- a/xinference/model/rerank/core.py
+++ b/xinference/model/rerank/core.py
@@ -179,6 +179,7 @@ class RerankModel:
         return rerank_type
 
     def load(self):
+        logger.info("Loading rerank model: %s", self._model_path)
         flash_attn_installed = importlib.util.find_spec("flash_attn") is not None
         if (
             self._auto_detect_type(self._model_path) != "normal"
@@ -189,6 +190,7 @@ class RerankModel:
                 "will force set `use_fp16` to True"
             )
             self._use_fp16 = True
+
         if self._model_spec.type == "normal":
             try:
                 import sentence_transformers
@@ -247,31 +249,29 @@ class RerankModel:
         max_chunks_per_doc: Optional[int],
         return_documents: Optional[bool],
         return_len: Optional[bool],
-        always_normalize: Optional[bool] = False,
         **kwargs,
     ) -> Rerank:
         assert self._model is not None
-        if kwargs:
-            raise ValueError("rerank hasn't support extra parameter.")
         if max_chunks_per_doc is not None:
             raise ValueError("rerank hasn't support `max_chunks_per_doc` parameter.")
+        logger.info("Rerank with kwargs: %s, model: %s", kwargs, self._model)
         sentence_combinations = [[query, doc] for doc in documents]
         # reset n tokens
         self._model.model.n_tokens = 0
         if self._model_spec.type == "normal":
             similarity_scores = self._model.predict(
-                sentence_combinations, convert_to_numpy=False, convert_to_tensor=True
+                sentence_combinations,
+                convert_to_numpy=False,
+                convert_to_tensor=True,
+                **kwargs,
             ).cpu()
             if similarity_scores.dtype == torch.bfloat16:
                 similarity_scores = similarity_scores.float()
         else:
             # Related issue: https://github.com/xorbitsai/inference/issues/1775
-            if always_normalize:
-                similarity_scores = self._model.compute_score(
-                    sentence_combinations, normalize=True
-                )
-            else:
-                similarity_scores = self._model.compute_score(sentence_combinations)
+            similarity_scores = self._model.compute_score(
+                sentence_combinations, **kwargs
+            )
 
             if not isinstance(similarity_scores, Sequence):
                 similarity_scores = [similarity_scores]

--- a/xinference/model/rerank/core.py
+++ b/xinference/model/rerank/core.py
@@ -247,6 +247,7 @@ class RerankModel:
         max_chunks_per_doc: Optional[int],
         return_documents: Optional[bool],
         return_len: Optional[bool],
+        always_normalize: Optional[bool] = False,
         **kwargs,
     ) -> Rerank:
         assert self._model is not None
@@ -265,9 +266,13 @@ class RerankModel:
                 similarity_scores = similarity_scores.float()
         else:
             # Related issue: https://github.com/xorbitsai/inference/issues/1775
-            similarity_scores = self._model.compute_score(
-                sentence_combinations, normalize=True
-            )
+            if always_normalize:
+                similarity_scores = self._model.compute_score(
+                    sentence_combinations, normalize=True
+                )
+            else:
+                similarity_scores = self._model.compute_score(sentence_combinations)
+
             if not isinstance(similarity_scores, Sequence):
                 similarity_scores = [similarity_scores]
             elif (

--- a/xinference/model/rerank/core.py
+++ b/xinference/model/rerank/core.py
@@ -265,7 +265,9 @@ class RerankModel:
                 similarity_scores = similarity_scores.float()
         else:
             # Related issue: https://github.com/xorbitsai/inference/issues/1775
-            similarity_scores = self._model.compute_score(sentence_combinations)
+            similarity_scores = self._model.compute_score(
+                sentence_combinations, normalize=True
+            )
             if not isinstance(similarity_scores, Sequence):
                 similarity_scores = [similarity_scores]
             elif (

--- a/xinference/model/rerank/tests/test_rerank.py
+++ b/xinference/model/rerank/tests/test_rerank.py
@@ -118,9 +118,8 @@ def test_restful_api(model_name, setup):
     kwargs = {
         "invalid": "invalid",
     }
-    with pytest.raises(RuntimeError) as err:
-        scores = model.rerank(corpus, query, **kwargs)
-    assert "hasn't support" in str(err.value)
+    with pytest.raises(RuntimeError):
+        model.rerank(corpus, query, **kwargs)
 
 
 def test_from_local_uri():


### PR DESCRIPTION
The current Rerank model return value is not normalized. FlagEmbedding provides a normalization option. It is recommended to return the normalized value.