### PR TITLE
fix: remove last message role restriction in chat completion endpoint

### DIFF
--- a/xinference/api/restful_api.py
+++ b/xinference/api/restful_api.py
@@ -2001,7 +2001,7 @@ class RESTfulAPI(CancelMixin):
 
         messages = body.messages and list(body.messages) or None
 
-        if not messages or messages[-1].get("role") not in ["user", "system", "tool"]:
+        if not messages:
             raise HTTPException(
                 status_code=400, detail="Invalid input. Please specify the prompt."
             )

--- a/xinference/core/tests/test_restful_api.py
+++ b/xinference/core/tests/test_restful_api.py
@@ -170,18 +170,6 @@ async def test_restful_api(setup):
     response = requests.post(url, json=payload)
     assert response.status_code == 400
 
-    # allow last message role to be assistant
-    payload = {
-        "model": model_uid_res,
-        "messages": [
-            {"role": "system", "content": "You are a helpful assistant."},
-            {"role": "user", "content": "Hello!"},
-            {"role": "assistant", "content": "Hi what can I help you?"},
-        ],
-    }
-    response = requests.post(url, json=payload)
-    assert response.status_code == 200
-
     # allow duplicate system messages
     payload = {
         "model": model_uid_res,

--- a/xinference/core/tests/test_restful_api.py
+++ b/xinference/core/tests/test_restful_api.py
@@ -170,6 +170,7 @@ async def test_restful_api(setup):
     response = requests.post(url, json=payload)
     assert response.status_code == 400
 
+    # allow last message role to be assistant
     payload = {
         "model": model_uid_res,
         "messages": [
@@ -179,7 +180,8 @@ async def test_restful_api(setup):
         ],
     }
     response = requests.post(url, json=payload)
-    assert response.status_code == 400
+    completion = response.json()
+    assert "content" in completion["choices"][0]["message"]
 
     # allow duplicate system messages
     payload = {

--- a/xinference/core/tests/test_restful_api.py
+++ b/xinference/core/tests/test_restful_api.py
@@ -180,8 +180,7 @@ async def test_restful_api(setup):
         ],
     }
     response = requests.post(url, json=payload)
-    completion = response.json()
-    assert "content" in completion["choices"][0]["message"]
+    assert response.status_code == 200
 
     # allow duplicate system messages
     payload = {


### PR DESCRIPTION
## Summary
- Remove the validation that required the last message role to be `"user"`, `"system"`, or `"tool"` in the `create_chat_completion` endpoint
- Only keep the `messages` empty check, aligning with OpenAI API behavior
- Fixes 400 errors from frameworks like LangGraph that pass conversation history including assistant messages

## Test plan
- [ ] Verify chat completion works with assistant message as the last message
- [ ] Verify empty messages still returns 400
- [ ] Verify normal user/system/tool messages still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)