### PR TITLE
FEAT: vacc support

### DIFF
--- a/xinference/model/embedding/vllm/core.py
+++ b/xinference/model/embedding/vllm/core.py
@@ -16,6 +16,7 @@ import json
 import logging
 from typing import List, Tuple, Union
 
+from ....device_utils import is_vacc_available
 from ....types import Embedding, EmbeddingData, EmbeddingUsage
 from ...batch import BatchMixin
 from ...utils import cache_clean, check_dependency_available
@@ -33,6 +34,8 @@ class VLLMEmbeddingModel(EmbeddingModel, BatchMixin):
 
     def load(self):
         try:
+            if is_vacc_available():
+                import vllm_vacc  # noqa: F401
             from vllm import LLM
 
         except ImportError:

--- a/xinference/model/llm/vllm/core.py
+++ b/xinference/model/llm/vllm/core.py
@@ -44,6 +44,7 @@ from packaging import version
 from typing_extensions import NotRequired
 
 from ....constants import XINFERENCE_MAX_TOKENS
+from ....device_utils import is_vacc_available
 from ....types import (
     ChatCompletion,
     ChatCompletionChunk,
@@ -133,6 +134,9 @@ class VLLMGenerateConfig(TypedDict, total=False):
 
 
 try:
+    if is_vacc_available():
+        import vllm_vacc  # noqa: F401
+
     import vllm  # noqa: F401
 
     if not getattr(vllm, "__version__", None):

--- a/xinference/model/rerank/vllm/core.py
+++ b/xinference/model/rerank/vllm/core.py
@@ -1,6 +1,7 @@
 import uuid
 from typing import List, Optional, Tuple, Union
 
+from ....device_utils import is_vacc_available
 from ....types import Document, DocumentObj, Meta, Rerank, RerankTokens
 from ...utils import cache_clean, check_dependency_available
 from ..core import RerankModel, RerankModelFamilyV2, RerankSpecV1
@@ -11,6 +12,8 @@ SUPPORTED_MODELS_PREFIXES = ["bge", "gte", "text2vec", "m3e", "gte", "Qwen3"]
 class VLLMRerankModel(RerankModel):
     def load(self):
         try:
+            if is_vacc_available():
+                import vllm_vacc  # noqa: F401
             from vllm import LLM
 
         except ImportError:


### PR DESCRIPTION
添加瀚博半导体的卡集成，主要是利用torch_vacc 来判断是否有加速卡， 可以用变量“VACC_VISIBLE_DEVICES” 可以透传需要的卡idx和卡数（类似CUDA_VISIBLE_DEVICES），主要场景是：利用vllm_vacc 的猴子补丁，来实现vllm 方式加载大模型，embedding, rerank 模型