### PR TITLE
fix: Set default enable-thinking option in command line to False

### DIFF
--- a/xinference/deploy/cmdline.py
+++ b/xinference/deploy/cmdline.py
@@ -859,7 +859,7 @@ def remove_cache(
     "--enable-thinking",
     "enable_thinking",
     flag_value=True,
-    default=None,
+    default=False,
     help="Enable thinking mode for hybrid reasoning LLMs (e.g., Qwen3).",
 )
 @click.option(


### PR DESCRIPTION
Close #4886 .

Fix the wrong default thinking behaviour when starting a model in command line without `--enable-thinking` option.

How to reproduce:

1. Start Qwen3.5 in command line without `--enable-thinking`.
2. Make a chat completion request to it:

```
from openai import OpenAI


API_BASE_URL = "http://your.xinference:port/v1"
API_KEY = "EMTPY"
LLM_MODEL = "qwen3.5"

client = OpenAI(
    base_url=API_BASE_URL,
    api_key=API_KEY
)

user_msg = "Hi"
result = client.chat.completions.create(
    messages=[
        {"role": "user", "content": user_msg},
    ],
    model=LLM_MODEL,
    # max_tokens=10,
)
print(result.model_dump_json())
```