### PR TITLE
fix: use constant-time comparison for auth credentials (CWE-208)

### DIFF
--- a/xinference/api/oauth2/auth_service.py
+++ b/xinference/api/oauth2/auth_service.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import hmac
 import re
 from datetime import timedelta
 from typing import List, Optional, Tuple
@@ -127,7 +128,7 @@ class AuthService:
     ) -> Tuple[Optional[User], List]:
         for user in self._config.user_config:
             for key in user.api_keys:
-                if api_key == key:
+                if hmac.compare_digest(api_key, key):
                     return user, user.permissions
         return None, []
 


### PR DESCRIPTION
## Summary

Fixes #4733 — replaces timing-vulnerable comparison with constant-time alternative.

## Changes

- `xinference/api/oauth2/auth_service.py`: Replace `==` API key comparison with `hmac.compare_digest()` in `get_user_and_scopes_with_api_key()`
- No behavioral change for valid authentication flows
- Uses stdlib only — no new dependencies

## CWE Reference

- **CWE-208**: Observable Timing Discrepancy

---
*Found by [SpiderShield](https://github.com/teehooai/spidershield) security scanner*