### PR TITLE
ENH: improve local cluster startup reliability via child-process readiness signaling

### DIFF
--- a/xinference/deploy/local.py
+++ b/xinference/deploy/local.py
@@ -144,9 +144,6 @@ def main(
         supervisor_address, metrics_exporter_host, metrics_exporter_port, logging_conf
     )
 
-    import time
-    time.sleep(3)
-
     if not health_check(
         address=supervisor_address,
         max_attempts=XINFERENCE_HEALTH_CHECK_FAILURE_THRESHOLD,

--- a/xinference/deploy/local.py
+++ b/xinference/deploy/local.py
@@ -115,6 +115,9 @@ def main(
         supervisor_address, metrics_exporter_host, metrics_exporter_port, logging_conf
     )
 
+    import time
+    time.sleep(3)
+
     if not health_check(
         address=supervisor_address,
         max_attempts=XINFERENCE_HEALTH_CHECK_FAILURE_THRESHOLD,

--- a/xinference/deploy/local.py
+++ b/xinference/deploy/local.py
@@ -67,7 +67,12 @@ async def _start_local_cluster(
             metrics_exporter_port=metrics_exporter_port,
         )
         if conn:
-            conn.send(READY)
+            try:
+                conn.send(READY)
+            except BrokenPipeError:
+                # connection may be gc collected,
+                # just ignore this error
+                pass
         await pool.join()
     except asyncio.CancelledError:
         if pool is not None:
@@ -101,7 +106,12 @@ def run(
     except:
         tb = traceback.format_exc()
         if conn:
-            conn.send(f"error: {tb}")
+            try:
+                conn.send(f"error: {tb}")
+            except BrokenPipeError:
+                # connection may be gc collected,
+                # just ignore this error
+                pass
         # raise again in subprocess
         raise
 

--- a/xinference/deploy/local.py
+++ b/xinference/deploy/local.py
@@ -128,6 +128,9 @@ def run_in_subprocess(
         args=(address, metrics_exporter_host, metrics_exporter_port, logging_conf),
         kwargs={"conn": child_conn},
     )
+    # Since Xoscar 0.7, we do not uses multiprocessing to create subpool any more,
+    # we should be able to use daemon here
+    p.daemon = True
     p.start()
     if parent_conn.poll(timeout=XINFERENCE_HEALTH_CHECK_TIMEOUT):
         msg = parent_conn.recv()

--- a/xinference/deploy/local.py
+++ b/xinference/deploy/local.py
@@ -17,6 +17,8 @@ import logging
 import multiprocessing
 import signal
 import sys
+import traceback
+from multiprocessing.connection import Connection
 from typing import Dict, Optional
 
 import xoscar as xo
@@ -25,6 +27,7 @@ from xoscar.utils import get_next_port
 from ..constants import (
     XINFERENCE_HEALTH_CHECK_FAILURE_THRESHOLD,
     XINFERENCE_HEALTH_CHECK_INTERVAL,
+    XINFERENCE_HEALTH_CHECK_TIMEOUT,
 )
 from ..core.supervisor import SupervisorActor
 from .utils import health_check
@@ -33,11 +36,15 @@ from .worker import start_worker_components
 logger = logging.getLogger(__name__)
 
 
+READY = "ok"
+
+
 async def _start_local_cluster(
     address: str,
     metrics_exporter_host: Optional[str] = None,
     metrics_exporter_port: Optional[int] = None,
     logging_conf: Optional[Dict] = None,
+    conn: Optional[Connection] = None,
 ):
     from .utils import create_worker_actor_pool
 
@@ -59,6 +66,8 @@ async def _start_local_cluster(
             metrics_exporter_host=metrics_exporter_host,
             metrics_exporter_port=metrics_exporter_port,
         )
+        if conn:
+            conn.send(READY)
         await pool.join()
     except asyncio.CancelledError:
         if pool is not None:
@@ -70,22 +79,31 @@ def run(
     metrics_exporter_host: Optional[str] = None,
     metrics_exporter_port: Optional[int] = None,
     logging_conf: Optional[Dict] = None,
+    conn: Optional[Connection] = None,
 ):
     def sigterm_handler(signum, frame):
         sys.exit(0)
 
     signal.signal(signal.SIGTERM, sigterm_handler)
 
-    loop = asyncio.get_event_loop()
-    task = loop.create_task(
-        _start_local_cluster(
-            address=address,
-            metrics_exporter_host=metrics_exporter_host,
-            metrics_exporter_port=metrics_exporter_port,
-            logging_conf=logging_conf,
+    try:
+        loop = asyncio.get_event_loop()
+        task = loop.create_task(
+            _start_local_cluster(
+                address=address,
+                metrics_exporter_host=metrics_exporter_host,
+                metrics_exporter_port=metrics_exporter_port,
+                logging_conf=logging_conf,
+                conn=conn,
+            )
         )
-    )
-    loop.run_until_complete(task)
+        loop.run_until_complete(task)
+    except:
+        tb = traceback.format_exc()
+        if conn:
+            conn.send(f"error: {tb}")
+        # raise again in subprocess
+        raise
 
 
 def run_in_subprocess(
@@ -94,11 +112,22 @@ def run_in_subprocess(
     metrics_exporter_port: Optional[int] = None,
     logging_conf: Optional[Dict] = None,
 ) -> multiprocessing.Process:
+    parent_conn, child_conn = multiprocessing.Pipe()
     p = multiprocessing.Process(
         target=run,
         args=(address, metrics_exporter_host, metrics_exporter_port, logging_conf),
+        kwargs={"conn": child_conn},
     )
     p.start()
+    if parent_conn.poll(timeout=XINFERENCE_HEALTH_CHECK_TIMEOUT):
+        msg = parent_conn.recv()
+        if msg != READY:
+            raise RuntimeError(f"Start service process failed during startup:\n{msg}")
+    else:
+        logger.info(
+            "No response from process after %s seconds", XINFERENCE_HEALTH_CHECK_TIMEOUT
+        )
+
     return p
 
 


### PR DESCRIPTION
fix: (xinference) C:\Windows\System32>xinference-local --host 127.0.0.1 -p 9997
Traceback (most recent call last):
  File "C:\tools\anaconda3\envs\xinference\lib\runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "C:\tools\anaconda3\envs\xinference\lib\runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "C:\tools\anaconda3\envs\xinference\Scripts\xinference-local.exe\__main__.py", line 7, in <module>
    sys.exit(local())
  File "C:\tools\anaconda3\envs\xinference\lib\site-packages\click\core.py", line 1161, in __call__
    return self.main(*args, **kwargs)
  File "C:\tools\anaconda3\envs\xinference\lib\site-packages\click\core.py", line 1082, in main
    rv = self.invoke(ctx)
  File "C:\tools\anaconda3\envs\xinference\lib\site-packages\click\core.py", line 1443, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "C:\tools\anaconda3\envs\xinference\lib\site-packages\click\core.py", line 788, in invoke
    return __callback(*args, **kwargs)
  File "C:\tools\anaconda3\envs\xinference\lib\site-packages\xinference\deploy\cmdline.py", line 228, in local
    start_local_cluster(
  File "C:\tools\anaconda3\envs\xinference\lib\site-packages\xinference\deploy\cmdline.py", line 115, in start_local_cluster
    main(
  File "C:\tools\anaconda3\envs\xinference\lib\site-packages\xinference\deploy\local.py", line 123, in main
    raise RuntimeError("Cluster is not available after multiple attempts")
RuntimeError: Cluster is not available after multiple attempts
2025-06-16 14:22:07,632 xinference.core.supervisor 11204 INFO     Xinference supervisor 127.0.0.1:10591 started
2025-06-16 14:22:07,678 xinference.core.worker 11204 INFO     Starting metrics export server at 127.0.0.1:None
2025-06-16 14:22:07,684 xinference.core.worker 11204 INFO     Checking metrics export server...
2025-06-16 14:22:13,178 xinference.core.worker 11204 INFO     Metrics server is started at: http://127.0.0.1:65388
2025-06-16 14:22:13,178 xinference.core.worker 11204 INFO     Purge cache directory: C:\Users\hjpxm\.xinference\cache
2025-06-16 14:22:13,178 xinference.core.worker 11204 INFO     Connected to supervisor as a fresh worker
2025-06-16 14:22:13,210 xinference.core.worker 11204 INFO     Xinference worker 127.0.0.1:10591 started