### PR TITLE
ENH: cmdline supports --n-worker, add --model-path and make it compatible with --model_path

### DIFF
--- a/xinference/client/restful/restful_client.py
+++ b/xinference/client/restful/restful_client.py
@@ -917,11 +917,13 @@ class Client:
         model_format: Optional[str] = None,
         quantization: Optional[str] = None,
         replica: int = 1,
+        n_worker: int = 1,
         n_gpu: Optional[Union[int, str]] = "auto",
         peft_model_config: Optional[Dict] = None,
         request_limits: Optional[int] = None,
         worker_ip: Optional[str] = None,
         gpu_idx: Optional[Union[int, List[int]]] = None,
+        model_path: Optional[str] = None,
         **kwargs,
     ) -> str:
         """
@@ -945,8 +947,10 @@ class Client:
             The quantization of model.
         replica: Optional[int]
             The replica of model, default is 1.
+        n_worker: int
+            Number of workers to run.
         n_gpu: Optional[Union[int, str]],
-            The number of GPUs used by the model, default is "auto".
+            The number of GPUs used by the model, default is "auto". If n_worker>1, means number of GPUs per worker.
             ``n_gpu=None`` means cpu only, ``n_gpu=auto`` lets the system automatically determine the best number of GPUs to use.
         peft_model_config: Optional[Dict]
             - "lora_list": A List of PEFT (Parameter-Efficient Fine-Tuning) model and path.
@@ -959,6 +963,8 @@ class Client:
             Specify the worker ip where the model is located in a distributed scenario.
         gpu_idx: Optional[Union[int, List[int]]]
             Specify the GPU index where the model is located.
+        model_path: Optional[str]
+            Model path, if gguf format, should be the file path, otherwise, should be directory of the model.
         **kwargs:
             Any other parameters been specified.
 
@@ -985,10 +991,12 @@ class Client:
             "model_format": model_format,
             "quantization": quantization,
             "replica": replica,
+            "n_worker": n_worker,
             "n_gpu": n_gpu,
             "request_limits": request_limits,
             "worker_ip": worker_ip,
             "gpu_idx": gpu_idx,
+            "model_path": model_path,
         }
 
         for key, value in kwargs.items():

--- a/xinference/deploy/test/test_cmdline.py
+++ b/xinference/deploy/test/test_cmdline.py
@@ -147,6 +147,38 @@ def test_cmdline(setup, stream, model_uid):
     assert model_uid not in result.stdout
 
 
+def test_cmdline_model_path_error(setup):
+    endpoint, _ = setup
+    runner = CliRunner(mix_stderr=False)
+
+    # launch model
+    result = runner.invoke(
+        model_launch,
+        [
+            "--endpoint",
+            endpoint,
+            "--model-name",
+            "tiny-llama",
+            "--size-in-billions",
+            1,
+            "--model-format",
+            "ggufv2",
+            "--quantization",
+            "Q2_K",
+            "--model-path",
+            "/path/to/model",
+            "--model_path",
+            "/path/to/model",
+        ],
+    )
+    assert result.exit_code > 0
+    with pytest.raises(
+        ValueError, match="Cannot set both for --model-path and --model_path"
+    ):
+        t, e, tb = result.exc_info
+        raise e.with_traceback(tb)
+
+
 def test_cmdline_of_custom_model(setup):
     endpoint, _ = setup
     runner = CliRunner()


### PR DESCRIPTION
This PR polished cmdline, added `--n-worker` to support distributed inference, and added `--model-path` which treats model_path as builtin option, meanwhile, makes sure that `--model_path` can work as well.