### PR TITLE
ENH: support cline style messages for all backend engines

### DIFF
--- a/xinference/model/llm/utils.py
+++ b/xinference/model/llm/utils.py
@@ -104,6 +104,7 @@ class ChatModelMixin:
         tokenize=False,
         **kwargs,
     ):
+        messages = self.convert_messages_with_content_list_to_str_conversion(messages)
         if tokenizer is not None:
             try:
                 full_context = tokenizer.apply_chat_template(

--- a/xinference/model/llm/utils.py
+++ b/xinference/model/llm/utils.py
@@ -104,8 +104,10 @@ class ChatModelMixin:
         tokenize=False,
         **kwargs,
     ):
-        if "vision" not in self.model_family.model_ability:
-            messages = self.convert_messages_with_content_list_to_str_conversion(messages)
+        if "vision" not in self.model_family.model_ability:  # type: ignore
+            messages = self.convert_messages_with_content_list_to_str_conversion(
+                messages
+            )
         if tokenizer is not None:
             try:
                 full_context = tokenizer.apply_chat_template(

--- a/xinference/model/llm/utils.py
+++ b/xinference/model/llm/utils.py
@@ -104,7 +104,8 @@ class ChatModelMixin:
         tokenize=False,
         **kwargs,
     ):
-        messages = self.convert_messages_with_content_list_to_str_conversion(messages)
+        if "vision" not in self.model_family.model_ability:
+            messages = self.convert_messages_with_content_list_to_str_conversion(messages)
         if tokenizer is not None:
             try:
                 full_context = tokenizer.apply_chat_template(

--- a/xinference/model/llm/vllm/core.py
+++ b/xinference/model/llm/vllm/core.py
@@ -804,7 +804,6 @@ class VLLMChatModel(VLLMModel, ChatModelMixin):
         generate_config: Optional[Dict] = None,
         request_id: Optional[str] = None,
     ) -> Union[ChatCompletion, AsyncGenerator[ChatCompletionChunk, None]]:
-        messages = self.convert_messages_with_content_list_to_str_conversion(messages)
         tools = generate_config.pop("tools", []) if generate_config else None
         model_family = self.model_family.model_family or self.model_family.model_name
         full_context_kwargs = {}


### PR DESCRIPTION
As described in #2659 the Cline extension uses a specific messages format.
#2734 supports cline for vLLM engine.
This PR applies it to all other engines.
Test on windows+transformers is success.
