### PR TITLE
fix: handle missing 'cpu' key in get_cluster_device_info to prevent KeyError 500

### DIFF
--- a/xinference/core/supervisor.py
+++ b/xinference/core/supervisor.py
@@ -734,12 +734,32 @@ class SupervisorActor(xo.StatelessActor):
                 "gpu_vram_total": total,
             }
             if detailed:
-                cpu_info = worker_status.status["cpu"]
-                info["cpu_available"] = cpu_info.total * (1 - cpu_info.usage)
-                info["cpu_count"] = cpu_info.total
-                info["mem_used"] = cpu_info.memory_used
-                info["mem_available"] = cpu_info.memory_available
-                info["mem_total"] = cpu_info.memory_total
+                cpu_raw = worker_status.status.get("cpu")
+                if isinstance(cpu_raw, ResourceStatus):
+                    info["cpu_available"] = cpu_raw.total * (1 - cpu_raw.usage)
+                    info["cpu_count"] = cpu_raw.total
+                    info["mem_used"] = cpu_raw.memory_used
+                    info["mem_available"] = cpu_raw.memory_available
+                    info["mem_total"] = cpu_raw.memory_total
+                else:
+                    if cpu_raw is not None:
+                        logger.warning(
+                            "Worker %s status['cpu'] has unexpected type %s; "
+                            "omitting cpu/mem fields in cluster device info",
+                            worker_addr,
+                            type(cpu_raw).__name__,
+                        )
+                    else:
+                        logger.debug(
+                            "Worker %s status missing 'cpu' key; "
+                            "omitting cpu/mem fields in cluster device info",
+                            worker_addr,
+                        )
+                    info["cpu_available"] = None
+                    info["cpu_count"] = None
+                    info["mem_used"] = None
+                    info["mem_available"] = None
+                    info["mem_total"] = None
                 info["gpu_vram_total"] = vram_total
                 info["gpu_utilization"] = _get_average_gpu_utilization(
                     worker_status.status

--- a/xinference/core/tests/test_cluster_metrics.py
+++ b/xinference/core/tests/test_cluster_metrics.py
@@ -40,6 +40,23 @@ def _build_worker_status(*, gpu_utils=None):
     return status
 
 
+def _build_worker_status_without_cpu(*, gpu_utils=None):
+    if gpu_utils is None:
+        gpu_utils = []
+
+    status: Dict[str, Union[ResourceStatus, GPUStatus]] = {}
+    for idx, gpu_util in enumerate(gpu_utils):
+        status[f"gpu-{idx}"] = GPUStatus(
+            name=f"GPU-{idx}",
+            mem_total=1000,
+            mem_free=400,
+            mem_used=600,
+            mem_usage=0.6,
+            gpu_util=gpu_util,
+        )
+    return status
+
+
 def test_cluster_metrics_collector_normalizes_gpu_utilization():
     collector = ClusterMetricsCollector()
     collector.update("worker-1", _build_worker_status(gpu_utils=[75]))
@@ -94,3 +111,82 @@ async def test_supervisor_cluster_device_info_includes_gpu_utilization_average()
     assert worker_without_gpu["gpu_count"] == 0
     assert worker_without_gpu["gpu_utilization"] is None
     assert supervisor_info["gpu_utilization"] is None
+
+
+@pytest.mark.asyncio
+async def test_supervisor_cluster_device_info_missing_cpu_key_with_gpus():
+    supervisor = DummySupervisor(
+        "127.0.0.1:9999",
+        {
+            "worker-no-cpu": WorkerStatus(
+                update_time=0,
+                failure_remaining_count=3,
+                status=_build_worker_status_without_cpu(gpu_utils=[40, 60]),
+            ),
+        },
+    )
+
+    result = await supervisor.get_cluster_device_info(detailed=True)
+
+    w = next(item for item in result if item["ip_address"] == "worker-no-cpu")
+    assert w["gpu_count"] == 2
+    assert w["gpu_utilization"] == 50.0
+    assert w["cpu_available"] is None
+    assert w["cpu_count"] is None
+    assert w["mem_used"] is None
+    assert w["mem_available"] is None
+    assert w["mem_total"] is None
+
+
+@pytest.mark.asyncio
+async def test_supervisor_cluster_device_info_missing_cpu_key_empty_status():
+    supervisor = DummySupervisor(
+        "127.0.0.1:9999",
+        {
+            "worker-empty": WorkerStatus(
+                update_time=0,
+                failure_remaining_count=3,
+                status={},
+            ),
+        },
+    )
+
+    result = await supervisor.get_cluster_device_info(detailed=True)
+
+    w = next(item for item in result if item["ip_address"] == "worker-empty")
+    assert w["gpu_count"] == 0
+    assert w["gpu_utilization"] is None
+    assert w["cpu_available"] is None
+    assert w["cpu_count"] is None
+    assert w["mem_used"] is None
+    assert w["mem_available"] is None
+    assert w["mem_total"] is None
+
+
+@pytest.mark.asyncio
+async def test_supervisor_cluster_device_info_mixed_with_and_without_cpu():
+    supervisor = DummySupervisor(
+        "127.0.0.1:9999",
+        {
+            "worker-normal": WorkerStatus(
+                update_time=0,
+                failure_remaining_count=3,
+                status=_build_worker_status(gpu_utils=[10]),
+            ),
+            "worker-no-cpu": WorkerStatus(
+                update_time=0,
+                failure_remaining_count=3,
+                status=_build_worker_status_without_cpu(gpu_utils=[20]),
+            ),
+        },
+    )
+
+    result = await supervisor.get_cluster_device_info(detailed=True)
+
+    normal = next(item for item in result if item["ip_address"] == "worker-normal")
+    assert normal["cpu_count"] == 32
+    assert normal["mem_total"] == 512
+
+    no_cpu = next(item for item in result if item["ip_address"] == "worker-no-cpu")
+    assert no_cpu["cpu_available"] is None
+    assert no_cpu["gpu_count"] == 1


### PR DESCRIPTION
## Summary                                                                                                         
                                                                                                                   
  - `get_cluster_device_info(detailed=True)` raises `KeyError: 'cpu'` when a worker's status dict is missing the
  `cpu` key (e.g. incomplete reporting, collection timeout), causing the management API to return 500
  - Replace `worker_status.status["cpu"]` with defensive `status.get("cpu")` + `isinstance(cpu_raw, ResourceStatus)`
  type check
  - When cpu info is missing or has unexpected type, set `cpu_available`, `cpu_count`, `mem_used`, `mem_available`,
  `mem_total` to `None` instead of crashing
  - Add `logger.debug` for missing key and `logger.warning` for unexpected type for observability

  ## Context

  The same method already handles GPU keys defensively with `if k != "cpu"`, but the `detailed=True` branch still
  hard-indexes `status["cpu"]`. This aligns the CPU branch with the existing defensive style.

  ## Test plan

  - [x] Added 3 unit tests in `xinference/core/tests/test_cluster_metrics.py`:
    - Worker missing `cpu` key but having GPUs — GPU fields computed correctly, CPU/mem fields are `None`
    - Worker with completely empty status dict
    - Mixed scenario: one normal worker + one worker missing `cpu` key coexist in the same result
  - [x] Existing `test_supervisor_cluster_device_info_includes_gpu_utilization_average` still passes (regression)    
  - [ ] `pytest xinference/core/tests/test_cluster_metrics.py -v`