### PR TITLE
fix: normalize dashes to underscores in CLI extra kwargs

### DIFF
--- a/xinference/deploy/cmdline.py
+++ b/xinference/deploy/cmdline.py
@@ -925,7 +925,7 @@ def model_launch(
                 f"You must specify extra kwargs with `--` prefix. "
                 f"There is an error in parameter passing that is {ctx.args[i]}."
             )
-        param_name = ctx.args[i][2:]
+        param_name = ctx.args[i][2:].replace("-", "_")
         param_value = handle_click_args_type(ctx.args[i + 1])
         if param_name == "model_path":
             # fix for --model_path which is the old fashion to set model_path,


### PR DESCRIPTION
Fixes #4830

## Problem

When launching a gguf model with `--multimodal-projector` (dashes, as the web UI's "Copy CLI command" feature generates), the projector is silently ignored, resulting in:

```
image input is not supported - hint: if this is unexpected, you may need to provide the mmproj
```

**Root cause:** The `xinference launch` command passes unrecognized options through `ctx.args`. The extra-kwargs parser extracted the key verbatim (`ctx.args[i][2:]`), preserving dashes. So `--multimodal-projector` became the dict key `"multimodal-projector"`, while downstream code looks for `"multimodal_projector"` (underscore).

The web UI's `commandBuilder.js` converts underscore keys to dash format (`key.replace(/_/g, '-')`), so the generated CLI command always uses dashes — making this a consistent failure for any user who copies from the UI.

## Solution

Normalize dashes to underscores in the extra-kwargs key, mirroring the standard behavior of Click's built-in options:

```python
param_name = ctx.args[i][2:].replace("-", "_")
```

This makes `--multimodal-projector` and `--multimodal_projector` equivalent, consistent with how Click handles its native options.

## Testing

Manually verified that:
- `--multimodal-projector mmproj-F16.gguf` now correctly maps to `kwargs["multimodal_projector"]`
- `--multimodal_projector mmproj-F16.gguf` (underscore) still works as before
- The existing `--model_path` backward-compat check still works correctly