### PR TITLE
ENH: calling model.load in a thread

### DIFF
--- a/xinference/core/model.py
+++ b/xinference/core/model.py
@@ -454,7 +454,7 @@ class ModelActor(xo.StatelessActor, CancelMixin):
         while True:
             i += 1
             try:
-                self._model.load()
+                await asyncio.to_thread(self._model.load)
                 break
             except Exception as e:
                 if (


### PR DESCRIPTION
Now model.load() is a synchronous function and in model actor, it's directly called, though a model actor runs on a single actor pool(a process), it's bizarre to see a blocking sync method is called inside an asynchronous function.