### PR TITLE
FEAT: SeACoParaformer model

### DIFF
--- a/xinference/model/audio/model_spec.json
+++ b/xinference/model/audio/model_spec.json
@@ -230,6 +230,7 @@
       "punc_model": "ct-punc"
     },
     "default_transcription_config": {
+      "hotword": "",
       "batch_size_s": 300
     }
   },
@@ -257,9 +258,26 @@
     "multilingual": false,
     "default_model_config": {
       "vad_model": "fsmn-vad",
+      "punc_model": "ct-punc",
+      "spk_model":"cam++"
+    },
+    "default_transcription_config": {
+      "batch_size_s": 300
+    }
+  },
+  {
+    "model_name": "seaco-paraformer-zh",
+    "model_family": "funasr",
+    "model_id": "JunHowie/speech_seaco_paraformer_large_asr_nat-zh-cn-16k-common-vocab8404-pytorch",
+    "model_revision": "42e6be00854cf8de0f40002794f99df2a444fa97",
+    "model_ability": ["audio2text"],
+    "multilingual": false,
+    "default_model_config": {
+      "vad_model": "fsmn-vad",
       "punc_model": "ct-punc"
     },
     "default_transcription_config": {
+      "hotword": "",
       "batch_size_s": 300
     }
   },   

--- a/xinference/model/audio/model_spec_modelscope.json
+++ b/xinference/model/audio/model_spec_modelscope.json
@@ -106,12 +106,30 @@
     "multilingual": false,
     "default_model_config": {
       "vad_model": "fsmn-vad",
-      "punc_model": "ct-punc"
+      "punc_model": "ct-punc",
+      "spk_model":"cam++"
     },
     "default_transcription_config": {
       "batch_size_s": 300
     }
   },
+  {
+    "model_name": "seaco-paraformer-zh",
+    "model_family": "funasr",
+    "model_hub": "modelscope",
+    "model_id": "iic/speech_seaco_paraformer_large_asr_nat-zh-cn-16k-common-vocab8404-pytorch",
+    "model_revision": "master",
+    "model_ability": ["audio2text"],
+    "multilingual": false,
+    "default_model_config": {
+      "vad_model": "fsmn-vad",
+      "punc_model": "ct-punc"
+    },
+    "default_transcription_config": {
+      "hotword": "",
+      "batch_size_s": 300
+    }
+  },  
   {
     "model_name": "ChatTTS",
     "model_family": "ChatTTS",


### PR DESCRIPTION
https://www.modelscope.cn/models/iic/speech_seaco_paraformer_large_asr_nat-zh-cn-16k-common-vocab8404-pytorch/summary
SeACoParaformer是阿里巴巴语音实验室提出的新一代热词定制化非自回归语音识别模型。相比于上一代基于CLAS的热词定制化方案，SeACoParaformer解耦了热词模块与ASR模型，通过后验概率融合的方式进行热词激励，使激励过程可见可控，并且热词召回率显著提升。
![图片](https://github.com/user-attachments/assets/492a6fe3-a640-4e9d-8c58-d5c8ef33461a)
