### PR TITLE
FEAT: image2image and inpainting for qwen-image

### DIFF
--- a/doc/source/gen_docs.py
+++ b/doc/source/gen_docs.py
@@ -364,6 +364,11 @@ def main():
                         model['gguf_model_id'] = hf_src['gguf_model_id']
                     if 'gguf_quantizations' in hf_src:
                         model['gguf_quantizations'] = ", ".join(hf_src['gguf_quantizations'])
+                    # Handle Lightning related fields
+                    if 'lightning_model_id' in hf_src:
+                        model['lightning_model_id'] = hf_src['lightning_model_id']
+                    if 'lightning_versions' in hf_src:
+                        model['lightning_versions'] = ", ".join(hf_src['lightning_versions'])
                 elif 'modelscope' in model['model_src']:
                     model['model_id'] = model['model_src']['modelscope']['model_id']
             

--- a/doc/source/models/builtin/image/qwen-image-edit.rst
+++ b/doc/source/models/builtin/image/qwen-image-edit.rst
@@ -16,12 +16,21 @@ Specifications
 - **GGUF Model ID**: QuantStack/Qwen-Image-Edit-GGUF
 - **GGUF Quantizations**: Q2_K, Q3_K_M, Q3_K_S, Q4_0, Q4_1, Q4_K_M, Q4_K_S, Q5_0, Q5_1, Q5_K_M, Q5_K_S, Q6_K, Q8_0
 
+- **Lightning Model ID**: lightx2v/Qwen-Image-Lightning
+- **Lightning Versions**: 4steps-V1.0-bf16, 4steps-V1.0, 8steps-V1.0-bf16, 8steps-V1.0
+
 
 Execute the following command to launch the model::
 
    xinference launch --model-name Qwen-Image-Edit --model-type image
 
 
-For GGUF quantization, using below command:
+For GGUF quantization, using below command::
 
     xinference launch --model-name Qwen-Image-Edit --model-type image --gguf_quantization ${gguf_quantization} --cpu_offload True
+
+
+
+For Lightning LoRA acceleration, using below command::
+
+    xinference launch --model-name Qwen-Image-Edit --model-type image --lightning_version ${lightning_version}

--- a/doc/source/models/builtin/image/qwen-image.rst
+++ b/doc/source/models/builtin/image/qwen-image.rst
@@ -6,7 +6,7 @@ Qwen-Image
 
 - **Model Name:** Qwen-Image
 - **Model Family:** stable_diffusion
-- **Abilities:** text2image
+- **Abilities:** text2image, image2image, inpainting
 - **Available ControlNet:** None
 
 Specifications
@@ -16,12 +16,21 @@ Specifications
 - **GGUF Model ID**: city96/Qwen-Image-gguf
 - **GGUF Quantizations**: F16, Q3_K_M, Q3_K_S, Q4_0, Q4_1, Q4_K_M, Q4_K_S, Q5_0, Q5_1, Q5_K_M, Q5_K_S, Q6_K, Q8_0
 
+- **Lightning Model ID**: lightx2v/Qwen-Image-Lightning
+- **Lightning Versions**: 4steps-V1.0-bf16, 4steps-V1.0, 8steps-V1.0, 8steps-V1.1-bf16, 8steps-V1.1
+
 
 Execute the following command to launch the model::
 
    xinference launch --model-name Qwen-Image --model-type image
 
 
-For GGUF quantization, using below command:
+For GGUF quantization, using below command::
 
     xinference launch --model-name Qwen-Image --model-type image --gguf_quantization ${gguf_quantization} --cpu_offload True
+
+
+
+For Lightning LoRA acceleration, using below command::
+
+    xinference launch --model-name Qwen-Image --model-type image --lightning_version ${lightning_version}

--- a/doc/source/models/builtin/llm/kat-v1.rst
+++ b/doc/source/models/builtin/llm/kat-v1.rst
@@ -1,0 +1,63 @@
+.. _models_llm_kat-v1:
+
+========================================
+KAT-V1
+========================================
+
+- **Context Length:** 131072
+- **Model Name:** KAT-V1
+- **Languages:** en, zh
+- **Abilities:** chat
+- **Description:** Kwaipilot-AutoThink ranks first among all open-source models on LiveCodeBench Pro, a challenging benchmark explicitly designed to prevent data leakage, and even surpasses strong proprietary systems such as Seed and o3-mini.
+
+Specifications
+^^^^^^^^^^^^^^
+
+
+Model Spec 1 (pytorch, 40 Billion)
+++++++++++++++++++++++++++++++++++++++++
+
+- **Model Format:** pytorch
+- **Model Size (in billions):** 40
+- **Quantizations:** none
+- **Engines**: vLLM, Transformers
+- **Model ID:** Kwaipilot/KAT-V1-40B
+- **Model Hubs**:  `Hugging Face <https://huggingface.co/Kwaipilot/KAT-V1-40B>`__, `ModelScope <https://modelscope.cn/models/Kwaipilot/KAT-V1-40B>`__
+
+Execute the following command to launch the model, remember to replace ``${quantization}`` with your
+chosen quantization method from the options listed above::
+
+   xinference launch --model-engine ${engine} --model-name KAT-V1 --size-in-billions 40 --model-format pytorch --quantization ${quantization}
+
+
+Model Spec 2 (gptq, 40 Billion)
+++++++++++++++++++++++++++++++++++++++++
+
+- **Model Format:** gptq
+- **Model Size (in billions):** 40
+- **Quantizations:** Int4-Int8Mix
+- **Engines**: vLLM, Transformers
+- **Model ID:** QuantTrio/KAT-V1-40B-GPTQ-Int4-Int8Mix
+- **Model Hubs**:  `Hugging Face <https://huggingface.co/QuantTrio/KAT-V1-40B-GPTQ-Int4-Int8Mix>`__, `ModelScope <https://modelscope.cn/models/tclf90/KAT-V1-40B-GPTQ-Int4-Int8Mix>`__
+
+Execute the following command to launch the model, remember to replace ``${quantization}`` with your
+chosen quantization method from the options listed above::
+
+   xinference launch --model-engine ${engine} --model-name KAT-V1 --size-in-billions 40 --model-format gptq --quantization ${quantization}
+
+
+Model Spec 3 (awq, 40 Billion)
+++++++++++++++++++++++++++++++++++++++++
+
+- **Model Format:** awq
+- **Model Size (in billions):** 40
+- **Quantizations:** Int4
+- **Engines**: vLLM, Transformers
+- **Model ID:** QuantTrio/KAT-V1-40B-AWQ
+- **Model Hubs**:  `Hugging Face <https://huggingface.co/QuantTrio/KAT-V1-40B-AWQ>`__, `ModelScope <https://modelscope.cn/models/tclf90/KAT-V1-40B-AWQ>`__
+
+Execute the following command to launch the model, remember to replace ``${quantization}`` with your
+chosen quantization method from the options listed above::
+
+   xinference launch --model-engine ${engine} --model-name KAT-V1 --size-in-billions 40 --model-format awq --quantization ${quantization}
+

--- a/doc/source/models/model_abilities/image.rst
+++ b/doc/source/models/model_abilities/image.rst
@@ -287,6 +287,8 @@ and significantly speeding up inference. The following models currently support 
 +===================+==============================================+===========================================+
 | Qwen-Image        | 4steps-V1.0-bf16, 4steps-V1.0, 8steps-V1.0, 8steps-V1.1-bf16, 8steps-V1.1                |
 +-------------------+------------------------------------------------------------------------------------------+
+| Qwen-Image-Edit   | 4steps-V1.0-bf16, 4steps-V1.0, 8steps-V1.0-bf16, 8steps-V1.0                             |
++-------------------+------------------------------------------------------------------------------------------+
 
 4 steps or 8 steps refer to the inference steps (``num_inference_steps``).
 When ``lightning_version`` is specified, Xinference will automatically set the number of inference steps.

--- a/doc/templates/image.rst.jinja
+++ b/doc/templates/image.rst.jinja
@@ -17,13 +17,23 @@ Specifications
 - **GGUF Model ID**: {{ gguf_model_id }}
 - **GGUF Quantizations**: {{ gguf_quantizations }}
 {% endif %}
+{%- if lightning_model_id %}
+- **Lightning Model ID**: {{ lightning_model_id }}
+- **Lightning Versions**: {{ lightning_versions }}
+{% endif %}
 
 Execute the following command to launch the model::
 
    xinference launch --model-name {{ model_name }} --model-type image
 
 {% if gguf_quantizations %}
-For GGUF quantization, using below command:
+For GGUF quantization, using below command::
 
     xinference launch --model-name {{ model_name }} --model-type image --gguf_quantization ${{ '{' }}gguf_quantization{{ '}' }} --cpu_offload True
+{% endif %}
+
+{% if lightning_versions %}
+For Lightning LoRA acceleration, using below command::
+
+    xinference launch --model-name {{ model_name }} --model-type image --lightning_version ${{ '{' }}lightning_version{{ '}' }}
 {% endif %}

--- a/xinference/model/image/model_spec.json
+++ b/xinference/model/image/model_spec.json
@@ -182,7 +182,9 @@
     "model_name": "Qwen-Image",
     "model_family": "stable_diffusion",
     "model_ability": [
-      "text2image"
+      "text2image",
+      "image2image",
+      "inpainting"
     ],
     "model_src": {
       "huggingface": {

--- a/xinference/model/image/model_spec.json
+++ b/xinference/model/image/model_spec.json
@@ -169,7 +169,7 @@
     },
     "virtualenv": {
       "packages": [
-        "git+https://github.com/huggingface/diffusers.git",
+        "diffusers==0.35.1",
         "peft>=0.17.0",
         "#system_torch#",
         "#system_numpy#"
@@ -259,7 +259,7 @@
     },
     "virtualenv": {
       "packages": [
-        "git+https://github.com/huggingface/diffusers.git",
+        "diffusers==0.35.1",
         "peft>=0.17.0",
         "#system_torch#",
         "#system_numpy#"
@@ -328,7 +328,7 @@
     },
     "virtualenv": {
       "packages": [
-        "git+https://github.com/huggingface/diffusers.git",
+        "diffusers==0.35.1",
         "peft>=0.17.0",
         "#system_torch#",
         "#system_numpy#"

--- a/xinference/model/image/model_spec.json
+++ b/xinference/model/image/model_spec.json
@@ -294,7 +294,15 @@
           "Q6_K",
           "Q8_0"
         ],
-        "gguf_model_file_name_template": "Qwen_Image_Edit-{quantization}.gguf"
+        "gguf_model_file_name_template": "Qwen_Image_Edit-{quantization}.gguf",
+        "lightning_model_id": "lightx2v/Qwen-Image-Lightning",
+        "lightning_versions": [
+          "4steps-V1.0-bf16",
+          "4steps-V1.0",
+          "8steps-V1.0-bf16",
+          "8steps-V1.0"
+        ],
+        "lightning_model_file_name_template": "Qwen-Image-Edit-Lightning-{lightning_version}.safetensors"
       },
       "modelscope": {
         "model_id": "Qwen/Qwen-Image-Edit",
@@ -315,7 +323,15 @@
           "Q6_K",
           "Q8_0"
         ],
-        "gguf_model_file_name_template": "Qwen_Image_Edit-{quantization}.gguf"
+        "gguf_model_file_name_template": "Qwen_Image_Edit-{quantization}.gguf",
+        "lightning_model_id": "lightx2v/Qwen-Image-Lightning",
+        "lightning_versions": [
+          "4steps-V1.0-bf16",
+          "4steps-V1.0",
+          "8steps-V1.0-bf16",
+          "8steps-V1.0"
+        ],
+        "lightning_model_file_name_template": "Qwen-Image-Edit-Lightning-{lightning_version}.safetensors"
       }
     },
     "default_model_config": {

--- a/xinference/model/image/stable_diffusion/core.py
+++ b/xinference/model/image/stable_diffusion/core.py
@@ -782,7 +782,7 @@ class DiffusionModel(SDAPIDiffusionModelMixin):
 
     def _gen_config_for_lightning(self, kwargs):
         if (
-            "num_inference_steps" not in kwargs
+            not kwargs.get("num_inference_steps")
             and self._lightning_model_path is not None
         ):
             is_4_steps = "4steps" in self._lightning_model_path

--- a/xinference/model/video/model_spec.json
+++ b/xinference/model/video/model_spec.json
@@ -224,7 +224,7 @@
     },
     "virtualenv": {
       "packages": [
-        "git+https://github.com/huggingface/diffusers",
+        "diffusers==0.35.1",
         "ftfy",
         "imageio-ffmpeg",
         "imageio",
@@ -255,7 +255,7 @@
     "default_generate_config": {},
     "virtualenv": {
       "packages": [
-        "git+https://github.com/huggingface/diffusers",
+        "diffusers==0.35.1",
         "ftfy",
         "imageio-ffmpeg",
         "imageio",
@@ -286,7 +286,7 @@
     "default_generate_config": {},
     "virtualenv": {
       "packages": [
-        "git+https://github.com/huggingface/diffusers",
+        "diffusers==0.35.1",
         "ftfy",
         "imageio-ffmpeg",
         "imageio",
@@ -318,7 +318,7 @@
     "default_generate_config": {},
     "virtualenv": {
       "packages": [
-        "git+https://github.com/huggingface/diffusers",
+        "diffusers==0.35.1",
         "ftfy",
         "imageio-ffmpeg",
         "imageio",

--- a/xinference/ui/gradio/media_interface.py
+++ b/xinference/ui/gradio/media_interface.py
@@ -224,6 +224,7 @@ class MediaInterface:
             guidance_scale: int,
             num_inference_steps: int,
             padding_image_to_multiple: int,
+            strength: float,
             sampler_name: Optional[str] = None,
             progress=gr.Progress(),
         ) -> PIL.Image.Image:
@@ -243,6 +244,10 @@ class MediaInterface:
                 None if num_inference_steps == -1 else num_inference_steps  # type: ignore
             )
             padding_image_to_multiple = None if padding_image_to_multiple == -1 else padding_image_to_multiple  # type: ignore
+            # Initialize kwargs and handle strength parameter
+            kwargs = {}
+            if strength is not None:
+                kwargs["strength"] = strength
             sampler_name = None if sampler_name == "default" else sampler_name
 
             bio = io.BytesIO()
@@ -267,6 +272,7 @@ class MediaInterface:
                         guidance_scale=guidance_scale,
                         padding_image_to_multiple=padding_image_to_multiple,
                         sampler_name=sampler_name,
+                        **kwargs,
                     )
                 except Exception as e:
                     exc = e
@@ -324,6 +330,9 @@ class MediaInterface:
                     padding_image_to_multiple = gr.Number(
                         label="Padding image to multiple", value=-1
                     )
+                    strength = gr.Slider(
+                        label="Strength", value=None, step=0.1, minimum=0.0, maximum=1.0
+                    )
                     sampler_name = gr.Dropdown(
                         choices=SAMPLING_METHODS,
                         value="default",
@@ -348,11 +357,310 @@ class MediaInterface:
                     guidance_scale,
                     num_inference_steps,
                     padding_image_to_multiple,
+                    strength,
                     sampler_name,
                 ],
                 outputs=output_gallery,
             )
         return image2image_inteface
+
+    def inpainting_interface(self) -> "gr.Blocks":
+        from ...model.image.stable_diffusion.core import SAMPLING_METHODS
+
+        def preview_mask(
+            image_editor_output: Dict[str, Any],
+        ) -> PIL.Image.Image:
+            """Preview the generated mask without submitting inpainting task"""
+            # Extract original image and mask from ImageEditor output
+            if not image_editor_output or "background" not in image_editor_output:
+                return PIL.Image.new(
+                    "L", (512, 512), 0
+                )  # Return black image if no input
+
+            # Get the original image (background)
+            original_image = image_editor_output["background"]
+
+            # Get the composite image which contains the edits
+            composite_image = image_editor_output.get("composite", original_image)
+
+            # Create mask from the differences between original and composite
+            # White areas in composite indicate regions to inpaint
+            if original_image.mode != "RGB":
+                original_image = original_image.convert("RGB")
+            if composite_image.mode != "RGB":
+                composite_image = composite_image.convert("RGB")
+
+            # Create mask by finding differences (white drawn areas)
+            mask_image = PIL.Image.new("L", original_image.size, 0)
+            orig_data = original_image.load()
+            comp_data = composite_image.load()
+            mask_data = mask_image.load()
+
+            for y in range(original_image.size[1]):
+                for x in range(original_image.size[0]):
+                    orig_pixel = orig_data[x, y]
+                    comp_pixel = comp_data[x, y]
+                    # If pixels are different, assume it's a drawn area (white for inpainting)
+                    if orig_pixel != comp_pixel:
+                        mask_data[x, y] = 255  # White for inpainting
+
+            return mask_image
+
+        def process_inpainting(
+            prompt: str,
+            negative_prompt: str,
+            image_editor_output: Dict[str, Any],
+            uploaded_mask: Optional[PIL.Image.Image],
+            n: int,
+            size_width: int,
+            size_height: int,
+            guidance_scale: int,
+            num_inference_steps: int,
+            padding_image_to_multiple: int,
+            strength: float,
+            sampler_name: Optional[str] = None,
+            progress=gr.Progress(),
+        ) -> List[PIL.Image.Image]:
+            from ...client import RESTfulClient
+
+            client = RESTfulClient(self.endpoint)
+            client._set_token(self.access_token)
+            model = client.get_model(self.model_uid)
+            assert isinstance(model, RESTfulImageModelHandle)
+
+            if size_width > 0 and size_height > 0:
+                size = f"{int(size_width)}*{int(size_height)}"
+            else:
+                size = None
+            guidance_scale = None if guidance_scale == -1 else guidance_scale  # type: ignore
+            num_inference_steps = (
+                None if num_inference_steps == -1 else num_inference_steps  # type: ignore
+            )
+            padding_image_to_multiple = None if padding_image_to_multiple == -1 else padding_image_to_multiple  # type: ignore
+            # Initialize kwargs and handle strength parameter
+            kwargs = {}
+            if strength is not None:
+                kwargs["strength"] = strength
+            sampler_name = None if sampler_name == "default" else sampler_name
+
+            # Get the original image for inpainting
+            if not image_editor_output or "background" not in image_editor_output:
+                raise ValueError("Please upload and edit an image first")
+            original_image = image_editor_output["background"]
+
+            # Convert original image to RGB if needed
+            if original_image.mode == "RGBA":
+                # Create a white background and paste the RGBA image onto it
+                rgb_image = PIL.Image.new("RGB", original_image.size, (255, 255, 255))
+                rgb_image.paste(
+                    original_image, mask=original_image.split()[3]
+                )  # Use alpha channel as mask
+                original_image = rgb_image
+            elif original_image.mode != "RGB":
+                original_image = original_image.convert("RGB")
+
+            # Assert that original image is RGB format
+            assert (
+                original_image.mode == "RGB"
+            ), f"Expected RGB image, got {original_image.mode}"
+
+            # Use uploaded mask if provided, otherwise generate from editor
+            if uploaded_mask is not None:
+                mask_image = uploaded_mask
+
+                # Convert RGBA to RGB if needed
+                if mask_image.mode == "RGBA":
+                    # Create a white background and paste the RGBA image onto it
+                    rgb_mask = PIL.Image.new("RGB", mask_image.size, (255, 255, 255))
+                    rgb_mask.paste(
+                        mask_image, mask=(mask_image.split()[3])
+                    )  # Use alpha channel as mask
+                    mask_image = rgb_mask
+                elif mask_image.mode != "RGB":
+                    mask_image = mask_image.convert("RGB")
+
+                # Ensure mask is the same size as original image
+                if mask_image.size != original_image.size:
+                    mask_image = mask_image.resize(original_image.size)
+
+                # Assert that mask image is RGB format
+                assert (
+                    mask_image.mode == "RGB"
+                ), f"Expected RGB mask, got {mask_image.mode}"
+            else:
+                # Generate mask using the preview function
+                mask_image = preview_mask(image_editor_output)
+                # Assert that generated mask is L format (grayscale)
+                assert mask_image.mode == "L", f"Expected L mask, got {mask_image.mode}"
+
+            bio = io.BytesIO()
+            original_image.save(bio, format="png")
+
+            mask_bio = io.BytesIO()
+            mask_image.save(mask_bio, format="png")
+
+            response = None
+            exc = None
+            request_id = str(uuid.uuid4())
+
+            def run_in_thread():
+                nonlocal exc, response
+                try:
+                    response = model.inpainting(
+                        request_id=request_id,
+                        prompt=prompt,
+                        negative_prompt=negative_prompt,
+                        n=n,
+                        image=bio.getvalue(),
+                        mask_image=mask_bio.getvalue(),
+                        size=size,
+                        response_format="b64_json",
+                        num_inference_steps=num_inference_steps,
+                        guidance_scale=guidance_scale,
+                        padding_image_to_multiple=padding_image_to_multiple,
+                        sampler_name=sampler_name,
+                        **kwargs,
+                    )
+                except Exception as e:
+                    exc = e
+
+            t = threading.Thread(target=run_in_thread)
+            t.start()
+            while t.is_alive():
+                try:
+                    cur_progress = client.get_progress(request_id)["progress"]
+                except (KeyError, RuntimeError):
+                    cur_progress = 0.0
+
+                progress(cur_progress, desc="Inpainting images")
+                time.sleep(1)
+
+            if exc:
+                raise exc
+
+            images = []
+            for image_dict in response["data"]:  # type: ignore
+                assert image_dict["b64_json"] is not None
+                image_data = base64.b64decode(image_dict["b64_json"])
+                image = PIL.Image.open(io.BytesIO(image_data))
+                images.append(image)
+
+            return images
+
+        with gr.Blocks() as inpainting_interface:
+            with gr.Column():
+                with gr.Row():
+                    with gr.Column(scale=10):
+                        prompt = gr.Textbox(
+                            label="Prompt",
+                            show_label=True,
+                            placeholder="Enter prompt here...",
+                        )
+                        negative_prompt = gr.Textbox(
+                            label="Negative Prompt",
+                            show_label=True,
+                            placeholder="Enter negative prompt here...",
+                        )
+                    with gr.Column(scale=1):
+                        generate_button = gr.Button("Generate")
+
+                with gr.Row():
+                    n = gr.Number(label="Number of image", value=1)
+                    size_width = gr.Number(label="Width", value=-1)
+                    size_height = gr.Number(label="Height", value=-1)
+
+                with gr.Row():
+                    guidance_scale = gr.Number(label="Guidance scale", value=-1)
+                    num_inference_steps = gr.Number(
+                        label="Inference Step Number", value=-1
+                    )
+                    padding_image_to_multiple = gr.Number(
+                        label="Padding image to multiple", value=-1
+                    )
+                    strength = gr.Slider(
+                        label="Strength", value=None, step=0.1, minimum=0.0, maximum=1.0
+                    )
+                    sampler_name = gr.Dropdown(
+                        choices=SAMPLING_METHODS,
+                        value="default",
+                        label="Sampling method",
+                    )
+
+                with gr.Row():
+                    with gr.Column(scale=2):
+                        image_editor = gr.ImageEditor(
+                            type="pil",
+                            label="Edit Image and Create Mask (Draw white areas to inpaint)",
+                            interactive=True,
+                            height=400,
+                        )
+
+                        # Mask controls below the editor
+                        with gr.Row():
+                            preview_button = gr.Button("Preview Mask", size="sm")
+                            upload_mask = gr.Image(
+                                type="pil",
+                                label="Or upload mask image directly",
+                                interactive=True,
+                            )
+                        with gr.Row():
+                            mask_output = gr.Image(
+                                label="Current Mask Preview",
+                                interactive=False,
+                                height=200,
+                            )
+
+                    with gr.Column(scale=1):
+                        gr.Markdown("### Inpainting Results")
+                        output_gallery = gr.Gallery()
+
+            preview_button.click(
+                preview_mask,
+                inputs=[image_editor],
+                outputs=[mask_output],
+            )
+
+            # When user uploads a mask, display it
+            def process_uploaded_mask(
+                mask: Optional[PIL.Image.Image],
+            ) -> PIL.Image.Image:
+                if mask is None:
+                    return PIL.Image.new("L", (512, 512), 0)
+
+                # Convert RGBA to grayscale for preview
+                if mask.mode == "RGBA":
+                    # Use alpha channel for mask preview
+                    alpha = mask.split()[3]
+                    mask = alpha.convert("L")
+                elif mask.mode != "L":
+                    # Convert to grayscale
+                    mask = mask.convert("L")
+
+                return mask
+
+            upload_mask.change(
+                process_uploaded_mask, inputs=[upload_mask], outputs=[mask_output]
+            )
+
+            generate_button.click(
+                process_inpainting,
+                inputs=[
+                    prompt,
+                    negative_prompt,
+                    image_editor,
+                    upload_mask,
+                    n,
+                    size_width,
+                    size_height,
+                    guidance_scale,
+                    num_inference_steps,
+                    padding_image_to_multiple,
+                    strength,
+                    sampler_name,
+                ],
+                outputs=[output_gallery],
+            )
+        return inpainting_interface
 
     def text2video_interface(self) -> "gr.Blocks":
         def text_generate_video(
@@ -906,6 +1214,9 @@ class MediaInterface:
             if "image2image" in self.model_ability:
                 with gr.Tab("Image to Image"):
                     self.image2image_interface()
+            if "inpainting" in self.model_ability:
+                with gr.Tab("Inpainting"):
+                    self.inpainting_interface()
             if "text2video" in self.model_ability:
                 with gr.Tab("Text to Video"):
                     self.text2video_interface()

--- a/xinference/ui/gradio/media_interface.py
+++ b/xinference/ui/gradio/media_interface.py
@@ -331,7 +331,7 @@ class MediaInterface:
                         label="Padding image to multiple", value=-1
                     )
                     strength = gr.Slider(
-                        label="Strength", value=None, step=0.1, minimum=0.0, maximum=1.0
+                        label="Strength", value=0.6, step=0.1, minimum=0.0, maximum=1.0
                     )
                     sampler_name = gr.Dropdown(
                         choices=SAMPLING_METHODS,
@@ -578,7 +578,7 @@ class MediaInterface:
                         label="Padding image to multiple", value=-1
                     )
                     strength = gr.Slider(
-                        label="Strength", value=None, step=0.1, minimum=0.0, maximum=1.0
+                        label="Strength", value=0.6, step=0.1, minimum=0.0, maximum=1.0
                     )
                     sampler_name = gr.Dropdown(
                         choices=SAMPLING_METHODS,


### PR DESCRIPTION
This PR introduced:

1. image2image and inpainting for qwen-image
2. inpainting UI
3. lightning models for qwen-image-edit
4. Lightning models are workable for image2image and inpainting in 4 or 8 steps.

<img width="5120" height="3155" alt="qwen-image-img2img" src="https://github.com/user-attachments/assets/faea97f1-e50c-4bfb-8d70-7495478769da" />

<img width="5120" height="3087" alt="qwen-image-inpainting" src="https://github.com/user-attachments/assets/0363a046-4b32-477a-9bb1-38d0526f13d7" />
