### PR TITLE
ENH: Use Qwen's official quantitative model repository

### DIFF
--- a/xinference/model/llm/llm_family.json
+++ b/xinference/model/llm/llm_family.json
@@ -9920,10 +9920,17 @@
         "model_format": "gptq",
         "model_size_in_billions": "0_6",
         "quantizations": [
-          "Int4",
           "Int8"
         ],
-        "model_id": "JunHowie/Qwen3-0.6B-GPTQ-{quantization}"
+        "model_id": "Qwen/Qwen3-0.6B-GPTQ-Int8"
+      },
+      {
+        "model_format": "gptq",
+        "model_size_in_billions": "0_6",
+        "quantizations": [
+          "Int4"
+        ],
+        "model_id": "JunHowie/Qwen3-0.6B-GPTQ-Int4"
       },
       {
         "model_format": "mlx",
@@ -9989,10 +9996,17 @@
         "model_format": "gptq",
         "model_size_in_billions": "1_7",
         "quantizations": [
-          "Int4",
           "Int8"
         ],
-        "model_id": "JunHowie/Qwen3-1.7B-GPTQ-{quantization}"
+        "model_id": "Qwen/Qwen3-1.7B-GPTQ-Int8"
+      },
+      {
+        "model_format": "gptq",
+        "model_size_in_billions": "1_7",
+        "quantizations": [
+          "Int4"
+        ],
+        "model_id": "JunHowie/Qwen3-1.7B-GPTQ-Int4"
       },
       {
         "model_format": "mlx",
@@ -10053,6 +10067,14 @@
           "fp8"
         ],
         "model_id": "Qwen/Qwen3-4B-FP8"
+      },
+      {
+        "model_format": "awq",
+        "model_size_in_billions": 4,
+        "quantizations": [
+          "Int4"
+        ],
+        "model_id": "Qwen/Qwen3-4B-AWQ"
       },
       {
         "model_format": "gptq",
@@ -10122,6 +10144,14 @@
           "fp8"
         ],
         "model_id": "Qwen/Qwen3-8B-FP8"
+      },
+      {
+        "model_format": "awq",
+        "model_size_in_billions": 8,
+        "quantizations": [
+          "Int4"
+        ],
+        "model_id": "Qwen/Qwen3-8B-AWQ"
       },
       {
         "model_format": "gptq",
@@ -10276,10 +10306,18 @@
         "model_size_in_billions": 30,
         "activated_size_in_billions": 3,
         "quantizations": [
-          "Int4",
           "Int8"
         ],
-        "model_id": "JunHowie/Qwen3-30B-A3B-GPTQ-{quantization}"
+        "model_id": "JunHowie/Qwen3-30B-A3B-GPTQ-Int8"
+      },
+      {
+        "model_format": "gptq",
+        "model_size_in_billions": 30,
+        "activated_size_in_billions": 3,
+        "quantizations": [
+          "Int4"
+        ],
+        "model_id": "Qwen/Qwen3-30B-A3B-GPTQ-Int4"
       },
       {
         "model_format": "mlx",
@@ -10433,6 +10471,15 @@
           "fp8"
         ],
         "model_id": "Qwen/Qwen3-235B-A22B-FP8"
+      },
+      {
+        "model_format": "gptq",
+        "model_size_in_billions": 235,
+        "activated_size_in_billions": 22,
+        "quantizations": [
+          "Int4"
+        ],
+        "model_id": "Qwen/Qwen3-235B-A22B-GPTQ-Int4"
       },
       {
         "model_format": "mlx",

--- a/xinference/model/llm/llm_family.json
+++ b/xinference/model/llm/llm_family.json
@@ -10477,6 +10477,15 @@
         "model_size_in_billions": 235,
         "activated_size_in_billions": 22,
         "quantizations": [
+          "Int8"
+        ],
+        "model_id": "QuantTrio/Qwen3-235B-A22B-GPTQ-Int8"
+      },
+      {
+        "model_format": "gptq",
+        "model_size_in_billions": 235,
+        "activated_size_in_billions": 22,
+        "quantizations": [
           "Int4"
         ],
         "model_id": "Qwen/Qwen3-235B-A22B-GPTQ-Int4"

--- a/xinference/model/llm/llm_family_modelscope.json
+++ b/xinference/model/llm/llm_family_modelscope.json
@@ -8009,10 +8009,18 @@
         "model_format": "gptq",
         "model_size_in_billions": "0_6",
         "quantizations": [
-          "Int4",
           "Int8"
         ],
-        "model_id": "JunHowie/Qwen3-0.6B-GPTQ-{quantization}",
+        "model_id": "Qwen/Qwen3-0.6B-GPTQ-Int8",
+        "model_hub": "modelscope"
+      },
+      {
+        "model_format": "gptq",
+        "model_size_in_billions": "0_6",
+        "quantizations": [
+          "Int4"
+        ],
+        "model_id": "JunHowie/Qwen3-0.6B-GPTQ-Int4",
         "model_hub": "modelscope"
       },
       {
@@ -8083,10 +8091,18 @@
         "model_format": "gptq",
         "model_size_in_billions": "1_7",
         "quantizations": [
-          "Int4",
           "Int8"
         ],
-        "model_id": "JunHowie/Qwen3-1.7B-GPTQ-{quantization}",
+        "model_id": "Qwen/Qwen3-1.7B-GPTQ-Int8",
+        "model_hub": "modelscope"
+      },
+      {
+        "model_format": "gptq",
+        "model_size_in_billions": "1_7",
+        "quantizations": [
+          "Int4"
+        ],
+        "model_id": "JunHowie/Qwen3-1.7B-GPTQ-Int4",
         "model_hub": "modelscope"
       },
       {
@@ -8151,6 +8167,15 @@
           "fp8"
         ],
         "model_id": "Qwen/Qwen3-4B-FP8",
+        "model_hub": "modelscope"
+      },
+      {
+        "model_format": "awq",
+        "model_size_in_billions": 4,
+        "quantizations": [
+          "Int4"
+        ],
+        "model_id": "Qwen/Qwen3-4B-AWQ",
         "model_hub": "modelscope"
       },
       {
@@ -8225,6 +8250,15 @@
           "fp8"
         ],
         "model_id": "Qwen/Qwen3-8B-FP8",
+        "model_hub": "modelscope"
+      },
+      {
+        "model_format": "awq",
+        "model_size_in_billions": 8,
+        "quantizations": [
+          "Int4"
+        ],
+        "model_id": "Qwen/Qwen3-8B-AWQ",
         "model_hub": "modelscope"
       },
       {
@@ -8391,10 +8425,19 @@
         "model_size_in_billions": 30,
         "activated_size_in_billions": 3,
         "quantizations": [
-          "Int4",
           "Int8"
         ],
-        "model_id": "JunHowie/Qwen3-30B-A3B-GPTQ-{quantization}",
+        "model_id": "JunHowie/Qwen3-30B-A3B-GPTQ-Int8",
+        "model_hub": "modelscope"
+      },
+      {
+        "model_format": "gptq",
+        "model_size_in_billions": 30,
+        "activated_size_in_billions": 3,
+        "quantizations": [
+          "Int4"
+        ],
+        "model_id": "Qwen/Qwen3-30B-A3B-GPTQ-Int4",
         "model_hub": "modelscope"
       },
       {
@@ -8565,10 +8608,19 @@
         "model_size_in_billions": 235,
         "activated_size_in_billions": 22,
         "quantizations": [
-          "Int4",
           "Int8"
         ],
-        "model_id": "tclf90/Qwen3-235B-A22B-GPTQ-{quantization}",
+        "model_id": "tclf90/Qwen3-235B-A22B-GPTQ-Int8",
+        "model_hub": "modelscope"
+      },
+      {
+        "model_format": "gptq",
+        "model_size_in_billions": 235,
+        "activated_size_in_billions": 22,
+        "quantizations": [
+          "Int4"
+        ],
+        "model_id": "Qwen/Qwen3-235B-A22B-GPTQ-Int4",
         "model_hub": "modelscope"
       },
       {


### PR DESCRIPTION
Use Qwen's official quantitative model repository
of which
GPTQ-Int8 quantization model for Qwen3-0.6B/Qwen3-1.7B
AWQ quantization model for Qwen3-4B/Qwen3-8B/Qwen3-14B/Qwen3-32B
GPTQ-Int4 quantization model for Qwen3-30B-A3B/Qwen3-235B-A22B
Due to the incomplete official GGUF format, GGUF still uses the quantization model provided by unsloth