### PR TITLE
FEAT: add kwargs for transripts client API

### DIFF
--- a/xinference/client/restful/restful_client.py
+++ b/xinference/client/restful/restful_client.py
@@ -690,6 +690,7 @@ class RESTfulAudioModelHandle(RESTfulModelHandle):
         response_format: Optional[str] = "json",
         temperature: Optional[float] = 0,
         timestamp_granularities: Optional[List[str]] = None,
+        **kwargs,
     ):
         """
         Transcribes audio into the input language.
@@ -731,6 +732,7 @@ class RESTfulAudioModelHandle(RESTfulModelHandle):
             "response_format": response_format,
             "temperature": temperature,
             "timestamp_granularities[]": timestamp_granularities,
+            "kwargs": json.dumps(kwargs),
         }
         files: List[Any] = []
         files.append(("file", ("file", audio, "application/octet-stream")))


### PR DESCRIPTION
We can pass some non-standard arguments to models if we need.
##  Here are some xinference-client usage examples below:
```
from xinference.client import Client


client = Client("http://192.168.1.33:9997")
model = client.get_model("seaco-paraformer-zh")
with open("asr_example.wav", "rb") as audio_file:
    audio = audio_file.read()
    res=model.transcriptions(audio)
    print(res)
    res=model.transcriptions(audio,hotword="小艾 魔搭")  #hotword  热词传递
    print(res)
model = client.get_model("SenseVoiceSmall")
with open("gaoli_20230611103808.wav", "rb") as audio_file:
    audio = audio_file.read()
    res=model.transcriptions(audio)
    print(res)
    res=model.transcriptions(audio,use_itn=False)  #use_itn  逆文本正则化关闭
    print(res)
```
## Response may like
```
{'text': '欢迎大家来到么哒社区进行体验。'}
{'text': '欢迎大家来到魔搭社区进行体验。'}
{'text': '少全支付模式境内外支付创新无主。如意金条是中国工商银行发行的实物黄金产品，工行品质实力铸就AU999.9黄金铸造，自身具有商品属性和货币属性，可投资也可收藏，品牌标识质量保障，刻有工行品牌标识是成设与品质的保证，精湛工艺品质卓越。多重工序打造的完美浮雕效果字样，简洁清晰，庄重大气，规格包含5克、10克、20克、50克、100克、200克、500克和1000克。'}
{'text': '少全支付模式境内外支付创新无主如意金条是中国工商银行发行的实物黄金产品工行品质实力铸就 a u 九九九点九黄金铸造自身具有商品属性和货币属性可投资也可收藏品牌标识质量保障刻有工行品牌标识是成设与品质的保证精湛工艺品质卓越多重工序打造的完美浮雕效果字样简洁清晰庄重大气规格包含五克十克二十克五十克一百克二百克五百克和一千克'}
```
