### PR TITLE
BUG: fix vLLM embedding check for qwen3-vl-embedding

### DIFF
--- a/xinference/model/embedding/vllm/core.py
+++ b/xinference/model/embedding/vllm/core.py
@@ -240,6 +240,11 @@ class VLLMEmbeddingModel(EmbeddingModel, BatchMixin):
         quantization: str,
     ) -> Union[bool, Tuple[bool, str]]:
 
+        if model_family.model_name.startswith("Qwen3-VL-Embedding"):
+            from packaging import version
+            import vllm
+            if version.parse(vllm.__version__) < version.parse("0.14.0"):
+                return False, f"Qwen3-VL embedding requires vLLM>=0.14.0, current: {vllm.__version__}"
         if model_spec.model_format not in ["pytorch"]:
             return False, "vLLM embedding engine only supports pytorch format"
         prefix = model_family.model_name.split("-", 1)[0]


### PR DESCRIPTION
#4644
添加 Qwen3-VL-Embedding 支持时，考虑到 vllm 版本兼容性，临时写了一个硬编码的版本门控：
```
# 问题代码
if model_family.model_name.startswith("Qwen3-VL-Embedding"):
    return False, "Qwen3-VL embedding requires vLLM>=0.14.0"
```

**根本问题**：这个判断**永远返回 False**，没有去真正检查当前 vllm 版本，导致即使用户已安装 vllm >= 0.14.0 也无法使用。正确做法应该是动态检查版本后再决定。

根本原因：模型仓库里的自定义脚本 scripts/qwen3_vl_embedding.py 定义了 Qwen3VLForEmbedding 类，但这个类是通过动态加载（importlib 或 exec）方式引入的，没有被正式注册到 sys.modules。