### PR TITLE
fix: resolve host/model-venv transformers version conflict for embedding/rerank engines

### DIFF
--- a/xinference/model/embedding/__init__.py
+++ b/xinference/model/embedding/__init__.py
@@ -78,6 +78,8 @@ def check_format_with_engine(model_format, engine):
 
 
 def generate_engine_config_by_model_name(model_family: "EmbeddingModelFamilyV2"):
+    from ...constants import XINFERENCE_ENABLE_VIRTUAL_ENV
+
     model_name = model_family.model_name
     engines: Dict[str, List[Dict[str, Any]]] = EMBEDDING_ENGINES.get(
         model_name, {}
@@ -90,8 +92,12 @@ def generate_engine_config_by_model_name(model_family: "EmbeddingModelFamilyV2")
                 continue
             CLASSES = SUPPORTED_ENGINES[engine]
             for cls in CLASSES:
-                # Every engine needs to implement match method
-                if cls.match(model_family, spec, quantization):
+                # virtualenv mode: skip import check, only verify format compatibility
+                if XINFERENCE_ENABLE_VIRTUAL_ENV:
+                    matched = cls.match_json(model_family, spec, quantization)
+                else:
+                    matched = cls.match(model_family, spec, quantization)
+                if matched == True:
                     # we only match the first class for an engine
                     if engine not in engines:
                         engines[engine] = [

--- a/xinference/model/embedding/model_spec.json
+++ b/xinference/model/embedding/model_spec.json
@@ -1454,9 +1454,12 @@
     "featured": true,
     "virtualenv": {
       "packages": [
-        "#sentence_transformers_dependencies# ; #engine# == \"sentence_transformers\"",
+        "sentence_transformers",
+        "einops",
+        "accelerate>=0.28.0",
         "#system_torchvision# ; #engine# == \"sentence_transformers\"",
-        "#system_torch# ; #engine# == \"sentence_transformers\""
+        "#system_torch# ; #engine# == \"sentence_transformers\"",
+        "transformers==4.52.0"
       ]
     }
   },

--- a/xinference/model/embedding/sentence_transformers/core.py
+++ b/xinference/model/embedding/sentence_transformers/core.py
@@ -574,24 +574,30 @@ class SentenceTransformerEmbeddingModel(EmbeddingModel, BatchMixin):
         model_spec: EmbeddingSpecV1,
         quantization: str,
     ) -> Union[bool, Tuple[bool, str]]:
+        from ....constants import XINFERENCE_ENABLE_VIRTUAL_ENV
+
         if model_family.model_name.startswith("Qwen3-VL-Embedding"):
-            dep_check = check_dependency_available("transformers", "transformers")
-            if dep_check != True:
-                return dep_check
-            dep_check = check_dependency_available("qwen_vl_utils", "qwen_vl_utils")
-            if dep_check != True:
-                return dep_check
-            dep_check = check_dependency_available("PIL", "Pillow")
-            if dep_check != True:
-                return dep_check
+            if not XINFERENCE_ENABLE_VIRTUAL_ENV:
+                dep_check = check_dependency_available("transformers", "transformers")
+                if dep_check != True:
+                    return dep_check
+                dep_check = check_dependency_available("qwen_vl_utils", "qwen_vl_utils")
+                if dep_check != True:
+                    return dep_check
+                dep_check = check_dependency_available("PIL", "Pillow")
+                if dep_check != True:
+                    return dep_check
             if model_spec.model_format not in ["pytorch"]:
                 return False, "Qwen3-VL embedding supports pytorch format only"
             return True
-        dep_check = check_dependency_available(
-            "sentence_transformers", "sentence-transformers"
-        )
-        if dep_check != True:
-            return dep_check
+
+        # virtualenv mode: dependencies provided by child venv, skip import check
+        if not XINFERENCE_ENABLE_VIRTUAL_ENV:
+            dep_check = check_dependency_available(
+                "sentence_transformers", "sentence-transformers"
+            )
+            if dep_check != True:
+                return dep_check
         if model_spec.model_format not in ["pytorch"]:
             return False, "SentenceTransformer embeddings require pytorch format"
         return True

--- a/xinference/model/embedding/vllm/core.py
+++ b/xinference/model/embedding/vllm/core.py
@@ -299,8 +299,11 @@ class VLLMEmbeddingModel(EmbeddingModel, BatchMixin):
     ) -> Union[bool, Tuple[bool, str]]:
 
         if model_family.model_name.startswith("Qwen3-VL-Embedding"):
-            import vllm
-            from packaging import version
+            try:
+                import vllm
+                from packaging import version
+            except ImportError:
+                return False, "vLLM is not installed"
 
             if version.parse(vllm.__version__) < version.parse("0.14.0"):
                 return (

--- a/xinference/model/rerank/__init__.py
+++ b/xinference/model/rerank/__init__.py
@@ -78,6 +78,8 @@ def check_format_with_engine(model_format, engine):
 
 
 def generate_engine_config_by_model_name(model_family: "RerankModelFamilyV2"):
+    from ...constants import XINFERENCE_ENABLE_VIRTUAL_ENV
+
     model_name = model_family.model_name
     engines: Dict[str, List[Dict[str, Any]]] = RERANK_ENGINES.get(
         model_name, {}
@@ -90,8 +92,12 @@ def generate_engine_config_by_model_name(model_family: "RerankModelFamilyV2"):
                 continue
             CLASSES = SUPPORTED_ENGINES[engine]
             for cls in CLASSES:
-                # Every engine needs to implement match method
-                if cls.match(model_family, spec, quantization):
+                # virtualenv mode: skip import check, only verify format compatibility
+                if XINFERENCE_ENABLE_VIRTUAL_ENV:
+                    matched = cls.match_json(model_family, spec, quantization)
+                else:
+                    matched = cls.match(model_family, spec, quantization)
+                if matched == True:
                     # we only match the first class for an engine
                     if engine not in engines:
                         engines[engine] = [

--- a/xinference/model/rerank/sentence_transformers/core.py
+++ b/xinference/model/rerank/sentence_transformers/core.py
@@ -704,27 +704,33 @@ class SentenceTransformerRerankModel(RerankModel, BatchMixin):
         model_spec: RerankSpecV1,
         quantization: str,
     ) -> Union[bool, Tuple[bool, str]]:
+        from ....constants import XINFERENCE_ENABLE_VIRTUAL_ENV
+
         if model_family.model_name.startswith("Qwen3-VL-Reranker"):
-            dep_check = check_dependency_available("transformers", "transformers")
-            if dep_check != True:
-                return dep_check
-            dep_check = check_dependency_available("qwen_vl_utils", "qwen_vl_utils")
-            if dep_check != True:
-                return dep_check
-            dep_check = check_dependency_available("PIL", "Pillow")
-            if dep_check != True:
-                return dep_check
-            dep_check = check_dependency_available("scipy", "scipy")
-            if dep_check != True:
-                return dep_check
+            if not XINFERENCE_ENABLE_VIRTUAL_ENV:
+                dep_check = check_dependency_available("transformers", "transformers")
+                if dep_check != True:
+                    return dep_check
+                dep_check = check_dependency_available("qwen_vl_utils", "qwen_vl_utils")
+                if dep_check != True:
+                    return dep_check
+                dep_check = check_dependency_available("PIL", "Pillow")
+                if dep_check != True:
+                    return dep_check
+                dep_check = check_dependency_available("scipy", "scipy")
+                if dep_check != True:
+                    return dep_check
             if model_spec.model_format not in ["pytorch"]:
                 return False, "Qwen3-VL reranker supports pytorch format only"
             return True
-        dep_check = check_dependency_available(
-            "sentence_transformers", "sentence-transformers"
-        )
-        if dep_check != True:
-            return dep_check
+
+        # virtualenv mode: dependencies provided by child venv, skip import check
+        if not XINFERENCE_ENABLE_VIRTUAL_ENV:
+            dep_check = check_dependency_available(
+                "sentence_transformers", "sentence-transformers"
+            )
+            if dep_check != True:
+                return dep_check
         if model_spec.model_format not in ["pytorch"]:
             return False, "SentenceTransformer rerank engine requires pytorch format"
         return True


### PR DESCRIPTION
## Summary

解决主机环境与模型专有虚拟环境之间 transformers 版本冲突导致 embedding/rerank 引擎注册失败的问题。

### 问题根因

1. **引擎注册时在主进程中执行 `import sentence_transformers`**：`generate_engine_config_by_model_name` 调用 `cls.match()` 触发实际 import，当主环境 transformers 版本不兼容时（如缺少 `HybridCache`），所有 sentence_transformers 引擎注册失败——即使模型配置了独立 venv。
2. **`match_json` 中无条件 `import vllm`**：Supervisor 节点未安装 vllm，启动时 `Qwen3-VL-Embedding` 的 `match_json` 直接 import vllm 导致 `ModuleNotFoundError`。
3. **jina-embeddings-v3 使用开放区间 `transformers>=4.53.3`**：`skip_installed` 模式下继承主环境不兼容版本，而 v4 用精确 pin `transformers==4.52.0` 则正常。

### 修复内容

- **virtualenv 模式下用 `match_json()` 替代 `match()`**：避免在主进程中执行依赖库的实际 import
- **`match_json` 中跳过 `check_dependency_available`**：virtualenv 模式下依赖由子 venv 提供，主环境无需检查
- **`import vllm` 加 try-except 保护**：Supervisor 节点无 vllm 时优雅降级
- **jina-embeddings-v3 锁定 `transformers==4.52.0`**：替换占位符的开放区间，迫使 uv 在独立 venv 中安装指定版本
- **移除 `setup.cfg` 中 `transformers<5.0.0` 上限**：根因已通过 virtualenv 隔离修复，无需全局限制版本

### 影响范围

- embedding/rerank 模块的引擎注册逻辑
- Supervisor 节点启动（不再因缺少 vllm 而失败）
- jina-embeddings-v3 的 virtualenv 依赖配置

## Test plan

- [ ] Supervisor 节点（无 vllm）正常启动，不报 ModuleNotFoundError
- [ ] Worker 节点部署 jina-embeddings-v3 不再报 `ImportError: cannot import name 'HybridCache'`
- [ ] jina-embeddings-v4 部署行为不变
- [ ] Qwen3-VL-Embedding 在有 vllm>=0.14.0 的 Worker 上正常注册
- [ ] 主环境 transformers>=5.0.0 时，embedding/rerank 引擎仍能正确注册（virtualenv 模式）