### PR TITLE
BUG: fix Error while using Langchain-chatchat, because the parameter [max_tokens] passed is None

### DIFF
--- a/xinference/model/llm/transformers/utils.py
+++ b/xinference/model/llm/transformers/utils.py
@@ -132,7 +132,7 @@ def _pad_seqs_inplace(seqs: List[List[int]], reqs: List[InferenceRequest], pad: 
 
 def get_max_src_len(context_len: int, r: InferenceRequest) -> int:
     max_new_tokens = int(
-        r.sanitized_generate_config.get("max_tokens", max_tokens_field.default)
+        r.sanitized_generate_config.get("max_tokens") or max_tokens_field.default
     )
     return context_len - max_new_tokens - 8
 


### PR DESCRIPTION
BUG: fix Error while using Langchain Chatchat ，because The parameter [max_tokens] passed is None

Fixes https://github.com/xorbitsai/inference/issues/2559