### PR TITLE
BUG: Fix max_tokens value in Qwen3 Reranker

### DIFF
--- a/xinference/model/rerank/model_spec.json
+++ b/xinference/model/rerank/model_spec.json
@@ -67,7 +67,7 @@
     "model_name": "Qwen3-Reranker-0.6B",
     "type": "normal",
     "language": ["en", "zh"],
-    "max_tokens": 40960,
+    "max_tokens": 32768,
     "model_id": "Qwen/Qwen3-Reranker-0.6B",
     "model_revision": "6e9e69830b95c52b5fd889b7690dda3329508de3"
   },
@@ -75,7 +75,7 @@
     "model_name": "Qwen3-Reranker-4B",
     "type": "normal",
     "language": ["en", "zh"],
-    "max_tokens": 40960,
+    "max_tokens": 32768,
     "model_id": "Qwen/Qwen3-Reranker-4B",
     "model_revision": "f16fc5d5d2b9b1d0db8280929242745d79794ef5"
   },
@@ -83,7 +83,7 @@
     "model_name": "Qwen3-Reranker-8B",
     "type": "normal",
     "language": ["en", "zh"],
-    "max_tokens": 40960,
+    "max_tokens": 32768,
     "model_id": "Qwen/Qwen3-Reranker-8B",
     "model_revision": "5fa94080caafeaa45a15d11f969d7978e087a3db"
   }

--- a/xinference/model/rerank/model_spec_modelscope.json
+++ b/xinference/model/rerank/model_spec_modelscope.json
@@ -62,7 +62,7 @@
     "model_name": "Qwen3-Reranker-0.6B",
     "type": "normal",
     "language": ["en", "zh"],
-    "max_tokens": 40960,
+    "max_tokens": 32768,
     "model_id": "Qwen/Qwen3-Reranker-0.6B",
     "model_hub": "modelscope"
   },
@@ -70,7 +70,7 @@
     "model_name": "Qwen3-Reranker-4B",
     "type": "normal",
     "language": ["en", "zh"],
-    "max_tokens": 40960,
+    "max_tokens": 32768,
     "model_id": "Qwen/Qwen3-Reranker-4B",
     "model_hub": "modelscope"
   },
@@ -78,7 +78,7 @@
     "model_name": "Qwen3-Reranker-8B",
     "type": "normal",
     "language": ["en", "zh"],
-    "max_tokens": 40960,
+    "max_tokens": 32768,
     "model_id": "Qwen/Qwen3-Reranker-8B",
     "model_hub": "modelscope"
   }


### PR DESCRIPTION
## Description
Corrects the max_tokens setting for Qwen3 Reranker from the mistaken 40960 to the intended 32768.

## Why
The inflated limit could mask overflow errors and misrepresent the model’s true context window.

## Change
config: max_tokens = 32768 (was 40960)

No other code or interface changes.