### PR TITLE
feat: add Glm4MoeLiteForCausalLM support

### DIFF
--- a/xinference/model/llm/transformers/chatglm.py
+++ b/xinference/model/llm/transformers/chatglm.py
@@ -37,7 +37,12 @@ logger = logging.getLogger(__name__)
 @register_transformer
 @register_non_default_model("GlmForCausalLM")
 class ChatglmPytorchChatModel(PytorchChatModel):
-    GLM4_ARCHITECTURES = {"GlmForCausalLM", "Glm4ForCausalLM", "Glm4MoeForCausalLM"}
+    GLM4_ARCHITECTURES = {
+        "GlmForCausalLM",
+        "Glm4ForCausalLM",
+        "Glm4MoeForCausalLM",
+        "Glm4MoeLiteForCausalLM",
+    }
 
     def __init__(
         self,

--- a/xinference/model/llm/vllm/core.py
+++ b/xinference/model/llm/vllm/core.py
@@ -310,6 +310,7 @@ def _update_vllm_supported_lists() -> None:
         _append_unique(
             VLLM_SUPPORTED_MULTI_MODEL_LIST, "KimiK25ForConditionalGeneration"
         )
+        _append_unique(VLLM_SUPPORTED_CHAT_MODELS, "Glm4MoeLiteForCausalLM")
 
     if effective_version >= version.parse("0.16.0"):
         _append_unique(VLLM_SUPPORTED_CHAT_MODELS, "GlmMoeDsaForCausalLM")


### PR DESCRIPTION
## Summary
- Add `Glm4MoeLiteForCausalLM` to vLLM supported chat models (requires vLLM >= 0.15.0)
- Add `Glm4MoeLiteForCausalLM` to Transformers GLM4 architectures set

Synced from enterprise MR: orbitai/xinference-enterprise/xinference-backend!424

## Test plan
- [ ] Verify Glm4MoeLite models load correctly with vLLM backend
- [ ] Verify Glm4MoeLite models load correctly with Transformers backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)