### PR TITLE
BLD: use gptqmodel to replace auto-gptq

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -95,7 +95,7 @@ all =
     imageio-ffmpeg  # For video
     controlnet_aux
     orjson
-    auto-gptq ; sys_platform!='darwin'
+    gptqmodel
     autoawq<0.2.6 ; sys_platform!='darwin'  # autoawq 0.2.6 pinned torch to 2.3
     optimum
     outlines>=0.0.34
@@ -167,7 +167,7 @@ transformers =
     protobuf
     einops
     tiktoken
-    auto-gptq ; sys_platform!='darwin'
+    gptqmodel
     autoawq<0.2.6 ; sys_platform!='darwin'  # autoawq 0.2.6 pinned torch to 2.3
     optimum
     attrdict  # For deepseek VL

--- a/xinference/deploy/docker/requirements.txt
+++ b/xinference/deploy/docker/requirements.txt
@@ -37,7 +37,7 @@ tiktoken>=0.6.0
 sentence-transformers>=3.1.0
 controlnet_aux
 orjson
-auto-gptq
+gptqmodel
 autoawq<0.2.6  # autoawq 0.2.6 pinned torch to 2.3
 optimum
 attrdict  # For deepseek VL

--- a/xinference/deploy/docker/requirements_cpu.txt
+++ b/xinference/deploy/docker/requirements_cpu.txt
@@ -33,7 +33,7 @@ sentence-transformers>=3.1.0
 FlagEmbedding
 controlnet_aux
 orjson
-auto-gptq
+gptqmodel
 autoawq<0.2.6  # autoawq 0.2.6 pinned torch to 2.3
 optimum
 peft


### PR DESCRIPTION
auto-gptq is not maintained, gptqmodel is way more faster and still under development. 

Transformers has integrated gptqmodel as well, thus no code needs to be modified.