### PR TITLE
BLD: fix model ui launch error with gradio 6.x

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ packages = find:
 install_requires =
     xoscar>=0.7.13
     torch
-    gradio
+    gradio<6.0.0
     pillow
     click<8.2.0
     tqdm>=4.27


### PR DESCRIPTION
fix: #4288 