### PR TITLE
ENH: Some improvements for Xavier

### DIFF
--- a/doc/source/locale/zh_CN/LC_MESSAGES/user_guide/vllm_enhancement.po
+++ b/doc/source/locale/zh_CN/LC_MESSAGES/user_guide/vllm_enhancement.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Xinference \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-01-10 14:44+0800\n"
+"POT-Creation-Date: 2025-01-23 14:46+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -31,9 +31,10 @@ msgid ""
 " instances. This allows KV cache computed by other replicas to be "
 "directly reused, avoiding redundant computations."
 msgstr ""
-"对于长文档查询和多轮对话等场景，在推理预填充阶段的计算可能特别繁重，这会影响整体吞吐量和单次推理的延迟。"
-"Xinference 通过引入 ``Xavier`` 框架来增强 vllm 引擎，支持在多个 vllm 实例之间共享 KV 缓存。"
-"这使得其他副本计算出的 KV 缓存可以被直接重用，从而避免了冗余计算。"
+"对于长文档查询和多轮对话等场景，在推理预填充阶段的计算可能特别繁重，这会"
+"影响整体吞吐量和单次推理的延迟。Xinference 通过引入 ``Xavier`` 框架来增强"
+" vllm 引擎，支持在多个 vllm 实例之间共享 KV 缓存。这使得其他副本计算出的 "
+"KV 缓存可以被直接重用，从而避免了冗余计算。"
 
 #: ../../source/user_guide/vllm_enhancement.rst:15
 msgid "Usage"
@@ -43,8 +44,7 @@ msgstr "使用"
 msgid ""
 "Simply add the parameter ``enable_xavier=True`` when starting the vllm "
 "model."
-msgstr ""
-"启动 vllm 模型时设置选项 ``enable_xavier=True`` 即可。"
+msgstr "启动 vllm 模型时设置选项 ``enable_xavier=True`` 即可。"
 
 #: ../../source/user_guide/vllm_enhancement.rst:20
 msgid "Limitations"
@@ -52,22 +52,14 @@ msgstr "限制"
 
 #: ../../source/user_guide/vllm_enhancement.rst:21
 msgid "Xavier requires vllm version >= ``0.6.5``."
-msgstr ""
-"Xavier 要求 vllm 版本不低于 ``0.6.5`` 。"
+msgstr "Xavier 要求 vllm 版本不低于 ``0.6.5`` 。"
 
 #: ../../source/user_guide/vllm_enhancement.rst:22
-msgid ""
-"Xavier is currently not compatible with model reloading after CUDA OOM in"
-" Xinference. (it will be supported in the future)"
-msgstr ""
-"目前 Xavier 与 Xinference 中模型 CUDA OOM 后的重新拉起特性不兼容（未来将解决此问题）。"
-
-#: ../../source/user_guide/vllm_enhancement.rst:23
 msgid ""
 "Due to the underlying communication not recognizing ``0.0.0.0``, the "
 "actual IP address needs to be passed when starting Xinference, for "
 "example: ``xinference-local -H 192.168.xx.xx``."
 msgstr ""
-"由于底层通信无法识别 ``0.0.0.0`` 地址，启动 xinference 时需要配置实际的 IP 地址，"
-"例如：``xinference-local -H 192.168.xx.xx`` 。"
+"由于底层通信无法识别 ``0.0.0.0`` 地址，启动 xinference 时需要配置实际的 "
+"IP 地址，例如：``xinference-local -H 192.168.xx.xx`` 。"
 

--- a/doc/source/user_guide/vllm_enhancement.rst
+++ b/doc/source/user_guide/vllm_enhancement.rst
@@ -19,5 +19,4 @@ Simply add the parameter ``enable_xavier=True`` when starting the vllm model.
 Limitations
 ***********
 * Xavier requires vllm version >= ``0.6.5``.
-* Xavier is currently not compatible with model reloading after CUDA OOM in Xinference. (it will be supported in the future)
 * Due to the underlying communication not recognizing ``0.0.0.0``, the actual IP address needs to be passed when starting Xinference, for example: ``xinference-local -H 192.168.xx.xx``.

--- a/xinference/core/model.py
+++ b/xinference/core/model.py
@@ -35,6 +35,7 @@ from typing import (
     List,
     Optional,
     Union,
+    no_type_check,
 )
 
 import sse_starlette.sse
@@ -302,6 +303,7 @@ class ModelActor(xo.StatelessActor, CancelMixin):
     def decrease_serve_count(self):
         self._serve_count -= 1
 
+    @no_type_check
     async def start_transfer_for_vllm(self, rank_addresses: List[str]):
         from ..model.llm.vllm.core import VLLMModel
         from ..model.llm.vllm.xavier.transfer import TransferActor

--- a/xinference/core/supervisor.py
+++ b/xinference/core/supervisor.py
@@ -1075,7 +1075,7 @@ class SupervisorActor(xo.StatelessActor):
                         if target_ip_worker_ref is not None
                         else await self._choose_worker()
                     )
-                    if _idx == 0:
+                    if enable_xavier and _idx == 0:
                         """
                         Start the rank 0 model actor on the worker that holds the rank 1 replica,
                         solely for constructing the collective communication world.

--- a/xinference/model/llm/memory.py
+++ b/xinference/model/llm/memory.py
@@ -14,7 +14,7 @@
 
 # NOTE:
 #
-#   The algorithum is ported from https://github.com/RahulSChand/gpu_poor
+#   The algorithm is ported from https://github.com/RahulSChand/gpu_poor
 #
 #   Improvement:
 #

--- a/xinference/model/llm/vllm/xavier/block.py
+++ b/xinference/model/llm/vllm/xavier/block.py
@@ -76,12 +76,11 @@ class XavierPrefixCachingBlockAllocator(PrefixCachingBlockAllocator):
         self._xavier_config = v
 
     async def _get_block_tracker_ref(self):
-        from .block_tracker import VLLMBlockTracker
-
         if self._block_tracker_ref is None:
             block_tracker_address = self.xavier_config.get("block_tracker_address")
+            block_tracker_uid = self.xavier_config.get("block_tracker_uid")
             self._block_tracker_ref = await xo.actor_ref(
-                address=block_tracker_address, uid=VLLMBlockTracker.default_uid()
+                address=block_tracker_address, uid=block_tracker_uid
             )
         return self._block_tracker_ref
 

--- a/xinference/model/llm/vllm/xavier/block.py
+++ b/xinference/model/llm/vllm/xavier/block.py
@@ -90,7 +90,7 @@ class XavierPrefixCachingBlockAllocator(PrefixCachingBlockAllocator):
         tracker_ref = await self._get_block_tracker_ref()
         await tracker_ref.unregister_block(
             self.xavier_config.get("virtual_engine"),
-            self.xavier_config.get("rank_address"),
+            self.xavier_config.get("rank"),
             block_id,
         )
 

--- a/xinference/model/llm/vllm/xavier/collective.py
+++ b/xinference/model/llm/vllm/xavier/collective.py
@@ -1,0 +1,74 @@
+# Copyright 2022-2025 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+from typing import List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class CollectiveRank:
+    def __init__(
+        self,
+        rank: int,
+        world_size: int,
+        rank_address: str,
+        store_address: str,
+        store_port: int,
+        world_addresses: List[str],
+    ):
+        self._rank = rank
+        self._world_size = world_size
+        self._rank_address = rank_address
+        self._world_addresses = world_addresses
+        self._store_address = store_address
+        self._store_port = store_port
+        self._device = None
+        self._tcp_store = None
+        self._context = None
+
+    def init_rank(self):
+        from xoscar.collective import xoscar_pygloo as xp
+
+        self._context = xp.rendezvous.Context(self._rank, self._world_size)
+
+        attr = xp.transport.tcp.attr(self._rank_address.split(":")[0])
+        self._device = xp.transport.tcp.CreateDevice(attr)
+
+        opt = xp.rendezvous.TCPStoreOptions()
+        opt.port = self._store_port
+        opt.numWorkers = self._world_size
+        opt.isServer = self._rank == 0
+        opt.waitWorkers = False
+
+        self._tcp_store = xp.rendezvous.TCPStore(self._store_address, opt)
+        if self._world_addresses:
+            self.connect_full_mesh()
+
+    def connect_full_mesh(
+        self, prefix: Optional[str] = None, world_addresses: Optional[List[str]] = None
+    ):
+        from xoscar.collective import xoscar_pygloo as xp
+
+        assert self._device is not None
+        assert self._tcp_store is not None
+        assert self._context is not None
+        if world_addresses is not None:
+            self._world_addresses = world_addresses
+        prefix_store = xp.rendezvous.PrefixStore(
+            prefix or str(self._world_size), self._tcp_store
+        )
+        self._context.connectFullMesh(prefix_store, self._device)
+        logger.debug(
+            f"Rank {self._rank} arrives successfully, world addresses: {self._world_addresses}"
+        )

--- a/xinference/model/llm/vllm/xavier/collective_manager.py
+++ b/xinference/model/llm/vllm/xavier/collective_manager.py
@@ -13,18 +13,59 @@
 # limitations under the License.
 import asyncio
 import logging
-from dataclasses import dataclass
-from typing import TYPE_CHECKING, Dict, Optional, Union
+import traceback
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, no_type_check
 
 import xoscar as xo
 
 from .block_tracker import VLLMBlockTracker
 
 if TYPE_CHECKING:
-    from .transfer import TransferActor
+    from .transfer import Rank0TransferActor, TransferActor
 
 
 logger = logging.getLogger(__name__)
+
+
+class Rank0ModelActor(xo.StatelessActor):
+    @classmethod
+    def default_uid(cls):
+        return "rank0-model-actor"
+
+    def __init__(self, xavier_config: Dict[str, Any]):
+        super().__init__()
+        self._rank = 0
+        self._xavier_config = xavier_config
+        self._transfer_ref: Optional[xo.ActorRefType["Rank0TransferActor"]] = None
+
+    async def __pre_destroy__(self):
+        if self._transfer_ref is not None:
+            try:
+                await xo.destroy_actor(self._transfer_ref)
+                del self._transfer_ref
+            except Exception as e:
+                logger.debug(
+                    f"Destroy transfer actor failed, rank: {self._rank}, address: {self.address}, error: {e}"
+                )
+
+    @no_type_check
+    async def start_transfer_for_vllm(self, rank_addresses: List[str]):
+        from .transfer import Rank0TransferActor
+
+        self._transfer_ref = await xo.create_actor(
+            Rank0TransferActor,
+            address=self.address,
+            uid=f"{Rank0TransferActor.default_uid()}-{self._rank}",
+            rank=self._rank,
+            world_size=self._xavier_config.get("world_size"),  # type: ignore
+            rank_address=self._xavier_config.get("rank_address"),  # type: ignore
+            store_address=self._xavier_config.get("store_address"),  # type: ignore
+            store_port=self._xavier_config.get("store_port"),  # type: ignore
+            world_addresses=rank_addresses,
+        )
+        logger.debug(
+            f"Init transfer actor: {self._transfer_ref.address}, rank: {self._rank} done for vllm."  # type: ignore
+        )
 
 
 def with_lock(method):
@@ -35,66 +76,23 @@ def with_lock(method):
     return wrapper
 
 
-@dataclass
-class NullRef:
-    address: str
-
-
 class CollectiveManager(xo.StatelessActor):
     @classmethod
     def default_uid(cls):
         return f"xavier-collective-manager"
 
-    def __init__(self, model_uid: str, world_size: int, store_port: int):
+    def __init__(self, model_uid: str):
         super().__init__()
         self._model_uid = model_uid
-        self._rank = 0
-        self._world_size = world_size
-        self._store_port = store_port
-        self._device = None
-        self._tcp_store = None
-        self._context = None
         self._tracker_ref: Optional[xo.ActorRefType["VLLMBlockTracker"]] = None
-        self._rank_to_ref: Dict[
-            int, Union[xo.ActorRefType["TransferActor"], NullRef]
-        ] = {}
+        self._rank_to_ref: Dict[int, xo.ActorRefType["TransferActor"]] = {}
         self._lock = asyncio.Lock()
 
     async def __post_create__(self):
-        self._rank_to_ref[self._rank] = NullRef(address=self.address)
         self._tracker_ref = await xo.actor_ref(
             address=self.address,
             uid=f"{VLLMBlockTracker.default_uid()}-{self._model_uid}",
         )
-
-        from xoscar.collective import xoscar_pygloo as xp
-
-        self._context = xp.rendezvous.Context(self._rank, self._world_size)
-        ip = self.address.split(":")[0]
-        attr = xp.transport.tcp.attr(ip)
-        self._device = xp.transport.tcp.CreateDevice(attr)
-
-    def _connect_full_mesh_inner(self, prefix: Optional[str] = None):
-        from xoscar.collective import xoscar_pygloo as xp
-
-        assert self._device is not None
-        assert self._context is not None
-        if self._tcp_store is None:
-            ip = self.address.split(":")[0]
-            opt = xp.rendezvous.TCPStoreOptions()
-            opt.port = self._store_port
-            opt.numWorkers = self._world_size
-            opt.isServer = True
-            self._tcp_store = xp.rendezvous.TCPStore(ip, opt)
-
-        prefix_store = xp.rendezvous.PrefixStore(
-            prefix or str(self._world_size), self._tcp_store
-        )
-        self._context.connectFullMesh(prefix_store, self._device)
-        logger.debug(f"Rank {self._rank} arrives successfully")
-
-    async def connect_full_mesh(self, prefix: Optional[str] = None):
-        await asyncio.to_thread(self._connect_full_mesh_inner, prefix)
 
     async def unregister_rank(self, rank: int):
         self._rank_to_ref.pop(rank, None)
@@ -115,6 +113,9 @@ class CollectiveManager(xo.StatelessActor):
 
     @with_lock
     async def _update_world(self):
+        """
+        Locking is used to prevent chaos when multiple replicas trigger recovery simultaneously.
+        """
         from .....core.utils import gen_random_string
 
         prefix = gen_random_string(6)
@@ -122,13 +123,12 @@ class CollectiveManager(xo.StatelessActor):
         rank_to_ref = self._rank_to_ref.copy()
         world_addresses = [ref.address for _, ref in sorted(rank_to_ref.items())]
         for rank, ref in rank_to_ref.items():
-            if rank != self._rank:
-                tasks.append(ref.connect_full_mesh(prefix, world_addresses))
+            tasks.append(ref.connect_full_mesh(prefix, world_addresses))
         try:
             logger.debug(
                 f"Rebuild collective communication with world_addresses: {world_addresses}, prefix: {prefix}"
             )
-            await asyncio.gather(self.connect_full_mesh(prefix), *tasks)
+            await asyncio.gather(*tasks)
             logger.debug(
                 f"Rebuild collective communication with world_addresses: {world_addresses}, prefix: {prefix} done."
             )
@@ -143,3 +143,5 @@ class CollectiveManager(xo.StatelessActor):
                 f"Rebuild collective communication with world_addresses: {world_addresses} failed. "
                 f"Exception: {e}"
             )
+            # Print the complete error stack
+            traceback.print_exception(type(e), e, e.__traceback__)

--- a/xinference/model/llm/vllm/xavier/collective_manager.py
+++ b/xinference/model/llm/vllm/xavier/collective_manager.py
@@ -1,0 +1,145 @@
+# Copyright 2022-2025 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import asyncio
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Dict, Optional, Union
+
+import xoscar as xo
+
+from .block_tracker import VLLMBlockTracker
+
+if TYPE_CHECKING:
+    from .transfer import TransferActor
+
+
+logger = logging.getLogger(__name__)
+
+
+def with_lock(method):
+    async def wrapper(self, *args, **kwargs):
+        async with self._lock:
+            return await method(self, *args, **kwargs)
+
+    return wrapper
+
+
+@dataclass
+class NullRef:
+    address: str
+
+
+class CollectiveManager(xo.StatelessActor):
+    @classmethod
+    def default_uid(cls):
+        return f"xavier-collective-manager"
+
+    def __init__(self, model_uid: str, world_size: int, store_port: int):
+        super().__init__()
+        self._model_uid = model_uid
+        self._rank = 0
+        self._world_size = world_size
+        self._store_port = store_port
+        self._device = None
+        self._tcp_store = None
+        self._context = None
+        self._tracker_ref: Optional[xo.ActorRefType["VLLMBlockTracker"]] = None
+        self._rank_to_ref: Dict[
+            int, Union[xo.ActorRefType["TransferActor"], NullRef]
+        ] = {}
+        self._lock = asyncio.Lock()
+
+    async def __post_create__(self):
+        self._rank_to_ref[self._rank] = NullRef(address=self.address)
+        self._tracker_ref = await xo.actor_ref(
+            address=self.address,
+            uid=f"{VLLMBlockTracker.default_uid()}-{self._model_uid}",
+        )
+
+        from xoscar.collective import xoscar_pygloo as xp
+
+        self._context = xp.rendezvous.Context(self._rank, self._world_size)
+        ip = self.address.split(":")[0]
+        attr = xp.transport.tcp.attr(ip)
+        self._device = xp.transport.tcp.CreateDevice(attr)
+
+    def _connect_full_mesh_inner(self, prefix: Optional[str] = None):
+        from xoscar.collective import xoscar_pygloo as xp
+
+        assert self._device is not None
+        assert self._context is not None
+        if self._tcp_store is None:
+            ip = self.address.split(":")[0]
+            opt = xp.rendezvous.TCPStoreOptions()
+            opt.port = self._store_port
+            opt.numWorkers = self._world_size
+            opt.isServer = True
+            self._tcp_store = xp.rendezvous.TCPStore(ip, opt)
+
+        prefix_store = xp.rendezvous.PrefixStore(
+            prefix or str(self._world_size), self._tcp_store
+        )
+        self._context.connectFullMesh(prefix_store, self._device)
+        logger.debug(f"Rank {self._rank} arrives successfully")
+
+    async def connect_full_mesh(self, prefix: Optional[str] = None):
+        await asyncio.to_thread(self._connect_full_mesh_inner, prefix)
+
+    async def unregister_rank(self, rank: int):
+        self._rank_to_ref.pop(rank, None)
+        await self._tracker_ref.unregister_rank(rank)  # type: ignore
+        logger.debug(f"Unregister rank: {rank}")
+
+    async def register_rank(self, rank: int, address: str, update: bool = False):
+        from .transfer import TransferActor
+
+        rank_ref = await xo.actor_ref(
+            address=address, uid=f"{TransferActor.default_uid()}-{rank}"
+        )
+        self._rank_to_ref[rank] = rank_ref
+        logger.debug(f"Register rank: {rank}, address: {address}")
+        if update:
+            await self._update_world()
+            await self._tracker_ref.register_rank(rank)  # type: ignore
+
+    @with_lock
+    async def _update_world(self):
+        from .....core.utils import gen_random_string
+
+        prefix = gen_random_string(6)
+        tasks = []
+        rank_to_ref = self._rank_to_ref.copy()
+        world_addresses = [ref.address for _, ref in sorted(rank_to_ref.items())]
+        for rank, ref in rank_to_ref.items():
+            if rank != self._rank:
+                tasks.append(ref.connect_full_mesh(prefix, world_addresses))
+        try:
+            logger.debug(
+                f"Rebuild collective communication with world_addresses: {world_addresses}, prefix: {prefix}"
+            )
+            await asyncio.gather(self.connect_full_mesh(prefix), *tasks)
+            logger.debug(
+                f"Rebuild collective communication with world_addresses: {world_addresses}, prefix: {prefix} done."
+            )
+        except Exception as e:
+            """
+            The exception here is most likely due to another replica triggering recovery during the recovery process,
+            causing `connect_full_mesh` to time out.
+            Simply log the exception and
+            let the subsequent update process handle the reconstruction of the collective communication world.
+            """
+            logger.error(
+                f"Rebuild collective communication with world_addresses: {world_addresses} failed. "
+                f"Exception: {e}"
+            )

--- a/xinference/model/llm/vllm/xavier/executor.py
+++ b/xinference/model/llm/vllm/xavier/executor.py
@@ -117,16 +117,19 @@ class XavierExecutor(GPUExecutorAsync):
 
         res = await super().execute_model_async(execute_model_req)
 
-        """
-        Why not collect and register the information after execution?
-        Because after execution, the model's execution callback hook will release the block_id,
-        causing the block manager to lose access to the correct information.
-        """
-        await block_tracker_ref.register_blocks(
-            virtual_engine, list(executed_blocks_details), rank_address
-        )
+        if executed_blocks_details:
+            """
+            Why not collect and register the information after execution?
+            Because after execution, the model's execution callback hook will release the block_id,
+            causing the block manager to lose access to the correct information.
+            """
+            await block_tracker_ref.register_blocks(
+                virtual_engine, list(executed_blocks_details), rank_address
+            )
 
-        for _, _id in executed_blocks_details:
-            scheduler.block_manager.set_block_status_by_block_id("executed", _id, True)
+            for _, _id in executed_blocks_details:
+                scheduler.block_manager.set_block_status_by_block_id(
+                    "executed", _id, True
+                )
 
         return res

--- a/xinference/model/llm/vllm/xavier/executor.py
+++ b/xinference/model/llm/vllm/xavier/executor.py
@@ -86,8 +86,8 @@ class XavierExecutor(GPUExecutorAsync):
             )
         return self._transfer_ref
 
-    def get_rank_address(self) -> str:
-        return self.vllm_config.xavier_config.get("rank_address")
+    def get_rank(self) -> int:
+        return self.vllm_config.xavier_config.get("rank")
 
     async def execute_model_async(
         self,
@@ -100,7 +100,7 @@ class XavierExecutor(GPUExecutorAsync):
         virtual_engine = execute_model_req.virtual_engine
         block_tracker_ref = await self._get_block_tracker_ref()
         scheduler = self.scheduler[virtual_engine]  # type: ignore
-        rank_address = self.get_rank_address()
+        rank = self.get_rank()
         executed_blocks_details: Set[Tuple[int, int]] = set()
         for meta in execute_model_req.seq_group_metadata_list:
             block_tables = meta.block_tables
@@ -124,7 +124,7 @@ class XavierExecutor(GPUExecutorAsync):
             causing the block manager to lose access to the correct information.
             """
             await block_tracker_ref.register_blocks(
-                virtual_engine, list(executed_blocks_details), rank_address
+                virtual_engine, list(executed_blocks_details), rank
             )
 
             for _, _id in executed_blocks_details:

--- a/xinference/model/llm/vllm/xavier/executor.py
+++ b/xinference/model/llm/vllm/xavier/executor.py
@@ -64,14 +64,13 @@ class XavierExecutor(GPUExecutorAsync):
         )
 
     async def _get_block_tracker_ref(self):
-        from .block_tracker import VLLMBlockTracker
-
         if self._block_tracker_ref is None:
             block_tracker_address = self.vllm_config.xavier_config.get(
                 "block_tracker_address"
             )
+            block_tracker_uid = self.vllm_config.xavier_config.get("block_tracker_uid")
             self._block_tracker_ref = await xo.actor_ref(
-                address=block_tracker_address, uid=VLLMBlockTracker.default_uid()
+                address=block_tracker_address, uid=block_tracker_uid
             )
         return self._block_tracker_ref
 

--- a/xinference/model/llm/vllm/xavier/test/test_xavier.py
+++ b/xinference/model/llm/vllm/xavier/test/test_xavier.py
@@ -121,3 +121,27 @@ async def test_block_tracker(actor_pool_context):
     rank_to_hash_and_block_id = await tracker_ref.get_rank_to_hash_and_block_id()
     assert virtual_engine in rank_to_hash_and_block_id
     assert rank_to_hash_and_block_id[virtual_engine] == {rank: {(123, 0), (789, 2)}}
+
+    # register blocks
+    new_rank = 1
+    block_infos = [(111, 7), (222, 8), (333, 9), (123, 10)]
+    await tracker_ref.register_blocks(virtual_engine, block_infos, new_rank)
+
+    # test unregister rank
+    await tracker_ref.unregister_rank(0)
+    res = await tracker_ref.query_blocks(virtual_engine, [(789, 5)])
+    assert len(res) == 0
+    res = await tracker_ref.query_blocks(virtual_engine, [(123, 6)])
+    assert len(res) == 1
+    assert new_rank in res
+
+    # check internal data
+    rank_to_hash_and_block_id = await tracker_ref.get_rank_to_hash_and_block_id()
+    assert rank in rank_to_hash_and_block_id[virtual_engine]
+    assert new_rank in rank_to_hash_and_block_id[virtual_engine]
+
+    # test register rank
+    await tracker_ref.register_rank(0)
+    rank_to_hash_and_block_id = await tracker_ref.get_rank_to_hash_and_block_id()
+    assert rank not in rank_to_hash_and_block_id[virtual_engine]
+    assert new_rank in rank_to_hash_and_block_id[virtual_engine]

--- a/xinference/model/llm/vllm/xavier/test/test_xavier.py
+++ b/xinference/model/llm/vllm/xavier/test/test_xavier.py
@@ -21,11 +21,11 @@ from ..block_tracker import VLLMBlockTracker
 
 
 class ExtendedBlockTracker(VLLMBlockTracker):
-    def get_hash_to_address_and_block_id(self):
-        return self._hash_to_address_and_block_id
+    def get_hash_to_rank_and_block_id(self):
+        return self._hash_to_rank_and_block_id
 
-    def get_address_to_hash_and_block_id(self):
-        return self._address_to_hash_and_block_id
+    def get_rank_to_hash_and_block_id(self):
+        return self._rank_to_hash_and_block_id
 
 
 @pytest.fixture
@@ -53,53 +53,54 @@ async def test_block_tracker(actor_pool_context):
     )
 
     virtual_engine = 0
+    rank = 0
     block_infos = [(123, 0), (456, 1), (789, 2)]
 
     # register blocks
-    await tracker_ref.register_blocks(virtual_engine, block_infos, addr)
+    await tracker_ref.register_blocks(virtual_engine, block_infos, rank)
 
     # query blocks
     res = await tracker_ref.query_blocks(virtual_engine, [(123, 4), (789, 5)])
     assert len(res) == 1
-    assert addr in res
-    assert len(res[addr]) == 2
-    assert {x[0] for x in res[addr]} == {123, 789}
-    assert {x[1] for x in res[addr]} == {0, 2}
-    assert {x[2] for x in res[addr]} == {4, 5}
+    assert rank in res
+    assert len(res[rank]) == 2
+    assert {x[0] for x in res[rank]} == {123, 789}
+    assert {x[1] for x in res[rank]} == {0, 2}
+    assert {x[2] for x in res[rank]} == {4, 5}
 
     # query with extra info
     res = await tracker_ref.query_blocks(virtual_engine, [(123, 4), (789, 5), (110, 6)])
     assert len(res) == 1
-    assert addr in res
-    assert len(res[addr]) == 2
-    assert {x[0] for x in res[addr]} == {123, 789}
-    assert {x[1] for x in res[addr]} == {0, 2}
-    assert {x[2] for x in res[addr]} == {4, 5}
+    assert rank in res
+    assert len(res[rank]) == 2
+    assert {x[0] for x in res[rank]} == {123, 789}
+    assert {x[1] for x in res[rank]} == {0, 2}
+    assert {x[2] for x in res[rank]} == {4, 5}
 
     # unregister block
-    await tracker_ref.unregister_block(virtual_engine, addr, 1)
+    await tracker_ref.unregister_block(virtual_engine, rank, 1)
     res = await tracker_ref.query_blocks(virtual_engine, [(123, 4), (456, 7)])
     assert len(res) == 1
-    assert addr in res
-    assert len(res[addr]) == 1
-    assert {x[0] for x in res[addr]} == {123}
-    assert {x[1] for x in res[addr]} == {
+    assert rank in res
+    assert len(res[rank]) == 1
+    assert {x[0] for x in res[rank]} == {123}
+    assert {x[1] for x in res[rank]} == {
         0,
     }
-    assert {x[2] for x in res[addr]} == {
+    assert {x[2] for x in res[rank]} == {
         4,
     }
     # nothing happens
-    await tracker_ref.unregister_block(virtual_engine, addr, 3)
+    await tracker_ref.unregister_block(virtual_engine, rank, 3)
     res = await tracker_ref.query_blocks(virtual_engine, [(123, 4), (456, 7)])
     assert len(res) == 1
-    assert addr in res
-    assert len(res[addr]) == 1
-    assert {x[0] for x in res[addr]} == {123}
-    assert {x[1] for x in res[addr]} == {
+    assert rank in res
+    assert len(res[rank]) == 1
+    assert {x[0] for x in res[rank]} == {123}
+    assert {x[1] for x in res[rank]} == {
         0,
     }
-    assert {x[2] for x in res[addr]} == {
+    assert {x[2] for x in res[rank]} == {
         4,
     }
     # query returns empty
@@ -107,16 +108,16 @@ async def test_block_tracker(actor_pool_context):
     assert res == {}
 
     # check internal data
-    hash_to_address_and_block_id = await tracker_ref.get_hash_to_address_and_block_id()
-    assert virtual_engine in hash_to_address_and_block_id
-    assert hash_to_address_and_block_id[virtual_engine] == {
+    hash_to_rank_and_block_id = await tracker_ref.get_hash_to_rank_and_block_id()
+    assert virtual_engine in hash_to_rank_and_block_id
+    assert hash_to_rank_and_block_id[virtual_engine] == {
         123: {
-            (addr, 0),
+            (rank, 0),
         },
         456: set(),
-        789: {(addr, 2)},
+        789: {(rank, 2)},
     }
 
-    address_to_hash_and_block_id = await tracker_ref.get_address_to_hash_and_block_id()
-    assert virtual_engine in address_to_hash_and_block_id
-    assert address_to_hash_and_block_id[virtual_engine] == {addr: {(123, 0), (789, 2)}}
+    rank_to_hash_and_block_id = await tracker_ref.get_rank_to_hash_and_block_id()
+    assert virtual_engine in rank_to_hash_and_block_id
+    assert rank_to_hash_and_block_id[virtual_engine] == {rank: {(123, 0), (789, 2)}}


### PR DESCRIPTION
1. Xavier supports model recovery. Due to the special nature of rank 0, a separate, simple model actor is created for rank 0. This actor is responsible only for constructing the collective communication world. A new role, `collective_manager`, is introduced. In the recovery logic, the `collective_manager` instructs all ranks to reconstruct the collective communication world.
2. If an error occurs during the transmission process (e.g., the sender is undergoing recovery), vllm's scheduling supports rollback, where it reverts to forcing computation instead of transmission.
3. Xavier's transmission process only applies to the PREFILL stage, and no data transmission occurs during the DECODE stage. This is because data transmission in the DECODE stage only affects the last token of a block when it is about to be filled with tokens. This would be counterproductive and negatively impact overall throughput, as it introduces additional RPC call times for many queries.
4. Fix the error when multiple models are enabled with Xavier simultaneously. This is because the block tracker should be one-to-one with the model, rather than having just one block tracker for all models.