### PR TITLE
Fix bugs in del async_client

### DIFF
--- a/xinference/client/restful/async_restful_client.py
+++ b/xinference/client/restful/async_restful_client.py
@@ -86,12 +86,8 @@ class AsyncRESTfulModelHandle:
 
     def __del__(self):
         if self.session:
-            try:
-                loop = asyncio.get_event_loop()
-            except RuntimeError:
-                loop = asyncio.new_event_loop()
-                asyncio.set_event_loop(loop)
-            loop.run_until_complete(self.close())
+            loop = asyncio.get_event_loop()
+            loop.create_task(self.close())
 
 
 class AsyncRESTfulEmbeddingModelHandle(AsyncRESTfulModelHandle):
@@ -418,7 +414,10 @@ class AsyncRESTfulImageModelHandle(AsyncRESTfulModelHandle):
             files.append((key, (None, value)))
         files.append(("image", ("image", image, "application/octet-stream")))
         files.append(
-            ("mask_image", ("mask_image", mask_image, "application/octet-stream"))
+            (
+                "mask_image",
+                ("mask_image", mask_image, "application/octet-stream"),
+            )
         )
         response = await self.session.post(url, files=files, headers=self.auth_headers)
         if response.status != 200:
@@ -986,12 +985,8 @@ class AsyncClient:
 
     def __del__(self):
         if self.session:
-            try:
-                loop = asyncio.get_event_loop()
-            except RuntimeError:
-                loop = asyncio.new_event_loop()
-                asyncio.set_event_loop(loop)
-            loop.run_until_complete(self.close())
+            loop = asyncio.get_event_loop()
+            loop.create_task(self.close())
 
     def _set_token(self, token: Optional[str]):
         if not self._cluster_authed or token is None:


### PR DESCRIPTION
asyncclient的__del__清理资源函数有bug，换成使用create_task清理资源
```log
Traceback (most recent call last):
  File "/home/bash/Documents/RAGBuild/.pixi/envs/default/lib/python3.12/site-packages/xinference/client/restful/async_restful_client.py", line 924, in __del__
    loop.run_until_complete(self.close())
  File "uvloop/loop.pyx", line 1512, in uvloop.loop.Loop.run_until_complete
  File "uvloop/loop.pyx", line 1505, in uvloop.loop.Loop.run_until_complete
  File "uvloop/loop.pyx", line 1379, in uvloop.loop.Loop.run_forever
  File "uvloop/loop.pyx", line 520, in uvloop.loop.Loop._run
RuntimeError: this event loop is already running.
```