### PR TITLE
BUG: wrong kwargs passing to encode method when using jina-clip-v2

### DIFF
--- a/xinference/model/embedding/core.py
+++ b/xinference/model/embedding/core.py
@@ -663,7 +663,7 @@ class EmbeddingModel:
                 self._model,
                 objs,
                 convert_to_numpy=False,
-                **self._kwargs,
+                **kwargs,
             )
         else:
             all_embeddings, all_token_nums = encode(


### PR DESCRIPTION
fix #3003 