### PR TITLE
ENH: Update the environment dependencies for cosyvoice2

### DIFF
--- a/xinference/model/audio/model_spec.json
+++ b/xinference/model/audio/model_spec.json
@@ -631,12 +631,10 @@
         "HyperPyYAML",
         "onnxruntime>=1.16.0",
         "pyworld>=0.3.4",
-        "WeTextProcessing<1.0.4",
-        "torch==2.8.0",
-        "torchaudio==2.8.0",
-        "torchvision==0.23.0",
-        "xformers==0.0.32.post2",
-        "transformers==4.51.3"
+        "wetext==0.0.9",
+        "transformers==4.51.3",
+        "#system_numpy#",
+        "#system_torch#"
       ]
     },
     "model_src": {


### PR DESCRIPTION
1.经过最新的nightly-main镜像测试单独指定torch不同版本会导致flash_attn等库的cuda版本不匹配问题，且cosyvoice2生成音频问题由[transformers引起](https://github.com/FunAudioLLM/CosyVoice/issues/1546)，因此更新依赖去除对torch的约束，仅约束transformers，修改后经镜像测试可以生成正确的音频。
2.根据cosyvoice依赖[更新](https://github.com/FunAudioLLM/CosyVoice/blob/main/requirements.txt#L39)以及nightly-main镜像测试，需要增加wetext依赖，且近期wetext更新了依赖文件的处理，优化了离线下载文件的问题，因此从0.0.4升级到0.0.9