### PR TITLE
ENH: fix assigning replica to make gpu idxes assigned continuous

### DIFF
--- a/xinference/core/utils.py
+++ b/xinference/core/utils.py
@@ -299,7 +299,11 @@ def assign_replica_gpu(
     if isinstance(gpu_idx, int):
         gpu_idx = [gpu_idx]
     if isinstance(gpu_idx, list) and gpu_idx:
-        return gpu_idx[rep_id::replica]
+        num_gpus = len(gpu_idx)
+        gpus_per_replica = num_gpus // replica
+        start = rep_id * gpus_per_replica
+        end = start + gpus_per_replica
+        return gpu_idx[start:end]
     return gpu_idx
 
 


### PR DESCRIPTION
处理这个issue 提到的问题 https://github.com/xorbitsai/inference/issues/4369
当启动多副本，worker 拿到连续的gpu idx 
否则就是跳跃的。

Fixes #4369 