### PR TITLE
FEAT: add DeepSeek V3.2 tool parser for DSML format

### DIFF
--- a/xinference/model/llm/tool_parsers/__init__.py
+++ b/xinference/model/llm/tool_parsers/__init__.py
@@ -52,6 +52,7 @@ def register_tool_parser(name: str):
 from . import (
     deepseek_r1_tool_parser,
     deepseek_v3_1_tool_parser,
+    deepseek_v3_2_tool_parser,
     deepseek_v3_tool_parser,
     glm4_tool_parser,
     llama3_tool_parser,

--- a/xinference/model/llm/tool_parsers/deepseek_v3_2_tool_parser.py
+++ b/xinference/model/llm/tool_parsers/deepseek_v3_2_tool_parser.py
@@ -134,7 +134,5 @@ class DeepseekV3_2ToolParser(ToolParser):
             return None
 
         except Exception as e:
-            logger.error(
-                "Error in DeepSeek V3.2 streaming tool call extraction: %s", e
-            )
+            logger.error("Error in DeepSeek V3.2 streaming tool call extraction: %s", e)
             raise

--- a/xinference/model/llm/tool_parsers/deepseek_v3_2_tool_parser.py
+++ b/xinference/model/llm/tool_parsers/deepseek_v3_2_tool_parser.py
@@ -1,0 +1,140 @@
+import logging
+import re
+from typing import Any, Dict, List, Optional, Tuple
+
+from . import register_tool_parser
+from .abstract_tool_parser import ToolParser
+
+logger = logging.getLogger(__name__)
+
+
+@register_tool_parser("deepseek-v3.2")
+class DeepseekV3_2ToolParser(ToolParser):
+    """
+    Tool parser implementation for DeepSeek V3.2 model.
+
+    Handles the DSML format used by DeepSeek V3.2 for tool calls:
+
+    <｜DSML｜function_calls>
+    <｜DSML｜invoke name="get_weather">
+    <｜DSML｜parameter name="location" string="true">杭州</｜DSML｜parameter>
+    <｜DSML｜parameter name="date" string="true">2024-01-16</｜DSML｜parameter>
+    </｜DSML｜invoke>
+    </｜DSML｜function_calls>
+    """
+
+    def __init__(self):
+        super().__init__()
+
+        self.tool_call_start_token: str = "<｜DSML｜function_calls>"
+
+        # Streaming state
+        self.is_tool_call_started: bool = False
+        self.current_tool_index: int = 0
+
+        # Regex patterns
+        self.tool_call_complete_regex = re.compile(
+            r"<｜DSML｜function_calls>(.*?)</｜DSML｜function_calls>", re.DOTALL
+        )
+        self.invoke_complete_regex = re.compile(
+            r'<｜DSML｜invoke\s+name="([^"]+)"\s*>(.*?)</｜DSML｜invoke>', re.DOTALL
+        )
+        self.parameter_complete_regex = re.compile(
+            r'<｜DSML｜parameter\s+name="([^"]+)"\s+string="(?:true|false)"\s*>'
+            r"(.*?)</｜DSML｜parameter>",
+            re.DOTALL,
+        )
+
+    def _parse_invoke_params(self, invoke_str: str) -> dict:
+        """Parse parameter name-value pairs from an invoke block."""
+        param_dict = {}
+        for param_name, param_val in self.parameter_complete_regex.findall(invoke_str):
+            param_dict[param_name] = param_val
+        return param_dict
+
+    def extract_tool_calls(
+        self, model_output: str
+    ) -> List[Tuple[Optional[str], Optional[str], Optional[Dict[str, Any]]]]:
+        """
+        Extract tool calls from complete model output.
+
+        Args:
+            model_output: The complete output string from the model.
+
+        Returns:
+            A list of tuples where each tuple contains:
+            - content: Raw content if parsing failed, None if successful
+            - function_name: Name of the function to call
+            - parameters: Function parameters as dict
+        """
+        if self.tool_call_start_token not in model_output:
+            return [(model_output, None, None)]
+
+        results: List[Tuple[Optional[str], Optional[str], Optional[Dict[str, Any]]]] = (
+            []
+        )
+
+        for tool_call_match in self.tool_call_complete_regex.findall(model_output):
+            for invoke_name, invoke_content in self.invoke_complete_regex.findall(
+                tool_call_match
+            ):
+                param_dict = self._parse_invoke_params(invoke_content)
+                results.append((None, invoke_name, param_dict))
+
+        if not results:
+            return [(model_output, None, None)]
+
+        return results
+
+    def extract_tool_calls_streaming(
+        self, previous_text: List[str], current_text: str, delta_text: str
+    ) -> Optional[Tuple[Optional[str], Optional[str], Optional[Dict[str, Any]]]]:
+        """
+        Extract tool calls from streaming output.
+
+        Buffers tokens until a complete invoke block is available, then
+        parses and returns it in one shot.
+
+        Args:
+            previous_text: Previous text chunks from the stream.
+            current_text: Current accumulated text.
+            delta_text: New text delta in this chunk.
+
+        Returns:
+            None if waiting for more data, or a tuple of (content, function_name, parameters).
+        """
+        try:
+            # First chunk of a new stream — reset state
+            if not previous_text:
+                self.is_tool_call_started = False
+                self.current_tool_index = 0
+
+            # Detect tool-call region
+            if not self.is_tool_call_started:
+                if self.tool_call_start_token in current_text:
+                    self.is_tool_call_started = True
+                else:
+                    # Still in plain-text region, forward as content
+                    for i in range(1, len(self.tool_call_start_token)):
+                        prefix = self.tool_call_start_token[:i]
+                        if current_text.endswith(prefix):
+                            return None
+                    return (delta_text, None, None) if delta_text else None
+
+            # Inside tool-call region: check for newly completed invokes
+            complete_invokes = self.invoke_complete_regex.findall(current_text)
+
+            if len(complete_invokes) > self.current_tool_index:
+                invoke_name, invoke_body = complete_invokes[self.current_tool_index]
+                self.current_tool_index += 1
+                param_dict = self._parse_invoke_params(invoke_body)
+                return (None, invoke_name, param_dict)
+
+            # Buffering — no complete invoke yet
+            return None
+
+        except Exception as e:
+            logger.error(
+                "Error in DeepSeek V3.2 streaming tool call extraction: %s", e
+            )
+            raise

--- a/xinference/model/llm/tool_parsers/tests/test_deepseek_v3_2_tool_parser.py
+++ b/xinference/model/llm/tool_parsers/tests/test_deepseek_v3_2_tool_parser.py
@@ -6,11 +6,11 @@ def test_extract_tool_calls_single_call():
     parser = DeepseekV3_2ToolParser()
 
     test_case = (
-        '<｜DSML｜function_calls>'
+        "<｜DSML｜function_calls>"
         '<｜DSML｜invoke name="get_current_weather">'
         '<｜DSML｜parameter name="location" string="true">上海</｜DSML｜parameter>'
-        '</｜DSML｜invoke>'
-        '</｜DSML｜function_calls>'
+        "</｜DSML｜invoke>"
+        "</｜DSML｜function_calls>"
     )
 
     expected_results = [(None, "get_current_weather", {"location": "上海"})]
@@ -25,14 +25,14 @@ def test_extract_tool_calls_multiple_calls():
     parser = DeepseekV3_2ToolParser()
 
     test_case = (
-        '<｜DSML｜function_calls>'
+        "<｜DSML｜function_calls>"
         '<｜DSML｜invoke name="get_current_weather">'
         '<｜DSML｜parameter name="location" string="true">上海</｜DSML｜parameter>'
-        '</｜DSML｜invoke>'
+        "</｜DSML｜invoke>"
         '<｜DSML｜invoke name="get_time">'
         '<｜DSML｜parameter name="timezone" string="true">UTC+8</｜DSML｜parameter>'
-        '</｜DSML｜invoke>'
-        '</｜DSML｜function_calls>'
+        "</｜DSML｜invoke>"
+        "</｜DSML｜function_calls>"
     )
 
     expected_results = [
@@ -50,12 +50,12 @@ def test_extract_tool_calls_multiple_params():
     parser = DeepseekV3_2ToolParser()
 
     test_case = (
-        '<｜DSML｜function_calls>'
+        "<｜DSML｜function_calls>"
         '<｜DSML｜invoke name="get_weather">'
         '<｜DSML｜parameter name="location" string="true">杭州</｜DSML｜parameter>'
         '<｜DSML｜parameter name="date" string="true">2024-01-16</｜DSML｜parameter>'
-        '</｜DSML｜invoke>'
-        '</｜DSML｜function_calls>'
+        "</｜DSML｜invoke>"
+        "</｜DSML｜function_calls>"
     )
 
     expected_results = [
@@ -95,22 +95,30 @@ STREAMING_TEST_CASES = [
         '<｜DSML｜parameter name="location" string="true">',
     ),
     (
-        ['<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">'],
+        [
+            '<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">'
+        ],
         '<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">上海',
         "上海",
     ),
     (
-        ['<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">上海'],
+        [
+            '<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">上海'
+        ],
         '<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">上海</｜DSML｜parameter>',
         "</｜DSML｜parameter>",
     ),
     (
-        ['<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">上海</｜DSML｜parameter>'],
+        [
+            '<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">上海</｜DSML｜parameter>'
+        ],
         '<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">上海</｜DSML｜parameter></｜DSML｜invoke>',
         "</｜DSML｜invoke>",
     ),
     (
-        ['<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">上海</｜DSML｜parameter></｜DSML｜invoke>'],
+        [
+            '<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">上海</｜DSML｜parameter></｜DSML｜invoke>'
+        ],
         '<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">上海</｜DSML｜parameter></｜DSML｜invoke></｜DSML｜function_calls>',
         "</｜DSML｜function_calls>",
     ),
@@ -131,48 +139,66 @@ STREAMING_TEST_MULTI_CASES = [
         '<｜DSML｜parameter name="location" string="true">',
     ),
     (
-        ['<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">'],
+        [
+            '<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">'
+        ],
         '<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">上海',
         "上海",
     ),
     (
-        ['<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">上海'],
+        [
+            '<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">上海'
+        ],
         '<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">上海</｜DSML｜parameter>',
         "</｜DSML｜parameter>",
     ),
     (
-        ['<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">上海</｜DSML｜parameter>'],
+        [
+            '<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">上海</｜DSML｜parameter>'
+        ],
         '<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">上海</｜DSML｜parameter></｜DSML｜invoke>',
         "</｜DSML｜invoke>",
     ),
     # First invoke complete, second invoke starts
     (
-        ['<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">上海</｜DSML｜parameter></｜DSML｜invoke>'],
+        [
+            '<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">上海</｜DSML｜parameter></｜DSML｜invoke>'
+        ],
         '<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">上海</｜DSML｜parameter></｜DSML｜invoke><｜DSML｜invoke name="get_time">',
         '<｜DSML｜invoke name="get_time">',
     ),
     (
-        ['<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">上海</｜DSML｜parameter></｜DSML｜invoke><｜DSML｜invoke name="get_time">'],
+        [
+            '<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">上海</｜DSML｜parameter></｜DSML｜invoke><｜DSML｜invoke name="get_time">'
+        ],
         '<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">上海</｜DSML｜parameter></｜DSML｜invoke><｜DSML｜invoke name="get_time"><｜DSML｜parameter name="timezone" string="true">',
         '<｜DSML｜parameter name="timezone" string="true">',
     ),
     (
-        ['<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">上海</｜DSML｜parameter></｜DSML｜invoke><｜DSML｜invoke name="get_time"><｜DSML｜parameter name="timezone" string="true">'],
+        [
+            '<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">上海</｜DSML｜parameter></｜DSML｜invoke><｜DSML｜invoke name="get_time"><｜DSML｜parameter name="timezone" string="true">'
+        ],
         '<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">上海</｜DSML｜parameter></｜DSML｜invoke><｜DSML｜invoke name="get_time"><｜DSML｜parameter name="timezone" string="true">UTC+8',
         "UTC+8",
     ),
     (
-        ['<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">上海</｜DSML｜parameter></｜DSML｜invoke><｜DSML｜invoke name="get_time"><｜DSML｜parameter name="timezone" string="true">UTC+8'],
+        [
+            '<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">上海</｜DSML｜parameter></｜DSML｜invoke><｜DSML｜invoke name="get_time"><｜DSML｜parameter name="timezone" string="true">UTC+8'
+        ],
         '<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">上海</｜DSML｜parameter></｜DSML｜invoke><｜DSML｜invoke name="get_time"><｜DSML｜parameter name="timezone" string="true">UTC+8</｜DSML｜parameter>',
         "</｜DSML｜parameter>",
     ),
     (
-        ['<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">上海</｜DSML｜parameter></｜DSML｜invoke><｜DSML｜invoke name="get_time"><｜DSML｜parameter name="timezone" string="true">UTC+8</｜DSML｜parameter>'],
+        [
+            '<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">上海</｜DSML｜parameter></｜DSML｜invoke><｜DSML｜invoke name="get_time"><｜DSML｜parameter name="timezone" string="true">UTC+8</｜DSML｜parameter>'
+        ],
         '<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">上海</｜DSML｜parameter></｜DSML｜invoke><｜DSML｜invoke name="get_time"><｜DSML｜parameter name="timezone" string="true">UTC+8</｜DSML｜parameter></｜DSML｜invoke>',
         "</｜DSML｜invoke>",
     ),
     (
-        ['<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">上海</｜DSML｜parameter></｜DSML｜invoke><｜DSML｜invoke name="get_time"><｜DSML｜parameter name="timezone" string="true">UTC+8</｜DSML｜parameter></｜DSML｜invoke>'],
+        [
+            '<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">上海</｜DSML｜parameter></｜DSML｜invoke><｜DSML｜invoke name="get_time"><｜DSML｜parameter name="timezone" string="true">UTC+8</｜DSML｜parameter></｜DSML｜invoke>'
+        ],
         '<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">上海</｜DSML｜parameter></｜DSML｜invoke><｜DSML｜invoke name="get_time"><｜DSML｜parameter name="timezone" string="true">UTC+8</｜DSML｜parameter></｜DSML｜invoke></｜DSML｜function_calls>',
         "</｜DSML｜function_calls>",
     ),
@@ -260,4 +286,8 @@ def test_extract_tool_calls_plain_text_before_tool_call():
     current_text = delta
     result = parser.extract_tool_calls_streaming(previous_texts, current_text, delta)
 
-    assert result == ("这是普通文本", None, None), f"Expected plain text passthrough, got {result}"
+    assert result == (
+        "这是普通文本",
+        None,
+        None,
+    ), f"Expected plain text passthrough, got {result}"

--- a/xinference/model/llm/tool_parsers/tests/test_deepseek_v3_2_tool_parser.py
+++ b/xinference/model/llm/tool_parsers/tests/test_deepseek_v3_2_tool_parser.py
@@ -1,0 +1,263 @@
+from ..deepseek_v3_2_tool_parser import DeepseekV3_2ToolParser
+
+
+def test_extract_tool_calls_single_call():
+    """Test extracting a single tool call."""
+    parser = DeepseekV3_2ToolParser()
+
+    test_case = (
+        '<｜DSML｜function_calls>'
+        '<｜DSML｜invoke name="get_current_weather">'
+        '<｜DSML｜parameter name="location" string="true">上海</｜DSML｜parameter>'
+        '</｜DSML｜invoke>'
+        '</｜DSML｜function_calls>'
+    )
+
+    expected_results = [(None, "get_current_weather", {"location": "上海"})]
+
+    result = parser.extract_tool_calls(test_case)
+
+    assert result == expected_results, f"Expected {expected_results}, but got {result}"
+
+
+def test_extract_tool_calls_multiple_calls():
+    """Test extracting multiple tool calls."""
+    parser = DeepseekV3_2ToolParser()
+
+    test_case = (
+        '<｜DSML｜function_calls>'
+        '<｜DSML｜invoke name="get_current_weather">'
+        '<｜DSML｜parameter name="location" string="true">上海</｜DSML｜parameter>'
+        '</｜DSML｜invoke>'
+        '<｜DSML｜invoke name="get_time">'
+        '<｜DSML｜parameter name="timezone" string="true">UTC+8</｜DSML｜parameter>'
+        '</｜DSML｜invoke>'
+        '</｜DSML｜function_calls>'
+    )
+
+    expected_results = [
+        (None, "get_current_weather", {"location": "上海"}),
+        (None, "get_time", {"timezone": "UTC+8"}),
+    ]
+
+    result = parser.extract_tool_calls(test_case)
+
+    assert result == expected_results, f"Expected {expected_results}, but got {result}"
+
+
+def test_extract_tool_calls_multiple_params():
+    """Test extracting a tool call with multiple parameters."""
+    parser = DeepseekV3_2ToolParser()
+
+    test_case = (
+        '<｜DSML｜function_calls>'
+        '<｜DSML｜invoke name="get_weather">'
+        '<｜DSML｜parameter name="location" string="true">杭州</｜DSML｜parameter>'
+        '<｜DSML｜parameter name="date" string="true">2024-01-16</｜DSML｜parameter>'
+        '</｜DSML｜invoke>'
+        '</｜DSML｜function_calls>'
+    )
+
+    expected_results = [
+        (None, "get_weather", {"location": "杭州", "date": "2024-01-16"}),
+    ]
+
+    result = parser.extract_tool_calls(test_case)
+
+    assert result == expected_results, f"Expected {expected_results}, but got {result}"
+
+
+def test_extract_tool_calls_no_tool_call():
+    """Test when no tool call is present."""
+    parser = DeepseekV3_2ToolParser()
+
+    test_case = "This is a normal response without any tool calls."
+
+    expected_results = [(test_case, None, None)]
+
+    result = parser.extract_tool_calls(test_case)
+
+    assert result == expected_results, f"Expected {expected_results}, but got {result}"
+
+
+# Streaming test cases: simulate chunks arriving for a single tool call
+STREAMING_TEST_CASES = [
+    # (previous_texts, current_text, delta_text)
+    ([""], "<｜DSML｜function_calls>", "<｜DSML｜function_calls>"),
+    (
+        ["<｜DSML｜function_calls>"],
+        '<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather">',
+        '<｜DSML｜invoke name="get_current_weather">',
+    ),
+    (
+        ['<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather">'],
+        '<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">',
+        '<｜DSML｜parameter name="location" string="true">',
+    ),
+    (
+        ['<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">'],
+        '<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">上海',
+        "上海",
+    ),
+    (
+        ['<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">上海'],
+        '<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">上海</｜DSML｜parameter>',
+        "</｜DSML｜parameter>",
+    ),
+    (
+        ['<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">上海</｜DSML｜parameter>'],
+        '<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">上海</｜DSML｜parameter></｜DSML｜invoke>',
+        "</｜DSML｜invoke>",
+    ),
+    (
+        ['<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">上海</｜DSML｜parameter></｜DSML｜invoke>'],
+        '<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">上海</｜DSML｜parameter></｜DSML｜invoke></｜DSML｜function_calls>',
+        "</｜DSML｜function_calls>",
+    ),
+]
+
+# Streaming test cases: simulate chunks arriving for multiple tool calls
+STREAMING_TEST_MULTI_CASES = [
+    # (previous_texts, current_text, delta_text)
+    ([""], "<｜DSML｜function_calls>", "<｜DSML｜function_calls>"),
+    (
+        ["<｜DSML｜function_calls>"],
+        '<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather">',
+        '<｜DSML｜invoke name="get_current_weather">',
+    ),
+    (
+        ['<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather">'],
+        '<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">',
+        '<｜DSML｜parameter name="location" string="true">',
+    ),
+    (
+        ['<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">'],
+        '<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">上海',
+        "上海",
+    ),
+    (
+        ['<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">上海'],
+        '<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">上海</｜DSML｜parameter>',
+        "</｜DSML｜parameter>",
+    ),
+    (
+        ['<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">上海</｜DSML｜parameter>'],
+        '<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">上海</｜DSML｜parameter></｜DSML｜invoke>',
+        "</｜DSML｜invoke>",
+    ),
+    # First invoke complete, second invoke starts
+    (
+        ['<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">上海</｜DSML｜parameter></｜DSML｜invoke>'],
+        '<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">上海</｜DSML｜parameter></｜DSML｜invoke><｜DSML｜invoke name="get_time">',
+        '<｜DSML｜invoke name="get_time">',
+    ),
+    (
+        ['<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">上海</｜DSML｜parameter></｜DSML｜invoke><｜DSML｜invoke name="get_time">'],
+        '<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">上海</｜DSML｜parameter></｜DSML｜invoke><｜DSML｜invoke name="get_time"><｜DSML｜parameter name="timezone" string="true">',
+        '<｜DSML｜parameter name="timezone" string="true">',
+    ),
+    (
+        ['<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">上海</｜DSML｜parameter></｜DSML｜invoke><｜DSML｜invoke name="get_time"><｜DSML｜parameter name="timezone" string="true">'],
+        '<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">上海</｜DSML｜parameter></｜DSML｜invoke><｜DSML｜invoke name="get_time"><｜DSML｜parameter name="timezone" string="true">UTC+8',
+        "UTC+8",
+    ),
+    (
+        ['<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">上海</｜DSML｜parameter></｜DSML｜invoke><｜DSML｜invoke name="get_time"><｜DSML｜parameter name="timezone" string="true">UTC+8'],
+        '<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">上海</｜DSML｜parameter></｜DSML｜invoke><｜DSML｜invoke name="get_time"><｜DSML｜parameter name="timezone" string="true">UTC+8</｜DSML｜parameter>',
+        "</｜DSML｜parameter>",
+    ),
+    (
+        ['<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">上海</｜DSML｜parameter></｜DSML｜invoke><｜DSML｜invoke name="get_time"><｜DSML｜parameter name="timezone" string="true">UTC+8</｜DSML｜parameter>'],
+        '<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">上海</｜DSML｜parameter></｜DSML｜invoke><｜DSML｜invoke name="get_time"><｜DSML｜parameter name="timezone" string="true">UTC+8</｜DSML｜parameter></｜DSML｜invoke>',
+        "</｜DSML｜invoke>",
+    ),
+    (
+        ['<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">上海</｜DSML｜parameter></｜DSML｜invoke><｜DSML｜invoke name="get_time"><｜DSML｜parameter name="timezone" string="true">UTC+8</｜DSML｜parameter></｜DSML｜invoke>'],
+        '<｜DSML｜function_calls><｜DSML｜invoke name="get_current_weather"><｜DSML｜parameter name="location" string="true">上海</｜DSML｜parameter></｜DSML｜invoke><｜DSML｜invoke name="get_time"><｜DSML｜parameter name="timezone" string="true">UTC+8</｜DSML｜parameter></｜DSML｜invoke></｜DSML｜function_calls>',
+        "</｜DSML｜function_calls>",
+    ),
+]
+
+
+def test_extract_tool_calls_streaming_full_sequence():
+    """Test streaming extraction through a complete single tool call sequence."""
+    parser = DeepseekV3_2ToolParser()
+
+    tool_call_detected = False
+    detected_result = None
+
+    for previous_texts, current_text, delta_text in STREAMING_TEST_CASES:
+        result = parser.extract_tool_calls_streaming(
+            previous_texts, current_text, delta_text
+        )
+
+        if result is not None and result[1] is not None:
+            tool_call_detected = True
+            detected_result = result
+
+    assert tool_call_detected, "Tool call should be detected during streaming"
+    assert detected_result == (
+        None,
+        "get_current_weather",
+        {"location": "上海"},
+    ), f"Expected tool call result, but got {detected_result}"
+
+
+def test_extract_tool_calls_streaming_multi_sequence():
+    """Test streaming extraction through a complete multiple tool calls sequence."""
+    parser = DeepseekV3_2ToolParser()
+    detected_results = []
+
+    for previous_texts, current_text, delta_text in STREAMING_TEST_MULTI_CASES:
+        result = parser.extract_tool_calls_streaming(
+            previous_texts, current_text, delta_text
+        )
+
+        if result is not None and result[1] is not None:
+            detected_results.append(result)
+
+    expected_results = [
+        (None, "get_current_weather", {"location": "上海"}),
+        (None, "get_time", {"timezone": "UTC+8"}),
+    ]
+
+    assert (
+        len(detected_results) == 2
+    ), f"Expected 2 tool calls, but got {len(detected_results)}"
+    assert (
+        detected_results == expected_results
+    ), f"Expected {expected_results}, but got {detected_results}"
+
+
+def test_extract_tool_calls_streaming_split_token():
+    """Test streaming extraction when the start token is split across chunks."""
+    parser = DeepseekV3_2ToolParser()
+
+    # Simulate start token being split: "<｜DSML｜function" + "_calls>"
+    previous_texts = [""]
+    delta1 = "<｜DSML｜function"
+    current_text1 = delta1
+    result1 = parser.extract_tool_calls_streaming(previous_texts, current_text1, delta1)
+    # Should return None (waiting, potential start token forming)
+    assert result1 is None, f"Expected None for partial token, got {result1}"
+
+    # Complete the start token
+    delta2 = "_calls>"
+    current_text2 = current_text1 + delta2
+    previous_texts.append(current_text1)
+    result2 = parser.extract_tool_calls_streaming(previous_texts, current_text2, delta2)
+    # Start token is now complete, but no invoke yet — should return None
+    assert result2 is None, f"Expected None after start token completed, got {result2}"
+
+
+def test_extract_tool_calls_plain_text_before_tool_call():
+    """Test streaming with plain text before tool calls."""
+    parser = DeepseekV3_2ToolParser()
+
+    # Plain text before tool call
+    previous_texts = [""]
+    delta = "这是普通文本"
+    current_text = delta
+    result = parser.extract_tool_calls_streaming(previous_texts, current_text, delta)
+
+    assert result == ("这是普通文本", None, None), f"Expected plain text passthrough, got {result}"

--- a/xinference/model/llm/utils.py
+++ b/xinference/model/llm/utils.py
@@ -96,7 +96,12 @@ LLAMA3_TOOL_CALL_FAMILY = [
     "HuatuoGPT-o1-LLaMA-3.1",
 ]
 
-DEEPSEEK_TOOL_CALL_FAMILY = ["deepseek-v3", "deepseek-r1-0528", "Deepseek-V3.1"]
+DEEPSEEK_TOOL_CALL_FAMILY = [
+    "deepseek-v3",
+    "deepseek-r1-0528",
+    "Deepseek-V3.1",
+    "DeepSeek-V3.2",
+]
 
 TOOL_CALL_FAMILY = (
     QWEN_TOOL_CALL_FAMILY

--- a/xinference/model/llm/vllm/core.py
+++ b/xinference/model/llm/vllm/core.py
@@ -1686,7 +1686,7 @@ class VLLMChatModel(VLLMModel, ChatModelMixin):
                     lora_request = lora
                     break
         tokenizer = await self._get_tokenizer(lora_request)
-
+        logger.debug("tokenizer class: %s", type(tokenizer).__name__)
         full_prompt = self.get_full_context(
             messages,
             self.model_family.chat_template,

--- a/xinference/model/llm/vllm/core.py
+++ b/xinference/model/llm/vllm/core.py
@@ -831,7 +831,11 @@ class VLLMModel(LLM):
         if model_config is None:
             model_config = VLLMModelConfig()
 
-        model_config.setdefault("tokenizer_mode", "auto")
+        architectures = getattr(self.model_family, "architectures", []) or []
+        if "DeepseekV32ForCausalLM" in architectures:
+            model_config.setdefault("tokenizer_mode", "deepseek_v32")
+        else:
+            model_config.setdefault("tokenizer_mode", "auto")
         model_config.setdefault("trust_remote_code", True)
         model_config.setdefault("tensor_parallel_size", self._device_count)  # type: ignore
         model_config.setdefault("pipeline_parallel_size", self._n_worker)  # type: ignore
@@ -1657,7 +1661,7 @@ class VLLMChatModel(VLLMModel, ChatModelMixin):
         # Preprocess messages to ensure content is not None
         messages = self.prefill_messages(messages)
 
-        tools = generate_config.pop("tools", []) if generate_config else None
+        tools = list(generate_config.pop("tools", [])) if generate_config else None
         model_family = self.model_family.model_family or self.model_family.model_name
         chat_template_kwargs = (
             self._get_chat_template_kwargs_from_generate_config(
@@ -1934,7 +1938,7 @@ class VLLMMultiModel(VLLMModel, ChatModelMixin):
         generate_config: Optional[Dict] = None,
         request_id: Optional[str] = None,
     ) -> Union[ChatCompletion, AsyncGenerator[ChatCompletionChunk, None]]:
-        tools = generate_config.pop("tools", []) if generate_config else None
+        tools = list(generate_config.pop("tools", [])) if generate_config else None
 
         model_family = self.model_family.model_family or self.model_family.model_name
         audios, images, videos, video_kwargs = None, None, None, None


### PR DESCRIPTION
Support parsing tool calls in the DSML format used by DeepSeek V3.2 models, including both complete and streaming output extraction.