### PR TITLE
fix: Fix vLLM `/v1/completions` TypeError in Qwen3.5

### DIFF
--- a/xinference/model/llm/vllm/core.py
+++ b/xinference/model/llm/vllm/core.py
@@ -1910,7 +1910,7 @@ class VLLMMultiModel(VLLMModel, ChatModelMixin):
         from vllm import TokensPrompt
 
         if isinstance(prompt, str):
-            return super()._gen_tokens_prompt(tokenizer, prompt, config)
+            return await super()._gen_tokens_prompt(tokenizer, prompt, config)
 
         prompt_str = prompt["prompt"]
         multi_modal_data = prompt.get("multi_modal_data")


### PR DESCRIPTION
Error message: 

```
TypeError: [address=0.0.0.0:44969, pid=1250567] 'coroutine' object is not subscriptable
```

Code to reproduce:

```
from openai import OpenAI

openai_api_key = "EMPTY"
openai_api_base = "http://your.xinference:port/v1/"
openai_model = "qwen3.5"

client = OpenAI(
    api_key=openai_api_key,
    base_url=openai_api_base,
)

USER_PROMPT = "以以下文字开头，写一篇400字文章：如何赚一个亿"
completion = client.completions.create(model=openai_model, prompt=USER_PROMPT, max_tokens=1000)
print("Completion result:", completion)
```