### PR TITLE
FEAT: use xo.wait_for instead of asyncio.wait_for for actor call

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ zip_safe = False
 include_package_data = True
 packages = find:
 install_requires =
-    xoscar>=0.7.0
+    xoscar>=0.7.1
     torch
     gradio
     pillow

--- a/xinference/core/model.py
+++ b/xinference/core/model.py
@@ -214,12 +214,8 @@ class ModelActor(xo.StatelessActor, CancelMixin):
                 raise ImportError(f"{error_message}\n\n{''.join(installation_guide)}")
 
             del self._model
-
-            def clean():
-                gc.collect()
-                empty_cache()
-
-            await asyncio.to_thread(clean)
+            gc.collect()
+            empty_cache()
 
     def __init__(
         self,

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -1255,6 +1255,13 @@ class WorkerActor(xo.StatelessActor):
         try:
             logger.debug("Start to destroy model actor: %s", model_ref)
             coro = xo.destroy_actor(model_ref)
+            # see https://github.com/xorbitsai/xoscar/pull/140
+            # asyncio.wait_for cannot work for Xoscar actor call,
+            # because when time out, the coroutine will be cancelled via raise CancelledEror,
+            # inside actor call, the error will be caught and
+            # a CancelMessage will be sent to dest actor pool,
+            # however the actor pool may be stuck already,
+            # thus the timeout will never be raised
             await xo.wait_for(coro, timeout=5)
         except Exception as e:
             logger.debug(

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -148,7 +148,7 @@ class WorkerActor(xo.StatelessActor):
         elif metrics_exporter_host is not None or metrics_exporter_port is not None:
             # metrics export server.
             logger.info(
-                f"Starting metrics export server at {metrics_exporter_host}:{metrics_exporter_port}"
+                f"Starting metrics export server at {metrics_exporter_host}:{metrics_exporter_port}"  # noqa: E231
             )
             q: queue.Queue = queue.Queue()
             self._metrics_thread = threading.Thread(
@@ -162,7 +162,9 @@ class WorkerActor(xo.StatelessActor):
             while self._metrics_thread.is_alive():
                 try:
                     host, port = q.get(block=False)[:2]
-                    logger.info(f"Metrics server is started at: http://{host}:{port}")
+                    logger.info(
+                        f"Metrics server is started at: http://{host}:{port}"  # noqa: E231
+                    )
                     break
                 except queue.Empty:
                     pass
@@ -1253,7 +1255,7 @@ class WorkerActor(xo.StatelessActor):
         try:
             logger.debug("Start to destroy model actor: %s", model_ref)
             coro = xo.destroy_actor(model_ref)
-            await asyncio.wait_for(coro, timeout=5)
+            await xo.wait_for(coro, timeout=5)
         except Exception as e:
             logger.debug(
                 "Destroy model actor failed, model uid: %s, error: %s", model_uid, e
@@ -1432,7 +1434,7 @@ class WorkerActor(xo.StatelessActor):
                 else:
                     logger.debug(f"{path} is not a valid path.")
             except Exception as e:
-                logger.error(f"Fail to delete {path} with error:{e}.")
+                logger.error(f"Fail to delete {path} with error:{e}.")  # noqa: E231
                 return False
         await self._cache_tracker_ref.confirm_and_remove_model(
             model_version, self.address

--- a/xinference/deploy/docker/requirements-base.txt
+++ b/xinference/deploy/docker/requirements-base.txt
@@ -1,4 +1,4 @@
-xoscar>=0.7.0
+xoscar>=0.7.1
 gradio==5.22.0
 pillow
 click

--- a/xinference/deploy/docker/requirements.txt
+++ b/xinference/deploy/docker/requirements.txt
@@ -1,5 +1,5 @@
 # required
-xoscar>=0.7.0
+xoscar>=0.7.1
 gradio==5.22.0
 pillow
 click

--- a/xinference/deploy/docker/requirements_cpu-base.txt
+++ b/xinference/deploy/docker/requirements_cpu-base.txt
@@ -1,4 +1,4 @@
-xoscar>=0.7.0
+xoscar>=0.7.1
 gradio==5.22.0
 pillow
 click

--- a/xinference/deploy/docker/requirements_cpu.txt
+++ b/xinference/deploy/docker/requirements_cpu.txt
@@ -1,4 +1,4 @@
-xoscar>=0.7.0
+xoscar>=0.7.1
 gradio==5.22.0
 pillow
 click


### PR DESCRIPTION
This PR reverts #3434  , as mentioned in https://github.com/xorbitsai/xoscar/pull/140 , xoscar introduced `wait_for` API to solve the issue that `asyncio.wait_for` cannot raise timeout for xoscar actor call.