### PR TITLE
CHORE: Xavier now supports `vLLM >= 0.7.0`, drops support for older versions

### DIFF
--- a/doc/source/locale/zh_CN/LC_MESSAGES/user_guide/vllm_enhancement.po
+++ b/doc/source/locale/zh_CN/LC_MESSAGES/user_guide/vllm_enhancement.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Xinference \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-01-23 14:46+0800\n"
+"POT-Creation-Date: 2025-02-17 18:23+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -51,8 +51,8 @@ msgid "Limitations"
 msgstr "限制"
 
 #: ../../source/user_guide/vllm_enhancement.rst:21
-msgid "Xavier requires vllm version >= ``0.6.5``."
-msgstr "Xavier 要求 vllm 版本不低于 ``0.6.5`` 。"
+msgid "Xavier requires vllm version >= ``0.7.0``."
+msgstr "Xavier 要求 vllm 版本不低于 ``0.7.0`` 。"
 
 #: ../../source/user_guide/vllm_enhancement.rst:22
 msgid ""

--- a/doc/source/user_guide/vllm_enhancement.rst
+++ b/doc/source/user_guide/vllm_enhancement.rst
@@ -18,5 +18,5 @@ Simply add the parameter ``enable_xavier=True`` when starting the vllm model.
 ***********
 Limitations
 ***********
-* Xavier requires vllm version >= ``0.6.5``.
+* Xavier requires vllm version >= ``0.7.0``.
 * Due to the underlying communication not recognizing ``0.0.0.0``, the actual IP address needs to be passed when starting Xinference, for example: ``xinference-local -H 192.168.xx.xx``.

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,6 +44,7 @@ install_requires =
     passlib[bcrypt]
     aioprometheus[starlette]>=23.12.0
     nvidia-ml-py
+    pynvml>=12
     async-timeout
     peft
     timm

--- a/xinference/deploy/docker/requirements.txt
+++ b/xinference/deploy/docker/requirements.txt
@@ -19,6 +19,7 @@ python-jose[cryptography]
 passlib[bcrypt]
 aioprometheus[starlette]>=23.12.0
 nvidia-ml-py
+pynvml>=12
 async-timeout
 peft
 opencv-contrib-python-headless

--- a/xinference/model/llm/vllm/xavier/executor.py
+++ b/xinference/model/llm/vllm/xavier/executor.py
@@ -14,7 +14,7 @@
 from typing import TYPE_CHECKING, List, Optional, Set, Tuple, Union
 
 import xoscar as xo
-from vllm.executor.gpu_executor import GPUExecutorAsync
+from vllm.executor.mp_distributed_executor import MultiprocessingDistributedExecutor
 from vllm.model_executor.layers.sampler import SamplerOutput
 from vllm.sequence import ExecuteModelRequest, PoolerOutput
 from vllm.utils import is_pin_memory_available
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
     from .scheduler import XavierScheduler
 
 
-class XavierExecutor(GPUExecutorAsync):
+class XavierExecutor(MultiprocessingDistributedExecutor):
     scheduler: Optional[List["XavierScheduler"]] = None
 
     def _init_executor(self) -> None:

--- a/xinference/model/llm/vllm/xavier/scheduler.py
+++ b/xinference/model/llm/vllm/xavier/scheduler.py
@@ -21,7 +21,7 @@ import xoscar as xo
 from vllm.config import CacheConfig, LoRAConfig, SchedulerConfig
 from vllm.core.block.interfaces import Block
 from vllm.core.interfaces import BlockSpaceManager
-from vllm.core.scheduler import Scheduler, SchedulerOutputs
+from vllm.core.scheduler import ScheduledSequenceGroup, Scheduler, SchedulerOutputs
 from vllm.sequence import (
     SequenceData,
     SequenceGroup,
@@ -216,7 +216,7 @@ class XavierScheduler(Scheduler):
         """Xinference Change!!!
         Additional data structures required by Xavier.
         """
-        scheduled_seq_groups = []
+        scheduled_seq_groups: List[ScheduledSequenceGroup] = []
         has_transferring = False
 
         # Create input data structures.
@@ -288,7 +288,7 @@ class XavierScheduler(Scheduler):
                     has_transferring = True
                     continue
                 else:
-                    scheduled_seq_groups.append(seq_group)
+                    scheduled_seq_groups.append(scheduled_seq_group)
 
             if self.cache_config.enable_prefix_caching:
                 common_computed_block_nums = (


### PR DESCRIPTION
1. Xavier now supports `vLLM >= 0.7.0`, drops support for older versions
2. Fixes #2866 
3. About pynvml >= 12: See https://github.com/vllm-project/vllm/issues/12947