### PR TITLE
FEAT:Support for GLM 4.5 quantized models

### DIFF
--- a/xinference/model/llm/llm_family.json
+++ b/xinference/model/llm/llm_family.json
@@ -20752,6 +20752,44 @@
         }
       },
       {
+        "model_format": "gptq",
+        "model_size_in_billions": 355,
+        "activated_size_in_billions": 32,
+        "model_src": {
+          "huggingface": {
+            "quantizations": [
+              "Int4-Int8Mix"
+            ],
+            "model_id": "QuantTrio/GLM-4.5-GPTQ-Int4-Int8Mix"
+          },
+          "modelscope": {
+            "quantizations": [
+              "Int4-Int8Mix"
+            ],
+            "model_id": "tclf90/GLM-4.5-GPTQ-Int4-Int8Mix"
+          }
+        }
+      },
+      {
+        "model_format": "awq",
+        "model_size_in_billions": 355,
+        "activated_size_in_billions": 32,
+        "model_src": {
+          "huggingface": {
+            "quantizations": [
+              "Int4"
+            ],
+            "model_id": "QuantTrio/GLM-4.5-AWQ"
+          },
+          "modelscope": {
+            "quantizations": [
+              "Int4"
+            ],
+            "model_id": "tclf90/GLM-4.5-AWQ"
+          }
+        }
+      },
+      {
         "model_format": "mlx",
         "model_size_in_billions": 355,
         "activated_size_in_billions": 32,
@@ -20805,6 +20843,44 @@
               "FP8"
             ],
             "model_id": "ZhipuAI/GLM-4.5-Air-FP8"
+          }
+        }
+      },
+      {
+        "model_format": "gptq",
+        "model_size_in_billions": 106,
+        "activated_size_in_billions": 12,
+        "model_src": {
+          "huggingface": {
+            "quantizations": [
+              "Int4-Int8Mix"
+            ],
+            "model_id": "QuantTrio/GLM-4.5-Air-GPTQ-Int4-Int8Mix"
+          },
+          "modelscope": {
+            "quantizations": [
+              "Int4-Int8Mix"
+            ],
+            "model_id": "tclf90/GLM-4.5-Air-GPTQ-Int4-Int8Mix"
+          }
+        }
+      },
+      {
+        "model_format": "awq",
+        "model_size_in_billions": 106,
+        "activated_size_in_billions": 12,
+        "model_src": {
+          "huggingface": {
+            "quantizations": [
+              "AWQ-FP16Mix"
+            ],
+            "model_id": "QuantTrio/GLM-4.5-Air-AWQ-FP16Mix"
+          },
+          "modelscope": {
+            "quantizations": [
+              "AWQ-FP16Mix"
+            ],
+            "model_id": "tclf90/GLM-4.5-Air-AWQ-FP16Mix"
           }
         }
       },

--- a/xinference/model/llm/vllm/core.py
+++ b/xinference/model/llm/vllm/core.py
@@ -273,8 +273,10 @@ if VLLM_INSTALLED and VLLM_VERSION >= version.parse("0.9.2"):
     VLLM_SUPPORTED_CHAT_MODELS.append("Qwen3-Thinking")
     VLLM_SUPPORTED_CHAT_MODELS.append("Qwen3-Coder")
 
-if VLLM_INSTALLED and VLLM_VERSION > version.parse("0.10.0"):
+if VLLM_INSTALLED and VLLM_VERSION >= version.parse("0.10.0"):
     VLLM_SUPPORTED_CHAT_MODELS.append("glm-4.5")
+
+if VLLM_INSTALLED and VLLM_VERSION > version.parse("0.10.0"):
     VLLM_SUPPORTED_CHAT_MODELS.append("gpt-oss")
 
 


### PR DESCRIPTION
FEAt:Support for GLM 4.5 quantized models
We have adopted a new quantization format, AWQ-FP16Mix.
The vLLM framework will support it in the next release (the PR [vllm-project/vllm#21888](https://github.com/vllm-project/vllm/pull/21888) has already been merged).