### PR TITLE
BLD: remove setuptools limitation in project.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,7 @@
 [build-system]
 requires = [
-    "setuptools<64; python_version<'3.12'",
-    "setuptools>=75; python_version>='3.12'",
-    "wheel<0.46.0; python_version<'3.12'",
-    "wheel; python_version>='3.12'"
+    "setuptools>=64; python_version<'3.12'",
+    "setuptools>=75; python_version>='3.12'"
 ]
 build-backend = "setuptools.build_meta"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools<64; python_version<'3.12'",
     "setuptools>=75; python_version>='3.12'",
-    "wheel!=0.46.1; python_version<'3.12'",
+    "wheel<0.46.0; python_version<'3.12'",
     "wheel; python_version>='3.12'"
 ]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,9 @@
 [build-system]
 requires = [
     "setuptools<64; python_version<'3.12'",
-    "setuptools>=75; python_version>='3.12'"
+    "setuptools>=75; python_version>='3.12'",
+    "wheel!=0.46.1; python_version<'3.12'",
+    "wheel; python_version>='3.12'"
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
See https://github.com/pypa/wheel/issues/662

From day 1 we limited setuptools for bdist_wheel, setuptools accepted this command in a newer version, thus remove the limitation.