### PR TITLE
Update restful_client.py，修复python api 调用rerank模型报错  RuntimeError:  rerank hasn't support extra parameter.

### DIFF
--- a/xinference/client/restful/restful_client.py
+++ b/xinference/client/restful/restful_client.py
@@ -210,8 +210,7 @@ class RESTfulRerankModelHandle(RESTfulModelHandle):
             "top_n": top_n,
             "max_chunks_per_doc": max_chunks_per_doc,
             "return_documents": return_documents,
-            "return_len": return_len,
-            "kwargs": json.dumps(kwargs),
+            "return_len": return_len
         }
         request_body.update(kwargs)
         response = requests.post(url, json=request_body, headers=self.auth_headers)

--- a/xinference/deploy/docker/dockerfile_djj
+++ b/xinference/deploy/docker/dockerfile_djj
@@ -1,0 +1,1 @@
+FROM vllm/vllm-openai:v0.6.0


### PR DESCRIPTION
python api 调用rerank模型报错  RuntimeError: Failed to rerank documents, detail:  rerank hasn't support extra parameter.

这是因为在RESTfulRerankModelHandle类中request_body传递参数时多了 "kwargs": json.dumps(kwargs) 这个参数。

在历史版本中并没有这个参数。