### PR TITLE
FEAT: support verbose_json for funasr family audio2text models

### DIFF
--- a/xinference/model/audio/funasr.py
+++ b/xinference/model/audio/funasr.py
@@ -103,6 +103,10 @@ class FunASRModel:
 
             if response_format == "json":
                 return {"text": text}
+            elif response_format == "verbose_json":
+                verbose=result[0]
+                verbose["text"]=text
+                return verbose
             else:
                 raise ValueError(f"Unsupported response format: {response_format}")
 


### PR DESCRIPTION
support verbose_json   for funasr family audio2text models
1. include timestamp (not supported by SenseVoiceSmall and paraformer-zh-hot)
2. include speaker info (if spk_model enabled,not supported by SenseVoiceSmall and paraformer-zh-hot)
![0521e413dddd3852c4dc9feab2a7c46](https://github.com/user-attachments/assets/45d9e5db-b4b6-4b78-ac5b-90e4f4a4842f)

Usage:
1. json 
```
curl -X 'POST' 'http://192.168.1.33:9997/v1/audio/transcriptions' \
  -H 'accept: application/json' \
  -H "Content-Type: multipart/form-data" \
  -F file="@./asr_example.wav" \
  -F model="seaco-paraformer-zh-CPU" 
```

```
{"text":"欢迎大家来到么哒社区进行体验。"}
```
2. verbose_json
```
curl -X 'POST' 'http://192.168.1.33:9997/v1/audio/transcriptions' \
  -H 'accept: application/json' \
  -H "Content-Type: multipart/form-data" \
  -F file="@./asr_example.wav" \
  -F model="seaco-paraformer-zh-CPU" \
  -F response_format="verbose_json" \
  -F 'kwargs={"hotword":"小艾 魔搭"}'
```
	
```

{
	"key": "tmpubevd6r7",
	"text": "欢迎大家来到魔搭社区进行体验。",
	"timestamp": [
		[1080, 1320],
		[1320, 1560],
		[1640, 1800],
		[1800, 2040],
		[2040, 2200],
		[2200, 2420],
		[2420, 2600],
		[2600, 2840],
		[2860, 3080],
		[3080, 3320],
		[3420, 3600],
		[3600, 3840],
		[3900, 4140],
		[4140, 4375]
	],
	"sentence_info": [{
		"text": "欢迎大家来到魔搭社区进行体验。",
		"start": 1080,
		"end": 4375,
		"timestamp": [
			[1080, 1320],
			[1320, 1560],
			[1640, 1800],
			[1800, 2040],
			[2040, 2200],
			[2200, 2420],
			[2420, 2600],
			[2600, 2840],
			[2860, 3080],
			[3080, 3320],
			[3420, 3600],
			[3600, 3840],
			[3900, 4140],
			[4140, 4375]
		],
		"spk": 0
	}]
}

```