### PR TITLE
BUG: replace 55 bare excepts with except Exception

### DIFF
--- a/examples/AI_podcast.py
+++ b/examples/AI_podcast.py
@@ -44,7 +44,7 @@ except ImportError:
 
 try:
     import soundfile as sf
-except:
+except Exception:
     raise ImportError(
         "Failed to import soundfile, please install soundfile with `pip install soundfile`"
     )

--- a/examples/AI_podcast_ZH.py
+++ b/examples/AI_podcast_ZH.py
@@ -50,7 +50,7 @@ except ImportError:
 
 try:
     import soundfile as sf
-except:
+except Exception:
     raise ImportError(
         "Failed to import soundfile, please install soundfile with `pip install soundfile`"
     )

--- a/xinference/__init__.py
+++ b/xinference/__init__.py
@@ -27,7 +27,7 @@ __version__ = _version.get_versions()["version"]
 
 try:
     import intel_extension_for_pytorch  # noqa: F401
-except:
+except Exception:
     pass
 
 

--- a/xinference/conftest.py
+++ b/xinference/conftest.py
@@ -302,5 +302,5 @@ def setup_with_auth():
         restful_api_proc.kill()
         try:
             os.remove(auth_file)
-        except:
+        except Exception:
             pass

--- a/xinference/core/supervisor.py
+++ b/xinference/core/supervisor.py
@@ -1491,7 +1491,7 @@ class SupervisorActor(xo.StatelessActor):
                     # wait for load complete
                     for worker_ref in worker_refs:
                         await worker_ref.wait_for_load(rep_model_uid)
-            except:
+            except Exception:
                 # terminate_model will remove the replica info.
                 await self.terminate_model(model_uid, suppress_exception=True)
                 await self._status_guard_ref.update_instance_info(

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -1681,7 +1681,7 @@ class WorkerActor(xo.StatelessActor):
                     except xo.ServerClosed:
                         check_cancel()
                         raise
-            except:
+            except Exception:
                 logger.error(f"Failed to load model {model_uid}", exc_info=True)
                 self.release_devices(model_uid=model_uid)
                 for addr in all_subpool_addresses:
@@ -2128,7 +2128,7 @@ class WorkerActor(xo.StatelessActor):
                     uid=rep_model_uid,
                     xavier_config=xavier_config,
                 )
-            except:
+            except Exception:
                 await self._main_pool.remove_sub_pool(subpool_address)
                 raise
             self._model_uid_to_model[rep_model_uid] = model_ref

--- a/xinference/deploy/local.py
+++ b/xinference/deploy/local.py
@@ -103,7 +103,7 @@ def run(
             )
         )
         loop.run_until_complete(task)
-    except:
+    except Exception:
         tb = traceback.format_exc()
         if conn:
             try:

--- a/xinference/deploy/utils.py
+++ b/xinference/deploy/utils.py
@@ -203,13 +203,13 @@ def handle_click_args_type(arg: str) -> Any:
     try:
         result = int(arg)
         return result
-    except:
+    except Exception:
         pass
 
     try:
         result = float(arg)
         return result
-    except:
+    except Exception:
         pass
 
     return arg

--- a/xinference/model/audio/indextts2.py
+++ b/xinference/model/audio/indextts2.py
@@ -195,5 +195,5 @@ class Indextts2:
                 os.unlink(temp_prompt_path)
                 if emo_prompt_path:
                     os.unlink(emo_prompt_path)
-            except:
+            except Exception:
                 pass

--- a/xinference/model/image/ocr/deepseek_ocr.py
+++ b/xinference/model/image/ocr/deepseek_ocr.py
@@ -80,7 +80,7 @@ def load_image(image_path: str) -> Optional[PIL.Image.Image]:
         logger.error(f"Error loading image {image_path}: {e}")
         try:
             return PIL.Image.open(image_path)
-        except:
+        except Exception:
             return None
 
 
@@ -251,7 +251,7 @@ def draw_bounding_boxes(
     # Use default font
     try:
         font = PIL.ImageFont.load_default()
-    except:
+    except Exception:
         font = None
 
     img_idx = 0
@@ -406,7 +406,7 @@ def extract_text_blocks(text: str) -> List[Dict[str, Any]]:
                         "bbox": coords[0] if len(coords) == 1 else coords,
                     }
                 )
-        except:
+        except Exception:
             # Skip if coordinates can't be parsed
             continue
 

--- a/xinference/model/llm/core.py
+++ b/xinference/model/llm/core.py
@@ -94,12 +94,12 @@ class LLM(abc.ABC):
         try:
             nvmlInit()
             device_count = nvmlDeviceGetCount()
-        except:
+        except Exception:
             pass
         finally:
             try:
                 nvmlShutdown()
-            except:
+            except Exception:
                 pass
 
         return device_count > 0
@@ -118,7 +118,7 @@ class LLM(abc.ABC):
                 ["cnmon", "info"], capture_output=True, text=True, timeout=5
             )
             return "Card 0" in result.stdout
-        except:
+        except Exception:
             return False
 
     @staticmethod
@@ -132,7 +132,7 @@ class LLM(abc.ABC):
             import glob
 
             return len(glob.glob("/dev/vacc*")) > 0
-        except:
+        except Exception:
             return False
 
     @staticmethod
@@ -151,12 +151,12 @@ class LLM(abc.ABC):
         try:
             nvmlInit()
             device_count = nvmlDeviceGetCount()
-        except:
+        except Exception:
             pass
         finally:
             try:
                 nvmlShutdown()
-            except:
+            except Exception:
                 pass
 
         return device_count > 0

--- a/xinference/model/llm/mlx/core.py
+++ b/xinference/model/llm/mlx/core.py
@@ -684,7 +684,7 @@ class MLXModel(LLM):
                         ).result()
 
                     self._load_model_shard(**kwargs)
-                except:
+                except Exception:
                     logger.exception("Loading mlx shard model failed")
                     self._loading_error = sys.exc_info()
 

--- a/xinference/model/llm/sglang/core.py
+++ b/xinference/model/llm/sglang/core.py
@@ -217,7 +217,7 @@ class SGLANGModel(LLM):
                         port=sgl_port,
                         **self._model_config,
                     )
-                except:
+                except Exception:
                     logger.exception("Creating sglang Runtime failed")
                     self._loading_error = sys.exc_info()
 

--- a/xinference/model/llm/vllm/utils.py
+++ b/xinference/model/llm/vllm/utils.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 def vllm_check(fn):
     try:
         from vllm.engine.async_llm_engine import AsyncEngineDeadError
-    except:
+    except Exception:
         return fn
 
     @functools.wraps(fn)
@@ -33,7 +33,7 @@ def vllm_check(fn):
             logger.info("Detecting vLLM is not health, prepare to quit the process")
             try:
                 self.stop()
-            except:
+            except Exception:
                 # ignore error when stop
                 pass
             # Just kill the process and let xinference auto-recover the model

--- a/xinference/model/utils.py
+++ b/xinference/model/utils.py
@@ -405,7 +405,7 @@ def is_locale_chinese_simplified() -> bool:
     try:
         lang, _ = locale.getdefaultlocale()
         return lang == "zh_CN"
-    except:
+    except Exception:
         return False
 
 

--- a/xinference/thirdparty/audiotools/core/playback.py
+++ b/xinference/thirdparty/audiotools/core/playback.py
@@ -25,12 +25,12 @@ DEFAULT_EXTENSION = ".wav"
 def _check_imports():  # pragma: no cover
     try:
         import ffmpy
-    except:
+    except Exception:
         ffmpy = False
 
     try:
         import IPython
-    except:
+    except Exception:
         raise ImportError("IPython must be installed in order to use this function!")
     return ffmpy, IPython
 

--- a/xinference/thirdparty/audiotools/core/util.py
+++ b/xinference/thirdparty/audiotools/core/util.py
@@ -208,7 +208,7 @@ def _close_temp_files(tmpfiles: list):
             try:
                 t.close()
                 os.unlink(t.name)
-            except:
+            except Exception:
                 pass
 
     try:
@@ -366,7 +366,7 @@ def prepare_batch(batch: typing.Union[dict, list, torch.Tensor], device: str = "
         for key, val in batch.items():
             try:
                 batch[key] = val.to(device)
-            except:
+            except Exception:
                 pass
         batch = unflatten(batch)
     elif torch.is_tensor(batch):
@@ -375,7 +375,7 @@ def prepare_batch(batch: typing.Union[dict, list, torch.Tensor], device: str = "
         for i in range(len(batch)):
             try:
                 batch[i] = batch[i].to(device)
-            except:
+            except Exception:
                 pass
     return batch
 

--- a/xinference/thirdparty/audiotools/data/datasets.py
+++ b/xinference/thirdparty/audiotools/data/datasets.py
@@ -83,7 +83,7 @@ class AudioLoader:
         if source_idx is not None and item_idx is not None:
             try:
                 audio_info = self.audio_lists[source_idx][item_idx]
-            except:
+            except Exception:
                 audio_info = {"path": "none"}
         elif global_idx is not None:
             source_idx, item_idx = self.audio_indices[

--- a/xinference/thirdparty/audiotools/ml/layers/base.py
+++ b/xinference/thirdparty/audiotools/ml/layers/base.py
@@ -168,7 +168,7 @@ class BaseModel(nn.Module):
         """
         try:
             model = cls._load_package(location, package_name=package_name)
-        except:
+        except Exception:
             model_dict = torch.load(location, "cpu")
             metadata = model_dict["metadata"]
             metadata["kwargs"].update(kwargs)

--- a/xinference/thirdparty/audiotools/preference.py
+++ b/xinference/thirdparty/audiotools/preference.py
@@ -582,7 +582,7 @@ class Samples:
             self.current += 1
             done = gr.update(interactive=True)
             pbar = self.progress()
-        except:
+        except Exception:
             traceback.print_exc()
             updates = [gr.update() for _ in range(len(self.order))]
             done = gr.update(value="No more samples!", interactive=False)

--- a/xinference/thirdparty/deepseek_vl2/serve/app_modules/utils.py
+++ b/xinference/thirdparty/deepseek_vl2/serve/app_modules/utils.py
@@ -309,7 +309,7 @@ def parse_ref_bbox(response, image: Image.Image):
 
         # print(f"boxes = {boxes}, labels = {labels}, re-render = {image}")
         return image
-    except:
+    except Exception:
         return None
 
 

--- a/xinference/thirdparty/fish_speech/tools/sensevoice/auto_model.py
+++ b/xinference/thirdparty/fish_speech/tools/sensevoice/auto_model.py
@@ -30,7 +30,7 @@ from .vad_utils import merge_vad, slice_padding_audio_samples
 try:
     from funasr.models.campplus.cluster_backend import ClusterBackend
     from funasr.models.campplus.utils import distribute_spk, postprocess, sv_chunk
-except:
+except Exception:
     pass
 
 
@@ -122,7 +122,7 @@ class AutoModel:
                 "Check update of funasr, and it would cost few times. You may disable it by set `disable_update=True` in AutoModel"
             )
             check_for_update(disable=kwargs.get("disable_update", False))
-        except:
+        except Exception:
             pass
 
         log_level = getattr(logging, kwargs.get("log_level", "INFO").upper())

--- a/xinference/thirdparty/indextts/infer.py
+++ b/xinference/thirdparty/indextts/infer.py
@@ -106,7 +106,7 @@ class IndexTTS:
 
                 anti_alias_activation_cuda = load.load()
                 print(">> Preload custom CUDA kernel for BigVGAN", anti_alias_activation_cuda)
-            except:
+            except Exception:
                 print(">> Failed to load custom CUDA kernel for BigVGAN. Falling back to torch.")
                 self.use_cuda_kernel = False
         self.bigvgan = Generator(self.cfg.bigvgan, use_cuda_kernel=self.use_cuda_kernel)

--- a/xinference/thirdparty/indextts/infer_v2.py
+++ b/xinference/thirdparty/indextts/infer_v2.py
@@ -994,7 +994,7 @@ class IndexTTS2:
                 try:
                     os.unlink(temp_output_path)
                     # print(f">> Cleaned up temp file: {temp_output_path}")
-                except:
+                except Exception:
                     pass
 
 

--- a/xinference/thirdparty/indextts/s2mel/modules/gpt_fast/quantize.py
+++ b/xinference/thirdparty/indextts/s2mel/modules/gpt_fast/quantize.py
@@ -14,7 +14,7 @@ from tokenizer import get_tokenizer
 try:
     from GPTQ import GenericGPTQRunner, InputRecorder
     from eval import get_task_dict, evaluate, lm_eval
-except:
+except Exception:
     pass
 
 from model import Transformer
@@ -252,7 +252,7 @@ class GPTQQuantHandler(QuantHandler):
 
         try:
             lm_eval.tasks.initialize_tasks()
-        except:
+        except Exception:
             pass
         task_dict = get_task_dict(calibration_tasks)
         print("Obtaining GPTQ calibration inputs on: ", calibration_tasks)

--- a/xinference/thirdparty/indextts/s2mel/modules/openvoice/utils.py
+++ b/xinference/thirdparty/indextts/s2mel/modules/openvoice/utils.py
@@ -138,7 +138,7 @@ def merge_short_segments_latin(sens):
         if len(sens_out[-1].split(" ")) <= 2:
             sens_out[-2] = sens_out[-2] + " " + sens_out[-1]
             sens_out.pop(-1)
-    except:
+    except Exception:
         pass
     return sens_out
 
@@ -189,6 +189,6 @@ def merge_short_segments_zh(sens):
         if len(sens_out[-1]) <= 2:
             sens_out[-2] = sens_out[-2] + " " + sens_out[-1]
             sens_out.pop(-1)
-    except:
+    except Exception:
         pass
     return sens_out

--- a/xinference/thirdparty/indextts/s2mel/optimizers.py
+++ b/xinference/thirdparty/indextts/s2mel/optimizers.py
@@ -29,14 +29,14 @@ class MultiOptimizer:
         for key, val in state_dict:
             try:
                 self.optimizers[key].load_state_dict(val)
-            except:
+            except Exception:
                 print("Unloaded %s" % key)
 
     def load_scheduler_state_dict(self, state_dict):
         for key, val in state_dict:
             try:
                 self.schedulers[key].load_state_dict(val)
-            except:
+            except Exception:
                 print("Unloaded %s" % key)
 
     def step(self, key=None, scaler=None):

--- a/xinference/thirdparty/indextts/utils/maskgct/models/codec/facodec/optimizer.py
+++ b/xinference/thirdparty/indextts/utils/maskgct/models/codec/facodec/optimizer.py
@@ -34,14 +34,14 @@ class MultiOptimizer:
         for key, val in state_dict:
             try:
                 self.optimizers[key].load_state_dict(val)
-            except:
+            except Exception:
                 print("Unloaded %s" % key)
 
     def load_scheduler_state_dict(self, state_dict):
         for key, val in state_dict:
             try:
                 self.schedulers[key].load_state_dict(val)
-            except:
+            except Exception:
                 print("Unloaded %s" % key)
 
     def step(self, key=None, scaler=None):

--- a/xinference/thirdparty/megatts3/tts/utils/commons/ckpt_utils.py
+++ b/xinference/thirdparty/megatts3/tts/utils/commons/ckpt_utils.py
@@ -114,7 +114,7 @@ def load_ckpt(cur_model, ckpt_base_dir, model_name='model', force=True, strict=T
                     cur_model.load_state_dict(state_dict, strict=True)
                     if not silent:
                         print(f"| loaded '{model_name}' from '{ckpt_path}' with strict=True.")
-                except:
+                except Exception:
                     cur_model_state_dict = cur_model.state_dict()
                     cur_model_state_dict = {k.replace('module.', '').replace('_orig_mod.', ''): v for k, v in
                                             cur_model_state_dict.items()}

--- a/xinference/thirdparty/megatts3/tts/utils/commons/hparams.py
+++ b/xinference/thirdparty/megatts3/tts/utils/commons/hparams.py
@@ -179,11 +179,11 @@ def set_hparams(config='', exp_name='', hparams_str='', print_hparams=True, glob
                 config_node[k] = v
                 try:
                     config_node[k] = float(v)
-                except:
+                except Exception:
                     pass
                 try:
                     config_node[k] = int(v)
-                except:
+                except Exception:
                     pass
                 if v.lower() in ['false', 'true']:
                     config_node[k] = v.lower() == 'true'

--- a/xinference/thirdparty/melo/data_utils.py
+++ b/xinference/thirdparty/melo/data_utils.py
@@ -67,7 +67,7 @@ class TextAudioSpeakerLoader(torch.utils.data.Dataset):
         ):
             try:
                 _id, spk, language, text, phones, tone, word2ph = item
-            except:
+            except Exception:
                 print(item)
                 raise
             audiopath = f"{_id}"
@@ -121,7 +121,7 @@ class TextAudioSpeakerLoader(torch.utils.data.Dataset):
         try:
             spec = torch.load(spec_filename)
             assert False
-        except:
+        except Exception:
             if self.use_mel_spec_posterior:
                 spec = mel_spectrogram_torch(
                     audio_norm,

--- a/xinference/thirdparty/melo/split_utils.py
+++ b/xinference/thirdparty/melo/split_utils.py
@@ -69,7 +69,7 @@ def merge_short_sentences_en(sens):
         if len(sens_out[-1].split(" ")) <= 2:
             sens_out[-2] = sens_out[-2] + " " + sens_out[-1]
             sens_out.pop(-1)
-    except:
+    except Exception:
         pass
     return sens_out
 
@@ -96,7 +96,7 @@ def merge_short_sentences_zh(sens):
         if len(sens_out[-1]) <= 2:
             sens_out[-2] = sens_out[-2] + " " + sens_out[-1]
             sens_out.pop(-1)
-    except:
+    except Exception:
         pass
     return sens_out
 

--- a/xinference/thirdparty/melo/text/japanese.py
+++ b/xinference/thirdparty/melo/text/japanese.py
@@ -379,7 +379,7 @@ def text2kata(text: str) -> str:
         if yomi:
             try:
                 res.append(yomi.split(',')[6])
-            except:
+            except Exception:
                 import pdb; pdb.set_trace()
         else:
             if word in _SYMBOL_TOKENS:

--- a/xinference/thirdparty/melo/text/tone_sandhi.py
+++ b/xinference/thirdparty/melo/text/tone_sandhi.py
@@ -753,7 +753,7 @@ class ToneSandhi:
         seg = self._merge_bu(seg)
         try:
             seg = self._merge_yi(seg)
-        except:
+        except Exception:
             print("_merge_yi failed")
         seg = self._merge_reduplication(seg)
         seg = self._merge_continuous_three_tones(seg)


### PR DESCRIPTION
Replace 55 bare `except:` with `except Exception:` across 34 files. Bare `except:` catches `KeyboardInterrupt` and `SystemExit`, masking real errors and preventing clean process termination.