### PR TITLE
BUG: fix error `WorkerWrapperBase.__init__() got multiple values for argument 'rpc_rank'`

### DIFF
--- a/xinference/model/llm/vllm/distributed_executor_v1.py
+++ b/xinference/model/llm/vllm/distributed_executor_v1.py
@@ -49,7 +49,7 @@ DEBUG_EXECUTOR = bool(int(os.getenv("XINFERENCE_DEBUG_VLLM_EXECUTOR", "0")))
 class WorkerActor(xo.StatelessActor):
     def __init__(self, vllm_config: "VllmConfig", rpc_rank: int = 0, **kwargs):
         super().__init__(**kwargs)
-        self._worker = WorkerWrapperBase(vllm_config, rpc_rank=rpc_rank)
+        self._worker = WorkerWrapperBase(rpc_rank=rpc_rank)
 
     async def __post_create__(self):
         try:
@@ -61,6 +61,10 @@ class WorkerActor(xo.StatelessActor):
             pass
 
     def __getattr__(self, item):
+        from xoscar.core import NO_LOCK_ATTRIBUTE_HINT
+
+        if item == NO_LOCK_ATTRIBUTE_HINT:
+            return True
         return getattr(self._worker, item)
 
     @classmethod


### PR DESCRIPTION
Close #4555 
There are two reasons causing this error:
1.Parameter changes in WorkerWrapperBase due to version differences - The __init__ signature changed from (vllm_config, rpc_rank=0) in v0.9.0 and earlier to (rpc_rank=0, global_rank=None) in v0.11.1+ / v1, causing got multiple values for argument 'rpc_rank' when passing arguments incorrectly.
2.Recursion depth issue triggered by xoscar calling xoscar.core._has_no_lock_hint_for_method - This internal xoscar method uses getattr() to check for the NO_LOCK_ATTRIBUTE_HINT attribute, which triggers WorkerActor.__getattr__. This in turn calls getattr(self._worker, item), but WorkerWrapperBase also implements __getattr__ to delegate to self.worker. Since self.worker hasn't been initialized yet (as init_worker() hasn't been called), accessing it triggers another __getattr__ call, creating an infinite recursion loop between the two __getattr__ implementations.