### PR TITLE
fix(docker): unpin torchcodec to fix 503 error on reranker/embedding model load

### DIFF
--- a/xinference/deploy/docker/Dockerfile
+++ b/xinference/deploy/docker/Dockerfile
@@ -79,7 +79,7 @@ RUN /opt/conda/bin/conda create -n ffmpeg-env -c conda-forge 'ffmpeg<7' -y && \
 RUN pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu128 \
     --no-deps && \
     pip install triton==3.4.0 && \
-    pip install torchcodec==0.9.0 && \
+    pip install torchcodec && \
     pip cache purge
 
 # Override the default entrypoint of the vllm base image

--- a/xinference/deploy/docker/Dockerfile
+++ b/xinference/deploy/docker/Dockerfile
@@ -79,7 +79,7 @@ RUN /opt/conda/bin/conda create -n ffmpeg-env -c conda-forge 'ffmpeg<7' -y && \
 RUN pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu128 \
     --no-deps && \
     pip install triton==3.4.0 && \
-    pip install torchcodec && \
+    pip install torchcodec==0.10.0 && \
     pip cache purge
 
 # Override the default entrypoint of the vllm base image

--- a/xinference/deploy/docker/Dockerfile.aarch64
+++ b/xinference/deploy/docker/Dockerfile.aarch64
@@ -38,7 +38,7 @@ RUN apt-get update -y && \
 RUN pip3 install --pre torch torchvision torchaudio --index-url https://download.pytorch.org/whl/nightly/cu128 \
     --no-deps && \
     pip install triton && \
-    pip install torchcodec && \
+    pip install torchcodec==0.10.0 && \
     pip install "numpy==2.2.6" && \
     pip cache purge
 


### PR DESCRIPTION
## Summary

  - Remove the hardcoded `torchcodec==0.9.0` version pin in Dockerfile so pip auto-resolves the version compatible with the installed torch release.

## Problem

When launching `bge-reranker-v2-m3` or `bge-m3`, xinference returns:

Server error: 503 - [address=0.0.0.0:40335, pid=696] Could not load libtorchcodec.
Likely causes: 1. FFmpeg is not properly installed in your environment. ...
2. The PyTorch version (2.10.0+cu129) is not compatible with this version of TorchCodec.

**Root cause:** `sentence-transformers` 5.x hard-imports `torchcodec` at module level (`modality_types.py`). The Dockerfile installs `torch` from the nightly channel (currently 2.10.0), but pins `torchcodec==0.9.0`, which is only compatible with `torch 2.9` per the [official compatibility
table](https://github.com/pytorch/torchcodec?tab=readme-ov-file#installing-torchcodec):

| torchcodec | torch |
|------------|-------|
| 0.10       | 2.10  |
| 0.9        | 2.9   |

This ABI mismatch causes `torchcodec` to fail with `undefined symbol: c10::MessageLogger`, which bubbles up as the misleading FFmpeg error.

## Why not pin the version

The original intent of pinning `torchcodec==0.9.0` was to ensure reproducibility, which is a valid concern. However, the Dockerfile already installs `torch` from the **nightly channel** (`--pre` + `--index-url https://download.pytorch.org/whl/nightly/cu128`), which means the torch version is inherently unpinned
and will change over time. Hardcoding `torchcodec` to a specific version while `torch` floats freely guarantees this breakage will recur every time torch releases a new major version.

Since `torchcodec` has a strict 1:1 version mapping with `torch`, the correct approach is to let pip resolve the compatible `torchcodec` version automatically based on the installed `torch` version.

## Test plan

- [x] Build the Docker image and verify `import sentence_transformers` succeeds
- [x] Launch `bge-reranker-v2-m3` / `bge-m3` and confirm the model starts without 503 error