### PR TITLE
Replace @torch.no_grad() with @torch.inference_mode() in Qwen3-Reranker

### DIFF
--- a/xinference/model/rerank/core.py
+++ b/xinference/model/rerank/core.py
@@ -276,7 +276,7 @@ class RerankModel:
             token_false_id = tokenizer.convert_tokens_to_ids("no")
             token_true_id = tokenizer.convert_tokens_to_ids("yes")
 
-            @torch.no_grad()
+            @torch.inference_mode()
             def compute_logits(inputs, **kwargs):
                 batch_scores = model(**inputs).logits[:, -1, :]
                 true_vector = batch_scores[:, token_true_id]


### PR DESCRIPTION
This PR updates the decorator from @torch.no_grad() to @torch.inference_mode() in the Qwen3-Reranker implementation.

torch.inference_mode() is a more optimized context for inference-only workloads, as it disables autograd and activates additional internal optimizations to reduce CPU overhead and improve execution speed. This change should not affect numerical results but can lead to better runtime performance and lower memory usage during inference.