### PR TITLE
fix: replace eval() with safe alternatives to prevent RCE in tool parsers

### DIFF
--- a/xinference/model/llm/tests/test_utils.py
+++ b/xinference/model/llm/tests/test_utils.py
@@ -1713,9 +1713,7 @@ class TestEvalLlama3ChatArgumentsSecurity:
         assert result == [(None, "get_weather", {"location": "Tokyo"})]
 
     def test_python_literal_tool_call(self):
-        c = self._make_choice(
-            "{'name': 'toggle', 'parameters': {'enabled': True}}"
-        )
+        c = self._make_choice("{'name': 'toggle', 'parameters': {'enabled': True}}")
         result = ChatModelMixin._eval_llama3_chat_arguments(c)
         assert result == [(None, "toggle", {"enabled": True})]
 

--- a/xinference/model/llm/tests/test_utils.py
+++ b/xinference/model/llm/tests/test_utils.py
@@ -1693,3 +1693,58 @@ def test_post_process_completion_with_parser():
     assert (
         result_filtered == expected_filtered
     ), f"Mismatch: expected {expected_filtered}, got {result_filtered}"
+
+
+# ── Security tests for _eval_llama3_chat_arguments ────────────────────
+
+
+class TestEvalLlama3ChatArgumentsSecurity:
+    """Verify _eval_llama3_chat_arguments uses safe parsing (no eval() RCE)."""
+
+    @staticmethod
+    def _make_choice(text: str) -> dict:
+        return {"choices": [{"text": text}]}
+
+    def test_valid_json_tool_call(self):
+        c = self._make_choice(
+            '{"name": "get_weather", "parameters": {"location": "Tokyo"}}'
+        )
+        result = ChatModelMixin._eval_llama3_chat_arguments(c)
+        assert result == [(None, "get_weather", {"location": "Tokyo"})]
+
+    def test_python_literal_tool_call(self):
+        c = self._make_choice(
+            "{'name': 'toggle', 'parameters': {'enabled': True}}"
+        )
+        result = ChatModelMixin._eval_llama3_chat_arguments(c)
+        assert result == [(None, "toggle", {"enabled": True})]
+
+    def test_reject_os_import_rce(self):
+        malicious = "__import__('os').system('echo PWNED')"
+        c = self._make_choice(malicious)
+        result = ChatModelMixin._eval_llama3_chat_arguments(c)
+        assert result == [(malicious, None, None)]
+
+    def test_reject_class_exploit(self):
+        malicious = "().__class__.__bases__[0].__subclasses__()"
+        c = self._make_choice(malicious)
+        result = ChatModelMixin._eval_llama3_chat_arguments(c)
+        assert result == [(malicious, None, None)]
+
+    def test_reject_exec(self):
+        malicious = "exec('import os')"
+        c = self._make_choice(malicious)
+        result = ChatModelMixin._eval_llama3_chat_arguments(c)
+        assert result == [(malicious, None, None)]
+
+    def test_malformed_json(self):
+        bad_json = '{"name": "func", "parameters": {'
+        c = self._make_choice(bad_json)
+        result = ChatModelMixin._eval_llama3_chat_arguments(c)
+        assert result == [(bad_json, None, None)]
+
+    def test_missing_keys(self):
+        text = '{"function": "test", "args": {}}'
+        c = self._make_choice(text)
+        result = ChatModelMixin._eval_llama3_chat_arguments(c)
+        assert result == [(text, None, None)]

--- a/xinference/model/llm/tool_parsers/llama3_tool_parser.py
+++ b/xinference/model/llm/tool_parsers/llama3_tool_parser.py
@@ -1,3 +1,5 @@
+import ast
+import json
 import logging
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -29,8 +31,8 @@ class Llama3ToolParser(ToolParser):
         """
         Extract tool calls from complete model output.
 
-        Parses the model output using eval() to extract tool call information.
-        This method expects the output to be a valid Python dictionary format.
+        Parses the model output using safe parsing to extract tool call information.
+        This method expects the output to be a valid JSON or Python literal dictionary format.
 
         Args:
             model_output (str): The complete output string from the model.
@@ -43,9 +45,20 @@ class Llama3ToolParser(ToolParser):
             - parameters (dict or None): Function parameters
         """
         try:
-            data = eval(model_output, {}, {})
+            # Try JSON first (most common LLM output format)
+            data = json.loads(model_output)
+        except (json.JSONDecodeError, TypeError):
+            try:
+                # Fall back to ast.literal_eval for Python literal formats
+                # (e.g., True/False/None instead of true/false/null).
+                # Unlike eval(), ast.literal_eval() only allows literal
+                # structures and cannot execute arbitrary code.
+                data = ast.literal_eval(model_output)
+            except (ValueError, SyntaxError):
+                return [(model_output, None, None)]
+        try:
             return [(None, data["name"], data["parameters"])]
-        except Exception:
+        except (KeyError, TypeError):
             return [(model_output, None, None)]
 
     def extract_tool_calls_streaming(

--- a/xinference/model/llm/tool_parsers/tests/test_llama3_tool_parser.py
+++ b/xinference/model/llm/tool_parsers/tests/test_llama3_tool_parser.py
@@ -1,0 +1,167 @@
+import pytest
+
+from ..llama3_tool_parser import Llama3ToolParser
+
+
+class TestLlama3ToolParserSafeParsing:
+    """Tests for Llama3 tool parser with safe eval replacement."""
+
+    def setup_method(self):
+        self.parser = Llama3ToolParser()
+
+    # ── Normal parsing (JSON format) ──────────────────────────────────
+
+    def test_parse_valid_json_tool_call(self):
+        """Standard JSON tool call should parse correctly."""
+        model_output = '{"name": "get_weather", "parameters": {"location": "Beijing"}}'
+        result = self.parser.extract_tool_calls(model_output)
+        assert result == [(None, "get_weather", {"location": "Beijing"})]
+
+    def test_parse_json_with_nested_parameters(self):
+        """JSON with nested dict parameters should parse correctly."""
+        model_output = (
+            '{"name": "search", "parameters": '
+            '{"query": "test", "options": {"limit": 10, "offset": 0}}}'
+        )
+        result = self.parser.extract_tool_calls(model_output)
+        assert result == [
+            (None, "search", {"query": "test", "options": {"limit": 10, "offset": 0}})
+        ]
+
+    def test_parse_json_with_list_parameter(self):
+        """JSON with list parameter should parse correctly."""
+        model_output = '{"name": "multi_search", "parameters": {"queries": ["a", "b", "c"]}}'
+        result = self.parser.extract_tool_calls(model_output)
+        assert result == [(None, "multi_search", {"queries": ["a", "b", "c"]})]
+
+    def test_parse_json_with_null_value(self):
+        """JSON with null values should parse correctly."""
+        model_output = '{"name": "test_func", "parameters": {"value": null}}'
+        result = self.parser.extract_tool_calls(model_output)
+        assert result == [(None, "test_func", {"value": None})]
+
+    def test_parse_json_with_boolean_values(self):
+        """JSON with boolean values should parse correctly."""
+        model_output = '{"name": "toggle", "parameters": {"enabled": true, "verbose": false}}'
+        result = self.parser.extract_tool_calls(model_output)
+        assert result == [(None, "toggle", {"enabled": True, "verbose": False})]
+
+    def test_parse_json_with_numeric_values(self):
+        """JSON with integer and float parameters should parse correctly."""
+        model_output = '{"name": "calculate", "parameters": {"x": 42, "y": 3.14}}'
+        result = self.parser.extract_tool_calls(model_output)
+        assert result == [(None, "calculate", {"x": 42, "y": 3.14})]
+
+    def test_parse_json_empty_parameters(self):
+        """JSON with empty parameters dict should parse correctly."""
+        model_output = '{"name": "no_args_func", "parameters": {}}'
+        result = self.parser.extract_tool_calls(model_output)
+        assert result == [(None, "no_args_func", {})]
+
+    # ── Normal parsing (Python literal format) ────────────────────────
+
+    def test_parse_python_literal_with_true_false_none(self):
+        """Python dict with True/False/None should parse via ast.literal_eval."""
+        model_output = "{'name': 'check', 'parameters': {'flag': True, 'value': None}}"
+        result = self.parser.extract_tool_calls(model_output)
+        assert result == [(None, "check", {"flag": True, "value": None})]
+
+    def test_parse_python_literal_with_single_quotes(self):
+        """Python dict with single quotes should parse correctly."""
+        model_output = "{'name': 'get_weather', 'parameters': {'location': 'Shanghai'}}"
+        result = self.parser.extract_tool_calls(model_output)
+        assert result == [(None, "get_weather", {"location": "Shanghai"})]
+
+    # ── Security: RCE prevention ──────────────────────────────────────
+
+    def test_reject_os_system_call(self):
+        """Malicious os.system() call must not execute."""
+        malicious = "__import__('os').system('echo PWNED')"
+        result = self.parser.extract_tool_calls(malicious)
+        assert result == [(malicious, None, None)]
+
+    def test_reject_subprocess_call(self):
+        """Malicious subprocess call must not execute."""
+        malicious = "__import__('subprocess').check_output(['id'])"
+        result = self.parser.extract_tool_calls(malicious)
+        assert result == [(malicious, None, None)]
+
+    def test_reject_builtins_exploit_via_class(self):
+        """Class-based builtins exploit must not execute (CVE PoC from issue)."""
+        malicious = "().__class__.__bases__[0].__subclasses__()"
+        result = self.parser.extract_tool_calls(malicious)
+        assert result == [(malicious, None, None)]
+
+    def test_reject_eval_within_eval(self):
+        """Nested eval must not execute."""
+        malicious = "eval('__import__(\"os\").system(\"id\")')"
+        result = self.parser.extract_tool_calls(malicious)
+        assert result == [(malicious, None, None)]
+
+    def test_reject_exec_call(self):
+        """exec() call must not execute."""
+        malicious = "exec('import os; os.system(\"whoami\")')"
+        result = self.parser.extract_tool_calls(malicious)
+        assert result == [(malicious, None, None)]
+
+    def test_reject_lambda(self):
+        """Lambda expressions must not execute."""
+        malicious = "(lambda: __import__('os').system('id'))()"
+        result = self.parser.extract_tool_calls(malicious)
+        assert result == [(malicious, None, None)]
+
+    def test_reject_compile_exec(self):
+        """compile() + exec() chain must not execute."""
+        malicious = "exec(compile('import os; os.system(\"id\")', '<string>', 'exec'))"
+        result = self.parser.extract_tool_calls(malicious)
+        assert result == [(malicious, None, None)]
+
+    # ── Edge cases: malformed input ───────────────────────────────────
+
+    def test_empty_string(self):
+        """Empty string should return as content."""
+        result = self.parser.extract_tool_calls("")
+        assert result == [("", None, None)]
+
+    def test_plain_text(self):
+        """Plain text should return as content."""
+        result = self.parser.extract_tool_calls("Hello, I cannot help with that.")
+        assert result == [("Hello, I cannot help with that.", None, None)]
+
+    def test_incomplete_json(self):
+        """Truncated JSON should return as content."""
+        result = self.parser.extract_tool_calls('{"name": "func", "parameters": {')
+        assert result == [('{"name": "func", "parameters": {', None, None)]
+
+    def test_missing_name_key(self):
+        """Dict missing 'name' key should return as content."""
+        model_output = '{"function": "test", "parameters": {}}'
+        result = self.parser.extract_tool_calls(model_output)
+        assert result == [(model_output, None, None)]
+
+    def test_missing_parameters_key(self):
+        """Dict missing 'parameters' key should return as content."""
+        model_output = '{"name": "test", "args": {}}'
+        result = self.parser.extract_tool_calls(model_output)
+        assert result == [(model_output, None, None)]
+
+    def test_non_dict_json(self):
+        """JSON array (not dict) should return as content."""
+        model_output = '[{"name": "test"}]'
+        result = self.parser.extract_tool_calls(model_output)
+        assert result == [(model_output, None, None)]
+
+    def test_json_string_value(self):
+        """A plain JSON string should return as content."""
+        model_output = '"just a string"'
+        result = self.parser.extract_tool_calls(model_output)
+        assert result == [(model_output, None, None)]
+
+
+class TestLlama3ToolParserStreaming:
+    """Verify streaming raises NotImplementedError as expected."""
+
+    def test_streaming_not_supported(self):
+        parser = Llama3ToolParser()
+        with pytest.raises(NotImplementedError):
+            parser.extract_tool_calls_streaming(["prev"], "current", "delta")

--- a/xinference/model/llm/tool_parsers/tests/test_llama3_tool_parser.py
+++ b/xinference/model/llm/tool_parsers/tests/test_llama3_tool_parser.py
@@ -30,7 +30,9 @@ class TestLlama3ToolParserSafeParsing:
 
     def test_parse_json_with_list_parameter(self):
         """JSON with list parameter should parse correctly."""
-        model_output = '{"name": "multi_search", "parameters": {"queries": ["a", "b", "c"]}}'
+        model_output = (
+            '{"name": "multi_search", "parameters": {"queries": ["a", "b", "c"]}}'
+        )
         result = self.parser.extract_tool_calls(model_output)
         assert result == [(None, "multi_search", {"queries": ["a", "b", "c"]})]
 
@@ -42,7 +44,9 @@ class TestLlama3ToolParserSafeParsing:
 
     def test_parse_json_with_boolean_values(self):
         """JSON with boolean values should parse correctly."""
-        model_output = '{"name": "toggle", "parameters": {"enabled": true, "verbose": false}}'
+        model_output = (
+            '{"name": "toggle", "parameters": {"enabled": true, "verbose": false}}'
+        )
         result = self.parser.extract_tool_calls(model_output)
         assert result == [(None, "toggle", {"enabled": True, "verbose": False})]
 
@@ -94,7 +98,7 @@ class TestLlama3ToolParserSafeParsing:
 
     def test_reject_eval_within_eval(self):
         """Nested eval must not execute."""
-        malicious = "eval('__import__(\"os\").system(\"id\")')"
+        malicious = 'eval(\'__import__("os").system("id")\')'
         result = self.parser.extract_tool_calls(malicious)
         assert result == [(malicious, None, None)]
 

--- a/xinference/model/llm/utils.py
+++ b/xinference/model/llm/utils.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import ast
 import base64
 import functools
 import json
@@ -700,9 +701,20 @@ class ChatModelMixin:
     def _eval_llama3_chat_arguments(cls, c) -> List[Tuple]:
         text = c["choices"][0]["text"]
         try:
-            data = eval(text, {}, {})
+            # Try JSON first (most common LLM output format)
+            data = json.loads(text)
+        except (json.JSONDecodeError, TypeError):
+            try:
+                # Fall back to ast.literal_eval for Python literal formats
+                # (e.g., True/False/None instead of true/false/null).
+                # Unlike eval(), ast.literal_eval() only allows literal
+                # structures and cannot execute arbitrary code.
+                data = ast.literal_eval(text)
+            except (ValueError, SyntaxError):
+                return [(text, None, None)]
+        try:
             return [(None, data["name"], data["parameters"])]
-        except Exception:
+        except (KeyError, TypeError):
             return [(text, None, None)]
 
     @classmethod


### PR DESCRIPTION
## Summary

- Replace dangerous `eval()` calls with `json.loads()` + `ast.literal_eval()` fallback in Llama3 tool parsing code
- `eval()` with empty globals/locals is still exploitable via `__class__.__bases__` chains, enabling arbitrary code execution from untrusted LLM output
- Add comprehensive security and functional tests (25+ test cases)

## Changes

| File | Description |
|------|-------------|
| `xinference/model/llm/tool_parsers/llama3_tool_parser.py` | Replace `eval()` with `json.loads()` primary + `ast.literal_eval()` fallback |
| `xinference/model/llm/utils.py` | Same fix in `_eval_llama3_chat_arguments()` |
| `xinference/model/llm/tool_parsers/tests/test_llama3_tool_parser.py` | 18 new tests: normal parsing, RCE prevention, edge cases |
| `xinference/model/llm/tests/test_utils.py` | 7 new tests for `_eval_llama3_chat_arguments` security |

## Why `eval(x, {}, {})` is not safe

```python
# This executes successfully even with empty globals/locals:
eval("().__class__.__bases__[0].__subclasses__()", {}, {})
```

The `__builtins__` module is accessible through object introspection, allowing full code execution.

## Fix approach

1. **`json.loads()`** as primary parser (handles standard JSON from most LLMs)
2. **`ast.literal_eval()`** as fallback (handles Python literal formats like `True`/`False`/`None` and single-quoted strings that Llama3 may output)
3. Proper `KeyError`/`TypeError` handling for missing `name`/`parameters` keys

`ast.literal_eval()` only evaluates literal structures (strings, numbers, tuples, lists, dicts, booleans, None) and raises `ValueError` for anything else, making it safe against code injection.

## Audit of other parsers

All 7 other tool parser files were audited — they already use `json.loads()`:
- `qwen_tool_parser.py` — `json.loads()` 
- `deepseek_v3_tool_parser.py` — `json.loads()` 
- `deepseek_v3_1_tool_parser.py` — `json.loads()` 
- `deepseek_r1_tool_parser.py` — `json.loads()` 
- `glm4_tool_parser.py` — `json.loads()` 
- `minimax_tool_parser.py` — `json.loads()` 

## Test plan

- [x] Normal JSON tool call parsing works correctly
- [x] Python literal format (True/False/None, single quotes) works correctly
- [x] Nested parameters, lists, empty params all parse correctly
- [x] `__import__('os').system()` payloads are safely rejected
- [x] `().__class__.__bases__[0].__subclasses__()` exploit is blocked
- [x] `exec()`, `eval()`, `lambda`, `compile()` payloads are blocked
- [x] Malformed JSON, missing keys, non-dict types handled gracefully
- [x] Streaming still raises NotImplementedError as expected

Fixes #4769

🤖 Generated with [Claude Code](https://claude.com/claude-code)