### PR TITLE
enh: adapt `normalize` param of vllm>0.16.0 for embedding models.

### DIFF
--- a/xinference/model/embedding/vllm/core.py
+++ b/xinference/model/embedding/vllm/core.py
@@ -127,7 +127,11 @@ class VLLMEmbeddingModel(EmbeddingModel, BatchMixin):
                 sentences = truncated_sentences[0]
             else:
                 sentences = truncated_sentences
-        if Version(vllm_version) > Version("0.10.1"):
+        if Version(vllm_version) > Version("0.16.0"):
+            pool_params = PoolingParams(
+                dimensions=dimensions, use_activation=normalize_embedding
+            )
+        elif Version(vllm_version) > Version("0.10.1"):
             pool_params = PoolingParams(
                 dimensions=dimensions, normalize=normalize_embedding
             )


### PR DESCRIPTION
See https://docs.vllm.ai/en/latest/models/pooling_models/embed/?h=use_activation#enabledisable-normalize .

Close #4721 .