### PR TITLE
fix: resolve Mixed Content blocking for Launch Web UI behind HTTPS proxy

### DIFF
--- a/xinference/api/restful_api.py
+++ b/xinference/api/restful_api.py
@@ -349,7 +349,12 @@ class RESTfulAPI(CancelMixin):
             )
 
         config = Config(
-            app=self._app, host=self._host, port=self._port, log_config=logging_conf
+            app=self._app,
+            host=self._host,
+            port=self._port,
+            log_config=logging_conf,
+            proxy_headers=True,
+            forwarded_allow_ips="*",
         )
         server = Server(config)
         server.run()

--- a/xinference/ui/web/ui/src/components/fetcher.js
+++ b/xinference/ui/web/ui/src/components/fetcher.js
@@ -16,8 +16,15 @@ const updateOptions = (url, options) => {
   return update
 }
 
+function ensureProtocol(url) {
+  if (window.location.protocol === 'https:' && url.startsWith('http://')) {
+    return url.replace('http://', 'https://')
+  }
+  return url
+}
+
 export default function fetcher(url, options) {
-  return fetch(url, updateOptions(url, options)).then((res) => {
+  return fetch(ensureProtocol(url), updateOptions(url, options)).then((res) => {
     // For the situation that server has already been restarted, the current token may become invalid,
     // which leads to UI hangs.
     if (res.status == 401 && localStorage.getItem('authStatus') !== '401') {

--- a/xinference/ui/web/ui/src/components/utils.js
+++ b/xinference/ui/web/ui/src/components/utils.js
@@ -1,12 +1,8 @@
 export const getEndpoint = () => {
-  let endPoint = ''
   if (!process.env.NODE_ENV || process.env.NODE_ENV === 'development') {
-    endPoint = 'http://127.0.0.1:9997'
-  } else {
-    const fullUrl = window.location.href
-    endPoint = fullUrl.split('/ui')[0]
+    return 'http://127.0.0.1:9997'
   }
-  return endPoint
+  return window.location.origin
 }
 
 export const isValidBearerToken = (token) => {


### PR DESCRIPTION
## Summary
When Xinference runs behind an HTTPS-terminating reverse proxy (e.g. Nginx), clicking **Launch Web UI** fails with `Mixed Content` error. Starlette's 302 redirect for Gradio routes uses `http://` in the `Location` header because Uvicorn does not read `X-Forwarded-Proto` by default.

### Changes

**Backend (root cause fix):**
- Enable `proxy_headers=True` and `forwarded_allow_ips="*"` in Uvicorn `Config` so Starlette generates redirects with the correct protocol from `X-Forwarded-Proto`

**Frontend (defense-in-depth):**
- Simplify `getEndpoint()` to use `window.location.origin` — more robust than `split('/ui')` parsing
- Add `ensureProtocol()` in `fetcher.js` to auto-upgrade `http://` to `https://` when the page is served over HTTPS

### Prerequisites
Nginx must pass `X-Forwarded-Proto`:
```nginx
proxy_set_header X-Forwarded-Proto $scheme;
```

## Changed Files
| File | Change |
|------|--------|
| `xinference/api/restful_api.py` | Uvicorn Config: add `proxy_headers=True`, `forwarded_allow_ips="*"` |
| `xinference/ui/web/ui/src/components/utils.js` | `getEndpoint()` uses `window.location.origin` |
| `xinference/ui/web/ui/src/components/fetcher.js` | Add `ensureProtocol()` for HTTPS auto-upgrade |

## Test plan
- [ ] Access via `https://domain/ui/`, click Launch Web UI — no Mixed Content error, Gradio opens correctly
- [ ] Access via `http://ip:port/ui/` directly — functionality unaffected (regression check)
- [ ] CI pipeline passes