### PR TITLE
fix(qwen3.5): support XML-like tool call format in non-streaming mode

### DIFF
--- a/xinference/model/llm/tool_parsers/qwen_tool_parser.py
+++ b/xinference/model/llm/tool_parsers/qwen_tool_parser.py
@@ -246,6 +246,10 @@ class QwenToolParser(ToolParser):
             for function_call in function_calls:
                 try:
                     parsed_json = self._parse_json_function_call(function_call)
+                    # Check for Qwen3.5 XML-like format before JSON parsing
+                    if "<function=" in parsed_json and "<parameter=" in parsed_json:
+                        results.append(self.parse_qwen35_tool_call(parsed_json))
+                        continue
                     res = json.loads(parsed_json, strict=False)
                     # Validate that we have the required fields
                     if "name" in res and "arguments" in res:


### PR DESCRIPTION
## Summary
- Fixed a bug where the non-streaming `extract_tool_calls` method in QwenToolParser was attempting JSON parsing on Qwen3.5's XML-like tool call format, causing parsing errors
- Added check for `<function=` and `<parameter=` patterns before JSON parsing to properly route to `parse_qwen35_tool_call`
- This aligns the non-streaming behavior with the existing streaming implementation
## Test plan
- [ ] Test with Qwen3.5 model using XML-like tool call format
- [ ] Verify no regression with JSON format tool calls
- [ ] Run existing qwen tool parser tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)