### PR TITLE
FEAT: support getting download progress and cancel download

### DIFF
--- a/xinference/client/restful/restful_client.py
+++ b/xinference/client/restful/restful_client.py
@@ -999,10 +999,17 @@ class Client:
             "model_path": model_path,
         }
 
+        wait_ready = kwargs.pop("wait_ready", True)
+
         for key, value in kwargs.items():
             payload[str(key)] = value
 
-        response = requests.post(url, json=payload, headers=self._headers)
+        if wait_ready:
+            response = requests.post(url, json=payload, headers=self._headers)
+        else:
+            response = requests.post(
+                url, json=payload, headers=self._headers, params={"wait_ready": False}
+            )
         if response.status_code != 200:
             raise RuntimeError(
                 f"Failed to launch model, detail: {_get_error_string(response)}"
@@ -1034,6 +1041,68 @@ class Client:
             raise RuntimeError(
                 f"Failed to terminate model, detail: {_get_error_string(response)}"
             )
+
+    def get_launch_model_progress(self, model_uid: str) -> dict:
+        """
+        Get progress of the specific model.
+
+        Parameters
+        ----------
+        model_uid: str
+            The unique id that identify the model we want.
+
+        Returns
+        -------
+        result: dict
+            Result that contains progress.
+
+        Raises
+        ------
+        RuntimeError
+            Report failure to get the wanted model with given model_uid. Provide details of failure through error message.
+        """
+        url = f"{self.base_url}/v1/models/{model_uid}/progress"
+
+        response = requests.get(url, headers=self._headers)
+        if response.status_code != 200:
+            raise RuntimeError(
+                f"Fail to get model launching progress, detail: {_get_error_string(response)}"
+            )
+        return response.json()
+
+    def cancel_launch_model(self, model_uid: str):
+        """
+        Cancel launching model.
+
+        Parameters
+        ----------
+        model_uid: str
+            The unique id that identify the model we want.
+
+        Raises
+        ------
+        RuntimeError
+            Report failure to get the wanted model with given model_uid. Provide details of failure through error message.
+        """
+        url = f"{self.base_url}/v1/models/{model_uid}/cancel"
+
+        response = requests.post(url, headers=self._headers)
+        if response.status_code != 200:
+            raise RuntimeError(
+                f"Fail to cancel launching model, detail: {_get_error_string(response)}"
+            )
+
+    def get_instance_info(self, model_name: str, model_uid: str):
+        url = f"{self.base_url}/v1/models/instances"
+        response = requests.get(
+            url,
+            headers=self._headers,
+            params={"model_name": model_name, "model_uid": model_uid},
+        )
+        if response.status_code != 200:
+            raise RuntimeError("Failed to get instance info")
+        response_data = response.json()
+        return response_data
 
     def _get_supervisor_internal_address(self):
         url = f"{self.base_url}/v1/address"

--- a/xinference/core/tests/test_restful_api.py
+++ b/xinference/core/tests/test_restful_api.py
@@ -1252,13 +1252,16 @@ def test_launch_model_async(setup):
     assert model_uid_res == "test_qwen_15"
 
     status_url = f"{endpoint}/v1/models/instances?model_uid=test_qwen_15"
+    progress_url = f"{endpoint}/v1/requests/launching-test_qwen_15-0/progress"
     while True:
         response = requests.get(status_url)
         response_data = response.json()
         assert len(response_data) == 1
         res = response_data[0]
-        print(res)
+        progress = requests.get(progress_url).json()
+        assert progress["progress"] is not None
         if res["status"] == "READY":
+            assert progress["progress"] == 1.0
             break
         time.sleep(2)
 

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -1058,6 +1058,11 @@ class WorkerActor(xo.StatelessActor):
                 for addr in launch_info.sub_pools:
                     coros.append(self._main_pool.remove_sub_pool(addr, force=True))
                 await asyncio.gather(*coros)
+            if self._status_guard_ref is not None:
+                await self._status_guard_ref.update_instance_info(
+                    parse_replica_model_uid(model_uid)[0],
+                    {"status": LaunchStatus.ERROR.name},
+                )
         except KeyError:
             raise RuntimeError(
                 "Model is not launching, may have launched or not launched yet"

--- a/xinference/model/tests/__init__.py
+++ b/xinference/model/tests/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2022-2025 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/xinference/model/tests/test_utils.py
+++ b/xinference/model/tests/test_utils.py
@@ -1,0 +1,153 @@
+# Copyright 2022-2025 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import asyncio
+import shutil
+
+import pytest
+from tqdm.auto import tqdm
+
+from ...utils import get_real_path
+from ..utils import CancellableDownloader
+
+
+def test_tqdm_patch():
+    downloader = CancellableDownloader(cancel_error_cls=RuntimeError)
+
+    with downloader:
+        all_bar = tqdm(total=10)
+
+        download_bars = [tqdm(total=300, unit="B") for _ in range(10)]
+
+        for i in range(5):
+            download_bars[i].update(300)
+
+        all_bar.update(5)
+
+        for i in range(5, 10):
+            download_bars[i].update(150)
+
+        expect = 0.5 + 0.5 * 1 / 2
+        assert expect == downloader.get_progress()
+
+        downloader.cancel()
+
+        with pytest.raises(RuntimeError):
+            all_bar.update(6)
+
+    assert downloader.done
+
+
+async def test_download_hugginface():
+    from ..llm import BUILTIN_LLM_FAMILIES
+    from ..llm.llm_family import cache_from_huggingface
+
+    cache_dir = None
+
+    try:
+        with CancellableDownloader() as downloader:
+            family = next(
+                f for f in BUILTIN_LLM_FAMILIES if f.model_name == "qwen2.5-instruct"
+            )
+            spec = next(
+                s
+                for s in family.model_specs
+                if s.model_format == "pytorch" and s.model_size_in_billions == "0_5"
+            )
+
+            async def check():
+                while not done:
+                    await asyncio.sleep(1)
+                    progress = downloader.get_progress()
+                    assert progress >= 0
+
+            done = False
+            check_task = asyncio.create_task(check())
+            # download from huggingface
+            cache_dir = await asyncio.to_thread(cache_from_huggingface, family, spec)
+            done = True
+
+            await check_task
+            assert downloader.get_progress() == 1.0
+    finally:
+        if cache_dir:
+            shutil.rmtree(get_real_path(cache_dir))
+            shutil.rmtree(cache_dir)
+
+
+async def test_download_modelscope():
+    from ..llm import BUILTIN_MODELSCOPE_LLM_FAMILIES
+    from ..llm.llm_family import cache_from_modelscope
+
+    cache_dir = None
+
+    try:
+        with CancellableDownloader() as downloader:
+            family = next(
+                f
+                for f in BUILTIN_MODELSCOPE_LLM_FAMILIES
+                if f.model_name == "qwen2.5-instruct"
+            )
+            spec = next(
+                s
+                for s in family.model_specs
+                if s.model_format == "pytorch" and s.model_size_in_billions == "0_5"
+            )
+
+            async def check():
+                while not done:
+                    await asyncio.sleep(1)
+                    progress = downloader.get_progress()
+                    assert progress >= 0
+
+            done = False
+            check_task = asyncio.create_task(check())
+            # download from huggingface
+            cache_dir = await asyncio.to_thread(cache_from_modelscope, family, spec)
+            done = True
+
+            await check_task
+            assert downloader.get_progress() == 1.0
+    finally:
+        if cache_dir:
+            shutil.rmtree(get_real_path(cache_dir))
+            shutil.rmtree(cache_dir)
+
+
+async def test_cancel():
+    from ..llm import BUILTIN_MODELSCOPE_LLM_FAMILIES
+    from ..llm.llm_family import cache_from_modelscope
+
+    with CancellableDownloader() as downloader:
+        family = next(
+            f
+            for f in BUILTIN_MODELSCOPE_LLM_FAMILIES
+            if f.model_name == "qwen2.5-instruct"
+        )
+        spec = next(
+            s
+            for s in family.model_specs
+            if s.model_format == "pytorch" and s.model_size_in_billions == "0_5"
+        )
+
+        # download from huggingface
+        cache_task = asyncio.create_task(
+            asyncio.to_thread(cache_from_modelscope, family, spec)
+        )
+
+        await asyncio.sleep(1)
+        downloader.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await cache_task
+        assert downloader.get_progress() == 1.0

--- a/xinference/model/utils.py
+++ b/xinference/model/utils.py
@@ -11,17 +11,21 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+import asyncio
 import json
 import logging
 import os
 import random
+import threading
 from json import JSONDecodeError
 from pathlib import Path
-from typing import Any, Callable, Dict, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Optional, Set, Tuple, Type, Union
 
 import huggingface_hub
 import numpy as np
 import torch
+from tqdm.auto import tqdm
 
 from ..constants import (
     XINFERENCE_CACHE_DIR,
@@ -343,3 +347,102 @@ def set_all_random_seed(seed: int):
     np.random.seed(seed)
     torch.manual_seed(seed)
     torch.cuda.manual_seed_all(seed)
+
+
+class CancellableDownloader:
+    def __init__(self, cancel_error_cls: Type[BaseException] = asyncio.CancelledError):
+        self._cancelled = False
+        self._done_event = threading.Event()
+        self._cancel_error_cls = cancel_error_cls
+        self._original_update = None
+        # progress for tqdm that is main
+        self._main_progresses: Set[tqdm] = set()
+        # progress for file downloader
+        # mainly when tqdm unit is set
+        self._download_progresses: Set[tqdm] = set()
+        # tqdm original update
+        self._original_tqdm_update = None
+
+    def reset(self):
+        self._main_progresses.clear()
+        self._download_progresses.clear()
+
+    def get_progress(self) -> float:
+        if self._cancelled or self.done:
+            # directly return 1.0 when cancelled or finished
+            return 1.0
+
+        tasks = finished_tasks = 0
+        for main_progress in self._main_progresses:
+            tasks += main_progress.total or 0
+            finished_tasks += main_progress.n
+
+        if tasks == 0:
+            return 0.0
+
+        finished_ratio = finished_tasks / tasks
+
+        all_download_progress = finished_download_progress = 0
+        for download_progress in self._download_progresses:
+            # we skip finished download
+            if download_progress.n == download_progress.total:
+                continue
+            all_download_progress += download_progress.total or (
+                download_progress.n * 10
+            )
+            finished_download_progress += download_progress.n
+
+        if all_download_progress > 0:
+            rest_ratio = (
+                (tasks - finished_tasks)
+                / tasks
+                * (finished_download_progress / all_download_progress)
+            )
+            return finished_ratio + rest_ratio
+        else:
+            return finished_ratio
+
+    def cancel(self):
+        self._cancelled = True
+
+    @property
+    def done(self):
+        return self._done_event.is_set()
+
+    def wait(self, timeout: float):
+        self._done_event.wait(timeout)
+
+    def patch_tqdm(self):
+        # patch tqdm
+        # raise error if cancelled
+        self._original_update = original_update = tqdm.update
+        downloader = self
+
+        def patched_update(self, n):
+            if downloader._cancelled:
+                raise downloader._cancel_error_cls("Download cancelled")
+            if not self.disable:
+                progresses = (
+                    downloader._main_progresses
+                    if getattr(self, "unit", "it") == "it"
+                    else downloader._download_progresses
+                )
+                progresses.add(self)
+            return original_update(self, n)
+
+        tqdm.update = patched_update
+
+    def unpatch_tqdm(self):
+        from tqdm.auto import tqdm
+
+        if self._original_update:
+            tqdm.update = self._original_update
+
+    def __enter__(self):
+        self.patch_tqdm()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.unpatch_tqdm()
+        self._done_event.set()
+        self.reset()

--- a/xinference/utils.py
+++ b/xinference/utils.py
@@ -12,9 +12,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+from typing import Optional
+
 
 def cuda_count():
     import torch
 
     # even if install torch cpu, this interface would return 0.
     return torch.cuda.device_count()
+
+
+def get_real_path(path: str) -> Optional[str]:
+    # parsing soft links
+    if os.path.isdir(path):
+        files = os.listdir(path)
+        # dir has files
+        if files:
+            resolved_file = os.path.realpath(os.path.join(path, files[0]))
+            if resolved_file:
+                return os.path.dirname(resolved_file)
+        return None
+    else:
+        return os.path.realpath(path)


### PR DESCRIPTION
This PR basically did two things:

1. Support getting progress when launching models
2. Support cancelling when downloading.

This main idea is to patch `tqdm.update`. All the hub libraries like huggingface_hub and modelscope all used tqdm as progress bar vendor. Important part is to identify which tqdm is the main progress( like downloading 11 files) and the file progress(for a file 300M of 500M downloaded), the progress is calculated from them. Further more, when user cancels the launching, the downloader will know and raise error in `tqdm.update`, thus the downloading can be cancelled as expected.

This PR only supports command lines, web UI needs to adapt new APIs about getting progress and cancelling.

Demo:


https://github.com/user-attachments/assets/99905b25-33d3-4e57-b8df-4027377aba3b

