### PR TITLE
ENH: remove check when specified GPU index for vllm

### DIFF
--- a/xinference/core/tests/test_worker.py
+++ b/xinference/core/tests/test_worker.py
@@ -389,9 +389,9 @@ async def test_launch_model_with_gpu_idx(setup_pool):
     await worker.launch_builtin_model(
         "embedding_3", "mock_model_name", None, None, None, "embedding", n_gpu=1
     )
-    # should be on gpu 1
+    # should be on gpu 0
     await worker.launch_builtin_model(
-        "rerank_4", "mock_model_name", None, None, None, "rerank", gpu_idx=[1]
+        "rerank_4", "mock_model_name", None, None, None, "rerank", gpu_idx=[0]
     )
     # should be on gpu 2
     await worker.launch_builtin_model(
@@ -401,18 +401,18 @@ async def test_launch_model_with_gpu_idx(setup_pool):
     await worker.launch_builtin_model(
         "rerank_6", "mock_model_name", None, None, None, "rerank", n_gpu=1
     )
-    # should be on gpu 2, due to there are the fewest models on it
+    # should be on gpu 1, due to there are the fewest models on it
     await worker.launch_builtin_model(
         "rerank_7", "mock_model_name", None, None, None, "rerank", n_gpu=1
     )
     embedding_info = await worker.get_gpu_to_embedding_model_uids()
     user_specified_info = await worker.get_user_specified_gpu_to_model_uids()
-    assert "rerank_7" in embedding_info[2]
+    assert "rerank_7" in embedding_info[1]
     assert len(embedding_info[0]) == 1
-    assert len(user_specified_info[0]) == 1
-    assert len(embedding_info[1]) == 1
-    assert len(user_specified_info[1]) == 1
-    assert len(embedding_info[2]) == 2
+    assert len(user_specified_info[0]) == 2
+    assert len(embedding_info[1]) == 2
+    assert len(user_specified_info[1]) == 0
+    assert len(embedding_info[2]) == 1
     assert len(user_specified_info[2]) == 0
     assert len(embedding_info[3]) == 1
     assert len(user_specified_info[3]) == 0

--- a/xinference/core/tests/test_worker.py
+++ b/xinference/core/tests/test_worker.py
@@ -379,11 +379,6 @@ async def test_launch_model_with_gpu_idx(setup_pool):
     assert list(user_specified_info[0])[0][0] == "vllm_mock_model_2"
     assert list(user_specified_info[0])[0][1] == "LLM"
 
-    # already has vllm model on gpu 0, error
-    with pytest.raises(RuntimeError):
-        await worker.launch_builtin_model(
-            "rerank_3", "mock_model_name", None, None, None, "rerank", gpu_idx=[0]
-        )
     # never choose gpu 0 again
     with pytest.raises(RuntimeError):
         await worker.launch_builtin_model(

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -533,16 +533,6 @@ class WorkerActor(xo.StatelessActor):
                 existing_model_uids.append(rep_uid)
             if idx in self._gpu_to_embedding_model_uids:
                 existing_model_uids.extend(self._gpu_to_embedding_model_uids[idx])
-            # If user has run the vLLM model on the GPU that was forced to be specified,
-            # it is not possible to force this GPU to be allocated again
-            if idx in self._user_specified_gpu_to_model_uids:
-                for rep_uid, _ in self._user_specified_gpu_to_model_uids[idx]:
-                    is_vllm_model = await self.is_model_vllm_backend(rep_uid)
-                    if is_vllm_model:
-                        raise RuntimeError(
-                            f"User specified GPU index {idx} has been occupied with a vLLM model: {rep_uid}, "
-                            f"therefore cannot allocate GPU memory for a new model."
-                        )
 
             if existing_model_uids:
                 logger.warning(


### PR DESCRIPTION
closes #1848 #2260 #2708 #3041

In the current implementation, after a user deploys a vLLM model, it is not possible to deploy another model using the same GPU. In particular, if you deploy a vLLM model to a specific device by setting the `--gpu_memory_utilization` parameter to a small value, an error in Xinference will stop the launch, even though the model can actually be launched in the remaining memory. This is unnatural behavior considering that, for example, you can deploy a vLLM model on the same GPU after deploying a Transformers model (the result is the same, but the order of deployment changes whether it can be deployed or not).

In this PR, we have removed this error only when the user specifies the GPU ID. This allows advanced users who want to launch multiple models on the same GPU to set it, while leaving the behavior unchanged for general users who do not intend to customize GPU control.

## Steps to reproduce the error

```
$ docker run -e XINFERENCE_ENABLE_VIRTUAL_ENV=1 -p 9997:9997 --gpus all xprobe/xinference:v1.6.0.post1 xinference-local -H 0.0.0.0

$ xinference launch --model-name qwen3 --model-type LLM --model-engine vLLM --model-format pytorch --size-in-billions 0_6 --quantization none --n-gpu auto --replica 1 --n-worker 1 --gpu-idx 0 --gpu_memory_utilization 0.4

$ xinference launch --model-name qwen3 --model-type LLM --model-engine Transformers --model-format pytorch --size-in-billions 0_6 --quantization none --n-gpu auto --replica 1 --n-worker 1 --gpu-idx 0

RuntimeError: [address=0.0.0.0:46013, pid=93] GPU index 0 has been occupied with a vLLM model: qwen3-0, therefore cannot allocate GPU memory for a new model.
```