### PR TITLE
FEAT: support min/max_pixels params for vision model

### DIFF
--- a/xinference/model/llm/transformers/gemma3.py
+++ b/xinference/model/llm/transformers/gemma3.py
@@ -24,6 +24,7 @@ from ....types import (
     ChatCompletionChunk,
     ChatCompletionMessage,
     CompletionChunk,
+    PytorchModelConfig,
 )
 from ..llm_family import LLMFamilyV1, LLMSpecV1
 from ..utils import generate_chat_completion, generate_completion_chunk
@@ -65,6 +66,15 @@ class Gemma3ChatModel(PytorchChatModel):
             return True
         return False
 
+    def _sanitize_model_config(
+        self, pytorch_model_config: Optional[PytorchModelConfig]
+    ) -> PytorchModelConfig:
+        pytorch_model_config = super()._sanitize_model_config(pytorch_model_config)
+        assert pytorch_model_config is not None
+        pytorch_model_config.setdefault("min_pixels", 256 * 28 * 28)
+        pytorch_model_config.setdefault("max_pixels", 1280 * 28 * 28)
+        return pytorch_model_config
+
     def load(self):
         from transformers import AutoProcessor, Gemma3ForConditionalGeneration
 
@@ -73,8 +83,13 @@ class Gemma3ChatModel(PytorchChatModel):
         self._device = device
         # for multiple GPU, set back to auto to make multiple devices work
         device = "auto" if device == "cuda" else device
-
-        self._processor = AutoProcessor.from_pretrained(self.model_path)
+        min_pixels = self._pytorch_model_config.get("min_pixels")
+        max_pixels = self._pytorch_model_config.get("max_pixels")
+        self._processor = AutoProcessor.from_pretrained(
+            self.model_path,
+            min_pixels=min_pixels,
+            max_pixels=max_pixels,
+        )
         self._tokenizer = self._processor.tokenizer
         self._model = Gemma3ForConditionalGeneration.from_pretrained(
             self.model_path,

--- a/xinference/model/llm/transformers/minicpmv26.py
+++ b/xinference/model/llm/transformers/minicpmv26.py
@@ -20,7 +20,12 @@ import torch
 from PIL import Image
 
 from ....core.scheduler import InferenceRequest
-from ....types import ChatCompletion, ChatCompletionChunk, CompletionChunk
+from ....types import (
+    ChatCompletion,
+    ChatCompletionChunk,
+    CompletionChunk,
+    PytorchModelConfig,
+)
 from ...utils import select_device
 from ..llm_family import LLMFamilyV1, LLMSpecV1
 from ..utils import (
@@ -51,6 +56,15 @@ class MiniCPMV26Model(PytorchChatModel):
         if "MiniCPM-V-2.6".lower() in family.lower():
             return True
         return False
+
+    def _sanitize_model_config(
+        self, pytorch_model_config: Optional[PytorchModelConfig]
+    ) -> PytorchModelConfig:
+        pytorch_model_config = super()._sanitize_model_config(pytorch_model_config)
+        assert pytorch_model_config is not None
+        pytorch_model_config.setdefault("min_pixels", 256 * 28 * 28)
+        pytorch_model_config.setdefault("max_pixels", 1280 * 28 * 28)
+        return pytorch_model_config
 
     def _get_model_class(self):
         from transformers import AutoModel
@@ -99,8 +113,13 @@ class MiniCPMV26Model(PytorchChatModel):
             self.model_path,
             trust_remote_code=True,
         )
+        min_pixels = self._pytorch_model_config.get("min_pixels")
+        max_pixels = self._pytorch_model_config.get("max_pixels")
         self._processor = AutoProcessor.from_pretrained(
-            self.model_path, trust_remote_code=True
+            self.model_path,
+            trust_remote_code=True,
+            min_pixels=min_pixels,
+            max_pixels=max_pixels,
         )
         self._device = self._model.device
         self._save_tensorizer()

--- a/xinference/model/llm/vllm/core.py
+++ b/xinference/model/llm/vllm/core.py
@@ -37,6 +37,7 @@ from typing import (
 )
 
 import xoscar as xo
+from typing_extensions import NotRequired
 
 from ....types import (
     ChatCompletion,
@@ -81,6 +82,7 @@ class VLLMModelConfig(TypedDict, total=False):
     scheduling_policy: Optional[str]
     reasoning_content: bool
     model_quantization: Optional[str]
+    mm_processor_kwargs: NotRequired[dict[str, Any]]
 
 
 class VLLMGenerateConfig(TypedDict, total=False):
@@ -531,6 +533,14 @@ class VLLMModel(LLM):
         # Add scheduling policy if vLLM version is 0.6.3 or higher
         if vllm.__version__ >= "0.6.3":
             model_config.setdefault("scheduling_policy", "fcfs")
+            if "mm_processor_kwargs" in model_config:
+                mm_processor_kwargs = model_config.pop("mm_processor_kwargs")
+                if isinstance(mm_processor_kwargs, str):
+                    model_config["mm_processor_kwargs"] = json.loads(
+                        mm_processor_kwargs
+                    )
+                else:
+                    model_config["mm_processor_kwargs"] = mm_processor_kwargs
         return model_config
 
     @staticmethod

--- a/xinference/types.py
+++ b/xinference/types.py
@@ -334,6 +334,8 @@ class PytorchModelConfig(TypedDict, total=False):
     max_num_seqs: int
     enable_tensorizer: Optional[bool]
     reasoning_content: bool
+    min_pixels: NotRequired[int]
+    max_pixels: NotRequired[int]
 
 
 def get_pydantic_model_from_method(

--- a/xinference/web/ui/src/scenes/launch_model/data/data.js
+++ b/xinference/web/ui/src/scenes/launch_model/data/data.js
@@ -42,6 +42,8 @@ export const additionalParameterTipList = {
     'limit_mm_per_prompt',
     'model_quantization',
     'mm_processor_kwargs',
+    'min_pixels',
+    'max_pixels',
   ],
   'sglang': [
     'mem_fraction_static',

--- a/xinference/web/ui/src/scenes/launch_model/data/data.js
+++ b/xinference/web/ui/src/scenes/launch_model/data/data.js
@@ -41,6 +41,7 @@ export const additionalParameterTipList = {
     'disable_custom_all_reduce',
     'limit_mm_per_prompt',
     'model_quantization',
+    'mm_processor_kwargs',
   ],
   'sglang': [
     'mem_fraction_static',


### PR DESCRIPTION
Support VLLM and Transformers pass min/max_pixels params for qwen2.5-vl/gemma3/minicpm2.6

Transformers/VLLM：：

> max_pixels=1003520
> min_pixels=200704
> 
<img width="755" alt="image" src="https://github.com/user-attachments/assets/c1eddf02-43ec-4741-a806-a73c32bffae3" />



