### PR TITLE
BUG: fix potential stop hang

### DIFF
--- a/xinference/core/model.py
+++ b/xinference/core/model.py
@@ -214,8 +214,12 @@ class ModelActor(xo.StatelessActor, CancelMixin):
                 raise ImportError(f"{error_message}\n\n{''.join(installation_guide)}")
 
             del self._model
-            gc.collect()
-            empty_cache()
+
+            def clean():
+                gc.collect()
+                empty_cache()
+
+            await asyncio.to_thread(clean)
 
     def __init__(
         self,


### PR DESCRIPTION
`gc.collect` may hang due to unknown reason, thus put it into thread to prevent from hanging the entire event loop.