### PR TITLE
fix(vllm): support for v0.19.0

### DIFF
--- a/xinference/model/llm/vllm/core.py
+++ b/xinference/model/llm/vllm/core.py
@@ -606,6 +606,8 @@ class VLLMModel(LLM):
                                 pool_addresses=worker_addresses,
                                 n_worker=self._n_worker,
                             )
+                            if VLLM_VERSION >= version.parse("0.19.0"):
+                                executor_cls.supports_async_scheduling = lambda: True  # type: ignore
                             # patch vllm Executor.get_class
                             Executor.get_class = lambda vllm_config: executor_cls
                             self._engine = AsyncLLMEngine.from_engine_args(engine_args)


### PR DESCRIPTION
There is a **piartial** for **Executor.get_class(self)**, so  the  **supports_async_scheduling** func is missing.
Fix #4854 