### PR TITLE
ENH: Guided Decoding OpenAIClient compatibility

### DIFF
--- a/xinference/_compat.py
+++ b/xinference/_compat.py
@@ -72,6 +72,7 @@ OpenAIChatCompletionToolParam = create_model_from_typeddict(ChatCompletionToolPa
 OpenAIChatCompletionNamedToolChoiceParam = create_model_from_typeddict(
     ChatCompletionNamedToolChoiceParam
 )
+from openai._types import Body
 
 
 class JSONSchema(BaseModel):
@@ -120,4 +121,5 @@ class CreateChatCompletionOpenAI(BaseModel):
     tools: Optional[Iterable[OpenAIChatCompletionToolParam]]  # type: ignore
     top_logprobs: Optional[int]
     top_p: Optional[float]
+    extra_body: Optional[Body]
     user: Optional[str]

--- a/xinference/api/restful_api.py
+++ b/xinference/api/restful_api.py
@@ -2346,7 +2346,8 @@ class RESTfulAPI(CancelMixin):
     @staticmethod
     def extract_guided_params(raw_body: dict) -> dict:
         kwargs = {}
-        if raw_body.get("guided_json") is not None:
+        raw_extra_body: dict = raw_body.get("extra_body")  # type: ignore
+        if raw_body.get("guided_json"):
             kwargs["guided_json"] = raw_body.get("guided_json")
         if raw_body.get("guided_regex") is not None:
             kwargs["guided_regex"] = raw_body.get("guided_regex")
@@ -2362,6 +2363,27 @@ class RESTfulAPI(CancelMixin):
             kwargs["guided_whitespace_pattern"] = raw_body.get(
                 "guided_whitespace_pattern"
             )
+        # Parse OpenAI extra_body
+        if raw_extra_body is not None:
+            if raw_extra_body.get("guided_json"):
+                kwargs["guided_json"] = raw_extra_body.get("guided_json")
+            if raw_extra_body.get("guided_regex") is not None:
+                kwargs["guided_regex"] = raw_extra_body.get("guided_regex")
+            if raw_extra_body.get("guided_choice") is not None:
+                kwargs["guided_choice"] = raw_extra_body.get("guided_choice")
+            if raw_extra_body.get("guided_grammar") is not None:
+                kwargs["guided_grammar"] = raw_extra_body.get("guided_grammar")
+            if raw_extra_body.get("guided_json_object") is not None:
+                kwargs["guided_json_object"] = raw_extra_body.get("guided_json_object")
+            if raw_extra_body.get("guided_decoding_backend") is not None:
+                kwargs["guided_decoding_backend"] = raw_extra_body.get(
+                    "guided_decoding_backend"
+                )
+            if raw_extra_body.get("guided_whitespace_pattern") is not None:
+                kwargs["guided_whitespace_pattern"] = raw_extra_body.get(
+                    "guided_whitespace_pattern"
+                )
+
         return kwargs
 
 


### PR DESCRIPTION
FIX: https://github.com/xorbitsai/inference/issues/2636
also https://github.com/xorbitsai/inference/issues/2620

cc @qinxuye 

```python
client = openai.Client(api_key="not empty", base_url="http://127.0.0.1:9997/v1")
class TSchema(BaseModel):
    test: str
    num: int
schema = TSchema.model_json_schema()
messages = [
{"role": "system", "content": "you are a helpful assistant"},
{"role": "user", "content": "give me an example json, fill a random number"}
]
completion = client.chat.completions.create(
model="qwen2-instruct",
messages = messages,
extra_body={
"guided_json": schema,
"guided_decoding_backend": "outlines"
})
```
Output:
```
{ "test": "Example JSON", "num": 42 }
```
Guided Choice also works fine.
