### PR TITLE
feat: comprehensive Prometheus metrics for cluster, worker, and model observability

### DIFF
--- a/xinference/api/restful_api.py
+++ b/xinference/api/restful_api.py
@@ -276,7 +276,7 @@ class RESTfulAPI(CancelMixin):
             # module level in metrics.py.
             for collector in list(REGISTRY.get_all()):
                 if not collector.name.startswith("xinference:"):
-                    REGISTRY.deregister(collector)
+                    REGISTRY.deregister(collector.name)
             self._app.add_middleware(MetricsMiddleware)
             self._app.include_router(self._router)
             self._app.add_route("/metrics", metrics)

--- a/xinference/api/restful_api.py
+++ b/xinference/api/restful_api.py
@@ -382,9 +382,7 @@ class RESTfulAPI(CancelMixin):
                 models_data = await supervisor_ref.list_models()
                 update_cluster_metrics(cluster_data, models_data)
             except Exception:
-                logger.warning(
-                    "Failed to update cluster metrics", exc_info=True
-                )
+                logger.warning("Failed to update cluster metrics", exc_info=True)
 
     async def _get_builtin_prompts(self) -> JSONResponse:
         """

--- a/xinference/api/restful_api.py
+++ b/xinference/api/restful_api.py
@@ -271,13 +271,22 @@ class RESTfulAPI(CancelMixin):
             )
             self._app.include_router(self._router)
         else:
-            # Clear the global Registry for the MetricsMiddleware, or
-            # the MetricsMiddleware will register duplicated metrics if the port
-            # conflict (This serve method run more than once).
-            REGISTRY.clear()
+            # Only remove MetricsMiddleware's HTTP counters to avoid duplicates
+            # on restart; preserve xinference:* custom metrics registered at
+            # module level in metrics.py.
+            for collector in list(REGISTRY.get_all()):
+                if not collector.name.startswith("xinference:"):
+                    REGISTRY.deregister(collector)
             self._app.add_middleware(MetricsMiddleware)
             self._app.include_router(self._router)
             self._app.add_route("/metrics", metrics)
+
+            # Start background task to periodically refresh cluster metrics
+            @self._app.on_event("startup")
+            async def _start_cluster_metrics_updater():
+                import asyncio
+
+                asyncio.create_task(self._cluster_metrics_update_loop())
 
         # Check all the routes returns Response.
         # This is to avoid `jsonable_encoder` performance issue:
@@ -358,6 +367,24 @@ class RESTfulAPI(CancelMixin):
         )
         server = Server(config)
         server.run()
+
+    async def _cluster_metrics_update_loop(self):
+        """Periodically refresh Supervisor-side Prometheus Gauges (every 15s)."""
+        import asyncio
+
+        from ..core.metrics import update_cluster_metrics
+
+        while True:
+            try:
+                await asyncio.sleep(15)
+                supervisor_ref = await self._get_supervisor_ref()
+                cluster_data = await supervisor_ref.get_cluster_metrics_data()
+                models_data = await supervisor_ref.list_models()
+                update_cluster_metrics(cluster_data, models_data)
+            except Exception:
+                logger.warning(
+                    "Failed to update cluster metrics", exc_info=True
+                )
 
     async def _get_builtin_prompts(self) -> JSONResponse:
         """

--- a/xinference/core/metrics.py
+++ b/xinference/core/metrics.py
@@ -13,38 +13,347 @@
 # limitations under the License.
 
 import asyncio
+import logging
+from collections import defaultdict
+from typing import Any, Dict, Set, Tuple
 
 import uvicorn
-from aioprometheus import Counter, Gauge
+from aioprometheus import REGISTRY, Counter, Gauge, Histogram
 from aioprometheus.asgi.starlette import metrics
 from fastapi import FastAPI
 from fastapi.responses import RedirectResponse
 
+logger = logging.getLogger(__name__)
+
 DEFAULT_METRICS_SERVER_LOG_LEVEL = "warning"
 
-
+# ===========================================================================
+# Worker-side inference metrics (LLM only)
+# ===========================================================================
 generate_throughput = Gauge(
-    "xinference:generate_tokens_per_s", "Generate throughput in tokens/s."
+    "xinference:generate_tokens_per_s",
+    "Generate throughput in tokens/s (LLM only).",
 )
-# Latency
 time_to_first_token = Gauge(
-    "xinference:time_to_first_token_ms", "First token latency in ms."
+    "xinference:time_to_first_token_ms",
+    "First token latency in ms (LLM only).",
 )
-# Tokens counter
 input_tokens_total_counter = Counter(
-    "xinference:input_tokens_total_counter", "Total number of input tokens."
+    "xinference:input_tokens_total_counter",
+    "Total number of input tokens (LLM only).",
 )
 output_tokens_total_counter = Counter(
-    "xinference:output_tokens_total_counter", "Total number of output tokens."
+    "xinference:output_tokens_total_counter",
+    "Total number of output tokens (LLM only).",
 )
+
+# ===========================================================================
+# Worker-side model service quality metrics (all model types)
+# ===========================================================================
+model_request_total = Counter(
+    "xinference:model_request_total",
+    "Total number of model requests.",
+)
+model_request_errors_total = Counter(
+    "xinference:model_request_errors_total",
+    "Total number of failed model requests.",
+)
+model_request_duration_seconds = Histogram(
+    "xinference:model_request_duration_seconds",
+    "Model request duration in seconds.",
+    buckets=(
+        0.01, 0.025, 0.05, 0.1, 0.25, 0.5,
+        1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 120.0, float("inf"),
+    ),
+)
+model_serve_count = Gauge(
+    "xinference:model_serve_count",
+    "Number of requests currently being served.",
+)
+model_request_limit_gauge = Gauge(
+    "xinference:model_request_limit",
+    "Maximum concurrent request limit for the model.",
+)
+
+# ===========================================================================
+# Supervisor-side cluster / worker / model info metrics
+# ===========================================================================
+supervisor_uptime = Gauge(
+    "xinference:supervisor_uptime_seconds",
+    "Supervisor uptime in seconds.",
+)
+workers_total = Gauge(
+    "xinference:workers_total",
+    "Number of online workers.",
+)
+models_loaded_total = Gauge(
+    "xinference:models_loaded_total",
+    "Number of loaded models by type.",
+)
+worker_cpu_utilization = Gauge(
+    "xinference:worker_cpu_utilization",
+    "Worker CPU utilization (0-1).",
+)
+worker_memory_used_bytes = Gauge(
+    "xinference:worker_memory_used_bytes",
+    "Worker memory used in bytes.",
+)
+worker_memory_total_bytes = Gauge(
+    "xinference:worker_memory_total_bytes",
+    "Worker total memory in bytes.",
+)
+worker_gpu_utilization_percent = Gauge(
+    "xinference:worker_gpu_utilization_percent",
+    "Worker GPU utilization (0-100).",
+)
+worker_gpu_memory_used_bytes = Gauge(
+    "xinference:worker_gpu_memory_used_bytes",
+    "Worker GPU memory used in bytes.",
+)
+worker_gpu_memory_total_bytes = Gauge(
+    "xinference:worker_gpu_memory_total_bytes",
+    "Worker GPU total memory in bytes.",
+)
+model_info_gauge = Gauge(
+    "xinference:model_info",
+    "Running model info (value=1).",
+)
+model_status_gauge = Gauge(
+    "xinference:model_status",
+    "Model lifecycle status (value=1).",
+)
+model_gpu_binding_gauge = Gauge(
+    "xinference:model_gpu_binding",
+    "Per-replica GPU binding (one series per GPU per replica, value=1).",
+)
+
+# ---------------------------------------------------------------------------
+# Supervisor-only metric names — removed from Worker Registry at startup
+# ---------------------------------------------------------------------------
+_SUPERVISOR_ONLY_METRICS = {
+    "xinference:supervisor_uptime_seconds",
+    "xinference:workers_total",
+    "xinference:models_loaded_total",
+    "xinference:model_info",
+    "xinference:model_status",
+    "xinference:worker_cpu_utilization",
+    "xinference:worker_memory_used_bytes",
+    "xinference:worker_memory_total_bytes",
+    "xinference:worker_gpu_utilization_percent",
+    "xinference:worker_gpu_memory_used_bytes",
+    "xinference:worker_gpu_memory_total_bytes",
+    "xinference:model_gpu_binding",
+}
+
+# ---------------------------------------------------------------------------
+# Stale-label tracking sets for update_cluster_metrics()
+# ---------------------------------------------------------------------------
+_prev_worker_labels: Set[Tuple[str, ...]] = set()
+_prev_gpu_labels: Set[Tuple[str, ...]] = set()
+_prev_model_labels: Set[Tuple[str, ...]] = set()
+_prev_status_labels: Set[Tuple[str, ...]] = set()
+_prev_gpu_binding_labels: Set[Tuple[str, ...]] = set()
 
 
 def record_metrics(name, op, kwargs):
     collector = globals().get(name)
-    getattr(collector, op)(**kwargs)
+    if collector is not None:
+        getattr(collector, op)(**kwargs)
+
+
+def update_cluster_metrics(
+    cluster_data: Dict[str, Any],
+    models_data: Dict[str, Dict[str, Any]],
+) -> None:
+    """Refresh all Supervisor-side Prometheus gauges from in-memory data."""
+    global _prev_worker_labels, _prev_gpu_labels
+    global _prev_model_labels, _prev_status_labels, _prev_gpu_binding_labels
+
+    # --- Supervisor uptime ---
+    supervisor_uptime.set({}, cluster_data.get("uptime", 0))
+
+    # --- Workers total ---
+    workers_total.set({}, cluster_data.get("worker_count", 0))
+
+    # --- Worker resources ---
+    cur_worker_labels: Set[Tuple[str, ...]] = set()
+    cur_gpu_labels: Set[Tuple[str, ...]] = set()
+
+    for addr, status in cluster_data.get("workers", {}).items():
+        w_labels = {"worker_address": addr}
+        label_key = (addr,)
+        cur_worker_labels.add(label_key)
+
+        # status is Dict[str, Union[ResourceStatus, GPUStatus]] serialized as dict
+        # "cpu" key -> ResourceStatus, integer keys -> GPUStatus
+        cpu_res = status.get("cpu")
+        if cpu_res:
+            worker_cpu_utilization.set(w_labels, getattr(cpu_res, "usage", 0))
+            worker_memory_used_bytes.set(w_labels, getattr(cpu_res, "memory_used", 0))
+            worker_memory_total_bytes.set(w_labels, getattr(cpu_res, "memory_total", 0))
+
+        for key, val in status.items():
+            if key == "cpu":
+                continue
+            # GPU entries keyed by integer index
+            gpu_idx = str(key)
+            gpu_name = getattr(val, "name", "unknown")
+            g_labels = {
+                "worker_address": addr,
+                "gpu_index": gpu_idx,
+                "gpu_name": gpu_name,
+            }
+            g_key = (addr, gpu_idx, gpu_name)
+            cur_gpu_labels.add(g_key)
+            worker_gpu_utilization_percent.set(g_labels, getattr(val, "gpu_util", 0))
+            worker_gpu_memory_used_bytes.set(g_labels, getattr(val, "gpu_mem_used", getattr(val, "mem_used", 0)))
+            worker_gpu_memory_total_bytes.set(g_labels, getattr(val, "gpu_mem_total", getattr(val, "mem_total", 0)))
+
+    # Clear stale worker labels
+    for stale in _prev_worker_labels - cur_worker_labels:
+        s = {"worker_address": stale[0]}
+        worker_cpu_utilization.set(s, 0)
+        worker_memory_used_bytes.set(s, 0)
+        worker_memory_total_bytes.set(s, 0)
+    _prev_worker_labels = cur_worker_labels
+
+    for stale in _prev_gpu_labels - cur_gpu_labels:
+        s = {"worker_address": stale[0], "gpu_index": stale[1], "gpu_name": stale[2]}
+        worker_gpu_utilization_percent.set(s, 0)
+        worker_gpu_memory_used_bytes.set(s, 0)
+        worker_gpu_memory_total_bytes.set(s, 0)
+    _prev_gpu_labels = cur_gpu_labels
+
+    # --- Models loaded by type ---
+    type_counts: Dict[str, int] = defaultdict(int)
+    cur_model_labels: Set[Tuple[str, ...]] = set()
+
+    model_replica_dist = cluster_data.get("model_replica_distribution", {})
+
+    for model_uid, info in models_data.items():
+        model_type = info.get("model_type", "unknown")
+        model_name = info.get("model_name", "unknown")
+        type_counts[model_type] += 1
+
+        dist = model_replica_dist.get(model_uid)
+        if dist and dist.get("worker_distribution"):
+            replica_total = str(dist["replica_total"])
+            for w_addr, w_count in dist["worker_distribution"].items():
+                m_labels = {
+                    "model_uid": model_uid,
+                    "model_name": model_name,
+                    "model_type": model_type,
+                    "worker_address": str(w_addr),
+                    "replica_on_worker": str(w_count),
+                    "replica_total": replica_total,
+                }
+                label_key = (
+                    model_uid, model_name, model_type,
+                    str(w_addr), str(w_count), replica_total,
+                )
+                cur_model_labels.add(label_key)
+                model_info_gauge.set(m_labels, 1)
+        else:
+            worker_address = info.get("address", "unknown")
+            replica = str(info.get("replica", 1))
+            m_labels = {
+                "model_uid": model_uid,
+                "model_name": model_name,
+                "model_type": model_type,
+                "worker_address": str(worker_address),
+                "replica_on_worker": replica,
+                "replica_total": replica,
+            }
+            label_key = (
+                model_uid, model_name, model_type,
+                str(worker_address), replica, replica,
+            )
+            cur_model_labels.add(label_key)
+            model_info_gauge.set(m_labels, 1)
+
+    # Clear stale model labels
+    for stale in _prev_model_labels - cur_model_labels:
+        stale_labels = {
+            "model_uid": stale[0],
+            "model_name": stale[1],
+            "model_type": stale[2],
+            "worker_address": stale[3],
+            "replica_on_worker": stale[4],
+            "replica_total": stale[5],
+        }
+        model_info_gauge.set(stale_labels, 0)
+    _prev_model_labels = cur_model_labels
+
+    # --- Model GPU binding (per-replica, per-GPU) ---
+    cur_gpu_binding_labels: Set[Tuple[str, ...]] = set()
+
+    for model_uid, info in models_data.items():
+        model_type = info.get("model_type", "unknown")
+        model_name = info.get("model_name", "unknown")
+        dist = model_replica_dist.get(model_uid)
+        if dist:
+            for rep_idx, w_addr, gpu_list in dist.get("replica_gpu_details", []):
+                for gpu_idx in gpu_list:
+                    b_labels = {
+                        "model_uid": model_uid,
+                        "model_name": model_name,
+                        "model_type": model_type,
+                        "worker_address": str(w_addr),
+                        "gpu_index": gpu_idx,
+                        "replica_index": rep_idx,
+                    }
+                    label_key = (
+                        model_uid, model_name, model_type,
+                        str(w_addr), gpu_idx, rep_idx,
+                    )
+                    cur_gpu_binding_labels.add(label_key)
+                    model_gpu_binding_gauge.set(b_labels, 1)
+
+    # Clear stale gpu_binding labels
+    for stale in _prev_gpu_binding_labels - cur_gpu_binding_labels:
+        stale_labels = {
+            "model_uid": stale[0],
+            "model_name": stale[1],
+            "model_type": stale[2],
+            "worker_address": stale[3],
+            "gpu_index": stale[4],
+            "replica_index": stale[5],
+        }
+        model_gpu_binding_gauge.set(stale_labels, 0)
+    _prev_gpu_binding_labels = cur_gpu_binding_labels
+
+    # --- Models loaded total (by type) ---
+    for mt, count in type_counts.items():
+        models_loaded_total.set({"model_type": mt}, count)
+
+    # --- Model lifecycle status ---
+    cur_status_labels: Set[Tuple[str, ...]] = set()
+    for inst in cluster_data.get("instance_infos", []):
+        uid = inst.get("model_uid", "unknown")
+        mname = inst.get("model_name", "unknown")
+        status = inst.get("status", "unknown")
+        s_labels = {"model_uid": uid, "model_name": mname, "status": status}
+        s_key = (uid, mname, status)
+        cur_status_labels.add(s_key)
+        model_status_gauge.set(s_labels, 1)
+
+    for stale in _prev_status_labels - cur_status_labels:
+        stale_labels = {
+            "model_uid": stale[0],
+            "model_name": stale[1],
+            "status": stale[2],
+        }
+        model_status_gauge.set(stale_labels, 0)
+    _prev_status_labels = cur_status_labels
 
 
 def launch_metrics_export_server(q, host=None, port=None):
+    # Remove Supervisor-only metrics from Worker's Registry to avoid
+    # empty HELP/TYPE headers on the Worker /metrics endpoint.
+    for collector in list(REGISTRY.get_all()):
+        if collector.name in _SUPERVISOR_ONLY_METRICS:
+            REGISTRY.deregister(collector)
+
     app = FastAPI()
     app.add_route("/metrics", metrics)
 

--- a/xinference/core/metrics.py
+++ b/xinference/core/metrics.py
@@ -380,7 +380,7 @@ def launch_metrics_export_server(q, host=None, port=None):
     # empty HELP/TYPE headers on the Worker /metrics endpoint.
     for collector in list(REGISTRY.get_all()):
         if collector.name in _SUPERVISOR_ONLY_METRICS:
-            REGISTRY.deregister(collector)
+            REGISTRY.deregister(collector.name)
 
     app = FastAPI()
     app.add_route("/metrics", metrics)

--- a/xinference/core/metrics.py
+++ b/xinference/core/metrics.py
@@ -62,8 +62,20 @@ model_request_duration_seconds = Histogram(
     "xinference:model_request_duration_seconds",
     "Model request duration in seconds.",
     buckets=(
-        0.01, 0.025, 0.05, 0.1, 0.25, 0.5,
-        1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 120.0, float("inf"),
+        0.01,
+        0.025,
+        0.05,
+        0.1,
+        0.25,
+        0.5,
+        1.0,
+        2.5,
+        5.0,
+        10.0,
+        30.0,
+        60.0,
+        120.0,
+        float("inf"),
     ),
 )
 model_serve_count = Gauge(
@@ -206,8 +218,12 @@ def update_cluster_metrics(
             g_key = (addr, gpu_idx, gpu_name)
             cur_gpu_labels.add(g_key)
             worker_gpu_utilization_percent.set(g_labels, getattr(val, "gpu_util", 0))
-            worker_gpu_memory_used_bytes.set(g_labels, getattr(val, "gpu_mem_used", getattr(val, "mem_used", 0)))
-            worker_gpu_memory_total_bytes.set(g_labels, getattr(val, "gpu_mem_total", getattr(val, "mem_total", 0)))
+            worker_gpu_memory_used_bytes.set(
+                g_labels, getattr(val, "gpu_mem_used", getattr(val, "mem_used", 0))
+            )
+            worker_gpu_memory_total_bytes.set(
+                g_labels, getattr(val, "gpu_mem_total", getattr(val, "mem_total", 0))
+            )
 
     # Clear stale worker labels
     for stale in _prev_worker_labels - cur_worker_labels:
@@ -226,7 +242,7 @@ def update_cluster_metrics(
 
     # --- Models loaded by type ---
     type_counts: Dict[str, int] = defaultdict(int)
-    cur_model_labels: Set[Tuple[str, ...]] = set()
+    cur_model_labels: set = set()
 
     model_replica_dist = cluster_data.get("model_replica_distribution", {})
 
@@ -247,9 +263,13 @@ def update_cluster_metrics(
                     "replica_on_worker": str(w_count),
                     "replica_total": replica_total,
                 }
-                label_key = (
-                    model_uid, model_name, model_type,
-                    str(w_addr), str(w_count), replica_total,
+                label_key = (  # type: ignore[assignment]
+                    model_uid,
+                    model_name,
+                    model_type,
+                    str(w_addr),
+                    str(w_count),
+                    replica_total,
                 )
                 cur_model_labels.add(label_key)
                 model_info_gauge.set(m_labels, 1)
@@ -264,9 +284,13 @@ def update_cluster_metrics(
                 "replica_on_worker": replica,
                 "replica_total": replica,
             }
-            label_key = (
-                model_uid, model_name, model_type,
-                str(worker_address), replica, replica,
+            label_key = (  # type: ignore[assignment]
+                model_uid,
+                model_name,
+                model_type,
+                str(worker_address),
+                replica,
+                replica,
             )
             cur_model_labels.add(label_key)
             model_info_gauge.set(m_labels, 1)
@@ -285,7 +309,7 @@ def update_cluster_metrics(
     _prev_model_labels = cur_model_labels
 
     # --- Model GPU binding (per-replica, per-GPU) ---
-    cur_gpu_binding_labels: Set[Tuple[str, ...]] = set()
+    cur_gpu_binding_labels: set = set()
 
     for model_uid, info in models_data.items():
         model_type = info.get("model_type", "unknown")
@@ -302,9 +326,13 @@ def update_cluster_metrics(
                         "gpu_index": gpu_idx,
                         "replica_index": rep_idx,
                     }
-                    label_key = (
-                        model_uid, model_name, model_type,
-                        str(w_addr), gpu_idx, rep_idx,
+                    label_key = (  # type: ignore[assignment]
+                        model_uid,
+                        model_name,
+                        model_type,
+                        str(w_addr),
+                        gpu_idx,
+                        rep_idx,
                     )
                     cur_gpu_binding_labels.add(label_key)
                     model_gpu_binding_gauge.set(b_labels, 1)

--- a/xinference/core/model.py
+++ b/xinference/core/model.py
@@ -94,16 +94,36 @@ def request_limit(fn):
         logger.debug(
             f"Request {fn.__name__}, current serve request count: {self._serve_count}, request limit: {self._request_limits} for the model {self.model_uid()}"
         )
+        # Count every incoming request (including those rejected by rate limit)
+        await self.record_metrics(
+            "model_request_total", "add",
+            {"labels": self._metrics_labels, "value": 1},
+        )
         if 1 + self._serve_count <= self._request_limits:
             self._serve_count += 1
         else:
+            # Rate-limited requests count as errors
+            await self.record_metrics(
+                "model_request_errors_total", "add",
+                {"labels": self._metrics_labels, "value": 1},
+            )
             raise RuntimeError(
                 f"Rate limit reached for the model. Request limit {self._request_limits} for the model: {self.model_uid()}"
             )
+        await self.record_metrics(
+            "model_serve_count", "set",
+            {"labels": self._metrics_labels, "value": self._serve_count},
+        )
+        start_time = time.time()
         ret = None
+        _error = False
         try:
             ret = await fn(self, *args, **kwargs)
+        except Exception:
+            _error = True
+            raise
         finally:
+            duration = time.time() - start_time
             if ret is not None and (
                 inspect.isasyncgen(ret) or inspect.isgenerator(ret)
             ):
@@ -111,8 +131,21 @@ def request_limit(fn):
                 pass
             else:
                 self._serve_count -= 1
+                await self.record_metrics(
+                    "model_serve_count", "set",
+                    {"labels": self._metrics_labels, "value": self._serve_count},
+                )
                 logger.debug(
                     f"After request {fn.__name__}, current serve request count: {self._serve_count} for the model {self.model_uid()}"
+                )
+            await self.record_metrics(
+                "model_request_duration_seconds", "observe",
+                {"labels": self._metrics_labels, "value": duration},
+            )
+            if _error:
+                await self.record_metrics(
+                    "model_request_errors_total", "add",
+                    {"labels": self._metrics_labels, "value": 1},
                 )
         return ret
 
@@ -203,6 +236,7 @@ class ModelActor(xo.StatelessActor, CancelMixin):
         n_worker: Optional[int] = 1,
         shard: Optional[int] = 0,
         driver_info: Optional[dict] = None,  # for model across workers
+        model_engine: Optional[str] = None,
     ):
         super().__init__()
 
@@ -227,9 +261,14 @@ class ModelActor(xo.StatelessActor, CancelMixin):
         self._metrics_labels = {
             "type": self._model_description.get("model_type", "unknown"),
             "model": self.model_uid(),
+            "model_name": self._model_description.get("model_name", "unknown"),
+            "engine": model_engine or "unknown",
             "node": self._worker_address,
             "format": self._model_description.get("model_format", "unknown"),
             "quantization": self._model_description.get("quantization", "none"),
+            "gpu_index": ",".join(
+                str(a) for a in (self._model_description.get("accelerators") or [])
+            ),
         }
         self._loop: Optional[asyncio.AbstractEventLoop] = None
         # model across workers
@@ -249,6 +288,13 @@ class ModelActor(xo.StatelessActor, CancelMixin):
 
         self._handle_pending_requests_task = asyncio.create_task(
             self._handle_pending_requests()
+        )
+
+        # Report static request limit gauge
+        limit_val = self._request_limits if self._request_limits != float("inf") else -1
+        await self.record_metrics(
+            "model_request_limit_gauge", "set",
+            {"labels": self._metrics_labels, "value": limit_val},
         )
 
     def __repr__(self) -> str:

--- a/xinference/core/model.py
+++ b/xinference/core/model.py
@@ -96,7 +96,8 @@ def request_limit(fn):
         )
         # Count every incoming request (including those rejected by rate limit)
         await self.record_metrics(
-            "model_request_total", "add",
+            "model_request_total",
+            "add",
             {"labels": self._metrics_labels, "value": 1},
         )
         if 1 + self._serve_count <= self._request_limits:
@@ -104,14 +105,16 @@ def request_limit(fn):
         else:
             # Rate-limited requests count as errors
             await self.record_metrics(
-                "model_request_errors_total", "add",
+                "model_request_errors_total",
+                "add",
                 {"labels": self._metrics_labels, "value": 1},
             )
             raise RuntimeError(
                 f"Rate limit reached for the model. Request limit {self._request_limits} for the model: {self.model_uid()}"
             )
         await self.record_metrics(
-            "model_serve_count", "set",
+            "model_serve_count",
+            "set",
             {"labels": self._metrics_labels, "value": self._serve_count},
         )
         start_time = time.time()
@@ -132,19 +135,22 @@ def request_limit(fn):
             else:
                 self._serve_count -= 1
                 await self.record_metrics(
-                    "model_serve_count", "set",
+                    "model_serve_count",
+                    "set",
                     {"labels": self._metrics_labels, "value": self._serve_count},
                 )
                 logger.debug(
                     f"After request {fn.__name__}, current serve request count: {self._serve_count} for the model {self.model_uid()}"
                 )
             await self.record_metrics(
-                "model_request_duration_seconds", "observe",
+                "model_request_duration_seconds",
+                "observe",
                 {"labels": self._metrics_labels, "value": duration},
             )
             if _error:
                 await self.record_metrics(
-                    "model_request_errors_total", "add",
+                    "model_request_errors_total",
+                    "add",
                     {"labels": self._metrics_labels, "value": 1},
                 )
         return ret
@@ -293,7 +299,8 @@ class ModelActor(xo.StatelessActor, CancelMixin):
         # Report static request limit gauge
         limit_val = self._request_limits if self._request_limits != float("inf") else -1
         await self.record_metrics(
-            "model_request_limit_gauge", "set",
+            "model_request_limit_gauge",
+            "set",
             {"labels": self._metrics_labels, "value": limit_val},
         )
 

--- a/xinference/core/supervisor.py
+++ b/xinference/core/supervisor.py
@@ -888,7 +888,11 @@ class SupervisorActor(xo.StatelessActor):
             )
             infos = await status_guard_ref.get_instance_info()
             instance_infos = [
-                {"model_uid": i.model_uid, "model_name": i.model_name, "status": i.status}
+                {
+                    "model_uid": i.model_uid,
+                    "model_name": i.model_name,
+                    "status": i.status,
+                }
                 for i in infos
             ]
         except Exception:

--- a/xinference/core/supervisor.py
+++ b/xinference/core/supervisor.py
@@ -127,6 +127,7 @@ class SupervisorActor(xo.StatelessActor):
         self._model_uid_to_replica_info: Dict[str, ReplicaInfo] = {}  # type: ignore
         self._uptime = None
         self._lock = asyncio.Lock()
+        self._replica_gpu_cache: Dict[str, list] = {}
         # list_models cache for graceful degradation when a worker is unreachable
         self._list_models_cache: Dict[str, Dict[str, Dict[str, Any]]] = {}
         # Reverse-ping failure counter per worker
@@ -869,6 +870,55 @@ class SupervisorActor(xo.StatelessActor):
         return {
             "uptime": int(time.time() - self._uptime),
             "workers": self._worker_status,
+        }
+
+    async def get_cluster_metrics_data(self) -> Dict:
+        """Return all data needed to refresh Supervisor-side Prometheus gauges."""
+        workers: Dict[str, Any] = {}
+        for addr, ws in self._worker_status.items():
+            workers[addr] = ws.status
+
+        # Model lifecycle statuses (CREATING/READY/ERROR)
+        instance_infos: list = []
+        try:
+            from .status_guard import StatusGuardActor
+
+            status_guard_ref = await xo.actor_ref(
+                address=self.address, uid=StatusGuardActor.default_uid()
+            )
+            infos = await status_guard_ref.get_instance_info()
+            instance_infos = [
+                {"model_uid": i.model_uid, "model_name": i.model_name, "status": i.status}
+                for i in infos
+            ]
+        except Exception:
+            logger.warning("Failed to get instance info for metrics", exc_info=True)
+
+        # Model replica distribution across workers
+        model_replica_distribution: Dict[str, Dict[str, Any]] = {}
+        for model_uid, replica_info in self._model_uid_to_replica_info.items():
+            worker_replica_count: Dict[str, int] = defaultdict(int)
+            replica_gpu_details: list = []
+            for _rep_idx, ref_list in replica_info.replica_to_worker_refs.items():
+                replica_uid = f"{model_uid}-{_rep_idx}"
+                gpu_indices = self._replica_gpu_cache.get(replica_uid, [])
+                for ref in ref_list:
+                    worker_replica_count[ref.address] += 1
+                    replica_gpu_details.append(
+                        (str(_rep_idx), ref.address, gpu_indices)
+                    )
+            model_replica_distribution[model_uid] = {
+                "replica_total": replica_info.replica,
+                "worker_distribution": dict(worker_replica_count),
+                "replica_gpu_details": replica_gpu_details,
+            }
+
+        return {
+            "uptime": int(time.time() - self._uptime) if self._uptime else 0,
+            "worker_count": len(self._worker_address_to_worker),
+            "workers": workers,
+            "instance_infos": instance_infos,
+            "model_replica_distribution": model_replica_distribution,
         }
 
     def _get_spec_dicts(
@@ -2451,6 +2501,15 @@ class SupervisorActor(xo.StatelessActor):
         parts = await asyncio.gather(*(_fetch_one(addr, ref) for addr, ref in workers))
         for part in parts:
             ret.update(part)
+
+        # Cache per-replica GPU info before dedup (for get_cluster_metrics_data)
+        replica_gpu_cache: Dict[str, list] = {}
+        for replica_uid, spec in ret.items():
+            accelerators = spec.get("accelerators")
+            if accelerators:
+                replica_gpu_cache[replica_uid] = [str(a) for a in accelerators]
+        self._replica_gpu_cache = replica_gpu_cache
+
         running_model_info = {parse_replica_model_uid(k)[0]: v for k, v in ret.items()}
         # add replica count
         for k, v in running_model_info.items():

--- a/xinference/core/tests/test_metrics.py
+++ b/xinference/core/tests/test_metrics.py
@@ -146,4 +146,4 @@ async def test_metrics_exporter_data(setup_cluster):
 
     response = requests.get(metrics_exporter_address)
     assert response.ok
-    assert 'format="ggufv2",model="qwen1.5-chat"' in response.text
+    assert 'format="ggufv2",gpu_index="",model="qwen1.5-chat"' in response.text

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -1921,6 +1921,7 @@ class WorkerActor(xo.StatelessActor):
                     n_worker=n_worker,
                     shard=shard,
                     driver_info=driver_info,
+                    model_engine=model_engine,
                 )
                 if await model_ref.need_create_pools() and (
                     len(devices) > 1 or n_worker > 1  # type: ignore

--- a/xinference/model/embedding/core.py
+++ b/xinference/model/embedding/core.py
@@ -100,6 +100,7 @@ class EmbeddingModelFamilyV2(BaseModel, ModelInstanceInfoMixin):
             "address": getattr(self, "address", None),
             "accelerators": getattr(self, "accelerators", None),
             "model_name": self.model_name,
+            "model_format": spec.model_format,
             "dimensions": self.dimensions,
             "max_tokens": self.max_tokens,
             "language": self.language,

--- a/xinference/model/rerank/core.py
+++ b/xinference/model/rerank/core.py
@@ -90,8 +90,10 @@ class RerankModelFamilyV2(BaseModel, ModelInstanceInfoMixin):
             "accelerators": getattr(self, "accelerators", None),
             "type": self.type,
             "model_name": self.model_name,
+            "model_format": spec.model_format,
             "language": self.language,
             "model_revision": spec.model_revision,
+            "quantization": spec.quantization,
         }
 
     def to_version_info(self):


### PR DESCRIPTION
## Summary

Extend Xinference Prometheus monitoring from 4 LLM-only metrics to **24 metrics** covering full production observability:

### New Metrics (20 new + 4 existing)

**Supervisor `/metrics` (12 metrics — single scrape target for full cluster view):**

| Metric | Type | Description |
|--------|------|-------------|
| `xinference:supervisor_uptime_seconds` | Gauge | Supervisor uptime |
| `xinference:workers_total` | Gauge | Online worker count |
| `xinference:models_loaded_total` | Gauge | Loaded models by type |
| `xinference:worker_cpu_utilization` | Gauge | Per-worker CPU (0-1) |
| `xinference:worker_memory_used_bytes` | Gauge | Per-worker memory used |
| `xinference:worker_memory_total_bytes` | Gauge | Per-worker memory total |
| `xinference:worker_gpu_utilization_percent` | Gauge | Per-GPU utilization |
| `xinference:worker_gpu_memory_used_bytes` | Gauge | Per-GPU memory used |
| `xinference:worker_gpu_memory_total_bytes` | Gauge | Per-GPU memory total |
| `xinference:model_info` | Gauge | Running model metadata with multi-worker replica distribution |
| `xinference:model_status` | Gauge | Model lifecycle (CREATING/READY/ERROR) |
| `xinference:model_gpu_binding` | Gauge | Per-replica per-GPU binding |

**Worker `/metrics` (9 metrics — 5 new + 4 existing):**

| Metric | Type | Description |
|--------|------|-------------|
| `xinference:model_request_total` | Counter | Request count (all model types) |
| `xinference:model_request_errors_total` | Counter | Error count |
| `xinference:model_request_duration_seconds` | Histogram | Latency P50/P95/P99 |
| `xinference:model_serve_count` | Gauge | Current concurrent requests |
| `xinference:model_request_limit` | Gauge | Max concurrent limit |

### Bug Fixes
- **`REGISTRY.clear()` → selective deregister**: Supervisor's `REGISTRY.clear()` was wiping all `xinference:*` metrics; replaced with selective removal of only HTTP middleware counters
- **Worker metric pollution**: Supervisor-only metrics removed from Worker Registry at startup
- **Embedding/Rerank `model_format`**: `to_description()` now includes `model_format` and `quantization` fields
- **Enhanced Worker labels**: All Worker metrics now include `model_name`, `engine`, and `gpu_index` labels

### PromQL Examples
```promql
# QPS per model
rate(xinference:model_request_total{model_name="qwen2.5-instruct"}[5m])

# Latency P95
histogram_quantile(0.95, rate(xinference:model_request_duration_seconds_bucket[5m]))

# Error rate
rate(xinference:model_request_errors_total[5m]) / rate(xinference:model_request_total[5m])

# GPU 0 models
xinference:model_gpu_binding{gpu_index="0"} == 1

# Overload detection
xinference:model_serve_count / xinference:model_request_limit > 0.9
```

### Files Changed
| File | Changes |
|------|---------|
| `xinference/core/metrics.py` | 16 new metric definitions + `update_cluster_metrics()` + Worker Registry cleanup |
| `xinference/core/model.py` | `request_limit` decorator instrumentation + `model_engine`/`model_name`/`gpu_index` labels |
| `xinference/core/supervisor.py` | `get_cluster_metrics_data()` + `_replica_gpu_cache` in `list_models()` |
| `xinference/api/restful_api.py` | Selective `REGISTRY.deregister` + background metrics refresh loop |
| `xinference/core/worker.py` | Pass `model_engine` to `ModelActor` |
| `xinference/model/embedding/core.py` | Add `model_format` to `to_description()` |
| `xinference/model/rerank/core.py` | Add `model_format` + `quantization` to `to_description()` |

## Test plan
- [ ] `xinference local` startup → `curl :9997/metrics` shows all cluster metrics with data
- [ ] Load LLM + Embedding model → verify `model_info`, `model_status`, `models_loaded_total` correct
- [ ] Send inference requests → verify `model_request_total`, `model_request_duration_seconds`, `model_serve_count` on Worker `/metrics`
- [ ] Unload model → verify stale labels cleared (set to 0)
- [ ] Worker `/metrics` shows only 9 Worker-owned metrics (no Supervisor pollution)
- [ ] `MetricsMiddleware` HTTP counters still functional on Supervisor
- [ ] Existing `pytest xinference/core/tests/test_metrics.py` passes