### PR TITLE
FEAT: support vlm for vacc

### DIFF
--- a/xinference/model/llm/core.py
+++ b/xinference/model/llm/core.py
@@ -123,6 +123,20 @@ class LLM(abc.ABC):
 
     @staticmethod
     @lru_cache
+    def _has_vacc_device():
+        """
+        Use glob command to detect VACC devices.
+        DO NOT USE torch to impl this, which will lead to some unexpected errors.
+        """
+        try:
+            import glob
+
+            return len(glob.glob("/dev/vacc*")) > 0
+        except:
+            return False
+
+    @staticmethod
+    @lru_cache
     def _get_cuda_count():
         from ...device_utils import get_available_device_env_name
         from ...utils import cuda_count

--- a/xinference/model/llm/vllm/core.py
+++ b/xinference/model/llm/vllm/core.py
@@ -930,8 +930,12 @@ class VLLMModel(LLM):
     def match_json(
         cls, llm_family: "LLMFamilyV2", llm_spec: "LLMSpecV1", quantization: str
     ) -> Union[bool, Tuple[bool, str]]:
-        if not cls._has_cuda_device() and not cls._has_mlu_device():
-            return False, "vLLM requires CUDA or MLU GPUs"
+        if (
+            not cls._has_cuda_device()
+            and not cls._has_mlu_device()
+            and not cls._has_vacc_device()
+        ):
+            return False, "vLLM requires CUDA or MLU GPUs or VACC GPUs"
         if not cls._is_linux():
             return False, "vLLM backend is only supported on Linux"
         if llm_spec.model_format not in ["pytorch", "gptq", "awq", "fp8", "bnb"]:
@@ -1653,8 +1657,15 @@ class VLLMMultiModel(VLLMModel, ChatModelMixin):
     def match_json(
         cls, llm_family: "LLMFamilyV2", llm_spec: "LLMSpecV1", quantization: str
     ) -> Union[bool, Tuple[bool, str]]:
-        if not cls._has_cuda_device() and not cls._has_mlu_device():
-            return False, "vLLM multimodal engine requires CUDA or MLU GPUs"
+        if (
+            not cls._has_cuda_device()
+            and not cls._has_mlu_device()
+            and not cls._has_vacc_device()
+        ):
+            return (
+                False,
+                "vLLM multimodal engine requires CUDA or MLU GPUs or VACC GPUs",
+            )
         if not cls._is_linux():
             return False, "vLLM multimodal engine is only supported on Linux"
         if llm_spec.model_format not in ["pytorch", "gptq", "awq", "fp8", "bnb"]:


### PR DESCRIPTION
瀚博半导体目前的vllm vacc 新版本，已经支持qwen3-vl-instruct/thinking,  我验证了这个PR的改动，能完全集成进去