### PR TITLE
fix: dynamic CUDA version check for extra_index_url

### DIFF
--- a/xinference/core/virtual_env_manager.py
+++ b/xinference/core/virtual_env_manager.py
@@ -14,9 +14,10 @@
 
 import logging
 import os
+import re
 import shutil
 import subprocess
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from ..constants import XINFERENCE_VIRTUAL_ENV_DIR
 
@@ -87,6 +88,45 @@ PYTORCH_CUDA_WHEEL_URLS: Dict[str, str] = {
 
 # Packages that use PyTorch CUDA wheels
 PYTORCH_PACKAGES = {"torch", "torchaudio", "torchvision", "torchcodec"}
+
+
+def extract_cuda_version_from_url(url: str) -> Optional[str]:
+    """Extract CUDA version suffix (e.g. 'cu130') from a wheel index URL."""
+    if not url:
+        return None
+
+    # Handles both:
+    #   - https://download.pytorch.org/whl/cu130
+    #   - https://wheels.vllm.ai/0.19.0/cu130
+    match = re.search(r"/(cu\d+)/?", url)
+    return match.group(1) if match else None
+
+
+def is_cuda_compatible(
+    extra_index_url: Optional[Union[str, List[str]]],
+    system_cuda_version: Optional[str],
+) -> bool:
+    """
+    Check whether all CUDA-indexed URLs in extra_index_url are compatible with
+    the system CUDA version.
+
+    Returns True if there is no mismatch. If any URL has a known CUDA version that
+    differs from the system, returns False. If the system version cannot be
+    detected, returns False to be safe.
+    """
+    if not extra_index_url:
+        return True
+    if not system_cuda_version:
+        return False
+
+    urls = extra_index_url if isinstance(extra_index_url, list) else [extra_index_url]
+    system_cuda_suffix = f"cu{system_cuda_version.replace('.', '')}"
+
+    for url in urls:
+        url_cuda_suffix = extract_cuda_version_from_url(url)
+        if url_cuda_suffix and url_cuda_suffix != system_cuda_suffix:
+            return False
+    return True
 
 
 def get_engine_virtualenv_packages(model_engine: Optional[str]) -> List[str]:

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -88,6 +88,7 @@ from .utils import (
 from .virtual_env_manager import VirtualEnvManager as XinferenceVirtualEnvManager
 from .virtual_env_manager import (
     expand_engine_dependency_placeholders,
+    is_cuda_compatible,
     resolve_virtualenv_python_path,
 )
 
@@ -1553,9 +1554,9 @@ class WorkerActor(xo.StatelessActor):
         except Exception:
             cuda_version = None
 
-        if not cuda_version or Version(cuda_version) < Version("13.0"):
+        if not is_cuda_compatible(settings.extra_index_url, cuda_version):
             logger.debug(
-                f"[DEBUG] CUDA version check: cuda_version={cuda_version}, clearing extra_index_url and index_strategy"
+                f"[DEBUG] CUDA version mismatch: cuda_version={cuda_version}, extra_index_url={settings.extra_index_url}, clearing extra_index_url and index_strategy"
             )
             settings.extra_index_url = None
             settings.index_strategy = None

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -42,7 +42,6 @@ from typing import (
 
 import xoscar as xo
 from async_timeout import timeout
-from packaging.version import Version
 from xoscar import MainActorPoolType
 
 from ..client.restful.restful_client import Client as RESTfulClient


### PR DESCRIPTION
Fixes #4805
虚拟环境管理中，显示约束 if not cuda_version or Version(cuda_version) < Version("13.0")，会导致cuda版本低于13.0的环境报错，根据代码逻辑该处目的是校验环境cuda 与extra_index_url（ENGINE_VIRTUALENV_EXTRA_INDEX_URLS中的链接都是cu130系列，[代码链接](https://github.com/xorbitsai/inference/blob/96ae6b7e9e1a91b62e37a392bb72c9a3b2f2a0c1/xinference/core/virtual_env_manager.py#L65)） 中的cuda版本是否满足，但是PYTORCH_CUDA_WHEEL_URLS以及docker对应的cuda版本有低于13.0的cuda12.8,12.9系列。
因此调整为根据extra_index_url推测出cuda版本，校验是否符合当前环境cuda版本，不符合才取消extra_index_url的引入。