### PR TITLE
fix: venv concurrent creation race, cold-start lock dir, and jina-embeddings-v4 torch mismatch

### DIFF
--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -110,6 +110,9 @@ def _exclusive_venv_path_lock(env_path: str):
     logical virtualenv path. Avoids TOCTOU races when multiple model replicas
     call ``create_env`` concurrently (see Xinference virtualenv v4 layout).
 
+    Ensures the lock file's parent directory exists before ``os.open`` so cold
+    starts work after the entire venv tree was removed.
+
     Uses a sibling lock file ``{realpath(env_path)}.xinference-venv.lock``.
     On Windows this is a no-op (``fcntl`` unavailable / different semantics).
     """
@@ -121,6 +124,9 @@ def _exclusive_venv_path_lock(env_path: str):
 
     real = os.path.realpath(os.path.normpath(env_path))
     lock_path = f"{real}.xinference-venv.lock"
+    lock_dir = os.path.dirname(lock_path)
+    if lock_dir:
+        os.makedirs(lock_dir, exist_ok=True)
     fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o644)
     try:
         fcntl.flock(fd, fcntl.LOCK_EX)

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -24,6 +24,7 @@ import sys
 import threading
 import time
 from collections import defaultdict
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from logging import getLogger
 from typing import (
@@ -100,6 +101,33 @@ if TYPE_CHECKING:
     from .progress_tracker import Progressor
 
 logger = getLogger(__name__)
+
+
+@contextmanager
+def _exclusive_venv_path_lock(env_path: str):
+    """
+    Serialize ``uv venv`` creation and subsequent .pth injection for the same
+    logical virtualenv path. Avoids TOCTOU races when multiple model replicas
+    call ``create_env`` concurrently (see Xinference virtualenv v4 layout).
+
+    Uses a sibling lock file ``{realpath(env_path)}.xinference-venv.lock``.
+    On Windows this is a no-op (``fcntl`` unavailable / different semantics).
+    """
+    if os.name == "nt":
+        yield
+        return
+
+    import fcntl
+
+    real = os.path.realpath(os.path.normpath(env_path))
+    lock_path = f"{real}.xinference-venv.lock"
+    fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o644)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        yield
+    finally:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
 
 
 MODEL_ACTOR_AUTO_RECOVER_LIMIT: Optional[int]
@@ -1382,76 +1410,81 @@ class WorkerActor(xo.StatelessActor):
 
         from xoscar.virtualenv import get_virtual_env_manager
 
-        virtual_env_manager: VirtualEnvManager = get_virtual_env_manager(
-            virtual_env_name or "uv", env_path
-        )
-        # create env
-        python_path = None
-        if not hasattr(sys, "_MEIPASS"):
-            # not in pyinstaller
-            # we specify python_path explicitly
-            # sometimes uv would find other versions.
-            python_path = pathlib.Path(sys.executable)
-        virtual_env_manager.create_env(python_path=python_path)
-
-        import site as _site
-        import sysconfig as _sysconfig
-
-        if not hasattr(sys, "_MEIPASS"):
-            # Normal execution (pip, venv, conda, source, Docker).
-            # Inject parent site-packages via .pth so xinference and xoscar are
-            # discoverable in the child venv while preserving child-venv isolation.
-            # .pth paths are appended AFTER child site-packages so child-installed
-            # packages always take precedence over parent ones.
-            parent_site_packages = _sysconfig.get_paths()["purelib"]
-
-            # Warn if xinference appears to be user-installed — child venvs
-            # cannot see user site-packages (~/.local/lib/...) by design.
-            user_site = (
-                _site.getusersitepackages()
-                if hasattr(_site, "getusersitepackages")
-                else None
+        with _exclusive_venv_path_lock(env_path):
+            virtual_env_manager: VirtualEnvManager = get_virtual_env_manager(
+                virtual_env_name or "uv", env_path
             )
-            if (
-                user_site
-                and not os.path.exists(os.path.join(parent_site_packages, "xinference"))
-                and os.path.exists(os.path.join(user_site, "xinference"))
-            ):
-                logger.warning(
-                    "xinference is installed in user site-packages (%s) which is "
-                    "not visible to child venvs. Re-install inside a virtual "
-                    "environment.",
-                    user_site,
-                )
+            # create env
+            python_path = None
+            if not hasattr(sys, "_MEIPASS"):
+                # not in pyinstaller
+                # we specify python_path explicitly
+                # sometimes uv would find other versions.
+                python_path = pathlib.Path(sys.executable)
+            virtual_env_manager.create_env(python_path=python_path)
 
-            if os.path.exists(parent_site_packages):
-                child_site_packages = pathlib.Path(virtual_env_manager.get_lib_path())
-                child_site_packages.mkdir(parents=True, exist_ok=True)
-                pth_file = child_site_packages / "_xinference_parent.pth"
-                pth_file.write_text(parent_site_packages + "\n")
-                logger.debug(
-                    "Injected parent site-packages into child venv via %s -> %s",
-                    pth_file,
-                    parent_site_packages,
+            import site as _site
+            import sysconfig as _sysconfig
+
+            if not hasattr(sys, "_MEIPASS"):
+                # Normal execution (pip, venv, conda, source, Docker).
+                # Inject parent site-packages via .pth so xinference and xoscar are
+                # discoverable in the child venv while preserving child-venv isolation.
+                # .pth paths are appended AFTER child site-packages so child-installed
+                # packages always take precedence over parent ones.
+                parent_site_packages = _sysconfig.get_paths()["purelib"]
+
+                # Warn if xinference appears to be user-installed — child venvs
+                # cannot see user site-packages (~/.local/lib/...) by design.
+                user_site = (
+                    _site.getusersitepackages()
+                    if hasattr(_site, "getusersitepackages")
+                    else None
                 )
+                if (
+                    user_site
+                    and not os.path.exists(
+                        os.path.join(parent_site_packages, "xinference")
+                    )
+                    and os.path.exists(os.path.join(user_site, "xinference"))
+                ):
+                    logger.warning(
+                        "xinference is installed in user site-packages (%s) which is "
+                        "not visible to child venvs. Re-install inside a virtual "
+                        "environment.",
+                        user_site,
+                    )
+
+                if os.path.exists(parent_site_packages):
+                    child_site_packages = pathlib.Path(
+                        virtual_env_manager.get_lib_path()
+                    )
+                    child_site_packages.mkdir(parents=True, exist_ok=True)
+                    pth_file = child_site_packages / "_xinference_parent.pth"
+                    pth_file.write_text(parent_site_packages + "\n")
+                    logger.debug(
+                        "Injected parent site-packages into child venv via %s -> %s",
+                        pth_file,
+                        parent_site_packages,
+                    )
+                else:
+                    logger.warning(
+                        "Parent site-packages path does not exist: %s — child venv "
+                        "may not be able to import xinference or xoscar.",
+                        parent_site_packages,
+                    )
             else:
-                logger.warning(
-                    "Parent site-packages path does not exist: %s — child venv "
-                    "may not be able to import xinference or xoscar.",
-                    parent_site_packages,
+                # PyInstaller bundle: sys._MEIPASS is a private temp directory
+                # belonging to the bundle process. The child venv runs an external
+                # Python interpreter that has no access to that directory.
+                # Skip .pth injection entirely — xinference in bundle mode manages
+                # its own package visibility through the bundle mechanism.
+                logger.debug(
+                    "Running inside PyInstaller bundle — skipping parent site-packages "
+                    "injection into child venv."
                 )
-        else:
-            # PyInstaller bundle: sys._MEIPASS is a private temp directory
-            # belonging to the bundle process. The child venv runs an external
-            # Python interpreter that has no access to that directory.
-            # Skip .pth injection entirely — xinference in bundle mode manages
-            # its own package visibility through the bundle mechanism.
-            logger.debug(
-                "Running inside PyInstaller bundle — skipping parent site-packages "
-                "injection into child venv."
-            )
 
-        return virtual_env_manager
+            return virtual_env_manager
 
     @classmethod
     def _prepare_virtual_env(

--- a/xinference/model/embedding/model_spec.json
+++ b/xinference/model/embedding/model_spec.json
@@ -1531,6 +1531,7 @@
         "einops",
         "accelerate>=0.28.0",
         "#system_torchvision# ; #engine# == \"sentence_transformers\"",
+        "#system_torch# ; #engine# == \"sentence_transformers\"",
         "transformers==4.52.0",
         "xformers"
       ],


### PR DESCRIPTION
## Summary                                                                                                                                       
                                                                                                                                                   
  Three related fixes for multi-replica virtualenv deployment failures:                                                                            
                                                                                                                                                   
  1. **Concurrent venv creation race** (`worker.py`): When deploying models with `replica>=2` on the same worker, concurrent `asyncio.to_thread`
  calls to `_create_virtual_env_manager` race on the same virtualenv path, causing `uv venv` to fail with "directory already exists". Added
  `_exclusive_venv_path_lock` context manager using `fcntl.flock` to serialize venv creation + `.pth` injection per normalized `env_path`.

  2. **Cold-start FileNotFoundError** (`worker.py`): After deleting the entire venv tree, `os.open` for the lock file fails because the parent
  directory doesn't exist yet. Added `os.makedirs(lock_dir, exist_ok=True)` before `os.open` in `_exclusive_venv_path_lock`.

  3. **torch/torchvision mismatch** (`model_spec.json`): `jina-embeddings-v4` declared `#system_torchvision#` but not `#system_torch#`, causing the
   child venv to install a different torch version. The version mismatch triggers `RuntimeError: operator torchvision::nms does not exist`. Added
  `"#system_torch# ; #engine# == \"sentence_transformers\""` to the virtualenv packages.                                                           
                                                                                                                                                 
  ## Files changed                                                                                                                               
                                                                                                                                                 
  - `xinference/core/worker.py` — `_exclusive_venv_path_lock` + lock wrapping in `_create_virtual_env_manager`
  - `xinference/model/embedding/model_spec.json` — `jina-embeddings-v4` virtualenv packages

  ## Test plan

  - [ ] Deploy `jina-embeddings-v4` with `replica>=2` on same worker — no `uv venv` exit status 2
  - [ ] Delete entire venv directory, redeploy — no `FileNotFoundError` on lock file
  - [ ] Multi-replica deployment — no `operator torchvision::nms does not exist`
  - [ ] Single replica deployment behaves identically to before
  - [ ] Different models with different venv paths remain parallel