### PR TITLE
FEAT: support SD3.5 series model

### DIFF
--- a/doc/source/locale/zh_CN/LC_MESSAGES/models/model_abilities/image.po
+++ b/doc/source/locale/zh_CN/LC_MESSAGES/models/model_abilities/image.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Xinference \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-30 07:49+0000\n"
+"POT-Creation-Date: 2024-12-25 18:32+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: zh_CN\n"
@@ -17,7 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.16.0\n"
+"Generated-By: Babel 2.14.0\n"
 
 #: ../../source/models/model_abilities/image.rst:5
 msgid "Images"
@@ -98,26 +98,39 @@ msgid "stable-diffusion-xl-base-1.0"
 msgstr ""
 
 #: ../../source/models/model_abilities/image.rst:43
+#: ../../source/models/model_abilities/image.rst:146
 msgid "sd3-medium"
 msgstr ""
 
 #: ../../source/models/model_abilities/image.rst:44
-msgid "FLUX.1-schnell"
+#: ../../source/models/model_abilities/image.rst:148
+msgid "sd3.5-medium"
 msgstr ""
 
 #: ../../source/models/model_abilities/image.rst:45
+#: ../../source/models/model_abilities/image.rst:150
+msgid "sd3.5-large"
+msgstr ""
+
+#: ../../source/models/model_abilities/image.rst:46
+#: ../../source/models/model_abilities/image.rst:144
+msgid "FLUX.1-schnell"
+msgstr ""
+
+#: ../../source/models/model_abilities/image.rst:47
+#: ../../source/models/model_abilities/image.rst:142
 msgid "FLUX.1-dev"
 msgstr ""
 
-#: ../../source/models/model_abilities/image.rst:49
+#: ../../source/models/model_abilities/image.rst:51
 msgid "Quickstart"
 msgstr "快速入门"
 
-#: ../../source/models/model_abilities/image.rst:52
+#: ../../source/models/model_abilities/image.rst:54
 msgid "Text-to-image"
 msgstr "文生图"
 
-#: ../../source/models/model_abilities/image.rst:54
+#: ../../source/models/model_abilities/image.rst:56
 msgid ""
 "The Text-to-image API mimics OpenAI's `create images API "
 "<https://platform.openai.com/docs/api-reference/images/create>`_. We can "
@@ -127,15 +140,15 @@ msgstr ""
 "可以通过 cURL、OpenAI Client 或 Xinference 的方式尝试使用 Text-to-image "
 "API。"
 
-#: ../../source/models/model_abilities/image.rst:109
+#: ../../source/models/model_abilities/image.rst:111
 msgid "Tips for Large Image Models including SD3-Medium, FLUX.1"
 msgstr "大型图像模型部署（sd3-medium、FLUX.1 系列）贴士"
 
-#: ../../source/models/model_abilities/image.rst:111
+#: ../../source/models/model_abilities/image.rst:113
 msgid "Useful extra parameters can be passed to launch including:"
 msgstr "有用的传递给加载模型的额外参数包括："
 
-#: ../../source/models/model_abilities/image.rst:113
+#: ../../source/models/model_abilities/image.rst:115
 msgid ""
 "``--cpu_offload True``: specifying ``True`` will offload the components "
 "of the model to CPU during inference in order to save memory, while "
@@ -147,7 +160,7 @@ msgstr ""
 "CPU 上以节省内存，这会导致推理延迟略有增加。模型卸载仅会在需要执行时将"
 "模型组件移动到 GPU 上，同时保持其余组件在 CPU 上"
 
-#: ../../source/models/model_abilities/image.rst:117
+#: ../../source/models/model_abilities/image.rst:119
 msgid ""
 "``--quantize_text_encoder <text encoder layer>``: We leveraged the "
 "``bitsandbytes`` library to load and quantize the T5-XXL text encoder to "
@@ -158,7 +171,7 @@ msgstr ""
 "`` 库加载并量化 T5-XXL 文本编码器至8位精度。这使得你能够在仅轻微影响性能"
 "的情况下继续使用全部文本编码器。"
 
-#: ../../source/models/model_abilities/image.rst:120
+#: ../../source/models/model_abilities/image.rst:122
 msgid ""
 "``--text_encoder_3 None``, for sd3-medium, removing the memory-intensive "
 "4.7B parameter T5-XXL text encoder during inference can significantly "
@@ -167,53 +180,139 @@ msgstr ""
 "``--text_encoder_3 None``，对于 sd3-medium，移除在推理过程中内存密集型的"
 "47亿参数T5-XXL文本编码器可以显著降低内存需求，而仅造成性能上的轻微损失。"
 
-#: ../../source/models/model_abilities/image.rst:124
+#: ../../source/models/model_abilities/image.rst:125
+msgid "``--transformer_nf4 True``: use nf4 for transformer quantization."
+msgstr "``--transformer_nf4 True`` ：使用 nf4 量化 transformer。"
+
+#: ../../source/models/model_abilities/image.rst:126
 msgid ""
-"If you are trying to run large image models liek sd3-medium or FLUX.1 "
-"series on GPU card that has less memory than 24GB, you may encounter OOM "
-"when launching or inference. Try below solutions."
+"``--quantize``: Only work for MLX on Mac, Flux.1-dev and Flux.1-schnell "
+"will switch to MLX engine on Mac, and ``quantize`` can be used to "
+"quantize the model."
 msgstr ""
-"如果你试图在显存小于24GB的GPU上运行像sd3-medium或FLUX.1系列这样的大型图像"
-"模型，你在启动或推理过程中可能会遇到显存溢出（OOM）的问题。尝试以下"
-"解决方案。"
+"``--quantize`` ：只对 Mac 上的 MLX 引擎生效，Flux.1-dev 和 Flux.1-schnell"
+"会在 Mac 上使用 MLX 引擎计算，``quantize`` 可以用来量化模型。"
 
-#: ../../source/models/model_abilities/image.rst:128
-msgid "For FLUX.1 series, try to apply quantization."
-msgstr "对于 FLUX.1 系列，尝试应用量化。"
+#: ../../source/models/model_abilities/image.rst:129
+msgid ""
+"For WebUI, Just add additional parameters, e.g. add key ``cpu_offload`` "
+"and value ``True`` to enable cpu offloading."
+msgstr ""
+"对于 WebUI，只需要添加额外参数，比如，添加 key ``cpu_offload`` 以及值 ``True`` "
+"来开启 CPU 卸载。"
 
-#: ../../source/models/model_abilities/image.rst:134
-msgid "For sd3-medium, apply quantization to ``text_encoder_3``."
-msgstr "对于 sd3-medium 模型，对 ``text_encoder_3`` 应用量化。"
+#: ../../source/models/model_abilities/image.rst:135
+msgid ""
+"From v0.16.1, Xinference by default enabled quantization for large image "
+"models like Flux.1 and SD3.5 series. Below list default options."
+msgstr ""
+"从 v0.16.1 开始，Xinference 默认对大图像模型如 Flux.1 和 SD3.5 系列开启"
+"量化。如下列出了默认的选项。"
 
-#: ../../source/models/model_abilities/image.rst:141
-msgid "Or removing memory-intensive T5-XXL text encoder for sd3-medium."
-msgstr "或者，移除 sd3-medium 模型中内存密集型的 T5-XXL 文本编码器。"
+#: ../../source/models/model_abilities/image.rst:140
+msgid "Model"
+msgstr "模型"
 
+#: ../../source/models/model_abilities/image.rst:140
+msgid "quantize_text_encoder"
+msgstr ""
+
+#: ../../source/models/model_abilities/image.rst:140
+msgid "quantize"
+msgstr ""
+
+#: ../../source/models/model_abilities/image.rst:140
+msgid "transformer_nf4"
+msgstr ""
+
+#: ../../source/models/model_abilities/image.rst:142
+#: ../../source/models/model_abilities/image.rst:144
+msgid "text_encoder_2"
+msgstr ""
+
+#: ../../source/models/model_abilities/image.rst:142
+#: ../../source/models/model_abilities/image.rst:144
+#: ../../source/models/model_abilities/image.rst:150
+msgid "True"
+msgstr ""
+
+#: ../../source/models/model_abilities/image.rst:142
+#: ../../source/models/model_abilities/image.rst:144
+#: ../../source/models/model_abilities/image.rst:146
 #: ../../source/models/model_abilities/image.rst:148
+msgid "False"
+msgstr ""
+
+#: ../../source/models/model_abilities/image.rst:146
+#: ../../source/models/model_abilities/image.rst:148
+#: ../../source/models/model_abilities/image.rst:150
+msgid "text_encoder_3"
+msgstr ""
+
+#: ../../source/models/model_abilities/image.rst:146
+#: ../../source/models/model_abilities/image.rst:148
+#: ../../source/models/model_abilities/image.rst:150
+msgid "N/A"
+msgstr ""
+
+#: ../../source/models/model_abilities/image.rst:153
+msgid ""
+"If you want to disable some quantization, just set the corresponding "
+"option to False. e.g. for Web UI, set key ``quantize_text_encoder`` and "
+"value ``False`` and for command line, specify ``--quantize_text_encoder "
+"False`` to disable quantization for text encoder."
+msgstr ""
+"如果你想关闭某些量化，只需要设置相应的选项为 False。比如，对于 Web UI，"
+"设置 key ``quantize_text_encoder`` 和值 ``False``，"
+"或对于命令行，指定 ``--quantize_text_encoder False`` 来关闭 text encoder 的量化。"
+
+#: ../../source/models/model_abilities/image.rst:160
 msgid "Image-to-image"
 msgstr "图生图"
 
-#: ../../source/models/model_abilities/image.rst:150
+#: ../../source/models/model_abilities/image.rst:162
 msgid "You can find more examples of Images API in the tutorial notebook:"
 msgstr "你可以在教程笔记本中找到更多 Images API 的示例。"
 
-#: ../../source/models/model_abilities/image.rst:154
+#: ../../source/models/model_abilities/image.rst:166
 msgid "Stable Diffusion ControlNet"
 msgstr ""
 
-#: ../../source/models/model_abilities/image.rst:157
+#: ../../source/models/model_abilities/image.rst:169
 msgid "Learn from a Stable Diffusion ControlNet example"
 msgstr "学习一个 Stable Diffusion 控制网络的示例"
 
-#: ../../source/models/model_abilities/image.rst:160
+#: ../../source/models/model_abilities/image.rst:172
 msgid "OCR"
 msgstr ""
 
-#: ../../source/models/model_abilities/image.rst:162
+#: ../../source/models/model_abilities/image.rst:174
 msgid "The OCR API accepts image bytes and returns the OCR text."
 msgstr "OCR API 接受图像字节并返回 OCR 文本。"
 
-#: ../../source/models/model_abilities/image.rst:164
+#: ../../source/models/model_abilities/image.rst:176
 msgid "We can try OCR API out either via cURL, or Xinference's python client:"
 msgstr "可以通过 cURL 或 Xinference 的 Python 客户端来尝试 OCR API。"
+
+#~ msgid ""
+#~ "If you are trying to run large "
+#~ "image models liek sd3-medium or FLUX.1"
+#~ " series on GPU card that has "
+#~ "less memory than 24GB, you may "
+#~ "encounter OOM when launching or "
+#~ "inference. Try below solutions."
+#~ msgstr ""
+#~ "如果你试图在显存小于24GB的GPU上运行像"
+#~ "sd3-medium或FLUX.1系列这样的大型图像模型"
+#~ "，你在启动或推理过程中可能会遇到显存"
+#~ "溢出（OOM）的问题。尝试以下解决方案。"
+
+#~ msgid "For FLUX.1 series, try to apply quantization."
+#~ msgstr "对于 FLUX.1 系列，尝试应用量化。"
+
+#~ msgid "For sd3-medium, apply quantization to ``text_encoder_3``."
+#~ msgstr "对于 sd3-medium 模型，对 ``text_encoder_3`` 应用量化。"
+
+#~ msgid "Or removing memory-intensive T5-XXL text encoder for sd3-medium."
+#~ msgstr "或者，移除 sd3-medium 模型中内存密集型的 T5-XXL 文本编码器。"
 

--- a/doc/source/models/model_abilities/image.rst
+++ b/doc/source/models/model_abilities/image.rst
@@ -1,4 +1,4 @@
-.. _image:
+ .. _image:
 
 ======
 Images
@@ -126,6 +126,9 @@ Useful extra parameters can be passed to launch including:
 * ``--quantize``: Only work for MLX on Mac, Flux.1-dev and Flux.1-schnell will switch to
   MLX engine on Mac, and ``quantize`` can be used to quantize the model.
 
+For WebUI, Just add additional parameters, e.g. add key ``cpu_offload`` and value ``True``
+to enable cpu offloading.
+
 
 .. note::
 
@@ -133,15 +136,25 @@ Useful extra parameters can be passed to launch including:
     large image models like Flux.1 and SD3.5 series.
     Below list default options.
 
-    ====  ====  ====  ===
-    Model quantize_text_encoder quantize transformer_nf4
-    ====  ====  ====  ===
-    FLUX.1-dev text_encoder_2 True False
-    FLUX.1-schnell text_encoder_2 True False
-    sd3-medium text_encoder_3 N/A False
-    sd3.5-medium text_encoder_3 N/A False
-    sd3.5-large text_encoder_3 N/A True
-    ====  ====  ====  ===
+    +----------------+-----------------------+----------------------+------------------+
+    | Model          | quantize_text_encoder | quantize             | transformer_nf4  |
+    +================+=======================+======================+==================+
+    | FLUX.1-dev     | text_encoder_2        | True                 | False            |
+    +----------------+-----------------------+----------------------+------------------+
+    | FLUX.1-schnell | text_encoder_2        | True                 | False            |
+    +----------------+-----------------------+----------------------+------------------+
+    | sd3-medium     | text_encoder_3        | N/A                  | False            |
+    +----------------+-----------------------+----------------------+------------------+
+    | sd3.5-medium   | text_encoder_3        | N/A                  | False            |
+    +----------------+-----------------------+----------------------+------------------+
+    | sd3.5-large    | text_encoder_3        | N/A                  | True             |
+    +----------------+-----------------------+----------------------+------------------+
+
+    If you want to disable some quantization, just set the corresponding option to False.
+    e.g. for Web UI, set key ``quantize_text_encoder`` and value ``False``
+    and for command line, specify ``--quantize_text_encoder False`` to disable quantization
+    for text encoder.
+
 
 Image-to-image
 --------------------

--- a/doc/source/models/model_abilities/image.rst
+++ b/doc/source/models/model_abilities/image.rst
@@ -41,6 +41,8 @@ The Text-to-image API is supported with the following models in Xinference:
 * stable-diffusion-v1.5
 * stable-diffusion-xl-base-1.0
 * sd3-medium
+* sd3.5-medium
+* sd3.5-large
 * FLUX.1-schnell
 * FLUX.1-dev
 
@@ -120,29 +122,26 @@ Useful extra parameters can be passed to launch including:
 * ``--text_encoder_3 None``, for sd3-medium, removing the memory-intensive 4.7B parameter
   T5-XXL text encoder during inference can significantly decrease the memory requirements
   with only a slight loss in performance.
-
-If you are trying to run large image models liek sd3-medium or FLUX.1 series on GPU card
-that has less memory than 24GB, you may encounter OOM when launching or inference.
-Try below solutions.
-
-For FLUX.1 series, try to apply quantization.
-
-.. code:: bash
-
-    xinference launch --model-name FLUX.1-dev --model-type image --quantize_text_encoder text_encoder_2
-
-For sd3-medium, apply quantization to ``text_encoder_3``.
-
-.. code:: bash
-
-    xinference launch --model-name sd3-medium --model-type image --quantize_text_encoder text_encoder_3
+* ``--transformer_nf4 True``: use nf4 for transformer quantization.
+* ``--quantize``: Only work for MLX on Mac, Flux.1-dev and Flux.1-schnell will switch to
+  MLX engine on Mac, and ``quantize`` can be used to quantize the model.
 
 
-Or removing memory-intensive T5-XXL text encoder for sd3-medium.
+.. note::
 
-.. code:: bash
+    From v0.16.1, Xinference by default enabled quantization for
+    large image models like Flux.1 and SD3.5 series.
+    Below list default options.
 
-    xinference launch --model-name sd3-medium --model-type image --text_encoder_3 None
+    ====  ====  ====  ===
+    Model quantize_text_encoder quantize transformer_nf4
+    ====  ====  ====  ===
+    FLUX.1-dev text_encoder_2 True False
+    FLUX.1-schnell text_encoder_2 True False
+    sd3-medium text_encoder_3 N/A False
+    sd3.5-medium text_encoder_3 N/A False
+    sd3.5-large text_encoder_3 N/A True
+    ====  ====  ====  ===
 
 Image-to-image
 --------------------

--- a/xinference/model/image/core.py
+++ b/xinference/model/image/core.py
@@ -22,7 +22,12 @@ from typing import Dict, List, Literal, Optional, Tuple, Union
 from ...constants import XINFERENCE_CACHE_DIR
 from ...types import PeftModelConfig
 from ..core import CacheableModelSpec, ModelDescription
-from ..utils import valid_model_revision
+from ..utils import (
+    IS_NEW_HUGGINGFACE_HUB,
+    retry_download,
+    symlink_local_file,
+    valid_model_revision,
+)
 from .ocr.got_ocr2 import GotOCR2Model
 from .stable_diffusion.core import DiffusionModel
 from .stable_diffusion.mlx import MLXDiffusionModel
@@ -51,6 +56,9 @@ class ImageModelFamilyV1(CacheableModelSpec):
     controlnet: Optional[List["ImageModelFamilyV1"]]
     default_model_config: Optional[dict] = {}
     default_generate_config: Optional[dict] = {}
+    gguf_model_id: Optional[str]
+    gguf_quantizations: Optional[List[str]]
+    gguf_model_file_name_template: Optional[str]
 
 
 class ImageModelDescription(ModelDescription):
@@ -187,6 +195,51 @@ def get_cache_status(
         return valid_model_revision(meta_path, model_spec.model_revision)
 
 
+def cache_gguf(spec: ImageModelFamilyV1, quantization: Optional[str] = None):
+    if not quantization:
+        return
+
+    cache_dir = os.path.realpath(os.path.join(XINFERENCE_CACHE_DIR, spec.model_name))
+    if not os.path.exists(cache_dir):
+        os.makedirs(cache_dir, exist_ok=True)
+
+    filename = spec.gguf_model_file_name_template.format(quantization=quantization)  # type: ignore
+    full_path = os.path.join(cache_dir, filename)
+
+    if spec.model_hub == "huggingface":
+        import huggingface_hub
+
+        use_symlinks = {}
+        if not IS_NEW_HUGGINGFACE_HUB:
+            use_symlinks = {"local_dir_use_symlinks": True, "local_dir": cache_dir}
+        download_file_path = retry_download(
+            huggingface_hub.hf_hub_download,
+            spec.model_name,
+            None,
+            spec.gguf_model_id,
+            filename=filename,
+            **use_symlinks,
+        )
+        if IS_NEW_HUGGINGFACE_HUB:
+            symlink_local_file(download_file_path, cache_dir, filename)
+    elif spec.model_hub == "modelscope":
+        from modelscope.hub.file_download import model_file_download
+
+        download_file_path = retry_download(
+            model_file_download,
+            spec.model_name,
+            None,
+            spec.gguf_model_id,
+            filename,
+            revision=spec.model_revision,
+        )
+        symlink_local_file(download_file_path, cache_dir, filename)
+    else:
+        raise NotImplementedError
+
+    return full_path
+
+
 def create_ocr_model_instance(
     subpool_addr: str,
     devices: List[str],
@@ -219,6 +272,8 @@ def create_image_model_instance(
         Literal["huggingface", "modelscope", "openmind_hub", "csghub"]
     ] = None,
     model_path: Optional[str] = None,
+    gguf_quantization: Optional[str] = None,
+    gguf_model_path: Optional[str] = None,
     **kwargs,
 ) -> Tuple[
     Union[DiffusionModel, MLXDiffusionModel, GotOCR2Model], ImageModelDescription
@@ -272,6 +327,8 @@ def create_image_model_instance(
             ]
     if not model_path:
         model_path = cache(model_spec)
+    if not gguf_model_path and gguf_quantization:
+        gguf_model_path = cache_gguf(model_spec, gguf_quantization)
     if peft_model_config is not None:
         lora_model = peft_model_config.peft_model
         lora_load_kwargs = peft_model_config.image_lora_load_kwargs
@@ -298,6 +355,7 @@ def create_image_model_instance(
         lora_load_kwargs=lora_load_kwargs,
         lora_fuse_kwargs=lora_fuse_kwargs,
         model_spec=model_spec,
+        gguf_model_path=gguf_model_path,
         **kwargs,
     )
     model_description = ImageModelDescription(

--- a/xinference/model/image/model_spec.json
+++ b/xinference/model/image/model_spec.json
@@ -94,6 +94,27 @@
     }
   },
   {
+    "model_name": "sd3.5-large-turbo",
+    "model_family": "stable_diffusion",
+    "model_id": "stabilityai/stable-diffusion-3.5-large-turbo",
+    "model_revision": "ec07796fc06b096cc56de9762974a28f4c632eda",
+    "model_ability": [
+      "text2image",
+      "image2image",
+      "inpainting"
+    ],
+    "default_model_config": {
+      "quantize": true,
+      "quantize_text_encoder": "text_encoder_3",
+      "torch_dtype": "bfloat16",
+      "transformer_nf4": true
+    },
+    "default_generate_config": {
+      "guidance_scale": 1.0,
+      "num_inference_steps": 4
+    }
+  },
+  {
     "model_name": "sd-turbo",
     "model_family": "stable_diffusion",
     "model_id": "stabilityai/sd-turbo",

--- a/xinference/model/image/model_spec.json
+++ b/xinference/model/image/model_spec.json
@@ -11,7 +11,8 @@
     ],
     "default_model_config": {
       "quantize": true,
-      "quantize_text_encoder": "text_encoder_2"
+      "quantize_text_encoder": "text_encoder_2",
+      "torch_dtype": "bfloat16"
     }
   },
   {
@@ -26,8 +27,24 @@
     ],
     "default_model_config": {
       "quantize": true,
-      "quantize_text_encoder": "text_encoder_2"
-    }
+      "quantize_text_encoder": "text_encoder_2",
+      "torch_dtype": "bfloat16"
+    },
+    "gguf_model_id": "city96/FLUX.1-dev-gguf",
+    "gguf_quantizations": [
+      "F16",
+      "Q2_K",
+      "Q3_K_S",
+      "Q4_0",
+      "Q4_1",
+      "Q4_K_S",
+      "Q5_0",
+      "Q5_1",
+      "Q5_K_S",
+      "Q6_K",
+      "Q8_0"
+    ],
+    "gguf_model_file_name_template": "flux1-dev-{quantization}.gguf"
   },
   {
     "model_name": "sd3-medium",

--- a/xinference/model/image/model_spec.json
+++ b/xinference/model/image/model_spec.json
@@ -45,6 +45,38 @@
     }
   },
   {
+    "model_name": "sd3.5-medium",
+    "model_family": "stable_diffusion",
+    "model_id": "stabilityai/stable-diffusion-3.5-medium",
+    "model_revision": "94b13ccbe959c51e8159d91f562c58f29fac971a",
+    "model_ability": [
+      "text2image",
+      "image2image",
+      "inpainting"
+    ],
+    "default_model_config": {
+      "quantize": true,
+      "quantize_text_encoder": "text_encoder_3"
+    }
+  },
+  {
+    "model_name": "sd3.5-large",
+    "model_family": "stable_diffusion",
+    "model_id": "stabilityai/stable-diffusion-3.5-large",
+    "model_revision": "ceddf0a7fdf2064ea28e2213e3b84e4afa170a0f",
+    "model_ability": [
+      "text2image",
+      "image2image",
+      "inpainting"
+    ],
+    "default_model_config": {
+      "quantize": true,
+      "quantize_text_encoder": "text_encoder_3",
+      "torch_dtype": "bfloat16",
+      "transformer_nf4": true
+    }
+  },
+  {
     "model_name": "sd-turbo",
     "model_family": "stable_diffusion",
     "model_id": "stabilityai/sd-turbo",

--- a/xinference/model/image/model_spec_modelscope.json
+++ b/xinference/model/image/model_spec_modelscope.json
@@ -48,6 +48,40 @@
     }
   },
   {
+    "model_name": "sd3.5-medium",
+    "model_family": "stable_diffusion",
+    "model_hub": "modelscope",
+    "model_id": "AI-ModelScope/stable-diffusion-3.5-medium",
+    "model_revision": "master",
+    "model_ability": [
+      "text2image",
+      "image2image",
+      "inpainting"
+    ],
+    "default_model_config": {
+      "quantize": true,
+      "quantize_text_encoder": "text_encoder_3"
+    }
+  },
+  {
+    "model_name": "sd3.5-large",
+    "model_family": "stable_diffusion",
+    "model_hub": "modelscope",
+    "model_id": "AI-ModelScope/stable-diffusion-3.5-large",
+    "model_revision": "master",
+    "model_ability": [
+      "text2image",
+      "image2image",
+      "inpainting"
+    ],
+    "default_model_config": {
+      "quantize": true,
+      "quantize_text_encoder": "text_encoder_3",
+      "torch_dtype": "bfloat16",
+      "transformer_nf4": true
+    }
+  },
+  {
     "model_name": "sd-turbo",
     "model_family": "stable_diffusion",
     "model_hub": "modelscope",

--- a/xinference/model/image/model_spec_modelscope.json
+++ b/xinference/model/image/model_spec_modelscope.json
@@ -12,7 +12,8 @@
     ],
     "default_model_config": {
       "quantize": true,
-      "quantize_text_encoder": "text_encoder_2"
+      "quantize_text_encoder": "text_encoder_2",
+      "torch_dtype": "bfloat16"
     }
   },
   {
@@ -28,8 +29,24 @@
     ],
     "default_model_config": {
       "quantize": true,
-      "quantize_text_encoder": "text_encoder_2"
-    }
+      "quantize_text_encoder": "text_encoder_2",
+      "torch_dtype": "bfloat16"
+    },
+    "gguf_model_id": "AI-ModelScope/FLUX.1-dev-gguf",
+    "gguf_quantizations": [
+      "F16",
+      "Q2_K",
+      "Q3_K_S",
+      "Q4_0",
+      "Q4_1",
+      "Q4_K_S",
+      "Q5_0",
+      "Q5_1",
+      "Q5_K_S",
+      "Q6_K",
+      "Q8_0"
+    ],
+    "gguf_model_file_name_template": "flux1-dev-{quantization}.gguf"
   },
   {
     "model_name": "sd3-medium",

--- a/xinference/model/image/model_spec_modelscope.json
+++ b/xinference/model/image/model_spec_modelscope.json
@@ -99,6 +99,28 @@
     }
   },
   {
+    "model_name": "sd3.5-large-turbo",
+    "model_family": "stable_diffusion",
+    "model_hub": "modelscope",
+    "model_id": "AI-ModelScope/stable-diffusion-3.5-large-turbo",
+    "model_revision": "master",
+    "model_ability": [
+      "text2image",
+      "image2image",
+      "inpainting"
+    ],
+    "default_model_config": {
+      "quantize": true,
+      "quantize_text_encoder": "text_encoder_3",
+      "torch_dtype": "bfloat16",
+      "transformer_nf4": true
+    },
+    "default_generate_config": {
+      "guidance_scale": 1.0,
+      "num_inference_steps": 4
+    }
+  },
+  {
     "model_name": "sd-turbo",
     "model_family": "stable_diffusion",
     "model_hub": "modelscope",


### PR DESCRIPTION
This PR tried to address a few issues.

1. Support SD 3.5 series models, fixes #2664 
2. Support GGUF for image models, fixes #2698 
3. Support nf4 quantization for transformer layer