### PR TITLE
REF: simplify transformers model registration with decorators.

### DIFF
--- a/xinference/model/llm/__init__.py
+++ b/xinference/model/llm/__init__.py
@@ -147,13 +147,11 @@ def _install():
     from .transformers.gemma3 import Gemma3ChatModel, Gemma3TextChatModel
     from .transformers.glm4v import Glm4VModel
     from .transformers.glm_edge_v import GlmEdgeVModel
-    from .transformers.intern_vl import InternVLChatModel
     from .transformers.internlm2 import Internlm2PytorchChatModel
     from .transformers.minicpmv25 import MiniCPMV25Model
     from .transformers.minicpmv26 import MiniCPMV26Model
     from .transformers.opt import OptPytorchModel
     from .transformers.qwen2_audio import Qwen2AudioChatModel
-    from .transformers.qwen2_vl import Qwen2VLChatModel
     from .transformers.qwen_vl import QwenVLChatModel
     from .transformers.yi_vl import YiVLChatModel
     from .vllm.core import VLLMChatModel, VLLMModel, VLLMVisionModel
@@ -184,12 +182,10 @@ def _install():
             PytorchChatModel,
             Internlm2PytorchChatModel,
             QwenVLChatModel,
-            Qwen2VLChatModel,
             Qwen2AudioChatModel,
             YiVLChatModel,
             DeepSeekVLChatModel,
             DeepSeekVL2ChatModel,
-            InternVLChatModel,
             PytorchModel,
             CogVLM2Model,
             CogVLM2VideoModel,

--- a/xinference/model/llm/llm_family.py
+++ b/xinference/model/llm/llm_family.py
@@ -263,6 +263,23 @@ SUPPORTED_ENGINES: Dict[str, List[Type[LLM]]] = {}
 
 LLM_LAUNCH_VERSIONS: Dict[str, List[str]] = {}
 
+# Add decorator definition
+def register_transformer(cls):
+    """
+    Decorator function to register a class as a transformer.
+
+    This decorator appends the provided class to the TRANSFORMERS_CLASSES list.
+    It is used to keep track of classes that are considered transformers.
+
+    Args:
+        cls (class): The class to be registered as a transformer.
+
+    Returns:
+        class: The same class that was passed in, after being registered.
+    """
+    # Append the class to the list of transformer classes
+    TRANSFORMERS_CLASSES.append(cls)
+    return cls
 
 def download_from_self_hosted_storage() -> bool:
     from ...constants import XINFERENCE_ENV_MODEL_SRC

--- a/xinference/model/llm/llm_family.py
+++ b/xinference/model/llm/llm_family.py
@@ -263,6 +263,7 @@ SUPPORTED_ENGINES: Dict[str, List[Type[LLM]]] = {}
 
 LLM_LAUNCH_VERSIONS: Dict[str, List[str]] = {}
 
+
 # Add decorator definition
 def register_transformer(cls):
     """
@@ -280,6 +281,7 @@ def register_transformer(cls):
     # Append the class to the list of transformer classes
     TRANSFORMERS_CLASSES.append(cls)
     return cls
+
 
 def download_from_self_hosted_storage() -> bool:
     from ...constants import XINFERENCE_ENV_MODEL_SRC

--- a/xinference/model/llm/transformers/__init__.py
+++ b/xinference/model/llm/transformers/__init__.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 # Automatically scan and import all python scripts at the same level
-import os
 import importlib
+import os
 import pkgutil
 
 # Get the path of the current package
@@ -22,6 +22,6 @@ __path__ = [os.path.dirname(os.path.abspath(__file__))]
 
 # Automatically import all modules under the current package
 for _, module_name, is_pkg in pkgutil.iter_modules(__path__):
-    if not module_name.startswith('_'):  # Skip modules starting with underscore
+    if not module_name.startswith("_"):  # Skip modules starting with underscore
         module = importlib.import_module(f"{__name__}.{module_name}")
         globals()[module_name] = module

--- a/xinference/model/llm/transformers/__init__.py
+++ b/xinference/model/llm/transformers/__init__.py
@@ -11,3 +11,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# Automatically scan and import all python scripts at the same level
+import os
+import importlib
+import pkgutil
+
+# Get the path of the current package
+__path__ = [os.path.dirname(os.path.abspath(__file__))]
+
+# Automatically import all modules under the current package
+for _, module_name, is_pkg in pkgutil.iter_modules(__path__):
+    if not module_name.startswith('_'):  # Skip modules starting with underscore
+        module = importlib.import_module(f"{__name__}.{module_name}")
+        globals()[module_name] = module

--- a/xinference/model/llm/transformers/core.py
+++ b/xinference/model/llm/transformers/core.py
@@ -84,6 +84,32 @@ NON_DEFAULT_MODEL_LIST: List[str] = [
     "deepseek-vl2",
 ]
 
+# Define the decorator to support multiple names registration
+def register_non_default_model(*model_names: str):
+    """
+    Decorator for registering new non-default model names (supports multiple names).
+
+    Args:
+        *model_names (str): One or more model names to be registered as non-default models.
+
+    Returns:
+        A decorator function that adds the provided model names to the NON_DEFAULT_MODEL_LIST.
+    """
+    def decorator(cls):
+        """
+        Inner decorator function that modifies the class by registering model names.
+
+        Args:
+            cls: The class to be decorated.
+
+        Returns:
+            The original class after registering the model names.
+        """
+        for name in model_names:
+            if name not in NON_DEFAULT_MODEL_LIST:
+                NON_DEFAULT_MODEL_LIST.append(name)
+        return cls
+    return decorator
 
 class PytorchModel(LLM):
     def __init__(

--- a/xinference/model/llm/transformers/core.py
+++ b/xinference/model/llm/transformers/core.py
@@ -59,17 +59,11 @@ NON_DEFAULT_MODEL_LIST: List[str] = [
     "OmniLMM",
     "yi-vl-chat",
     "deepseek-vl-chat",
-    "internvl-chat",
-    "internvl2",
-    "Internvl2.5",
-    "Internvl2.5-MPO",
     "cogvlm2",
     "cogvlm2-video-llama3-chat",
     "MiniCPM-Llama3-V-2_5",
     "MiniCPM-V-2.6",
     "glm-4v",
-    "qwen2-vl-instruct",
-    "qwen2.5-vl-instruct",
     "qwen2-audio",
     "qwen2-audio-instruct",
     "deepseek-v2",
@@ -84,6 +78,7 @@ NON_DEFAULT_MODEL_LIST: List[str] = [
     "deepseek-vl2",
 ]
 
+
 # Define the decorator to support multiple names registration
 def register_non_default_model(*model_names: str):
     """
@@ -95,6 +90,7 @@ def register_non_default_model(*model_names: str):
     Returns:
         A decorator function that adds the provided model names to the NON_DEFAULT_MODEL_LIST.
     """
+
     def decorator(cls):
         """
         Inner decorator function that modifies the class by registering model names.
@@ -109,7 +105,9 @@ def register_non_default_model(*model_names: str):
             if name not in NON_DEFAULT_MODEL_LIST:
                 NON_DEFAULT_MODEL_LIST.append(name)
         return cls
+
     return decorator
+
 
 class PytorchModel(LLM):
     def __init__(

--- a/xinference/model/llm/transformers/intern_vl.py
+++ b/xinference/model/llm/transformers/intern_vl.py
@@ -19,14 +19,14 @@ from typing import Dict, Iterator, List, Optional, Union
 import torch
 
 from ....types import ChatCompletion, ChatCompletionChunk
-from ..llm_family import LLMFamilyV1, LLMSpecV1
+from ..llm_family import LLMFamilyV1, LLMSpecV1, register_transformer
 from ..utils import (
     _decode_image,
     generate_chat_completion,
     generate_completion_chunk,
     parse_messages,
 )
-from .core import PytorchChatModel, PytorchGenerateConfig
+from .core import PytorchChatModel, PytorchGenerateConfig, register_non_default_model
 from .utils import cache_clean
 
 logger = logging.getLogger(__name__)
@@ -232,6 +232,10 @@ def _load_video(video_path, bound=None, input_size=448, max_num=1, num_segments=
     return pixel_values, num_patches_list
 
 
+@register_transformer
+@register_non_default_model(
+    "internvl-chat", "internvl2", "Internvl2.5", "Internvl2.5-MPO"
+)
 class InternVLChatModel(PytorchChatModel):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/xinference/model/llm/transformers/qwen2_vl.py
+++ b/xinference/model/llm/transformers/qwen2_vl.py
@@ -25,14 +25,16 @@ from ....types import (
     ChatCompletionMessage,
     CompletionChunk,
 )
-from ..llm_family import LLMFamilyV1, LLMSpecV1
+from ..llm_family import LLMFamilyV1, LLMSpecV1, register_transformer
 from ..utils import generate_chat_completion, generate_completion_chunk
-from .core import PytorchChatModel, PytorchGenerateConfig
+from .core import PytorchChatModel, PytorchGenerateConfig, register_non_default_model
 from .utils import cache_clean
 
 logger = logging.getLogger(__name__)
 
 
+@register_transformer
+@register_non_default_model("qwen2-vl-instruct", "qwen2.5-vl-instruct")
 class Qwen2VLChatModel(PytorchChatModel):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
define two decorators for self registering only in new model code file, keep codes loose coupling

![image](https://github.com/user-attachments/assets/83b8a243-7b51-4e8a-b7e3-7a96a1c10103)
![image](https://github.com/user-attachments/assets/fa86694c-883a-446b-bb0b-9e130e3d32c2)
