### PR TITLE
FEAT: Qwen-Image-Edit

### DIFF
--- a/doc/source/models/builtin/image/index.rst
+++ b/doc/source/models/builtin/image/index.rst
@@ -29,6 +29,8 @@ The following is a list of built-in image models in Xinference:
   
    qwen-image
   
+   qwen-image-edit
+  
    sd-turbo
   
    sd3-medium

--- a/doc/source/models/builtin/image/qwen-image-edit.rst
+++ b/doc/source/models/builtin/image/qwen-image-edit.rst
@@ -1,0 +1,27 @@
+.. _models_builtin_qwen-image-edit:
+
+===============
+Qwen-Image-Edit
+===============
+
+- **Model Name:** Qwen-Image-Edit
+- **Model Family:** stable_diffusion
+- **Abilities:** image2image
+- **Available ControlNet:** None
+
+Specifications
+^^^^^^^^^^^^^^
+
+- **Model ID:** Qwen/Qwen-Image-Edit
+- **GGUF Model ID**: QuantStack/Qwen-Image-Edit-GGUF
+- **GGUF Quantizations**: Q2_K, Q3_K_M, Q3_K_S, Q4_0, Q4_1, Q4_K_M, Q4_K_S, Q5_0, Q5_1, Q5_K_M, Q5_K_S, Q6_K, Q8_0
+
+
+Execute the following command to launch the model::
+
+   xinference launch --model-name Qwen-Image-Edit --model-type image
+
+
+For GGUF quantization, using below command:
+
+    xinference launch --model-name Qwen-Image-Edit --model-type image --gguf_quantization ${gguf_quantization} --cpu_offload True

--- a/doc/source/models/model_abilities/image.rst
+++ b/doc/source/models/model_abilities/image.rst
@@ -46,12 +46,16 @@ The Text-to-image API is supported with the following models in Xinference:
 * sd3.5-large-turbo
 * FLUX.1-schnell
 * FLUX.1-dev
-* Flux.1-Kontext-dev
 * Kolors
 * hunyuandit-v1.2
 * hunyuandit-v1.2-distilled
 * cogview4
 * Qwen-Image
+
+Image-to-image supported models:
+
+* Flux.1-Kontext-dev
+* Qwen-Image-Edit
 
 
 Quickstart
@@ -250,6 +254,8 @@ internally by Xinference. Below is the mode list.
 | sd3.5-large-turbo | F16, Q4_0, Q4_1, Q5_0, Q5_1, Q8_0                                                        |
 +-------------------+------------------------------------------------------------------------------------------+
 | Qwen-Image        | F16, Q3_K_M, Q3_K_S, Q4_0, Q4_1, Q4_K_M, Q4_K_S, Q5_0, Q5_1, Q5_K_M, Q5_K_S, Q6_K, Q8_0  |
++-------------------+------------------------------------------------------------------------------------------+
+| Qwen-Image-Edit   | Q2_K, Q3_K_M, Q3_K_S, Q4_0, Q4_1, Q4_K_M, Q4_K_S, Q5_0, Q5_1, Q5_K_M, Q5_K_S, Q6_K, Q8_0 |
 +-------------------+------------------------------------------------------------------------------------------+
 
 .. note::

--- a/xinference/model/image/model_spec.json
+++ b/xinference/model/image/model_spec.json
@@ -170,6 +170,8 @@
     "virtualenv": {
       "packages": [
         "git+https://github.com/huggingface/diffusers.git",
+        "peft>=0.17.0",
+        "#system_torch#",
         "#system_numpy#"
       ],
       "no_build_isolation": true
@@ -233,6 +235,75 @@
     },
     "default_generate_config": {
       "guidance_scale": 1.0
+    },
+    "virtualenv": {
+      "packages": [
+        "git+https://github.com/huggingface/diffusers.git",
+        "peft>=0.17.0",
+        "#system_torch#",
+        "#system_numpy#"
+      ],
+      "no_build_isolation": true
+    }
+  },
+  {
+    "version": 2,
+    "model_name": "Qwen-Image-Edit",
+    "model_family": "stable_diffusion",
+    "model_ability": [
+      "image2image"
+    ],
+    "model_src": {
+      "huggingface": {
+        "model_id": "Qwen/Qwen-Image-Edit",
+        "model_revision": "0b71959872ea3bf4d106c578b7c480ebb133dba7",
+        "gguf_model_id": "QuantStack/Qwen-Image-Edit-GGUF",
+        "gguf_quantizations": [
+          "Q2_K",
+          "Q3_K_M",
+          "Q3_K_S",
+          "Q4_0",
+          "Q4_1",
+          "Q4_K_M",
+          "Q4_K_S",
+          "Q5_0",
+          "Q5_1",
+          "Q5_K_M",
+          "Q5_K_S",
+          "Q6_K",
+          "Q8_0"
+        ],
+        "gguf_model_file_name_template": "Qwen_Image_Edit-{quantization}.gguf"
+      },
+      "modelscope": {
+        "model_id": "Qwen/Qwen-Image-Edit",
+        "model_revision": "master",
+        "gguf_model_id": "QuantStack/Qwen-Image-Edit-GGUF",
+        "gguf_quantizations": [
+          "Q2_K",
+          "Q3_K_M",
+          "Q3_K_S",
+          "Q4_0",
+          "Q4_1",
+          "Q4_K_M",
+          "Q4_K_S",
+          "Q5_0",
+          "Q5_1",
+          "Q5_K_M",
+          "Q5_K_S",
+          "Q6_K",
+          "Q8_0"
+        ],
+        "gguf_model_file_name_template": "Qwen_Image_Edit-{quantization}.gguf"
+      }
+    },
+    "default_model_config": {
+      "quantize": true,
+      "quantize_text_encoder": "text_encoder",
+      "torch_dtype": "bfloat16"
+    },
+    "default_generate_config": {
+      "true_cfg_scale": 4.0
     },
     "virtualenv": {
       "packages": [

--- a/xinference/ui/web/ui/src/scenes/launch_model/data/data.js
+++ b/xinference/ui/web/ui/src/scenes/launch_model/data/data.js
@@ -114,6 +114,7 @@ export const featureModels = [
     type: 'image',
     feature_models: [
       'Qwen-Image',
+      'Qwen-Image-Edit',
       'FLUX.1-dev',
       'FLUX.1-Kontext-dev',
       'FLUX.1-schnell',


### PR DESCRIPTION
Fixes #3978

Below used Q2_K GGUF format:

<img width="1923" height="1228" alt="qwen-image-edit" src="https://github.com/user-attachments/assets/82fc1b53-22af-434b-9812-4368b85bd961" />
