### PR TITLE
FEAT:Add vLLM backend support for DeepSeek-V3.2-Exp.

### DIFF
--- a/xinference/model/llm/vllm/core.py
+++ b/xinference/model/llm/vllm/core.py
@@ -315,6 +315,7 @@ if VLLM_INSTALLED and VLLM_VERSION >= version.parse("0.11.0"):
     VLLM_SUPPORTED_MULTI_MODEL_LIST.append("Qwen3-Omni-Instruct")
     VLLM_SUPPORTED_CHAT_MODELS.append("DeepSeek-V3.2-Exp")
 
+
 class VLLMModel(LLM):
     allow_batch = True
 


### PR DESCRIPTION
--Only Hopper and Blackwell data center GPUs are supported for now.

--The kernels are mainly optimized for TP=1, so it is recommended to run this model under DP/EP mode

--DP mode may result in increased serving latency. To mitigate this, we recommend enabling MTP to maintain optimal speed. To disable MTP, simply remove the --speculative-config flag.

--Some users have observed improved performance on H20 machines by setting export VLLM_USE_DEEP_GEMM=0