### PR TITLE
fix: vLLM multi-node distributed init and pipeline parallel inference

### DIFF
--- a/xinference/model/llm/vllm/core.py
+++ b/xinference/model/llm/vllm/core.py
@@ -42,6 +42,7 @@ from typing import (
 import xoscar as xo
 from packaging import version
 from typing_extensions import NotRequired
+from xoscar.utils import get_next_port
 
 from ....constants import XINFERENCE_MAX_TOKENS
 from ....device_utils import is_vacc_available
@@ -855,6 +856,16 @@ class VLLMModel(LLM):
             model_config.setdefault("node_rank", self._shard)  # type: ignore
             # Use mp backend to satisfy vLLM validation; executor is patched later.
             model_config.setdefault("distributed_executor_backend", "mp")
+            # vLLM's init_distributed_environment overrides distributed_init_method
+            # with parallel_config.master_addr/master_port when nnodes > 1.
+            # We must set them to avoid falling back to the defaults
+            # ("127.0.0.1" and 29501).
+            if self._address and ":" in self._address:
+                master_addr = self._address.split(":", 1)[0]
+            else:
+                master_addr = self._address
+            model_config.setdefault("master_addr", master_addr)  # type: ignore
+            model_config.setdefault("master_port", get_next_port())  # type: ignore
         model_config.setdefault("block_size", 16)
         if VLLM_VERSION < version.parse("0.18.0"):
             model_config.setdefault("swap_space", 4)

--- a/xinference/model/llm/vllm/distributed_executor_v1.py
+++ b/xinference/model/llm/vllm/distributed_executor_v1.py
@@ -91,6 +91,8 @@ class WorkerActor(xo.StatelessActor):
             return method(self._worker, *args, **kwargs)
 
     def _sanitize_result(self, obj):
+        if obj is None:
+            return obj
         output = obj.get_output()
         return output
 
@@ -238,6 +240,17 @@ class XinferenceDistributedExecutorV1(Executor):
 
         self.pp_locks: Optional[List[asyncio.Lock]] = None
 
+    def _get_output_rank(self) -> int:
+        """Get the rank that produces the final output.
+
+        In pipeline parallelism, only the last PP stage produces
+        ModelRunnerOutput. The output rank is the first TP worker
+        of the last PP stage.
+        """
+        return (
+            self.parallel_config.world_size - self.parallel_config.tensor_parallel_size
+        )
+
     def collective_rpc(
         self,
         method: Union[str, Callable],
@@ -254,7 +267,19 @@ class XinferenceDistributedExecutorV1(Executor):
         outputs = self._run_workers(
             "execute_model", scheduler_output, non_block=non_block
         )
-        return outputs[0]
+        # In pipeline parallelism, only the last PP stage returns output.
+        return outputs[self._get_output_rank()]
+
+    def sample_tokens(
+        self, grammar_output: Optional[Any] = None, non_block: bool = False
+    ) -> Any:
+        outputs = self._run_workers(
+            "sample_tokens", grammar_output, non_block=non_block
+        )
+        # In pipeline parallelism, only the last PP stage produces
+        # sampled tokens. The output_rank is the first TP worker of
+        # the last PP stage.
+        return outputs[self._get_output_rank()]
 
     def check_health(self) -> None:
         # Assume that the workers are healthy.


### PR DESCRIPTION
## Summary
- Set `master_addr`/`master_port` in model config to prevent vLLM from falling back to `127.0.0.1:29501` when `nnodes > 1`
- Fix pipeline parallel inference by fetching output from the correct rank (last PP stage) instead of always using rank 0
- Handle `None` results in `_sanitize_result` for PP workers that don't produce output

## Test plan
- [ ] Verify single-node vLLM deployment still works
- [ ] Verify multi-node vLLM deployment uses correct master_addr/master_port
- [ ] Verify pipeline parallel inference returns correct results

🤖 Generated with [Claude Code](https://claude.com/claude-code)