### PR TITLE
FEAT: add ggufv2 support for vLLM

### DIFF
--- a/xinference/model/llm/__init__.py
+++ b/xinference/model/llm/__init__.py
@@ -57,7 +57,7 @@ from .llm_family import (
 
 def check_format_with_engine(model_format, engine):
     # only llama-cpp-python support and only support ggufv2
-    if model_format in ["ggufv2"] and engine != "llama.cpp":
+    if model_format in ["ggufv2"] and engine not in ["llama.cpp", "vLLM"]:
         return False
     if model_format not in ["ggufv2"] and engine == "llama.cpp":
         return False

--- a/xinference/model/llm/llm_family.py
+++ b/xinference/model/llm/llm_family.py
@@ -17,7 +17,6 @@ import os
 from threading import Lock
 from typing import Any, Dict, List, Optional, Set, Tuple, Type, Union
 
-import huggingface_hub
 from typing_extensions import Annotated, Literal
 
 from ..._compat import (
@@ -377,8 +376,10 @@ def cache_model_tokenizer_and_config(
     cache_dir = _get_cache_dir_for_model_mem(llm_family, llm_spec, "tokenizer_config")
     os.makedirs(cache_dir, exist_ok=True)
     if llm_spec.model_hub == "huggingface":
+        from huggingface_hub import snapshot_download
+
         download_dir = retry_download(
-            huggingface_hub.snapshot_download,
+            snapshot_download,
             llm_family.model_name,
             {
                 "model_size": llm_spec.model_size_in_billions,

--- a/xinference/model/llm/llm_family.py
+++ b/xinference/model/llm/llm_family.py
@@ -17,6 +17,7 @@ import os
 from threading import Lock
 from typing import Any, Dict, List, Optional, Set, Tuple, Type, Union
 
+import huggingface_hub
 from typing_extensions import Annotated, Literal
 
 from ..._compat import (
@@ -366,6 +367,51 @@ def cache_from_uri(
         raise ValueError(f"Unsupported URL scheme: {src_scheme}")
 
 
+def cache_model_tokenizer_and_config(
+    llm_family: LLMFamilyV1,
+    llm_spec: "LLMSpecV1",
+) -> str:
+    """
+    Download model config.json and tokenizers only
+    """
+    cache_dir = _get_cache_dir_for_model_mem(llm_family, llm_spec, "tokenizer_config")
+    os.makedirs(cache_dir, exist_ok=True)
+    if llm_spec.model_hub == "huggingface":
+        download_dir = retry_download(
+            huggingface_hub.snapshot_download,
+            llm_family.model_name,
+            {
+                "model_size": llm_spec.model_size_in_billions,
+                "model_format": llm_spec.model_format,
+            },
+            llm_spec.model_id,
+            revision=llm_spec.model_revision,
+            allow_patterns=["tokenizer*", "config.json"],
+            local_dir=cache_dir,
+        )
+    elif llm_spec.model_hub == "modelscope":
+        from modelscope.hub.snapshot_download import snapshot_download
+
+        download_dir = retry_download(
+            snapshot_download,
+            llm_family.model_name,
+            {
+                "model_size": llm_spec.model_size_in_billions,
+                "model_format": llm_spec.model_format,
+            },
+            llm_spec.model_id,
+            revision=llm_spec.model_revision,
+            allow_patterns=["tokenizer*", "config.json"],
+            local_dir=cache_dir,
+        )
+    else:
+        raise NotImplementedError(
+            f"Does not support download config.json and "
+            f"tokenizer related files via {llm_spec.model_hub}"
+        )
+    return download_dir
+
+
 def cache_model_config(
     llm_family: LLMFamilyV1,
     llm_spec: "LLMSpecV1",
@@ -373,7 +419,7 @@ def cache_model_config(
     """Download model config.json into cache_dir,
     returns local filepath
     """
-    cache_dir = _get_cache_dir_for_model_mem(llm_family, llm_spec)
+    cache_dir = _get_cache_dir_for_model_mem(llm_family, llm_spec, "model_mem")
     config_file = os.path.join(cache_dir, "config.json")
     if not os.path.islink(config_file) and not os.path.exists(config_file):
         os.makedirs(cache_dir, exist_ok=True)
@@ -396,10 +442,13 @@ def cache_model_config(
 def _get_cache_dir_for_model_mem(
     llm_family: LLMFamilyV1,
     llm_spec: "LLMSpecV1",
+    category: str,
     create_if_not_exist=True,
 ):
     """
-    For cal-model-mem only. (might called from supervisor / cli)
+    Get file dir for special usage, like `cal-model-mem` and download partial files for
+
+    e.g. for cal-model-mem, (might called from supervisor / cli)
     Temporary use separate dir from worker's cache_dir, due to issue of different style of symlink.
     """
     quant_suffix = ""
@@ -414,7 +463,7 @@ def _get_cache_dir_for_model_mem(
     if quant_suffix:
         cache_dir_name += f"-{quant_suffix}"
     cache_dir = os.path.realpath(
-        os.path.join(XINFERENCE_CACHE_DIR, "model_mem", cache_dir_name)
+        os.path.join(XINFERENCE_CACHE_DIR, category, cache_dir_name)
     )
     if create_if_not_exist and not os.path.exists(cache_dir):
         os.makedirs(cache_dir, exist_ok=True)

--- a/xinference/model/llm/vllm/core.py
+++ b/xinference/model/llm/vllm/core.py
@@ -498,10 +498,7 @@ class VLLMModel(LLM):
                 "provide `model_path` with merged file"
             )
 
-        if (
-            "tokenizer" not in self._model_config
-            and "hf_config_path" not in self._model_config
-        ):
+        if "tokenizer" not in self._model_config:
             # find pytorch format without quantization
             non_quant_spec = next(
                 spec

--- a/xinference/model/llm/vllm/core.py
+++ b/xinference/model/llm/vllm/core.py
@@ -280,7 +280,7 @@ class VLLMModel(LLM):
         from ..llm_family import LlamaCppLLMSpecV1
         if isinstance(self.model_spec, LlamaCppLLMSpecV1):
             if self.model_spec.model_format=='ggufv2':
-                gguf_path=self.model_spec.model_file_name_template.format(quantization=self.model_spec.quantizations[0])
+                gguf_path=self.model_spec.model_file_name_template.format(quantization=quantization)
                 self.model_path=os.path.join(self.model_path, gguf_path)
                 if 'tokenizer' not in self._model_config.keys():
                     self._model_config.update({'tokenizer':os.path.dirname(self.model_path)})

--- a/xinference/model/llm/vllm/core.py
+++ b/xinference/model/llm/vllm/core.py
@@ -918,7 +918,7 @@ class VLLMChatModel(VLLMModel, ChatModelMixin):
     def match(
         cls, llm_family: "LLMFamilyV1", llm_spec: "LLMSpecV1", quantization: str
     ) -> bool:
-        if llm_spec.model_format not in ["pytorch", "gptq", "awq", "fp8"]:
+        if llm_spec.model_format not in ["pytorch", "gptq", "awq", "fp8", "ggufv2"]:
             return False
         if llm_spec.model_format == "pytorch":
             if quantization != "none" and not (quantization is None):

--- a/xinference/model/llm/vllm/core.py
+++ b/xinference/model/llm/vllm/core.py
@@ -276,16 +276,6 @@ class VLLMModel(LLM):
         self._all_worker_ready: Optional[threading.Event] = None
         # used to call async
         self._loop = None
-        # # model path processing for gguf
-        # from ..llm_family import LlamaCppLLMSpecV1
-        # if isinstance(self.model_spec, LlamaCppLLMSpecV1):
-        #     if self.model_spec.model_format=='ggufv2':
-        #         gguf_path=self.model_spec.model_file_name_template.format(quantization=quantization)
-        #         self.model_path=os.path.join(self.model_path, gguf_path)
-        #         if 'tokenizer' not in self._model_config.keys():
-        #             self._model_config.update({'tokenizer':os.path.dirname(self.model_path)})
-        #         if 'hf_config_path' not in self._model_config.keys():
-        #             self._model_config.update({'hf_config_path':os.path.dirname(self.model_path)})
 
     def set_xavier_config(self, value: Optional[Dict]):
         self._xavier_config = value  # type: ignore


### PR DESCRIPTION
Add ggufv2 support for vLLM. 
A 671B Deepseek-R1 model from [here](https://huggingface.co/unsloth/DeepSeek-R1-GGUF/tree/main/DeepSeek-R1-UD-Q2_K_XL) has been tested.

Due to limitation from vLLM, currently only supports single gguf model (merge by llama.cpp's tool) and requires loading config and tokenizer from config files. More details can be found in [here](https://github.com/vllm-project/vllm/pull/13167).

The testing config is attached below.
![微信截图_20250415175050](https://github.com/user-attachments/assets/ccf8fa33-64e1-478a-b815-5116ff627dc8)

Note that this feature will be available only when vllm>=0.8.2, thus requires manual update of vllm.
