### PR TITLE
fix:增加对"test_"文件导入的过滤， 以去除对pytest不必要的依赖，该依赖目前会导致nightly-main镜像运行失败

### DIFF
--- a/xinference/model/llm/transformers/__init__.py
+++ b/xinference/model/llm/transformers/__init__.py
@@ -26,7 +26,7 @@ def import_submodules(package_path: str, package_name: str, globals_dict: Dict) 
     for _, module_name, is_pkg in pkgutil.iter_modules([package_path]):
         full_module_name = f"{package_name}.{module_name}"
 
-        if module_name.startswith("_"):  # Skip the modules which start with "_"
+        if module_name.startswith(("_", "test_")):  # Skip the modules which start with "_" or "test_"
             continue
 
         module = importlib.import_module(full_module_name)


### PR DESCRIPTION
增加对”test_“的过滤，以修复[issue](https://github.com/xorbitsai/inference/issues/3543)