### PR TITLE
ENH: pass extra arguments for speech2text API.

### DIFF
--- a/xinference/core/model.py
+++ b/xinference/core/model.py
@@ -977,6 +977,7 @@ class ModelActor(xo.StatelessActor, CancelMixin):
                 response_format,
                 temperature,
                 timestamp_granularities,
+                **kwargs,
             )
         raise AttributeError(
             f"Model {self._model.model_spec} is not for creating transcriptions."


### PR DESCRIPTION
- before
![图片](https://github.com/user-attachments/assets/2ce55f22-63b5-4370-b2a0-902b216873f5)

- after
![图片](https://github.com/user-attachments/assets/f73842ef-9e3b-43ea-b47a-19a5fe87a164)
curl -X 'POST' 'http://192.168.1.33:9997/v1/audio/transcriptions' \
  -H 'accept: application/json' \
  -H "Content-Type: multipart/form-data" \
  -F file="@./chinese_test.wav" \
  -F 'kwargs={"use_itn":false}' \
  -F model="SenseVoiceSmall"

We can pass extra arguments via kwargs

Closes https://github.com/xorbitsai/inference/issues/2075
Closes https://github.com/xorbitsai/inference/issues/3497


