### PR TITLE
ENH: add `enable_flash_attn` param for loading qwen3 embedding & rerank

### DIFF
--- a/xinference/model/embedding/sentence_transformers/core.py
+++ b/xinference/model/embedding/sentence_transformers/core.py
@@ -90,9 +90,10 @@ class SentenceTransformerEmbeddingModel(EmbeddingModel):
         elif "qwen3" in self._model_spec.model_name.lower():
             # qwen3 embedding
             flash_attn_installed = importlib.util.find_spec("flash_attn") is not None
+            flash_attn_enabled = self._kwargs.get("enable_flash_attn", True)
             model_kwargs = {"device_map": "auto"}
             tokenizer_kwargs = {}
-            if flash_attn_installed:
+            if flash_attn_installed and flash_attn_enabled:
                 model_kwargs["attn_implementation"] = "flash_attention_2"
                 model_kwargs["torch_dtype"] = "bfloat16"
                 tokenizer_kwargs["padding_side"] = "left"

--- a/xinference/model/rerank/core.py
+++ b/xinference/model/rerank/core.py
@@ -257,6 +257,7 @@ class RerankModel:
             if flash_attn_installed and enable_flash_attn:
                 model_kwargs["attn_implementation"] = "flash_attention_2"
                 model_kwargs["torch_dtype"] = torch.float16
+            model_kwargs.update(self._model_config)
             logger.debug("Loading qwen3 rerank with kwargs %s", model_kwargs)
             model = self._model = AutoModelForCausalLM.from_pretrained(
                 self._model_path, **model_kwargs

--- a/xinference/model/rerank/core.py
+++ b/xinference/model/rerank/core.py
@@ -252,11 +252,12 @@ class RerankModel:
             tokenizer = AutoTokenizer.from_pretrained(
                 self._model_path, padding_side="left"
             )
-            flash_attn_installed = importlib.util.find_spec("flash_attn") is not None
+            enable_flash_attn = self._model_config.get("enable_flash_attn", True)
             model_kwargs = {"device_map": "auto"}
-            if flash_attn_installed:
+            if flash_attn_installed and enable_flash_attn:
                 model_kwargs["attn_implementation"] = "flash_attention_2"
                 model_kwargs["torch_dtype"] = torch.float16
+            logger.debug("Loading qwen3 rerank with kwargs %s", model_kwargs)
             model = self._model = AutoModelForCausalLM.from_pretrained(
                 self._model_path, **model_kwargs
             ).eval()


### PR DESCRIPTION
Now for qwen3 embedding & rerank, `flash_attn2` will be detected and set once it's installed, however, when users have limited resource, some layers may be offloaded because we specified `device_map=auto`, hence, in this PR, we added a `enable_flash_attn` option, when off, the flash_attn will not be used.

Fixes #3638 