### PR TITLE
BUG: fix failure of clearing resources when loading model failed

### DIFF
--- a/xinference/core/supervisor.py
+++ b/xinference/core/supervisor.py
@@ -1102,8 +1102,8 @@ class SupervisorActor(xo.StatelessActor):
                 xavier_config=xavier_config,
                 **kwargs,
             )
-            await worker_ref.wait_for_load(_replica_model_uid)
             self._replica_model_uid_to_worker[_replica_model_uid] = worker_ref
+            await worker_ref.wait_for_load(_replica_model_uid)
             return subpool_address
 
         async def _launch_model():


### PR DESCRIPTION
When model loads in a thread, e.g vllm xinf distributed executor, when loading failed which raised in `wait_for_load`, the worker status is not recorded yet, thus the `terminate_model` will skip, resources is occupied on workers already, this PR fixed it.