### PR TITLE
fix(ui): handle mixed dict and ChatMessage types in history

### DIFF
--- a/xinference/api/restful_api.py
+++ b/xinference/api/restful_api.py
@@ -933,7 +933,7 @@ class RESTfulAPI(CancelMixin):
 
         # Handle tools parameter
         if hasattr(body, "tools") and body.tools:
-            kwargs["tools"] = body.tools
+            kwargs["tools"] = list(body.tools)
 
         # Handle tool_choice parameter
         if hasattr(body, "tool_choice") and body.tool_choice:

--- a/xinference/model/llm/llama_cpp/core.py
+++ b/xinference/model/llm/llama_cpp/core.py
@@ -347,7 +347,7 @@ class XllamaCppModel(LLM, ChatModelMixin):
         )
         chat_context_var.set(chat_template_kwargs)
 
-        tools = generate_config.pop("tools", []) if generate_config else None
+        tools = list(generate_config.pop("tools", [])) if generate_config else []
         q: queue.Queue = queue.Queue()
 
         def _handle_chat_completion():

--- a/xinference/ui/gradio/chat_interface.py
+++ b/xinference/ui/gradio/chat_interface.py
@@ -169,8 +169,17 @@ class GradioInterface:
                         metadata=message_metadata,
                     )
 
-                    if history and history[-1]["role"] == "assistant":
-                        history[-1] = current_message
+                    if history:
+                        last_msg = history[-1]
+                        last_role = (
+                            last_msg.get("role")
+                            if isinstance(last_msg, dict)
+                            else last_msg.role
+                        )
+                        if last_role == "assistant":
+                            history[-1] = current_message
+                        else:
+                            history.append(current_message)
                     else:
                         history.append(current_message)
 


### PR DESCRIPTION
Fix TypeError/AttributeError when history contains both dict and ChatMessage objects. Add type checking to safely access role attribute from either format.