### PR TITLE
DOC: add missing periods in docstrings

### DIFF
--- a/xinference/client/restful/async_restful_client.py
+++ b/xinference/client/restful/async_restful_client.py
@@ -537,9 +537,9 @@ class AsyncRESTfulImageModelHandle(AsyncRESTfulModelHandle):
         image: `Union[str, bytes]`
             an image batch to be inpainted (which parts of the image to
             be masked out with `mask_image` and repainted according to `prompt`). For both numpy array and pytorch
-            tensor, the expected value range is between `[0, 1]` If it's a tensor or a list or tensors, the
+            tensor, the expected value range is between `[0, 1]`. If it's a tensor or a list or tensors, the
             expected shape should be `(B, C, H, W)` or `(C, H, W)`. If it is a numpy array or a list of arrays, the
-            expected shape should be `(B, H, W, C)` or `(H, W, C)` It can also accept image latents as `image`, but
+            expected shape should be `(B, H, W, C)` or `(H, W, C)`. It can also accept image latents as `image`, but
             if passing latents directly it is not encoded again.
         mask_image: `Union[str, bytes]`
             representing an image batch to mask `image`. White pixels in the mask

--- a/xinference/client/restful/restful_client.py
+++ b/xinference/client/restful/restful_client.py
@@ -479,9 +479,9 @@ class RESTfulImageModelHandle(RESTfulModelHandle):
         image: `Union[str, bytes]`
             an image batch to be inpainted (which parts of the image to
             be masked out with `mask_image` and repainted according to `prompt`). For both numpy array and pytorch
-            tensor, the expected value range is between `[0, 1]` If it's a tensor or a list or tensors, the
+            tensor, the expected value range is between `[0, 1]`. If it's a tensor or a list or tensors, the
             expected shape should be `(B, C, H, W)` or `(C, H, W)`. If it is a numpy array or a list of arrays, the
-            expected shape should be `(B, H, W, C)` or `(H, W, C)` It can also accept image latents as `image`, but
+            expected shape should be `(B, H, W, C)` or `(H, W, C)`. It can also accept image latents as `image`, but
             if passing latents directly it is not encoded again.
         mask_image: `Union[str, bytes]`
             representing an image batch to mask `image`. White pixels in the mask


### PR DESCRIPTION
## Summary

Fixed missing periods in docstrings for the image parameter documentation:

- Added missing period after `[0, 1]` in image parameter docstring
- Added missing period before `It can also accept` in shape description

These changes improve the readability and consistency of the documentation.

## Changes

- `xinference/client/restful/restful_client.py`: 2 fixes
- `xinference/client/restful/async_restful_client.py`: 2 fixes

Signed-off-by: RoomWithOutRoof <roomwithoutroof@outlook.com>