### PR TITLE
BUG: fix llm stream response

### DIFF
--- a/xinference/client/tests/test_client.py
+++ b/xinference/client/tests/test_client.py
@@ -83,7 +83,6 @@ def test_RESTful_client(setup):
             generate_config={"stream": True, "max_tokens": 5},
         )
         for chunk in streaming_response:
-            print(chunk)
             assert "finish_reason" in chunk["choices"][0]
             finish_reason = chunk["choices"][0]["finish_reason"]
             if finish_reason is None:

--- a/xinference/client/tests/test_client.py
+++ b/xinference/client/tests/test_client.py
@@ -90,7 +90,7 @@ def test_RESTful_client(setup):
                     "role" in chunk["choices"][0]["delta"]
                 )
             else:
-                assert chunk["choices"][0]["delta"] == {}
+                assert chunk["choices"][0]["delta"] == {"content": ""}
 
     _check_stream()
 

--- a/xinference/client/tests/test_client.py
+++ b/xinference/client/tests/test_client.py
@@ -54,13 +54,13 @@ def test_RESTful_client(setup):
     with pytest.raises(RuntimeError):
         completion = model.generate({"max_tokens": 64})
 
-    # completion = model.generate("Once upon a time, there was a very old computer")
-    # assert "text" in completion["choices"][0]
-    #
-    # completion = model.generate(
-    #     "Once upon a time, there was a very old computer", {"max_tokens": 64}
-    # )
-    # assert "text" in completion["choices"][0]
+    completion = model.generate("Once upon a time, there was a very old computer")
+    assert "text" in completion["choices"][0]
+
+    completion = model.generate(
+        "Once upon a time, there was a very old computer", {"max_tokens": 64}
+    )
+    assert "text" in completion["choices"][0]
 
     streaming_response = model.generate(
         "Once upon a time, there was a very old computer",

--- a/xinference/client/tests/test_client.py
+++ b/xinference/client/tests/test_client.py
@@ -54,13 +54,13 @@ def test_RESTful_client(setup):
     with pytest.raises(RuntimeError):
         completion = model.generate({"max_tokens": 64})
 
-    completion = model.generate("Once upon a time, there was a very old computer")
-    assert "text" in completion["choices"][0]
-
-    completion = model.generate(
-        "Once upon a time, there was a very old computer", {"max_tokens": 64}
-    )
-    assert "text" in completion["choices"][0]
+    # completion = model.generate("Once upon a time, there was a very old computer")
+    # assert "text" in completion["choices"][0]
+    #
+    # completion = model.generate(
+    #     "Once upon a time, there was a very old computer", {"max_tokens": 64}
+    # )
+    # assert "text" in completion["choices"][0]
 
     streaming_response = model.generate(
         "Once upon a time, there was a very old computer",
@@ -83,6 +83,7 @@ def test_RESTful_client(setup):
             generate_config={"stream": True, "max_tokens": 5},
         )
         for chunk in streaming_response:
+            print(chunk)
             assert "finish_reason" in chunk["choices"][0]
             finish_reason = chunk["choices"][0]["finish_reason"]
             if finish_reason is None:

--- a/xinference/model/llm/llama_cpp/core.py
+++ b/xinference/model/llm/llama_cpp/core.py
@@ -304,7 +304,9 @@ class XllamaCppModel(LLM, ChatModelMixin):
                         raise Exception("Got error in chat stream: %s", r.msg)
                     # Get valid keys (O(1) lookup)
                     chunk_keys = ChatCompletionChunk.__annotations__
-                    # Filter out keys that are not part of ChatCompletionChunk
+                    # The chunk may contain additional keys (e.g., system_fingerprint),
+                    # which might not conform to OpenAI/DeepSeek formats.
+                    # Filter out keys that are not part of ChatCompletionChunk.
                     yield {key: r[key] for key in chunk_keys if key in r}
 
             return self._to_chat_completion_chunks(

--- a/xinference/model/llm/llama_cpp/core.py
+++ b/xinference/model/llm/llama_cpp/core.py
@@ -302,7 +302,9 @@ class XllamaCppModel(LLM, ChatModelMixin):
                 while (r := q.get()) is not _Done:
                     if type(r) is _Error:
                         raise Exception("Got error in chat stream: %s", r.msg)
-                    chunk_keys = ChatCompletionChunk.__annotations__.keys()
+                    # Get valid keys (O(1) lookup)
+                    chunk_keys = ChatCompletionChunk.__annotations__
+                    # Filter out keys that are not part of ChatCompletionChunk
                     yield {key: r[key] for key in chunk_keys if key in r}
 
             return self._to_chat_completion_chunks(

--- a/xinference/model/llm/llama_cpp/core.py
+++ b/xinference/model/llm/llama_cpp/core.py
@@ -302,7 +302,8 @@ class XllamaCppModel(LLM, ChatModelMixin):
                 while (r := q.get()) is not _Done:
                     if type(r) is _Error:
                         raise Exception("Got error in chat stream: %s", r.msg)
-                    yield r
+                    chunk_keys = ChatCompletionChunk.__annotations__.keys()
+                    yield {key: r[key] for key in chunk_keys if key in r}
 
             return self._to_chat_completion_chunks(
                 _to_iterator(), self.reasoning_parser

--- a/xinference/model/llm/reasoning_parser.py
+++ b/xinference/model/llm/reasoning_parser.py
@@ -43,7 +43,7 @@ class ReasoningParser:
                 reasoning_content = delta_text[:end_idx]
                 content = delta_text[end_idx + len(self.reasoning_end_tag) :]
                 delta["reasoning_content"] = reasoning_content
-                if content is not None:
+                if content:
                     delta["content"] = content
                 else:
                     delta["content"] = None
@@ -71,7 +71,7 @@ class ReasoningParser:
                 ]
                 content = delta_text[end_idx + len(self.reasoning_end_tag) :]
                 delta["reasoning_content"] = reasoning_content
-                if content is not None:
+                if content:
                     delta["content"] = content
                 else:
                     delta["content"] = None
@@ -93,7 +93,7 @@ class ReasoningParser:
                 reasoning_content = delta_text[:end_idx]
                 content = delta_text[end_idx + len(self.reasoning_end_tag) :]
                 delta["reasoning_content"] = reasoning_content
-                if content is not None:
+                if content:
                     delta["content"] = content
                 else:
                     delta["content"] = None

--- a/xinference/model/llm/utils.py
+++ b/xinference/model/llm/utils.py
@@ -269,6 +269,7 @@ class ChatModelMixin:
                     previous_texts[-1] = current_text
                     choices[0]["delta"] = delta  # type: ignore
             # Already a ChatCompletionChunk, we don't need to convert chunk.
+
             return cast(ChatCompletionChunk, chunk)
 
         choices_list = []
@@ -368,6 +369,7 @@ class ChatModelMixin:
         previous_texts = [""]
         for _, chunk in enumerate(chunks):
             # usage
+            print(chunk)
             choices = chunk.get("choices")
             if not choices:
                 yield cls._get_final_chat_completion_chunk(chunk)

--- a/xinference/model/llm/utils.py
+++ b/xinference/model/llm/utils.py
@@ -323,8 +323,9 @@ class ChatModelMixin:
     ) -> ChatCompletionChunk:
         choices_list = []
         for i, choice in enumerate(chunk["choices"]):
-            delta = {"role": "assistant", "content": ""}
+            delta = ChatCompletionChunkDelta(role="assistant", content="")
             if reasoning_parser is not None:
+                delta["content"] = None
                 delta["reasoning_content"] = ""
             choices_list.append(
                 {

--- a/xinference/model/llm/utils.py
+++ b/xinference/model/llm/utils.py
@@ -255,7 +255,7 @@ class ChatModelMixin:
             and choices
             and "delta" in choices[0]
         ):
-            delta = ChatCompletionChunkDelta()
+            delta = {}
             if choices[0]["finish_reason"] is None:
                 if reasoning_parser is not None:
                     # process parsing reasoning content

--- a/xinference/model/llm/utils.py
+++ b/xinference/model/llm/utils.py
@@ -286,7 +286,11 @@ class ChatModelMixin:
                         delta_text=choice["text"],
                     )
                     previous_texts[-1] = current_text
-            if "tool_calls" in choice:
+            elif "text" in choice and choice["finish_reason"] is not None:
+                delta["content"] = choice["text"]
+                if reasoning_parser is not None:
+                    delta["reasoning_content"] = None
+            elif "tool_calls" in choice:
                 delta["tool_calls"] = choice["tool_calls"]
             choices_list.append(
                 {
@@ -409,6 +413,7 @@ class ChatModelMixin:
     ) -> AsyncGenerator[ChatCompletionChunk, None]:
         previous_texts = [""]
         async for chunk in chunks:
+            print(chunk)
             choices = chunk.get("choices")
             if not choices:
                 # usage
@@ -417,6 +422,7 @@ class ChatModelMixin:
                 chat_chunk = cls._to_chat_completion_chunk(
                     chunk, reasoning_parser, previous_texts
                 )
+            print(chat_chunk)
             yield chat_chunk
 
     @staticmethod

--- a/xinference/model/llm/utils.py
+++ b/xinference/model/llm/utils.py
@@ -255,7 +255,6 @@ class ChatModelMixin:
             and choices
             and "delta" in choices[0]
         ):
-            delta = {}
             if choices[0]["finish_reason"] is None:
                 if reasoning_parser is not None:
                     # process parsing reasoning content

--- a/xinference/model/llm/utils.py
+++ b/xinference/model/llm/utils.py
@@ -269,12 +269,13 @@ class ChatModelMixin:
                         )
                         previous_texts[-1] = current_text
                         choices[0]["delta"] = delta  # type: ignore
-            # Already a ChatCompletionChunk, we don't need to convert chunk.
             elif choices[0]["finish_reason"] is not None:
                 delta = choices[0]["delta"]  # type: ignore
-                delta["content"] = delta.get("content", "")  # type: ignore
+                if "content" not in delta:
+                    delta["content"] = ""  # type: ignore
                 if reasoning_parser is not None:
                     delta["reasoning_content"] = None  # type: ignore
+            # Already a ChatCompletionChunk, we don't need to convert chunk.
             return cast(ChatCompletionChunk, chunk)
 
         choices_list = []
@@ -374,7 +375,6 @@ class ChatModelMixin:
         previous_texts = [""]
         for _, chunk in enumerate(chunks):
             # usage
-            print(chunk)
             choices = chunk.get("choices")
             if not choices:
                 yield cls._get_final_chat_completion_chunk(chunk)

--- a/xinference/model/llm/utils.py
+++ b/xinference/model/llm/utils.py
@@ -272,9 +272,10 @@ class ChatModelMixin:
                         choices[0]["delta"] = delta  # type: ignore
             # Already a ChatCompletionChunk, we don't need to convert chunk.
             elif choices[0]["finish_reason"] is not None:
-                delta["content"] = choices[0].get("content", "")
+                delta = choices[0]["delta"]  # type: ignore
+                delta["content"] = delta.get("content", "")  # type: ignore
                 if reasoning_parser is not None:
-                    delta["reasoning_content"] = None
+                    delta["reasoning_content"] = None  # type: ignore
             return cast(ChatCompletionChunk, chunk)
 
         choices_list = []

--- a/xinference/model/llm/utils.py
+++ b/xinference/model/llm/utils.py
@@ -414,7 +414,6 @@ class ChatModelMixin:
     ) -> AsyncGenerator[ChatCompletionChunk, None]:
         previous_texts = [""]
         async for chunk in chunks:
-            print(chunk)
             choices = chunk.get("choices")
             if not choices:
                 # usage
@@ -423,7 +422,6 @@ class ChatModelMixin:
                 chat_chunk = cls._to_chat_completion_chunk(
                     chunk, reasoning_parser, previous_texts
                 )
-            print(chat_chunk)
             yield chat_chunk
 
     @staticmethod


### PR DESCRIPTION
1. Modify xinference/client/tests/test_client.py: For chunk where finish_reason is not None, assert that delta = {"content": ""}.

2. Modify xinference/model/llm/llama_cpp/core.py: Filter out keys in the returned results that do not belong to ChatCompletionChunk.

3. Modify xinference/model/llm/reasoning_parser.py: Fix the issue where both reasoning_content="" and content="".

4. Modify xinference/model/llm/utils.py:  Ensure that chunk with finish_reason not being None includes values for both content and reasoning_content.