### PR TITLE
FEAT: support image_to_video

### DIFF
--- a/doc/source/locale/zh_CN/LC_MESSAGES/models/model_abilities/video.po
+++ b/doc/source/locale/zh_CN/LC_MESSAGES/models/model_abilities/video.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Xinference \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-08-13 17:44+0800\n"
+"POT-Creation-Date: 2025-05-06 18:52+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: zh_CN\n"
@@ -63,39 +63,178 @@ msgstr "支持的模型列表"
 
 #: ../../source/models/model_abilities/video.rst:33
 msgid ""
-"The Text-to-video API is supported with the following models in "
+"The text-to-video API is supported with the following models in "
 "Xinference:"
 msgstr "Text-to-video API 在 Xinference 中支持以下模型："
 
 #: ../../source/models/model_abilities/video.rst:35
-msgid "CogVideoX-2b"
+msgid ":ref:`CogVideoX-2b <models_builtin_cogvideox-2b>`"
+msgstr ""
+
+#: ../../source/models/model_abilities/video.rst:36
+msgid ":ref:`CogVideoX-5b <models_builtin_cogvideox-5b>`"
+msgstr ""
+
+#: ../../source/models/model_abilities/video.rst:37
+msgid ":ref:`HunyuanVideo <models_builtin_hunyuanvideo>`"
+msgstr ""
+
+#: ../../source/models/model_abilities/video.rst:38
+msgid ":ref:`Wan2.1-1.3B <models_builtin_wan2.1-1.3b>`"
 msgstr ""
 
 #: ../../source/models/model_abilities/video.rst:39
+msgid ":ref:`Wan2.1-14B <models_builtin_wan2.1-14b>`"
+msgstr ""
+
+#: ../../source/models/model_abilities/video.rst:41
+msgid ""
+"The image-to-video API is supported with the following models in "
+"Xinference:"
+msgstr "Image-to-video API 在 Xinference 中支持以下模型："
+
+#: ../../source/models/model_abilities/video.rst:43
+msgid ":ref:`Wan2.1-i2v-14B-480p <models_builtin_wan2.1-i2v-14b-480p>`"
+msgstr ""
+
+#: ../../source/models/model_abilities/video.rst:44
+msgid ":ref:`Wan2.1-i2v-14B-720p <models_builtin_wan2.1-i2v-14b-720p>`"
+msgstr ""
+
+#: ../../source/models/model_abilities/video.rst:47
 msgid "Quickstart"
 msgstr "快速入门"
 
-#: ../../source/models/model_abilities/video.rst:42
+#: ../../source/models/model_abilities/video.rst:50
 msgid "Text-to-video"
 msgstr "文生视频"
 
-#: ../../source/models/model_abilities/video.rst:44
+#: ../../source/models/model_abilities/video.rst:52
 msgid ""
-"You can try Text-to-video API out either via cURL, or Xinference's python"
+"You can try text-to-video API out either via cURL, or Xinference's python"
 " client:"
-msgstr "可以通过 cURL 或 Xinference 的方式尝试使用 Text-to-video API"
+msgstr "可以通过 cURL 或 Xinference 的方式尝试使用 text-to-video API"
 
-#: ../../source/models/model_abilities/video.rst:72
-msgid "Tips when running on GPU whose memory less than 24GB"
-msgstr "在小于 24GB 显存的 GPU 上运行贴士"
+#: ../../source/models/model_abilities/video.rst:79
+msgid "Image-to-video"
+msgstr "图生视频"
 
-#: ../../source/models/model_abilities/video.rst:74
+#: ../../source/models/model_abilities/video.rst:81
 msgid ""
-"Text-to-video will occupy huge GPU memory, for instance, running "
-"CogVideoX may require up to around 35 GB GPU memory. When running on GPU "
-"whose memory is less than 24 GB, we recommend to add ``--cpu_offload "
-"True`` when launching model."
+"You can try image-to-video API out either via cURL, or Xinference's "
+"python client:"
+msgstr "可以通过 cURL 或 Xinference 的方式尝试使用 image-to-video API"
+
+#: ../../source/models/model_abilities/video.rst:107
+msgid "Memory optimization"
+msgstr "内存优化"
+
+#: ../../source/models/model_abilities/video.rst:109
+msgid ""
+"Video generation will occupy huge GPU memory, for instance, running "
+"CogVideoX may require up to around 35 GB GPU memory."
 msgstr ""
-"Text-to-video 会占用大量显存，举例来说，运行 CogVideoX 可能会使用到约 35 GB 的显存，"
-"当在小于 24 GB 的 GPU 上运行时，推荐添加 ``--cpu_offload True`` 来加载模型。"
+"视频生成会占用大量显存，举例来说，运行 CogVideoX 可能会使用到约 35 "
+"GB 的显存。"
+
+#: ../../source/models/model_abilities/video.rst:112
+msgid ""
+"Xinference supports several options to optimize video model memory (VRAM)"
+" usage."
+msgstr "Xinference 支持若干选项，来优化视频模型显存（VRAM）使用。"
+
+#: ../../source/models/model_abilities/video.rst:114
+msgid "CPU offloading or block level group offloading."
+msgstr "CPU 卸载或块级分组卸载。"
+
+#: ../../source/models/model_abilities/video.rst:115
+msgid "Layerwise casting."
+msgstr "逐层类型转换（Layerwise casting）。"
+
+#: ../../source/models/model_abilities/video.rst:119
+msgid ""
+"CPU offloading and Block Level Group Offloading cannot be enabled at the "
+"same time, but layerwise casting can be used in combination with either "
+"of them."
+msgstr "CPU 卸载和块级分组卸载不能同时开启，但逐层类型转换可以与其中之一配合使用。"
+
+#: ../../source/models/model_abilities/video.rst:123
+msgid "CPU offloading"
+msgstr "CPU 卸载"
+
+#: ../../source/models/model_abilities/video.rst:125
+msgid ""
+"CPU offloading keeps the model weights on the CPU and only loads them to "
+"the GPU when a forward pass needs to be executed. It is suitable for "
+"scenarios with extremely limited GPU memory, but it has a significant "
+"impact on performance."
+msgstr "CPU 卸载会将模型权重保留在 CPU 上，仅在执行前向传播时才加载到 GPU。"
+"适用于显存极其有限的场景，但对性能影响较大。"
+
+#: ../../source/models/model_abilities/video.rst:129
+msgid ""
+"When running on GPU whose memory is less than 24 GB, we recommend to add "
+"``--cpu_offload True`` when launching model. For Web UI, add an extra "
+"option, ``cpu_offload`` with value set to ``True``."
+msgstr "当使用显存小于 24 GB 的 GPU 时，建议在启动模型时添加 ``--cpu_offload True``。"
+"对于 Web UI，可添加额外选项 ``cpu_offload``，值设为 ``True``。"
+
+#: ../../source/models/model_abilities/video.rst:138
+msgid "Block Level Group Offloading"
+msgstr "块级分组卸载"
+
+#: ../../source/models/model_abilities/video.rst:140
+msgid ""
+"Block Level Group Offloading groups multiple internal layers of the model"
+" (such as ``torch.nn.ModuleList`` or ``torch.nn.Sequential``) and loads "
+"these groups from the CPU to the GPU as needed during inference. Compared"
+" to CPU offloading, it uses more memory but has less impact on "
+"performance."
+msgstr "块级分组卸载将模型的多个内部层（如 ``torch.nn.ModuleList`` 或 ``torch.nn.Sequential``）分组，"
+"并根据需要在推理过程中将这些分组从 CPU 加载到 GPU。与 CPU 卸载相比，它使用更多的内存，但对性能的影响更小。"
+
+#: ../../source/models/model_abilities/video.rst:144
+msgid ""
+"For the command line, add the ``--group_offload True`` option; for the "
+"Web UI, add an additional option ``group_offload`` with the value set to "
+"``True``."
+msgstr "对于命令行，添加 ``--group_offload True`` 选项；对于 Web UI，添加一个额外选项 ``group_offload``，值设为 ``True``。"
+
+#: ../../source/models/model_abilities/video.rst:147
+msgid ""
+"We can speed up group offloading inference, by enabling the use of CUDA "
+"streams. However, using CUDA streams requires moving the model parameters"
+" into pinned memory. This allocation is handled by Pytorch under the "
+"hood, and can result in a significant spike in CPU RAM usage. Please "
+"consider this option if your CPU RAM is atleast 2X the size of the model "
+"you are group offloading. Enable CUDA streams via adding ``--use_stream "
+"True`` for command line; for the Web UI, add an additional option "
+"``use_stream`` with the value set to ``True``."
+msgstr "通过启用 CUDA 流，我们可以加速分组卸载推理。然而，使用 CUDA 流需要将模型参数移动到固定内存中。这项分配由 Pytorch 在后台处理，"
+"并可能导致 CPU RAM 使用量显著增加。如果您的 CPU RAM 至少是模型大小的两倍，请考虑使用此选项。"
+"通过在命令行中添加 ``--use_stream True`` 启用 CUDA 流；对于 Web UI，添加一个额外选项 ``use_stream``，值设为 ``True``。"
+
+#: ../../source/models/model_abilities/video.rst:159
+msgid "Applying Layerwise Casting to the Transformer"
+msgstr "将逐层类型转换应用于 Transformer"
+
+#: ../../source/models/model_abilities/video.rst:161
+msgid ""
+"Layerwise casting will downcast each layer’s weights to ``torch.float8_"
+"e4m3fn``, temporarily upcast to ``torch.bfloat16`` during the forward "
+"pass of the layer, then revert to ``torch.float8_e4m3fn`` afterward. This"
+" approach reduces memory requirements by approximately 50% while "
+"introducing a minor quality reduction in the generated video due to the "
+"precision trade-off. Enable layerwise casting via adding ``--layerwise_"
+"cast True`` for command line; for the Web UI, add an additional option ``"
+"layerwise_cast`` with the value set to ``True``."
+msgstr "逐层类型转换将把每个层的权重降级为 ``torch.float8_e4m3fn``，在层的前向传播过程中暂时升级为 ``torch.bfloat16``，"
+"然后在之后恢复为 ``torch.float8_e4m3fn``。这种方法将内存需求减少约 50%，同时由于精度折衷，"
+"生成的视频质量会略有下降。通过在命令行中添加 ``--layerwise_cast True`` 来启用逐层类型转换；"
+"对于 Web UI，添加一个额外选项 ``layerwise_cast``，值设为 ``True``。"
+
+#: ../../source/models/model_abilities/video.rst:168
+msgid "This example will require 20GB of VRAM."
+msgstr "此示例将需要 20GB 的显存。"
+
 

--- a/doc/source/locale/zh_CN/LC_MESSAGES/models/model_abilities/video.po
+++ b/doc/source/locale/zh_CN/LC_MESSAGES/models/model_abilities/video.po
@@ -45,7 +45,7 @@ msgstr "Text-to-video 端点将一段文本提示词从头开始创建视频"
 msgid ""
 "The image-to-video endpoint create videos from scratch based on an input "
 "image."
-msgstr "Text-to-video 端点将一张图片从头开始创建视频"
+msgstr "Image-to-video 端点将一张图片从头开始创建视频"
 
 #: ../../source/models/model_abilities/video.rst:25
 msgid "API"

--- a/doc/source/locale/zh_CN/LC_MESSAGES/models/model_abilities/video.po
+++ b/doc/source/locale/zh_CN/LC_MESSAGES/models/model_abilities/video.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Xinference \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-05-06 18:52+0800\n"
+"POT-Creation-Date: 2025-05-06 20:32+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: zh_CN\n"
@@ -41,166 +41,186 @@ msgid ""
 "prompt."
 msgstr "Text-to-video 端点将一段文本提示词从头开始创建视频"
 
-#: ../../source/models/model_abilities/video.rst:24
-msgid "API ENDPOINT"
-msgstr "API 端点"
+#: ../../source/models/model_abilities/video.rst:18
+msgid ""
+"The image-to-video endpoint create videos from scratch based on an input "
+"image."
+msgstr "Text-to-video 端点将一张图片从头开始创建视频"
 
 #: ../../source/models/model_abilities/video.rst:25
-msgid "OpenAI-compatible ENDPOINT"
-msgstr "OpenAI 兼容端点"
-
-#: ../../source/models/model_abilities/video.rst:27
-msgid "Text-to-Video API"
+msgid "API"
 msgstr ""
 
+#: ../../source/models/model_abilities/video.rst:26
+msgid "Endpoint"
+msgstr "端点"
+
 #: ../../source/models/model_abilities/video.rst:28
+msgid "Text-to-Video API"
+msgstr "文生视频 API"
+
+#: ../../source/models/model_abilities/video.rst:29
 msgid "/v1/video/generations"
 msgstr ""
 
 #: ../../source/models/model_abilities/video.rst:31
+msgid "Image-to-Video API"
+msgstr "图生视频 API"
+
+#: ../../source/models/model_abilities/video.rst:32
+msgid "/v1/video/generations/image"
+msgstr ""
+
+#: ../../source/models/model_abilities/video.rst:35
 msgid "Supported models"
 msgstr "支持的模型列表"
 
-#: ../../source/models/model_abilities/video.rst:33
+#: ../../source/models/model_abilities/video.rst:37
 msgid ""
 "The text-to-video API is supported with the following models in "
 "Xinference:"
 msgstr "Text-to-video API 在 Xinference 中支持以下模型："
 
-#: ../../source/models/model_abilities/video.rst:35
+#: ../../source/models/model_abilities/video.rst:39
 msgid ":ref:`CogVideoX-2b <models_builtin_cogvideox-2b>`"
 msgstr ""
 
-#: ../../source/models/model_abilities/video.rst:36
+#: ../../source/models/model_abilities/video.rst:40
 msgid ":ref:`CogVideoX-5b <models_builtin_cogvideox-5b>`"
 msgstr ""
 
-#: ../../source/models/model_abilities/video.rst:37
+#: ../../source/models/model_abilities/video.rst:41
 msgid ":ref:`HunyuanVideo <models_builtin_hunyuanvideo>`"
 msgstr ""
 
-#: ../../source/models/model_abilities/video.rst:38
+#: ../../source/models/model_abilities/video.rst:42
 msgid ":ref:`Wan2.1-1.3B <models_builtin_wan2.1-1.3b>`"
 msgstr ""
 
-#: ../../source/models/model_abilities/video.rst:39
+#: ../../source/models/model_abilities/video.rst:43
 msgid ":ref:`Wan2.1-14B <models_builtin_wan2.1-14b>`"
 msgstr ""
 
-#: ../../source/models/model_abilities/video.rst:41
+#: ../../source/models/model_abilities/video.rst:45
 msgid ""
 "The image-to-video API is supported with the following models in "
 "Xinference:"
 msgstr "Image-to-video API 在 Xinference 中支持以下模型："
 
-#: ../../source/models/model_abilities/video.rst:43
+#: ../../source/models/model_abilities/video.rst:47
 msgid ":ref:`Wan2.1-i2v-14B-480p <models_builtin_wan2.1-i2v-14b-480p>`"
 msgstr ""
 
-#: ../../source/models/model_abilities/video.rst:44
+#: ../../source/models/model_abilities/video.rst:48
 msgid ":ref:`Wan2.1-i2v-14B-720p <models_builtin_wan2.1-i2v-14b-720p>`"
 msgstr ""
 
-#: ../../source/models/model_abilities/video.rst:47
+#: ../../source/models/model_abilities/video.rst:51
 msgid "Quickstart"
 msgstr "快速入门"
 
-#: ../../source/models/model_abilities/video.rst:50
+#: ../../source/models/model_abilities/video.rst:54
 msgid "Text-to-video"
 msgstr "文生视频"
 
-#: ../../source/models/model_abilities/video.rst:52
+#: ../../source/models/model_abilities/video.rst:56
 msgid ""
 "You can try text-to-video API out either via cURL, or Xinference's python"
 " client:"
 msgstr "可以通过 cURL 或 Xinference 的方式尝试使用 text-to-video API"
 
-#: ../../source/models/model_abilities/video.rst:79
+#: ../../source/models/model_abilities/video.rst:83
 msgid "Image-to-video"
 msgstr "图生视频"
 
-#: ../../source/models/model_abilities/video.rst:81
+#: ../../source/models/model_abilities/video.rst:85
 msgid ""
 "You can try image-to-video API out either via cURL, or Xinference's "
 "python client:"
 msgstr "可以通过 cURL 或 Xinference 的方式尝试使用 image-to-video API"
 
-#: ../../source/models/model_abilities/video.rst:107
+#: ../../source/models/model_abilities/video.rst:111
 msgid "Memory optimization"
 msgstr "内存优化"
 
-#: ../../source/models/model_abilities/video.rst:109
+#: ../../source/models/model_abilities/video.rst:113
 msgid ""
 "Video generation will occupy huge GPU memory, for instance, running "
 "CogVideoX may require up to around 35 GB GPU memory."
 msgstr ""
-"视频生成会占用大量显存，举例来说，运行 CogVideoX 可能会使用到约 35 "
-"GB 的显存。"
+"视频生成会占用大量显存，举例来说，运行 CogVideoX 可能会使用到约 35 GB 的"
+"显存。"
 
-#: ../../source/models/model_abilities/video.rst:112
+#: ../../source/models/model_abilities/video.rst:116
 msgid ""
 "Xinference supports several options to optimize video model memory (VRAM)"
 " usage."
 msgstr "Xinference 支持若干选项，来优化视频模型显存（VRAM）使用。"
 
-#: ../../source/models/model_abilities/video.rst:114
+#: ../../source/models/model_abilities/video.rst:118
 msgid "CPU offloading or block level group offloading."
 msgstr "CPU 卸载或块级分组卸载。"
 
-#: ../../source/models/model_abilities/video.rst:115
+#: ../../source/models/model_abilities/video.rst:119
 msgid "Layerwise casting."
 msgstr "逐层类型转换（Layerwise casting）。"
 
-#: ../../source/models/model_abilities/video.rst:119
+#: ../../source/models/model_abilities/video.rst:123
 msgid ""
 "CPU offloading and Block Level Group Offloading cannot be enabled at the "
 "same time, but layerwise casting can be used in combination with either "
 "of them."
 msgstr "CPU 卸载和块级分组卸载不能同时开启，但逐层类型转换可以与其中之一配合使用。"
 
-#: ../../source/models/model_abilities/video.rst:123
+#: ../../source/models/model_abilities/video.rst:127
 msgid "CPU offloading"
 msgstr "CPU 卸载"
 
-#: ../../source/models/model_abilities/video.rst:125
+#: ../../source/models/model_abilities/video.rst:129
 msgid ""
 "CPU offloading keeps the model weights on the CPU and only loads them to "
 "the GPU when a forward pass needs to be executed. It is suitable for "
 "scenarios with extremely limited GPU memory, but it has a significant "
 "impact on performance."
-msgstr "CPU 卸载会将模型权重保留在 CPU 上，仅在执行前向传播时才加载到 GPU。"
-"适用于显存极其有限的场景，但对性能影响较大。"
+msgstr ""
+"CPU 卸载会将模型权重保留在 CPU 上，仅在执行前向传播时才加载到 GPU。适用于"
+"显存极其有限的场景，但对性能影响较大。"
 
-#: ../../source/models/model_abilities/video.rst:129
+#: ../../source/models/model_abilities/video.rst:133
 msgid ""
 "When running on GPU whose memory is less than 24 GB, we recommend to add "
 "``--cpu_offload True`` when launching model. For Web UI, add an extra "
 "option, ``cpu_offload`` with value set to ``True``."
-msgstr "当使用显存小于 24 GB 的 GPU 时，建议在启动模型时添加 ``--cpu_offload True``。"
-"对于 Web UI，可添加额外选项 ``cpu_offload``，值设为 ``True``。"
+msgstr ""
+"当使用显存小于 24 GB 的 GPU 时，建议在启动模型时添加 ``--cpu_offload True"
+"``。对于 Web UI，可添加额外选项 ``cpu_offload``，值设为 ``True``。"
 
-#: ../../source/models/model_abilities/video.rst:138
+#: ../../source/models/model_abilities/video.rst:142
 msgid "Block Level Group Offloading"
 msgstr "块级分组卸载"
 
-#: ../../source/models/model_abilities/video.rst:140
+#: ../../source/models/model_abilities/video.rst:144
 msgid ""
 "Block Level Group Offloading groups multiple internal layers of the model"
 " (such as ``torch.nn.ModuleList`` or ``torch.nn.Sequential``) and loads "
 "these groups from the CPU to the GPU as needed during inference. Compared"
 " to CPU offloading, it uses more memory but has less impact on "
 "performance."
-msgstr "块级分组卸载将模型的多个内部层（如 ``torch.nn.ModuleList`` 或 ``torch.nn.Sequential``）分组，"
-"并根据需要在推理过程中将这些分组从 CPU 加载到 GPU。与 CPU 卸载相比，它使用更多的内存，但对性能的影响更小。"
+msgstr ""
+"块级分组卸载将模型的多个内部层（如 ``torch.nn.ModuleList`` 或 ``torch.nn."
+"Sequential``）分组，并根据需要在推理过程中将这些分组从 CPU 加载到 GPU。与"
+" CPU 卸载相比，它使用更多的内存，但对性能的影响更小。"
 
-#: ../../source/models/model_abilities/video.rst:144
+#: ../../source/models/model_abilities/video.rst:148
 msgid ""
 "For the command line, add the ``--group_offload True`` option; for the "
 "Web UI, add an additional option ``group_offload`` with the value set to "
 "``True``."
-msgstr "对于命令行，添加 ``--group_offload True`` 选项；对于 Web UI，添加一个额外选项 ``group_offload``，值设为 ``True``。"
+msgstr ""
+"对于命令行，添加 ``--group_offload True`` 选项；对于 Web UI，添加一个额外"
+"选项 ``group_offload``，值设为 ``True``。"
 
-#: ../../source/models/model_abilities/video.rst:147
+#: ../../source/models/model_abilities/video.rst:151
 msgid ""
 "We can speed up group offloading inference, by enabling the use of CUDA "
 "streams. However, using CUDA streams requires moving the model parameters"
@@ -210,15 +230,18 @@ msgid ""
 "you are group offloading. Enable CUDA streams via adding ``--use_stream "
 "True`` for command line; for the Web UI, add an additional option "
 "``use_stream`` with the value set to ``True``."
-msgstr "通过启用 CUDA 流，我们可以加速分组卸载推理。然而，使用 CUDA 流需要将模型参数移动到固定内存中。这项分配由 Pytorch 在后台处理，"
-"并可能导致 CPU RAM 使用量显著增加。如果您的 CPU RAM 至少是模型大小的两倍，请考虑使用此选项。"
-"通过在命令行中添加 ``--use_stream True`` 启用 CUDA 流；对于 Web UI，添加一个额外选项 ``use_stream``，值设为 ``True``。"
+msgstr ""
+"通过启用 CUDA 流，我们可以加速分组卸载推理。然而，使用 CUDA 流需要将模型"
+"参数移动到固定内存中。这项分配由 Pytorch 在后台处理，并可能导致 CPU RAM "
+"使用量显著增加。如果您的 CPU RAM 至少是模型大小的两倍，请考虑使用此选项。"
+"通过在命令行中添加 ``--use_stream True`` 启用 CUDA 流；对于 Web UI，添加"
+"一个额外选项 ``use_stream``，值设为 ``True``。"
 
-#: ../../source/models/model_abilities/video.rst:159
+#: ../../source/models/model_abilities/video.rst:163
 msgid "Applying Layerwise Casting to the Transformer"
 msgstr "将逐层类型转换应用于 Transformer"
 
-#: ../../source/models/model_abilities/video.rst:161
+#: ../../source/models/model_abilities/video.rst:165
 msgid ""
 "Layerwise casting will downcast each layer’s weights to ``torch.float8_"
 "e4m3fn``, temporarily upcast to ``torch.bfloat16`` during the forward "
@@ -228,13 +251,18 @@ msgid ""
 "precision trade-off. Enable layerwise casting via adding ``--layerwise_"
 "cast True`` for command line; for the Web UI, add an additional option ``"
 "layerwise_cast`` with the value set to ``True``."
-msgstr "逐层类型转换将把每个层的权重降级为 ``torch.float8_e4m3fn``，在层的前向传播过程中暂时升级为 ``torch.bfloat16``，"
-"然后在之后恢复为 ``torch.float8_e4m3fn``。这种方法将内存需求减少约 50%，同时由于精度折衷，"
-"生成的视频质量会略有下降。通过在命令行中添加 ``--layerwise_cast True`` 来启用逐层类型转换；"
-"对于 Web UI，添加一个额外选项 ``layerwise_cast``，值设为 ``True``。"
+msgstr ""
+"逐层类型转换将把每个层的权重降级为 ``torch.float8_e4m3fn``，在层的前向"
+"传播过程中暂时升级为 ``torch.bfloat16``，然后在之后恢复为 ``torch.float8_"
+"e4m3fn``。这种方法将内存需求减少约 50%，同时由于精度折衷，生成的视频质量"
+"会略有下降。通过在命令行中添加 ``--layerwise_cast True`` 来启用逐层"
+"类型转换；对于 Web UI，添加一个额外选项 ``layerwise_cast``，值设为 ``True"
+"``。"
 
-#: ../../source/models/model_abilities/video.rst:168
+#: ../../source/models/model_abilities/video.rst:172
 msgid "This example will require 20GB of VRAM."
 msgstr "此示例将需要 20GB 的显存。"
 
+#~ msgid "OpenAI-compatible ENDPOINT"
+#~ msgstr "OpenAI 兼容端点"
 

--- a/doc/source/models/builtin/video/index.rst
+++ b/doc/source/models/builtin/video/index.rst
@@ -21,3 +21,7 @@ The following is a list of built-in video models in Xinference:
   
    wan2.1-14b
   
+   wan2.1-i2v-14b-480p
+  
+   wan2.1-i2v-14b-720p
+  

--- a/doc/source/models/builtin/video/wan2.1-i2v-14b-480p.rst
+++ b/doc/source/models/builtin/video/wan2.1-i2v-14b-480p.rst
@@ -1,0 +1,18 @@
+.. _models_builtin_wan2.1-i2v-14b-480p:
+
+===================
+Wan2.1-i2v-14B-480p
+===================
+
+- **Model Name:** Wan2.1-i2v-14B-480p
+- **Model Family:** Wan
+- **Abilities:** image2video
+
+Specifications
+^^^^^^^^^^^^^^
+
+- **Model ID:** Wan-AI/Wan2.1-I2V-14B-480P-Diffusers
+
+Execute the following command to launch the model::
+
+   xinference launch --model-name Wan2.1-i2v-14B-480p --model-type video

--- a/doc/source/models/builtin/video/wan2.1-i2v-14b-720p.rst
+++ b/doc/source/models/builtin/video/wan2.1-i2v-14b-720p.rst
@@ -1,0 +1,18 @@
+.. _models_builtin_wan2.1-i2v-14b-720p:
+
+===================
+Wan2.1-i2v-14B-720p
+===================
+
+- **Model Name:** Wan2.1-i2v-14B-720p
+- **Model Family:** Wan
+- **Abilities:** image2video
+
+Specifications
+^^^^^^^^^^^^^^
+
+- **Model ID:** Wan-AI/Wan2.1-I2V-14B-720P-Diffusers
+
+Execute the following command to launch the model::
+
+   xinference launch --model-name Wan2.1-i2v-14B-720p --model-type video

--- a/doc/source/models/model_abilities/video.rst
+++ b/doc/source/models/model_abilities/video.rst
@@ -21,11 +21,14 @@ The Video API provides the ability to interact with videos:
    :widths: 25  50
    :header-rows: 1
 
-   * - API ENDPOINT
-     - OpenAI-compatible ENDPOINT
+   * - API
+     - URL
 
    * - Text-to-Video API
      - /v1/video/generations
+
+   * - Image-to-Video API
+     - /v1/video/generations/image
 
 Supported models
 -------------------

--- a/doc/source/models/model_abilities/video.rst
+++ b/doc/source/models/model_abilities/video.rst
@@ -15,6 +15,7 @@ The Video API provides the ability to interact with videos:
 
 
 * The text-to-video endpoint create videos from scratch based on a text prompt.
+* The image-to-video endpoint create videos from scratch based on an input image.
 
 
 .. list-table::
@@ -22,7 +23,7 @@ The Video API provides the ability to interact with videos:
    :header-rows: 1
 
    * - API
-     - URL
+     - Endpoint
 
    * - Text-to-Video API
      - /v1/video/generations

--- a/doc/source/models/model_abilities/video.rst
+++ b/doc/source/models/model_abilities/video.rst
@@ -30,10 +30,18 @@ The Video API provides the ability to interact with videos:
 Supported models
 -------------------
 
-The Text-to-video API is supported with the following models in Xinference:
+The text-to-video API is supported with the following models in Xinference:
 
-* CogVideoX-2b
+* :ref:`CogVideoX-2b <models_builtin_cogvideox-2b>`
+* :ref:`CogVideoX-5b <models_builtin_cogvideox-5b>`
+* :ref:`HunyuanVideo <models_builtin_hunyuanvideo>`
+* :ref:`Wan2.1-1.3B <models_builtin_wan2.1-1.3b>`
+* :ref:`Wan2.1-14B <models_builtin_wan2.1-14b>`
 
+The image-to-video API is supported with the following models in Xinference:
+
+* :ref:`Wan2.1-i2v-14B-480p <models_builtin_wan2.1-i2v-14b-480p>`
+* :ref:`Wan2.1-i2v-14B-720p <models_builtin_wan2.1-i2v-14b-720p>`
 
 Quickstart
 ===================
@@ -41,7 +49,7 @@ Quickstart
 Text-to-video
 --------------------
 
-You can try Text-to-video API out either via cURL, or Xinference's python client:
+You can try text-to-video API out either via cURL, or Xinference's python client:
 
 .. tabs::
 
@@ -67,16 +75,99 @@ You can try Text-to-video API out either via cURL, or Xinference's python client
     input_text = "an apple"
     model.text_to_video(input_text)
 
+Image-to-video
+--------------------
 
-Tips when running on GPU whose memory less than 24GB
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+You can try image-to-video API out either via cURL, or Xinference's python client:
 
-Text-to-video will occupy huge GPU memory, for instance,
+.. tabs::
+
+  .. code-tab:: bash cURL
+
+    curl -X 'POST' \
+      'http://<XINFERENCE_HOST>:<XINFERENCE_PORT>/v1/video/generations/image' \
+      -F model=<MODEL_UID> \
+      -F image=@xxx.jpg \
+      -F prompt=<prompt>
+
+
+  .. code-tab:: python Xinference Python Client
+
+    from xinference.client import Client
+
+    client = Client("http://<XINFERENCE_HOST>:<XINFERENCE_PORT>")
+
+    model = client.get_model("<MODEL_UID>")
+    with open("xxx.jpg", "rb") as f:
+        prompt = ""
+        model.image_to_video(image=f.read(), prompt=prompt)
+
+
+Memory optimization
+===================
+
+Video generation will occupy huge GPU memory, for instance,
 running CogVideoX may require up to around 35 GB GPU memory.
+
+Xinference supports several options to optimize video model memory (VRAM) usage.
+
+* CPU offloading or block level group offloading.
+* Layerwise casting.
+
+.. note::
+
+  CPU offloading and Block Level Group Offloading cannot be enabled at the same time,
+  but layerwise casting can be used in combination with either of them.
+
+CPU offloading
+--------------------
+
+CPU offloading keeps the model weights on the CPU and only loads them to the GPU
+when a forward pass needs to be executed. It is suitable for scenarios with extremely limited GPU memory,
+but it has a significant impact on performance.
+
 When running on GPU whose memory is less than 24 GB,
 we recommend to add ``--cpu_offload True`` when launching model.
-
+For Web UI, add an extra option, ``cpu_offload`` with value set to ``True``.
 
 .. code-block:: bash
 
-    xinference launch --model-name CogVideoX-2b --model-type video --cpu_offload True
+    xinference launch --model-name Wan2.1-i2v-14B-480p --model-type video --cpu_offload True
+
+Block Level Group Offloading
+-------------------------------
+
+Block Level Group Offloading groups multiple internal layers of the model
+(such as ``torch.nn.ModuleList`` or ``torch.nn.Sequential``) and loads these groups from the CPU to the GPU
+as needed during inference. Compared to CPU offloading, it uses more memory but has less impact on performance.
+
+For the command line, add the ``--group_offload True`` option; for the Web UI,
+add an additional option ``group_offload`` with the value set to ``True``.
+
+We can speed up group offloading inference, by enabling the use of CUDA streams. However,
+using CUDA streams requires moving the model parameters into pinned memory.
+This allocation is handled by Pytorch under the hood, and can result in a significant spike in CPU RAM usage.
+Please consider this option if your CPU RAM is atleast 2X the size of the model you are group offloading.
+Enable CUDA streams via adding ``--use_stream True`` for command line; for the Web UI,
+add an additional option ``use_stream`` with the value set to ``True``.
+
+.. code-block:: bash
+
+    xinference launch --model-name Wan2.1-i2v-14B-480p --model-type video --group_offload True --use_stream True
+
+Applying Layerwise Casting to the Transformer
+------------------------------------------------
+
+Layerwise casting will downcast each layer’s weights to ``torch.float8_e4m3fn``,
+temporarily upcast to ``torch.bfloat16`` during the forward pass of the layer,
+then revert to ``torch.float8_e4m3fn`` afterward. This approach reduces memory requirements
+by approximately 50% while introducing a minor quality reduction in the generated video due to the precision trade-off.
+Enable layerwise casting via adding ``--layerwise_cast True`` for command line; for the Web UI,
+add an additional option ``layerwise_cast`` with the value set to ``True``.
+
+This example will require 20GB of VRAM.
+
+.. code-block:: bash
+
+    xinference launch --model-name Wan2.1-i2v-14B-480p --model-type video --layerwise_cast True --cpu_offload True
+

--- a/xinference/client/restful/restful_client.py
+++ b/xinference/client/restful/restful_client.py
@@ -464,6 +464,53 @@ class RESTfulVideoModelHandle(RESTfulModelHandle):
         response_data = response.json()
         return response_data
 
+    def image_to_video(
+        self,
+        image: Union[str, bytes],
+        prompt: str,
+        negative_prompt: Optional[str] = None,
+        n: int = 1,
+        **kwargs,
+    ) -> "VideoList":
+        """
+        Creates a video by the input image and text.
+
+        Parameters
+        ----------
+        image: `Union[str, bytes]`
+            The input image to condition the generation on.
+        prompt: `str` or `List[str]`
+            The prompt or prompts to guide video generation. If not defined, you need to pass `prompt_embeds`.
+        negative_prompt (`str` or `List[str]`, *optional*):
+            The prompt or prompts not to guide the image generation.
+        n: `int`, defaults to 1
+            The number of videos to generate per prompt. Must be between 1 and 10.
+        Returns
+        -------
+        VideoList
+            A list of video objects.
+        """
+        url = f"{self._base_url}/v1/video/generations/image"
+        params = {
+            "model": self._model_uid,
+            "prompt": prompt,
+            "negative_prompt": negative_prompt,
+            "n": n,
+            "kwargs": json.dumps(kwargs),
+        }
+        files: List[Any] = []
+        for key, value in params.items():
+            files.append((key, (None, value)))
+        files.append(("image", ("image", image, "application/octet-stream")))
+        response = requests.post(url, files=files, headers=self.auth_headers)
+        if response.status_code != 200:
+            raise RuntimeError(
+                f"Failed to create the video from image, detail: {_get_error_string(response)}"
+            )
+
+        response_data = response.json()
+        return response_data
+
 
 class RESTfulGenerateModelHandle(RESTfulModelHandle):
     def generate(

--- a/xinference/core/model.py
+++ b/xinference/core/model.py
@@ -1242,6 +1242,32 @@ class ModelActor(xo.StatelessActor, CancelMixin):
             f"Model {self._model.model_spec} is not for creating video."
         )
 
+    @request_limit
+    @log_async(logger=logger)
+    async def image_to_video(
+        self,
+        image: "PIL.Image",
+        prompt: str,
+        negative_prompt: Optional[str] = None,
+        n: int = 1,
+        *args,
+        **kwargs,
+    ):
+        kwargs.pop("request_id", None)
+        kwargs["negative_prompt"] = negative_prompt
+        if hasattr(self._model, "image_to_video"):
+            return await self._call_wrapper_json(
+                self._model.image_to_video,
+                image,
+                prompt,
+                n,
+                *args,
+                **kwargs,
+            )
+        raise AttributeError(
+            f"Model {self._model.model_spec} is not for creating video from image."
+        )
+
     async def record_metrics(self, name, op, kwargs):
         worker_ref = await self._get_worker_ref()
         await worker_ref.record_metrics(name, op, kwargs)

--- a/xinference/model/video/diffusers.py
+++ b/xinference/model/video/diffusers.py
@@ -14,12 +14,13 @@
 
 import base64
 import logging
+import operator
 import os
 import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor
-from functools import partial
-from typing import TYPE_CHECKING, List, Union
+from functools import partial, reduce
+from typing import TYPE_CHECKING, Any, List, Optional, Union
 
 import numpy as np
 import PIL.Image
@@ -111,11 +112,27 @@ class DiffUsersVideoModel:
                 self._model_path, transformer=transformer, **kwargs
             )
         elif self.model_spec.model_family == "Wan":
-            from diffusers import WanPipeline
+            from diffusers import AutoencoderKLWan, WanImageToVideoPipeline, WanPipeline
+            from transformers import CLIPVisionModel
 
-            pipeline = self._model = WanPipeline.from_pretrained(
-                self._model_path, **kwargs
-            )
+            if "text2video" in self.model_spec.model_ability:
+                pipeline = self._model = WanPipeline.from_pretrained(
+                    self._model_path, **kwargs
+                )
+            else:
+                assert "image2video" in self.model_spec.model_ability
+
+                image_encoder = CLIPVisionModel.from_pretrained(
+                    self._model_path,
+                    subfolder="image_encoder",
+                    torch_dtype=torch.float32,
+                )
+                vae = AutoencoderKLWan.from_pretrained(
+                    self._model_path, subfolder="vae", torch_dtype=torch.float32
+                )
+                pipeline = self._model = WanImageToVideoPipeline.from_pretrained(
+                    self._model_path, vae=vae, image_encoder=image_encoder, **kwargs
+                )
         else:
             raise Exception(
                 f"Unsupported model family: {self._model_spec.model_family}"
@@ -129,6 +146,11 @@ class DiffUsersVideoModel:
         if kwargs.get("compile_graph", False):
             pipeline.transformer = torch.compile(
                 pipeline.transformer, mode="max-autotune", fullgraph=True
+            )
+        if kwargs.get("layerwise_cast", False):
+            compute_dtype = pipeline.transformer.dtype
+            pipeline.transformer.enable_layerwise_casting(
+                storage_dtype=torch.float8_e4m3fn, compute_dtype=compute_dtype
             )
         if kwargs.get("cpu_offload", False):
             logger.debug("CPU offloading model")
@@ -145,6 +167,33 @@ class DiffUsersVideoModel:
             except AttributeError:
                 # model does support tiling
                 pass
+        elif kwargs.get("group_offload", False):
+            from diffusers.hooks.group_offloading import apply_group_offloading
+
+            onload_device = torch.device("cuda")
+            offload_device = torch.device("cpu")
+
+            apply_group_offloading(
+                pipeline.text_encoder,
+                onload_device=onload_device,
+                offload_device=offload_device,
+                offload_type="block_level",
+                num_blocks_per_group=4,
+            )
+            group_offload_kwargs = {}
+            if kwargs.get("use_stream", False):
+                group_offload_kwargs["offload_type"] = "block_level"
+                group_offload_kwargs["num_blocks_per_group"] = 4
+            else:
+                group_offload_kwargs["offload_type"] = "leaf_level"
+                group_offload_kwargs["use_stream"] = True
+            pipeline.transformer.enable_group_offload(
+                onload_device=onload_device,
+                offload_device=offload_device,
+                **group_offload_kwargs,
+            )
+            # Since we've offloaded the larger models already, we can move the rest of the model components to GPU
+            pipeline = move_model_to_available_device(pipeline)
         elif not kwargs.get("device_map"):
             logger.debug("Loading model to available device")
             if gpu_count() > 1:
@@ -162,15 +211,6 @@ class DiffUsersVideoModel:
         response_format: str = "b64_json",
         **kwargs,
     ) -> VideoList:
-        import gc
-
-        from diffusers.utils import export_to_video
-
-        # cv2 bug will cause the video cannot be normally displayed
-        # thus we use the imageio one
-        # from diffusers.utils import export_to_video
-        from ...device_utils import empty_cache
-
         assert self._model is not None
         assert callable(self._model)
         generate_kwargs = self._model_spec.default_generate_config.copy()
@@ -186,6 +226,58 @@ class DiffUsersVideoModel:
             num_inference_steps=num_inference_steps,
             **generate_kwargs,
         )
+        return self._output_to_video(output, fps, response_format)
+
+    def image_to_video(
+        self,
+        image: PIL.Image,
+        prompt: str,
+        n: int = 1,
+        num_inference_steps: Optional[int] = None,
+        response_format: str = "b64_json",
+        **kwargs,
+    ):
+        assert self._model is not None
+        assert callable(self._model)
+        generate_kwargs = self._model_spec.default_generate_config.copy()
+        generate_kwargs.update(kwargs)
+        generate_kwargs["num_videos_per_prompt"] = n
+        if num_inference_steps:
+            generate_kwargs["num_inference_steps"] = num_inference_steps
+        fps = generate_kwargs.pop("fps", 10)
+
+        # process image
+        max_area = generate_kwargs.pop("max_area")
+        if isinstance(max_area, str):
+            max_area = [int(v) for v in max_area.split("*")]
+        max_area = reduce(operator.mul, max_area, 1)
+        image = self._process_image(image, max_area)
+
+        height, width = image.height, image.width
+        output = self._model(
+            image=image, prompt=prompt, height=height, width=width, **generate_kwargs
+        )
+        return self._output_to_video(output, fps, response_format)
+
+    def _process_image(self, image: PIL.Image, max_area: int) -> PIL.Image:
+        assert self._model is not None
+        aspect_ratio = image.height / image.width
+        mod_value = (
+            self._model.vae_scale_factor_spatial
+            * self._model.transformer.config.patch_size[1]
+        )
+        height = round(np.sqrt(max_area * aspect_ratio)) // mod_value * mod_value
+        width = round(np.sqrt(max_area / aspect_ratio)) // mod_value * mod_value
+        return image.resize((width, height))
+
+    def _output_to_video(self, output: Any, fps: int, response_format: str):
+        import gc
+
+        # cv2 bug will cause the video cannot be normally displayed
+        # thus we use the imageio one
+        from diffusers.utils import export_to_video
+
+        from ...device_utils import empty_cache
 
         # clean cache
         gc.collect()

--- a/xinference/model/video/model_spec.json
+++ b/xinference/model/video/model_spec.json
@@ -91,5 +91,59 @@
         "numpy==1.26.4"
       ]
     }
+  },
+  {
+    "model_name": "Wan2.1-i2v-14B-480p",
+    "model_family": "Wan",
+    "model_id": "Wan-AI/Wan2.1-I2V-14B-480P-Diffusers",
+    "model_revision": "b184e23a8a16b20f108f727c902e769e873ffc73",
+    "model_ability": [
+      "image2video"
+    ],
+    "default_model_config": {
+      "torch_dtype": "bfloat16"
+    },
+    "default_generate_config": {
+      "max_area": [
+        480,
+        832
+      ]
+    },
+    "virtualenv": {
+      "packages": [
+        "diffusers>=0.33.0",
+        "ftfy",
+        "imageio-ffmpeg",
+        "imageio",
+        "numpy==1.26.4"
+      ]
+    }
+  },
+  {
+    "model_name": "Wan2.1-i2v-14B-720p",
+    "model_family": "Wan",
+    "model_id": "Wan-AI/Wan2.1-I2V-14B-720P-Diffusers",
+    "model_revision": "eb849f76dfa246545b65774a9e25943ee69b3fa3",
+    "model_ability": [
+      "image2video"
+    ],
+    "default_model_config": {
+      "torch_dtype": "bfloat16"
+    },
+    "default_generate_config": {
+      "max_area": [
+        720,
+        1280
+      ]
+    },
+    "virtualenv": {
+      "packages": [
+        "diffusers>=0.33.0",
+        "ftfy",
+        "imageio-ffmpeg",
+        "imageio",
+        "numpy==1.26.4"
+      ]
+    }
   }
 ]

--- a/xinference/model/video/model_spec_modelscope.json
+++ b/xinference/model/video/model_spec_modelscope.json
@@ -96,5 +96,61 @@
         "numpy==1.26.4"
       ]
     }
+  },
+  {
+    "model_name": "Wan2.1-i2v-14B-480p",
+    "model_family": "Wan",
+    "model_hub": "modelscope",
+    "model_id": "Wan-AI/Wan2.1-I2V-14B-480P-Diffusers",
+    "model_revision": "master",
+    "model_ability": [
+      "image2video"
+    ],
+    "default_model_config": {
+      "torch_dtype": "bfloat16"
+    },
+    "default_generate_config": {
+      "max_area": [
+        480,
+        832
+      ]
+    },
+    "virtualenv": {
+      "packages": [
+        "diffusers>=0.33.0",
+        "ftfy",
+        "imageio-ffmpeg",
+        "imageio",
+        "numpy==1.26.4"
+      ]
+    }
+  },
+  {
+    "model_name": "Wan2.1-i2v-14B-720p",
+    "model_family": "Wan",
+    "model_hub": "modelscope",
+    "model_id": "Wan-AI/Wan2.1-I2V-14B-720P-Diffusers",
+    "model_revision": "master",
+    "model_ability": [
+      "image2video"
+    ],
+    "default_model_config": {
+      "torch_dtype": "bfloat16"
+    },
+    "default_generate_config": {
+      "max_area": [
+        720,
+        1280
+      ]
+    },
+    "virtualenv": {
+      "packages": [
+        "diffusers>=0.33.0",
+        "ftfy",
+        "imageio-ffmpeg",
+        "imageio",
+        "numpy==1.26.4"
+      ]
+    }
   }
 ]


### PR DESCRIPTION
This PR added `image_to_video` support.

```
import base64
import io
from xinference.client import Client
from diffusers.utils import load_image

model = client.get_model('Wan2.1-i2v-14B-480p')

image = load_image("https://hf-mirror.com/datasets/huggingface/documentation-images/resolve/main/diffusers/astronaut.jpg")

prompt = (
    "An astronaut hatching from an egg, on the surface of the moon, the darkness and depth of space realised in "
    "the background. High quality, ultrarealistic detail and breath-taking movie-like camera shot."
)
negative_prompt = "Bright tones, overexposed, static, blurred details, subtitles, style, works, paintings, images, static, overall gray, worst quality, low quality, JPEG compression residue, ugly, incomplete, extra fingers, poorly drawn hands, poorly drawn faces, deformed, disfigured, misshapen limbs, fused fingers, still picture, messy background, three legs, many people in the background, walking backwards"
num_frames = 33
num_inference_steps=5
guidance_scale=5.0
bio = io.BytesIO()
image.save(bio, format="jpeg")

resp = model.image_to_video(
    image=bio.getvalue(),
    prompt=prompt,
    negative_prompt=negative_prompt,
    num_frames=num_frames,
    guidance_scale=guidance_scale,
    num_inference_steps=num_inference_steps,
    fps=15
)

b64_video = resp['data'][0]['b64_json']
video_bytes = base64.b64decode(b64_video)

with open('wan-i2v.mp4', 'wb') as f:
    f.write(video_bytes)
```


https://github.com/user-attachments/assets/06b63e61-61b9-428d-8096-c799563fe811

