### PR TITLE
BUG: pre check to prevent from list index out of range for FunASR family models

### DIFF
--- a/xinference/model/audio/funasr.py
+++ b/xinference/model/audio/funasr.py
@@ -137,6 +137,10 @@ class FunASRModel:
             result = self._model.generate(  # type: ignore
                 input=f.name, cache={}, language=language, **kw
             )
+            if not result or not isinstance(result, list):
+                raise RuntimeError(f"FunASR returned empty or invalid result: {result}")
+            if "text" not in result[0]:
+                raise RuntimeError(f"Missing 'text' field in result[0]: {result[0]}")
             text = rich_transcription_postprocess(result[0]["text"])
 
             if response_format == "json":


### PR DESCRIPTION

   ret = await asyncio.to_thread(fn, *args, **kwargs)
  File "/usr/lib/python3.10/asyncio/threads.py", line 25, in to_thread
    return await loop.run_in_executor(None, func_call)
  File "/usr/lib/python3.10/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/opt/inference/xinference/model/audio/funasr.py", line 140, in transcriptions
    text = rich_transcription_postprocess(result[0]["text"])
IndexError: list index out of range