### PR TITLE
BLD: torchaudio 2.9 introduces the breaking change in torchaudio.save

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -166,10 +166,10 @@ audio =
     WeTextProcessing<1.0.4; sys_platform == 'linux'  # 1.0.4 requires pynini==2.1.6
     librosa
     xxhash
-    torchaudio
+    torch>=2.0.0,<2.9.0  # Pin to <2.9.0 to avoid BytesIO issues, for CosyVoice, matcha
+    torchaudio>=2.0.0,<2.9.0  # Pin to <2.9.0 to maintain compatibility, for ChatTTS, F5-TTS
     ChatTTS>=0.2.1
-    tiktoken  # For CosyVoice, openai-whisper
-    torch>=2.0.0  # For CosyVoice, matcha
+    tiktoken # For CosyVoice, openai-whisper
     lightning>=2.0.0  # For CosyVoice, matcha
     hydra-core>=1.3.2  # For CosyVoice, matcha
     inflect  # For CosyVoice, matcha


### PR DESCRIPTION
torchaudio 2.9 introduces the breaking change in torchaudio.save, refer to https://github.com/xorbitsai/inference/issues/4167 for the detailed information.

Before we can fully understand the change, pin 2.8 for the temporary  solution.