### PR TITLE
Xinference integration with Microsoft Word

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ potential of cutting-edge AI models.
 - [FastGPT](https://github.com/labring/FastGPT): a knowledge-based platform built on the LLM, offers out-of-the-box data processing and model invocation capabilities, allows for workflow orchestration through Flow visualization.
 - [Chatbox](https://chatboxai.app/): a desktop client for multiple cutting-edge LLM models, available on Windows, Mac and Linux.
 - [RAGFlow](https://github.com/infiniflow/ragflow): is an open-source RAG engine based on deep document understanding.
+- [GPTLocalhost (Word Add-in)](https://gptlocalhost.com/demo#LocalAI): run Xinference in Microsoft Word locally.
 
 
 ## Key Features


### PR DESCRIPTION
Thank you for this great repo. I have recently integrated Xinference with Microsoft Word through a local Word Add-in ([GPTLocalhost](https://gptlocalhost.com/demo#Xinference)). Would it be possible to add this integration in the repo, providing users with another reason to try Xinference? Appreciate your consideration.