### PR TITLE
BUG: Fix PyTorch TypeError: Make _ModelWrapper Inherit from nn.Module

### DIFF
--- a/xinference/model/rerank/core.py
+++ b/xinference/model/rerank/core.py
@@ -106,8 +106,9 @@ def generate_rerank_description(model_spec: RerankModelSpec) -> Dict[str, List[D
     return res
 
 
-class _ModelWrapper:
+class _ModelWrapper(nn.Module):
     def __init__(self, module: nn.Module):
+        super().__init__()
         self._module = module
         self._local_data = threading.local()
 
@@ -119,15 +120,13 @@ class _ModelWrapper:
     def n_tokens(self, new_n_tokens):
         self._local_data.n_tokens = new_n_tokens
 
-    def __getattr__(self, attr):
-        return getattr(self._module, attr)
-
-    def __call__(self, **kwargs):
+    def forward(self, **kwargs):
         attention_mask = kwargs["attention_mask"]
-        # when batching, the attention mask 1 means there is a token
-        # thus we just sum up it to get the total number of tokens
         self.n_tokens += attention_mask.sum().item()
         return self._module(**kwargs)
+
+    def __getattr__(self, attr):
+        return getattr(self._module, attr)
 
 
 class RerankModel:

--- a/xinference/model/rerank/core.py
+++ b/xinference/model/rerank/core.py
@@ -122,6 +122,8 @@ class _ModelWrapper(nn.Module):
 
     def forward(self, **kwargs):
         attention_mask = kwargs["attention_mask"]
+        # when batching, the attention mask 1 means there is a token
+        # thus we just sum up it to get the total number of tokens
         self.n_tokens += attention_mask.sum().item()
         return self._module(**kwargs)
 


### PR DESCRIPTION
### Problem Description
An error occurs when assigning an instance of `_ModelWrapper` to a sub-module in a PyTorch model:

```
TypeError: cannot assign '_ModelWrapper' as child module 'model'; (torch.nn.Module or None expected)
```

### Cause of the Problem
PyTorch requires all sub-modules to inherit from `nn.Module`, but the original implementation of `_ModelWrapper` does not.

### Solution
- Have `_ModelWrapper` class inherit from `nn.Module`
- Call `super().__init__()` in the constructor
- Rename the existing `__call__` method to conform with PyTorch’s standard naming convention, which is called `forward`

The modifications are minimal and do not introduce any further changes beyond necessary adjustments for compatibility.

### How to Verify
- The original TypeError no longer appears after reloading the model  
- The model runs as expected, and the logic of counting tokens by `n_tokens` remains unchanged