### PR TITLE
FEAT: support HunyuanVideo

### DIFF
--- a/doc/source/getting_started/installation.rst
+++ b/doc/source/getting_started/installation.rst
@@ -39,7 +39,7 @@ Currently, supported models include:
 
 .. vllm_start
 
-- ``llama-2``, ``llama-3``, ``llama-3.1``, ``llama-3.2-vision``, ``llama-2-chat``, ``llama-3-instruct``, ``llama-3.1-instruct``
+- ``llama-2``, ``llama-3``, ``llama-3.1``, ``llama-3.2-vision``, ``llama-2-chat``, ``llama-3-instruct``, ``llama-3.1-instruct``, ``llama-3.3-instruct``
 - ``mistral-v0.1``, ``mistral-instruct-v0.1``, ``mistral-instruct-v0.2``, ``mistral-instruct-v0.3``, ``mistral-nemo-instruct``, ``mistral-large-instruct``
 - ``codestral-v0.1``
 - ``Yi``, ``Yi-1.5``, ``Yi-chat``, ``Yi-1.5-chat``, ``Yi-1.5-chat-16k``
@@ -62,6 +62,7 @@ Currently, supported models include:
 - ``gemma-it``, ``gemma-2-it``
 - ``orion-chat``, ``orion-chat-rag``
 - ``c4ai-command-r-v01``
+- ``minicpm3-4b``
 .. vllm_end
 
 To install Xinference and vLLM::

--- a/doc/source/models/builtin/llm/index.rst
+++ b/doc/source/models/builtin/llm/index.rst
@@ -396,6 +396,11 @@ The following is a list of built-in LLM in Xinference:
      - 4096
      - Platypus-70B-instruct is a merge of garage-bAInd/Platypus2-70B and upstage/Llama-2-70b-instruct-v2.
 
+   * - :ref:`qvq-72b-preview <models_llm_qvq-72b-preview>`
+     - chat, vision
+     - 32768
+     - QVQ-72B-Preview is an experimental research model developed by the Qwen team, focusing on enhancing visual reasoning capabilities.
+
    * - :ref:`qwen-chat <models_llm_qwen-chat>`
      - chat
      - 32768
@@ -722,6 +727,8 @@ The following is a list of built-in LLM in Xinference:
    phi-3-mini-4k-instruct
   
    platypus2-70b-instruct
+  
+   qvq-72b-preview
   
    qwen-chat
   

--- a/doc/source/models/builtin/llm/minicpm3-4b.rst
+++ b/doc/source/models/builtin/llm/minicpm3-4b.rst
@@ -20,7 +20,7 @@ Model Spec 1 (pytorch, 4 Billion)
 - **Model Format:** pytorch
 - **Model Size (in billions):** 4
 - **Quantizations:** none
-- **Engines**: Transformers
+- **Engines**: vLLM, Transformers
 - **Model ID:** openbmb/MiniCPM3-4B
 - **Model Hubs**:  `Hugging Face <https://huggingface.co/openbmb/MiniCPM3-4B>`__, `ModelScope <https://modelscope.cn/models/OpenBMB/MiniCPM3-4B>`__
 

--- a/doc/source/models/builtin/llm/qvq-72b-preview.rst
+++ b/doc/source/models/builtin/llm/qvq-72b-preview.rst
@@ -20,7 +20,7 @@ Model Spec 1 (pytorch, 72 Billion)
 - **Model Format:** pytorch
 - **Model Size (in billions):** 72
 - **Quantizations:** 4-bit, 8-bit, none
-- **Engines**: Transformers
+- **Engines**: vLLM, Transformers (vLLM only available for quantization none)
 - **Model ID:** Qwen/QVQ-72B-Preview
 - **Model Hubs**:  `Hugging Face <https://huggingface.co/Qwen/QVQ-72B-Preview>`__, `ModelScope <https://modelscope.cn/models/Qwen/QVQ-72B-Preview>`__
 

--- a/doc/source/models/builtin/llm/qvq-72b-preview.rst
+++ b/doc/source/models/builtin/llm/qvq-72b-preview.rst
@@ -1,0 +1,47 @@
+.. _models_llm_qvq-72b-preview:
+
+========================================
+QvQ-72B-Preview
+========================================
+
+- **Context Length:** 32768
+- **Model Name:** QvQ-72B-Preview
+- **Languages:** en, zh
+- **Abilities:** chat, vision
+- **Description:** QVQ-72B-Preview is an experimental research model developed by the Qwen team, focusing on enhancing visual reasoning capabilities.
+
+Specifications
+^^^^^^^^^^^^^^
+
+
+Model Spec 1 (pytorch, 72 Billion)
+++++++++++++++++++++++++++++++++++++++++
+
+- **Model Format:** pytorch
+- **Model Size (in billions):** 72
+- **Quantizations:** 4-bit, 8-bit, none
+- **Engines**: Transformers
+- **Model ID:** Qwen/QVQ-72B-Preview
+- **Model Hubs**:  `Hugging Face <https://huggingface.co/Qwen/QVQ-72B-Preview>`__, `ModelScope <https://modelscope.cn/models/Qwen/QVQ-72B-Preview>`__
+
+Execute the following command to launch the model, remember to replace ``${quantization}`` with your
+chosen quantization method from the options listed above::
+
+   xinference launch --model-engine ${engine} --model-name QvQ-72B-Preview --size-in-billions 72 --model-format pytorch --quantization ${quantization}
+
+
+Model Spec 2 (mlx, 72 Billion)
+++++++++++++++++++++++++++++++++++++++++
+
+- **Model Format:** mlx
+- **Model Size (in billions):** 72
+- **Quantizations:** 3bit, 4bit, 6bit, 8bit, bf16
+- **Engines**: Transformers, MLX
+- **Model ID:** mlx-community/QVQ-72B-Preview-{quantization}
+- **Model Hubs**:  `Hugging Face <https://huggingface.co/mlx-community/QVQ-72B-Preview-{quantization}>`__, `ModelScope <https://modelscope.cn/models/mlx-community/QVQ-72B-Preview-{quantization}>`__
+
+Execute the following command to launch the model, remember to replace ``${quantization}`` with your
+chosen quantization method from the options listed above::
+
+   xinference launch --model-engine ${engine} --model-name QvQ-72B-Preview --size-in-billions 72 --model-format mlx --quantization ${quantization}
+

--- a/doc/source/models/builtin/video/hunyuanvideo.rst
+++ b/doc/source/models/builtin/video/hunyuanvideo.rst
@@ -1,0 +1,18 @@
+.. _models_builtin_hunyuanvideo:
+
+============
+HunyuanVideo
+============
+
+- **Model Name:** HunyuanVideo
+- **Model Family:** HunyuanVideo
+- **Abilities:** text2video
+
+Specifications
+^^^^^^^^^^^^^^
+
+- **Model ID:** hunyuanvideo-community/HunyuanVideo
+
+Execute the following command to launch the model::
+
+   xinference launch --model-name HunyuanVideo --model-type video

--- a/doc/source/models/builtin/video/index.rst
+++ b/doc/source/models/builtin/video/index.rst
@@ -15,3 +15,5 @@ The following is a list of built-in video models in Xinference:
   
    cogvideox-5b
   
+   hunyuanvideo
+  

--- a/doc/source/user_guide/backends.rst
+++ b/doc/source/user_guide/backends.rst
@@ -69,6 +69,7 @@ Currently, supported model includes:
 - ``gemma-it``, ``gemma-2-it``
 - ``orion-chat``, ``orion-chat-rag``
 - ``c4ai-command-r-v01``
+- ``minicpm3-4b``
 .. vllm_end
 
 SGLang

--- a/xinference/model/video/diffusers.py
+++ b/xinference/model/video/diffusers.py
@@ -95,6 +95,8 @@ class DiffUsersVideoModel:
             from diffusers import HunyuanVideoPipeline, HunyuanVideoTransformer3DModel
 
             transformer_torch_dtype = kwargs.pop("transformer_torch_dtype")
+            if isinstance(transformer_torch_dtype, str):
+                transformer_torch_dtype = getattr(torch, transformer_torch_dtype)
             transformer = HunyuanVideoTransformer3DModel.from_pretrained(
                 self._model_path,
                 subfolder="transformer",

--- a/xinference/model/video/diffusers.py
+++ b/xinference/model/video/diffusers.py
@@ -102,7 +102,7 @@ class DiffUsersVideoModel:
                 subfolder="transformer",
                 torch_dtype=transformer_torch_dtype,
             )
-            pipeline = HunyuanVideoPipeline.from_pretrained(
+            pipeline = self._model = HunyuanVideoPipeline.from_pretrained(
                 self._model_path, transformer=transformer, **kwargs
             )
         else:

--- a/xinference/model/video/diffusers.py
+++ b/xinference/model/video/diffusers.py
@@ -91,6 +91,18 @@ class DiffUsersVideoModel:
             pipeline = self._model = CogVideoXPipeline.from_pretrained(
                 self._model_path, **kwargs
             )
+        elif self._model_spec.model_family == "HunyuanVideo":
+            from diffusers import HunyuanVideoPipeline, HunyuanVideoTransformer3DModel
+
+            transformer_torch_dtype = kwargs.pop("transformer_torch_dtype")
+            transformer = HunyuanVideoTransformer3DModel.from_pretrained(
+                self._model_path,
+                subfolder="transformer",
+                torch_dtype=transformer_torch_dtype,
+            )
+            pipeline = HunyuanVideoPipeline.from_pretrained(
+                self._model_path, transformer=transformer, **kwargs
+            )
         else:
             raise Exception(
                 f"Unsupported model family: {self._model_spec.model_family}"

--- a/xinference/model/video/model_spec.json
+++ b/xinference/model/video/model_spec.json
@@ -30,5 +30,20 @@
     "default_generate_config": {
       "guidance_scale": 7
     }
+  },
+  {
+    "model_name": "HunyuanVideo",
+    "model_family": "HunyuanVideo",
+    "model_id": "hunyuanvideo-community/HunyuanVideo",
+    "model_revision": "e8c2aaa66fe3742a32c11a6766aecbf07c56e773",
+    "model_ability": [
+      "text2video"
+    ],
+    "default_model_config": {
+      "transformer_torch_dtype": "bfloat16",
+      "torch_dtype": "float16"
+    },
+    "default_generate_config": {
+    }
   }
 ]


### PR DESCRIPTION
I ran on a 48GB GPU. Loading model with CPU offload, or OOM will occur even for 320x512 resolusion.

Loading model:

```
xinference launch --model-name HunyuanVideo --model-type video --cpu_offload True
```

Inference:

```
from xinference.client import Client

client = Client("http://127.0.0.1:9997")
model = client.get_model("HunyuanVideo")

input_text = "A cat walks on the grass, realistic"

resp = model.text_to_video(input_text, height=320, width=512, num_frames=61, num_inference_steps=30)

b64_video = resp['data'][0]['b64_json']
video_bytes = base64.b64decode(b64_video)
with open('1.mp4', 'wb') as f:
    f.write(video_bytes)
```

Result:

https://github.com/user-attachments/assets/fafe6e9c-343c-48b7-8a7d-9e77a113d99b


