### PR TITLE
BUG: fix jina-clip-v2 for text only or image only

### DIFF
--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -829,25 +829,18 @@ class WorkerActor(xo.StatelessActor):
                 if hasattr(settings, k) and not getattr(settings, k):
                     setattr(settings, k, v)
 
+        conf = dict(settings)
         packages = settings.packages
-        index_url = settings.index_url
-        extra_index_url = settings.extra_index_url
-        find_links = settings.find_links
-        trusted_host = settings.trusted_host
+        conf.pop("packages", None)
+        conf.pop("inherit_pip_config", None)
 
         logger.info(
-            "Installing packages %s in virtual env %s, with settings(index_url=%s)",
+            "Installing packages %s in virtual env %s, with settings(%s)",
             packages,
             virtual_env_manager.env_path,
-            index_url,
+            ", ".join([f"{k}={v}" for k, v in conf.items() if v]),
         )
-        virtual_env_manager.install_packages(
-            packages,
-            index_url=index_url,
-            extra_index_url=extra_index_url,
-            find_links=find_links,
-            trusted_host=trusted_host,
-        )
+        virtual_env_manager.install_packages(packages, **conf)
 
     async def _get_progressor(self, request_id: str):
         from .progress_tracker import Progressor, ProgressTrackerActor

--- a/xinference/model/audio/model_spec.json
+++ b/xinference/model/audio/model_spec.json
@@ -280,7 +280,7 @@
       "hotword": "",
       "batch_size_s": 300
     }
-  },   
+  },
   {
     "model_name": "ChatTTS",
     "model_family": "ChatTTS",
@@ -329,6 +329,7 @@
     "multilingual": true,
     "virtualenv": {
       "packages": [
+        "librosa",
         "tiktoken",
         "lightning>=2.0.0",
         "hydra-core>=1.3.2",
@@ -340,7 +341,8 @@
         "HyperPyYAML",
         "onnxruntime>=1.16.0",
         "pyworld>=0.3.4",
-        "numpy==1.26.4",
+        "WeTextProcessing<1.0.4",
+        "#system_numpy#",
         "#system_torch#"
       ]
     }

--- a/xinference/model/audio/model_spec_modelscope.json
+++ b/xinference/model/audio/model_spec_modelscope.json
@@ -129,7 +129,7 @@
       "hotword": "",
       "batch_size_s": 300
     }
-  },  
+  },
   {
     "model_name": "ChatTTS",
     "model_family": "ChatTTS",
@@ -183,6 +183,7 @@
     "multilingual": true,
     "virtualenv": {
       "packages": [
+        "librosa",
         "tiktoken",
         "lightning>=2.0.0",
         "hydra-core>=1.3.2",
@@ -194,7 +195,8 @@
         "HyperPyYAML",
         "onnxruntime>=1.16.0",
         "pyworld>=0.3.4",
-        "numpy==1.26.4",
+        "WeTextProcessing<1.0.4",
+        "#system_numpy#",
         "#system_torch#"
       ]
     }

--- a/xinference/model/core.py
+++ b/xinference/model/core.py
@@ -170,3 +170,4 @@ class VirtualEnvSettings(BaseModel):
     extra_index_url: Optional[str] = None
     find_links: Optional[str] = None
     trusted_host: Optional[str] = None
+    no_build_isolation: Optional[bool] = None

--- a/xinference/model/embedding/model_spec.json
+++ b/xinference/model/embedding/model_spec.json
@@ -275,6 +275,15 @@
     "dimensions": 1024,
     "max_tokens": 8192,
     "language": ["89 languages supported"],
-    "model_id": "jinaai/jina-clip-v2"
+    "model_id": "jinaai/jina-clip-v2",
+    "virtualenv": {
+      "packages": [
+        "sentence_transformers",
+        "transformers==4.51.3",
+        "xformers",
+        "flash_attn==2.7.4 ; sys_platform=='linux'"
+      ],
+      "no_build_isolation": true
+    }
   }
 ]

--- a/xinference/model/embedding/model_spec_modelscope.json
+++ b/xinference/model/embedding/model_spec_modelscope.json
@@ -279,6 +279,15 @@
     "max_tokens": 8192,
     "language": ["89 languages supported"],
     "model_id": "jinaai/jina-clip-v2",
-    "model_hub": "modelscope"
+    "model_hub": "modelscope",
+    "virtualenv": {
+      "packages": [
+        "sentence_transformers",
+        "transformers==4.51.3",
+        "xformers",
+        "flash_attn==2.7.3 ; sys_platform=='linux'"
+      ],
+      "no_build_isolation": true
+    }
   }
 ]

--- a/xinference/model/embedding/sentence_transformers/core.py
+++ b/xinference/model/embedding/sentence_transformers/core.py
@@ -255,8 +255,14 @@ class SentenceTransformerEmbeddingModel(EmbeddingModel):
                 # when batching, the attention mask 1 means there is a token
                 # thus we just sum up it to get the total number of tokens
                 if "clip" in self._model_spec.model_name.lower():
-                    all_token_nums += features["input_ids"].numel()
-                    all_token_nums += features["pixel_values"].numel()
+                    if "input_ids" in features and hasattr(
+                        features["input_ids"], "numel"
+                    ):
+                        all_token_nums += features["input_ids"].numel()
+                    if "pixel_values" in features and hasattr(
+                        features["pixel_values"], "numel"
+                    ):
+                        all_token_nums += features["pixel_values"].numel()
                 else:
                     all_token_nums += features["attention_mask"].sum().item()
 

--- a/xinference/model/embedding/sentence_transformers/core.py
+++ b/xinference/model/embedding/sentence_transformers/core.py
@@ -364,7 +364,7 @@ class SentenceTransformerEmbeddingModel(EmbeddingModel):
                 self._model,
                 objs,
                 convert_to_numpy=False,
-                **self._kwargs,
+                **kwargs,
             )
         else:
             all_embeddings, all_token_nums = encode(


### PR DESCRIPTION
#2791 introduced engines for embedding models, it's proposed quite early, during this period, a few fixes on jina-clip-v2 like #2991 and #2974 was merged, unfortunately they are not included in #2791. This PR bring them back.

Besides, I found that the latest transformers cannot run this model, see https://huggingface.co/microsoft/Florence-2-large/discussions/104 , thus I added the virtualenv to limit versions.