### PR TITLE
BUG: disable flash_attn for qwen3 embedding & rerank when no gpu available

### DIFF
--- a/xinference/model/embedding/sentence_transformers/core.py
+++ b/xinference/model/embedding/sentence_transformers/core.py
@@ -20,6 +20,7 @@ from typing import List, Optional, Union, no_type_check
 import numpy as np
 import torch
 
+from ....device_utils import is_device_available
 from ....types import Dict, Embedding, EmbeddingData, EmbeddingUsage
 from ..core import EmbeddingModel, EmbeddingModelSpec
 
@@ -90,7 +91,9 @@ class SentenceTransformerEmbeddingModel(EmbeddingModel):
         elif "qwen3" in self._model_spec.model_name.lower():
             # qwen3 embedding
             flash_attn_installed = importlib.util.find_spec("flash_attn") is not None
-            flash_attn_enabled = self._kwargs.get("enable_flash_attn", True)
+            flash_attn_enabled = self._kwargs.get(
+                "enable_flash_attn", is_device_available("cuda")
+            )
             model_kwargs = {"device_map": "auto"}
             tokenizer_kwargs = {}
             if flash_attn_installed and flash_attn_enabled:

--- a/xinference/model/rerank/core.py
+++ b/xinference/model/rerank/core.py
@@ -28,7 +28,7 @@ import torch
 import torch.nn as nn
 
 from ...constants import XINFERENCE_CACHE_DIR
-from ...device_utils import empty_cache
+from ...device_utils import empty_cache, is_device_available
 from ...types import Document, DocumentObj, Rerank, RerankTokens
 from ..core import CacheableModelSpec, ModelDescription, VirtualEnvSettings
 from ..utils import is_model_cached
@@ -252,7 +252,9 @@ class RerankModel:
             tokenizer = AutoTokenizer.from_pretrained(
                 self._model_path, padding_side="left"
             )
-            enable_flash_attn = self._model_config.get("enable_flash_attn", True)
+            enable_flash_attn = self._model_config.get(
+                "enable_flash_attn", is_device_available("cuda")
+            )
             model_kwargs = {"device_map": "auto"}
             if flash_attn_installed and enable_flash_attn:
                 model_kwargs["attn_implementation"] = "flash_attention_2"

--- a/xinference/model/rerank/core.py
+++ b/xinference/model/rerank/core.py
@@ -252,7 +252,7 @@ class RerankModel:
             tokenizer = AutoTokenizer.from_pretrained(
                 self._model_path, padding_side="left"
             )
-            enable_flash_attn = self._model_config.get(
+            enable_flash_attn = self._model_config.pop(
                 "enable_flash_attn", is_device_available("cuda")
             )
             model_kwargs = {"device_map": "auto"}


### PR DESCRIPTION
Fixes #3732

When flash_attn installed and CPU specified, the error will show `FlashAttention2 has been toggled on, but it cannot be used due to the following error: Flash Attention 2 is not available on CPU. Please make sure torch can access a CUDA device. `.

In this PR, flash_attn is disabled if no cuda available even it's installed.