### PR TITLE
FEAT: Add support for FLUX.2-Klein-9B and -4B models

### DIFF
--- a/xinference/model/image/model_spec.json
+++ b/xinference/model/image/model_spec.json
@@ -1,66 +1,6 @@
 [
   {
     "version": 2,
-    "model_name": "FLUX.2-klein-4B",
-    "model_family": "stable_diffusion",
-    "model_ability": [
-      "text2image",
-      "image2image"
-    ],
-    "default_model_config": {
-      "quantize": false,
-      "torch_dtype": "bfloat16"
-    },
-    "model_src": {
-      "huggingface": {
-        "model_id": "black-forest-labs/FLUX.2-klein-4B",
-        "model_revision": "main"
-      }
-    },
-    "featured": true,
-    "updated_at": 1769418375,
-    "virtualenv": {
-      "packages": [
-        "#diffusers_dependencies# ; #engine# == \"diffusers\"",
-        "transformers>=4.51.0",
-        "#system_torch#",
-        "#system_numpy#"
-      ],
-      "no_build_isolation": true
-    }
-  },
-  {
-    "version": 2,
-    "model_name": "FLUX.2-klein-9B",
-    "model_family": "stable_diffusion",
-    "model_ability": [
-      "text2image",
-      "image2image"
-    ],
-    "default_model_config": {
-      "quantize": false,
-      "torch_dtype": "bfloat16"
-    },
-    "model_src": {
-      "huggingface": {
-        "model_id": "black-forest-labs/FLUX.2-klein-9B",
-        "model_revision": "main"
-      }
-    },
-    "featured": true,
-    "updated_at": 1769418375,
-    "virtualenv": {
-      "packages": [
-        "#diffusers_dependencies# ; #engine# == \"diffusers\"",
-        "transformers>=4.51.0",
-        "#system_torch#",
-        "#system_numpy#"
-      ],
-      "no_build_isolation": true
-    }
-  },
-  {
-    "version": 2,
     "model_name": "FLUX.1-schnell",
     "model_family": "stable_diffusion",
     "model_ability": [


### PR DESCRIPTION
**Important**: `Flux2KleinPipeline` is not yet included in `diffusers==0.36.0`. Requires latest version of diffusers or github-build with `python3 -m pip install --no-cache-dir "git+https://github.com/huggingface/diffusers.git"`


Fixes #4591 