### PR TITLE
fix(vllm): use VLLM_HOST_IP for distributed_init_method in multi-machine setup

### DIFF
--- a/xinference/model/llm/vllm/distributed_executor.py
+++ b/xinference/model/llm/vllm/distributed_executor.py
@@ -188,8 +188,14 @@ class XinferenceDistributedExecutor(DistributedExecutorBase):
         )
 
         all_kwargs = []
+        # Use VLLM_HOST_IP if set (required for multi-machine deployments where
+        # pool addresses may resolve to 127.0.0.1 instead of the actual machine IP).
+        # Fall back to extracting IP from pool address for single-machine setups.
+        driver_ip = os.environ.get(
+            "VLLM_HOST_IP"
+        ) or self._pool_addresses[0].split(":", 1)[0]
         distributed_init_method = get_distributed_init_method(
-            self._pool_addresses[0].split(":", 1)[0], get_next_port()
+            driver_ip, get_next_port()
         )
         for rank in range(world_size):
             local_rank = rank % (world_size // self._n_worker)

--- a/xinference/model/llm/vllm/distributed_executor_v1.py
+++ b/xinference/model/llm/vllm/distributed_executor_v1.py
@@ -197,8 +197,14 @@ class XinferenceDistributedExecutorV1(Executor):
         )
 
         all_kwargs = []
+        # Use VLLM_HOST_IP if set (required for multi-machine deployments where
+        # pool addresses may resolve to 127.0.0.1 instead of the actual machine IP).
+        # Fall back to extracting IP from pool address for single-machine setups.
+        driver_ip = os.environ.get(
+            "VLLM_HOST_IP"
+        ) or self._pool_addresses[0].split(":", 1)[0]
         distributed_init_method = get_distributed_init_method(
-            self._pool_addresses[0].split(":", 1)[0], get_next_port()
+            driver_ip, get_next_port()
         )
         for rank in range(world_size):
             local_rank = rank % (world_size // self._n_worker)


### PR DESCRIPTION
Fixes #4810

## Problem

In multi-machine vLLM deployments, `distributed_init_method` was constructed by extracting the IP from `pool_addresses[0]`. Xoscar sub-pool processes can bind to `127.0.0.1` (localhost) even when the main worker pool is configured with a real network IP (via `-H`). This caused `distributed_init_method` to be set to `tcp://127.0.0.1:<port>`, which is unreachable from other machines, causing model loading to fail in multi-machine setups.

## Solution

Check the `VLLM_HOST_IP` environment variable first (the standard way to configure vLLM's distributed communication IP in multi-machine deployments). If not set, fall back to extracting the IP from the pool address (preserving existing behavior for single-machine setups).

The fix is applied to both the v0 (`XinferenceDistributedExecutor`) and v1 (`XinferenceDistributedExecutorV1`) executor implementations.

## Testing

The fix is logically straightforward: `os.environ.get("VLLM_HOST_IP")` returns the configured IP when set, or `None` when not set (which triggers the fallback). No GPU environment is required to verify the logic.

Users affected by this issue typically set `VLLM_HOST_IP` in their deployment (as shown in the issue's Docker setup), which will now be correctly used for `distributed_init_method`.