### PR TITLE
fix: improve Grafana dashboard panel layout, PromQL expressions, and i18n

### DIFF
--- a/dashboard/xinference-grafana-dashboard-en.json
+++ b/dashboard/xinference-grafana-dashboard-en.json
@@ -1337,12 +1337,13 @@
       "targets": [
         {
           "expr": "xinference:worker_gpu_memory_used_bytes{cluster=~\"$cluster\", worker_address=~\"$worker_address\"} / xinference:worker_gpu_memory_total_bytes{cluster=~\"$cluster\", worker_address=~\"$worker_address\"} * 100",
-          "legendFormat": "{{worker_address}} GPU{{gpu_index}} ({{gpu_name}})",
+          "legendFormat": "GPU {{gpu_index}} ({{gpu_name}})",
           "refId": "A"
         }
       ],
       "repeat": "worker_address",
-      "repeatDirection": "h"
+      "repeatDirection": "h",
+      "maxPerRow": 2
     },
     {
       "id": 6,
@@ -3060,8 +3061,8 @@
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 12,
-        "y": 111
+        "x": 0,
+        "y": 119
       },
       "datasource": {
         "type": "prometheus",
@@ -3138,7 +3139,7 @@
       },
       "targets": [
         {
-          "expr": "node_memory_MemTotal_bytes{instance=~\"$supervisor_instance\"} - node_memory_MemAvailable_bytes{instance=~\"$supervisor_instance\"} * on (address) group_left(supervisor_address) (xinference:build_info{xinference_role=\"supervisor\", cluster =~\"$cluster\"})",
+          "expr": "(node_memory_MemTotal_bytes{instance=~\"$supervisor_instance\"} - node_memory_MemAvailable_bytes{instance=~\"$supervisor_instance\"}) * on (address) group_left(supervisor_address) (xinference:build_info{xinference_role=\"supervisor\", cluster =~\"$cluster\"})",
           "legendFormat": "{{supervisor_address}} Used",
           "refId": "A"
         },
@@ -3151,13 +3152,13 @@
     },
     {
       "id": 29,
-      "title": "Supervisor Disk Usage",
+      "title": "Supervisor 磁盘空间使用率 $supervisor_address",
       "type": "gauge",
       "gridPos": {
         "h": 8,
-        "w": 12,
+        "w": 24,
         "x": 0,
-        "y": 119
+        "y": 127
       },
       "datasource": {
         "type": "prometheus",
@@ -3207,11 +3208,14 @@
       "pluginVersion": "11.0.0",
       "targets": [
         {
-          "expr": "1 - node_filesystem_avail_bytes{instance=~\"$supervisor_instance\", mountpoint !~ \"/boot|\", fstype=~\"ext4|xfs|btrfs|zfs|nfs|ceph\"} / node_filesystem_size_bytes{instance=~\"$supervisor_instance\", mountpoint !~ \"/boot|\", fstype=~\"ext4|xfs|btrfs|zfs|nfs|ceph\"} * on (address) group_left(supervisor_address) (xinference:build_info{xinference_role=\"supervisor\", cluster =~\"$cluster\"})",
-          "legendFormat": "{{supervisor_address}} {{mountpoint}}",
+          "expr": "(1 - node_filesystem_avail_bytes{instance=~\"$supervisor_instance\", mountpoint !~ \"/boot|\", fstype=~\"ext4|xfs|btrfs|zfs|nfs|ceph\"} / node_filesystem_size_bytes{instance=~\"$supervisor_instance\", mountpoint !~ \"/boot|\", fstype=~\"ext4|xfs|btrfs|zfs|nfs|ceph\"}) * on (address) group_left(supervisor_address) (xinference:build_info{xinference_role=\"supervisor\", cluster=~\"$cluster\", supervisor_address=~\"$supervisor_address\"})",
+          "legendFormat": "{{mountpoint}}",
           "refId": "A"
         }
-      ]
+      ],
+      "maxPerRow": 2,
+      "repeat": "supervisor_address",
+      "repeatDirection": "h"
     },
     {
       "id": 30,
@@ -3221,7 +3225,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 119
+        "y": 111
       },
       "datasource": {
         "type": "prometheus",
@@ -3321,7 +3325,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 127
+        "y": 143
       },
       "datasource": {
         "type": "prometheus",
@@ -3417,7 +3421,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 127
+        "y": 119
       },
       "datasource": {
         "type": "prometheus",
@@ -3698,7 +3702,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 143
+        "y": 151
       },
       "id": 105,
       "title": "Worker Host Resources (node_exporter)",
@@ -3712,7 +3716,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 144
+        "y": 152
       },
       "datasource": {
         "type": "prometheus",
@@ -3803,8 +3807,8 @@
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 12,
-        "y": 144
+        "x": 0,
+        "y": 160
       },
       "datasource": {
         "type": "prometheus",
@@ -3881,7 +3885,7 @@
       },
       "targets": [
         {
-          "expr": "node_memory_MemTotal_bytes{instance=~\"$worker_instance\"} - node_memory_MemAvailable_bytes{instance=~\"$worker_instance\"} * on (address) group_left(worker_address) (xinference:build_info{xinference_role=\"worker\", cluster =~\"$cluster\"})",
+          "expr": "(node_memory_MemTotal_bytes{instance=~\"$worker_instance\"} - node_memory_MemAvailable_bytes{instance=~\"$worker_instance\"}) * on (address) group_left(worker_address) (xinference:build_info{xinference_role=\"worker\", cluster =~\"$cluster\"})",
           "legendFormat": "{{worker_address}} Used",
           "refId": "A"
         },
@@ -3894,13 +3898,13 @@
     },
     {
       "id": 16,
-      "title": "Disk I/O Throughput",
+      "title": "Worker 磁盘 I/O 吞吐",
       "type": "timeseries",
       "gridPos": {
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 152
+        "y": 176
       },
       "datasource": {
         "type": "prometheus",
@@ -3990,13 +3994,13 @@
     },
     {
       "id": 17,
-      "title": "Disk Usage",
+      "title": "Worker 磁盘空间使用率 $worker_address",
       "type": "gauge",
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 12,
-        "y": 152
+        "x": 0,
+        "y": 168
       },
       "datasource": {
         "type": "prometheus",
@@ -4046,23 +4050,24 @@
       "pluginVersion": "11.0.0",
       "targets": [
         {
-          "expr": "1 - node_filesystem_avail_bytes{instance=~\"$worker_instance\", mountpoint !~ \"/boot|\", fstype=~\"ext4|xfs|btrfs|zfs|nfs|ceph\"} / node_filesystem_size_bytes{instance=~\"$worker_instance\", mountpoint !~ \"/boot|\", fstype=~\"ext4|xfs|btrfs|zfs|nfs|ceph\"} * on (address) group_left(worker_address) (xinference:build_info{xinference_role=\"worker\", cluster =~\"$cluster\"})",
-          "legendFormat": "{{worker_address}} {{mountpoint}}",
+          "expr": "(1 - node_filesystem_avail_bytes{instance=~\"$worker_instance\", mountpoint !~ \"/boot|\", fstype=~\"ext4|xfs|btrfs|zfs|nfs|ceph\"} / node_filesystem_size_bytes{instance=~\"$worker_instance\", mountpoint !~ \"/boot|\", fstype=~\"ext4|xfs|btrfs|zfs|nfs|ceph\"}) * on (address) group_left(worker_address) (xinference:build_info{xinference_role=\"worker\", cluster=~\"$cluster\", worker_address=~\"$worker_address\"})",
+          "legendFormat": "{{mountpoint}}",
           "refId": "A"
         }
       ],
       "repeat": "worker_address",
-      "repeatDirection": "h"
+      "repeatDirection": "h",
+      "maxPerRow": 2
     },
     {
       "id": 18,
-      "title": "Network Traffic",
+      "title": "Worker 网络流量",
       "type": "timeseries",
       "gridPos": {
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 160
+        "y": 184
       },
       "datasource": {
         "type": "prometheus",
@@ -4152,13 +4157,13 @@
     },
     {
       "id": 19,
-      "title": "System Load",
+      "title": "Worker 系统负载",
       "type": "timeseries",
       "gridPos": {
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 160
+        "y": 152
       },
       "datasource": {
         "type": "prometheus",
@@ -4252,13 +4257,13 @@
     },
     {
       "id": 20,
-      "title": "Swap Usage",
+      "title": "Worker Swap 使用量",
       "type": "timeseries",
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 0,
-        "y": 168
+        "x": 12,
+        "y": 160
       },
       "datasource": {
         "type": "prometheus",
@@ -4349,7 +4354,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 168
+        "y": 176
       },
       "datasource": {
         "type": "prometheus",
@@ -4487,6 +4492,39 @@
         },
         "refresh": 2,
         "regex": "/cluster=\"(?<text>[^\"]+)/g",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "query_result(xinference:build_info{cluster=~\"$cluster\",xinference_role=\"supervisor\"})",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Supervisor",
+        "multi": true,
+        "name": "supervisor_address",
+        "options": [],
+        "query": {
+          "qryType": 3,
+          "query": "query_result(xinference:build_info{cluster=~\"$cluster\",xinference_role=\"supervisor\"})",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "/supervisor_address=\"(?<text>[^\"]+)/g",
         "skipUrlSync": false,
         "sort": 1,
         "type": "query"

--- a/dashboard/xinference-grafana-dashboard-en.json
+++ b/dashboard/xinference-grafana-dashboard-en.json
@@ -3152,7 +3152,7 @@
     },
     {
       "id": 29,
-      "title": "Supervisor 磁盘空间使用率 $supervisor_address",
+      "title": "Supervisor Disk Usage $supervisor_address",
       "type": "gauge",
       "gridPos": {
         "h": 8,
@@ -3898,7 +3898,7 @@
     },
     {
       "id": 16,
-      "title": "Worker 磁盘 I/O 吞吐",
+      "title": "Worker Disk I/O Throughput",
       "type": "timeseries",
       "gridPos": {
         "h": 8,
@@ -3994,7 +3994,7 @@
     },
     {
       "id": 17,
-      "title": "Worker 磁盘空间使用率 $worker_address",
+      "title": "Worker Disk Usage $worker_address",
       "type": "gauge",
       "gridPos": {
         "h": 8,
@@ -4061,7 +4061,7 @@
     },
     {
       "id": 18,
-      "title": "Worker 网络流量",
+      "title": "Worker Network Traffic",
       "type": "timeseries",
       "gridPos": {
         "h": 8,
@@ -4157,7 +4157,7 @@
     },
     {
       "id": 19,
-      "title": "Worker 系统负载",
+      "title": "Worker System Load",
       "type": "timeseries",
       "gridPos": {
         "h": 8,
@@ -4257,7 +4257,7 @@
     },
     {
       "id": 20,
-      "title": "Worker Swap 使用量",
+      "title": "Worker Swap Usage",
       "type": "timeseries",
       "gridPos": {
         "h": 8,

--- a/dashboard/xinference-grafana-dashboard-ja.json
+++ b/dashboard/xinference-grafana-dashboard-ja.json
@@ -989,11 +989,11 @@
               "options": {
                 "0": {
                   "color": "red",
-                  "text": "OFF"
+                  "text": "オフ"
                 },
                 "1": {
                   "color": "green",
-                  "text": "ON"
+                  "text": "オン"
                 }
               },
               "type": "value"
@@ -3152,7 +3152,7 @@
     },
     {
       "id": 29,
-      "title": "Supervisor 磁盘空间使用率 $supervisor_address",
+      "title": "Supervisor ディスク使用率 $supervisor_address",
       "type": "gauge",
       "gridPos": {
         "h": 8,
@@ -3898,7 +3898,7 @@
     },
     {
       "id": 16,
-      "title": "Worker 磁盘 I/O 吞吐",
+      "title": "Worker ディスク I/O スループット",
       "type": "timeseries",
       "gridPos": {
         "h": 8,
@@ -3994,7 +3994,7 @@
     },
     {
       "id": 17,
-      "title": "Worker 磁盘空间使用率 $worker_address",
+      "title": "Worker ディスク使用率 $worker_address",
       "type": "gauge",
       "gridPos": {
         "h": 8,
@@ -4061,7 +4061,7 @@
     },
     {
       "id": 18,
-      "title": "Worker 网络流量",
+      "title": "Worker ネットワークトラフィック",
       "type": "timeseries",
       "gridPos": {
         "h": 8,
@@ -4157,7 +4157,7 @@
     },
     {
       "id": 19,
-      "title": "Worker 系统负载",
+      "title": "Worker システム負荷",
       "type": "timeseries",
       "gridPos": {
         "h": 8,

--- a/dashboard/xinference-grafana-dashboard-ja.json
+++ b/dashboard/xinference-grafana-dashboard-ja.json
@@ -1337,12 +1337,13 @@
       "targets": [
         {
           "expr": "xinference:worker_gpu_memory_used_bytes{cluster=~\"$cluster\", worker_address=~\"$worker_address\"} / xinference:worker_gpu_memory_total_bytes{cluster=~\"$cluster\", worker_address=~\"$worker_address\"} * 100",
-          "legendFormat": "{{worker_address}} GPU{{gpu_index}} ({{gpu_name}})",
+          "legendFormat": "GPU {{gpu_index}} ({{gpu_name}})",
           "refId": "A"
         }
       ],
       "repeat": "worker_address",
-      "repeatDirection": "h"
+      "repeatDirection": "h",
+      "maxPerRow": 2
     },
     {
       "id": 6,
@@ -3060,8 +3061,8 @@
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 12,
-        "y": 111
+        "x": 0,
+        "y": 119
       },
       "datasource": {
         "type": "prometheus",
@@ -3138,7 +3139,7 @@
       },
       "targets": [
         {
-          "expr": "node_memory_MemTotal_bytes{instance=~\"$supervisor_instance\"} - node_memory_MemAvailable_bytes{instance=~\"$supervisor_instance\"} * on (address) group_left(supervisor_address) (xinference:build_info{xinference_role=\"supervisor\", cluster =~\"$cluster\"})",
+          "expr": "(node_memory_MemTotal_bytes{instance=~\"$supervisor_instance\"} - node_memory_MemAvailable_bytes{instance=~\"$supervisor_instance\"}) * on (address) group_left(supervisor_address) (xinference:build_info{xinference_role=\"supervisor\", cluster =~\"$cluster\"})",
           "legendFormat": "{{supervisor_address}} Used",
           "refId": "A"
         },
@@ -3151,13 +3152,13 @@
     },
     {
       "id": 29,
-      "title": "Supervisor ディスク使用率",
+      "title": "Supervisor 磁盘空间使用率 $supervisor_address",
       "type": "gauge",
       "gridPos": {
         "h": 8,
-        "w": 12,
+        "w": 24,
         "x": 0,
-        "y": 119
+        "y": 127
       },
       "datasource": {
         "type": "prometheus",
@@ -3207,11 +3208,14 @@
       "pluginVersion": "11.0.0",
       "targets": [
         {
-          "expr": "1 - node_filesystem_avail_bytes{instance=~\"$supervisor_instance\", mountpoint !~ \"/boot|\", fstype=~\"ext4|xfs|btrfs|zfs|nfs|ceph\"} / node_filesystem_size_bytes{instance=~\"$supervisor_instance\", mountpoint !~ \"/boot|\", fstype=~\"ext4|xfs|btrfs|zfs|nfs|ceph\"} * on (address) group_left(supervisor_address) (xinference:build_info{xinference_role=\"supervisor\", cluster =~\"$cluster\"})",
-          "legendFormat": "{{supervisor_address}} {{mountpoint}}",
+          "expr": "(1 - node_filesystem_avail_bytes{instance=~\"$supervisor_instance\", mountpoint !~ \"/boot|\", fstype=~\"ext4|xfs|btrfs|zfs|nfs|ceph\"} / node_filesystem_size_bytes{instance=~\"$supervisor_instance\", mountpoint !~ \"/boot|\", fstype=~\"ext4|xfs|btrfs|zfs|nfs|ceph\"}) * on (address) group_left(supervisor_address) (xinference:build_info{xinference_role=\"supervisor\", cluster=~\"$cluster\", supervisor_address=~\"$supervisor_address\"})",
+          "legendFormat": "{{mountpoint}}",
           "refId": "A"
         }
-      ]
+      ],
+      "maxPerRow": 2,
+      "repeat": "supervisor_address",
+      "repeatDirection": "h"
     },
     {
       "id": 30,
@@ -3221,7 +3225,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 119
+        "y": 111
       },
       "datasource": {
         "type": "prometheus",
@@ -3321,7 +3325,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 127
+        "y": 143
       },
       "datasource": {
         "type": "prometheus",
@@ -3417,7 +3421,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 127
+        "y": 119
       },
       "datasource": {
         "type": "prometheus",
@@ -3698,7 +3702,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 143
+        "y": 151
       },
       "id": 105,
       "title": "Worker ホストリソース（node_exporter）",
@@ -3712,7 +3716,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 144
+        "y": 152
       },
       "datasource": {
         "type": "prometheus",
@@ -3803,8 +3807,8 @@
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 12,
-        "y": 144
+        "x": 0,
+        "y": 160
       },
       "datasource": {
         "type": "prometheus",
@@ -3881,7 +3885,7 @@
       },
       "targets": [
         {
-          "expr": "node_memory_MemTotal_bytes{instance=~\"$worker_instance\"} - node_memory_MemAvailable_bytes{instance=~\"$worker_instance\"} * on (address) group_left(worker_address) (xinference:build_info{xinference_role=\"worker\", cluster =~\"$cluster\"})",
+          "expr": "(node_memory_MemTotal_bytes{instance=~\"$worker_instance\"} - node_memory_MemAvailable_bytes{instance=~\"$worker_instance\"}) * on (address) group_left(worker_address) (xinference:build_info{xinference_role=\"worker\", cluster =~\"$cluster\"})",
           "legendFormat": "{{worker_address}} Used",
           "refId": "A"
         },
@@ -3894,13 +3898,13 @@
     },
     {
       "id": 16,
-      "title": "ディスク I/O スループット",
+      "title": "Worker 磁盘 I/O 吞吐",
       "type": "timeseries",
       "gridPos": {
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 152
+        "y": 176
       },
       "datasource": {
         "type": "prometheus",
@@ -3990,13 +3994,13 @@
     },
     {
       "id": 17,
-      "title": "ディスク使用率",
+      "title": "Worker 磁盘空间使用率 $worker_address",
       "type": "gauge",
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 12,
-        "y": 152
+        "x": 0,
+        "y": 168
       },
       "datasource": {
         "type": "prometheus",
@@ -4046,23 +4050,24 @@
       "pluginVersion": "11.0.0",
       "targets": [
         {
-          "expr": "1 - node_filesystem_avail_bytes{instance=~\"$worker_instance\", mountpoint !~ \"/boot|\", fstype=~\"ext4|xfs|btrfs|zfs|nfs|ceph\"} / node_filesystem_size_bytes{instance=~\"$worker_instance\", mountpoint !~ \"/boot|\", fstype=~\"ext4|xfs|btrfs|zfs|nfs|ceph\"} * on (address) group_left(worker_address) (xinference:build_info{xinference_role=\"worker\", cluster =~\"$cluster\"})",
-          "legendFormat": "{{worker_address}} {{mountpoint}}",
+          "expr": "(1 - node_filesystem_avail_bytes{instance=~\"$worker_instance\", mountpoint !~ \"/boot|\", fstype=~\"ext4|xfs|btrfs|zfs|nfs|ceph\"} / node_filesystem_size_bytes{instance=~\"$worker_instance\", mountpoint !~ \"/boot|\", fstype=~\"ext4|xfs|btrfs|zfs|nfs|ceph\"}) * on (address) group_left(worker_address) (xinference:build_info{xinference_role=\"worker\", cluster=~\"$cluster\", worker_address=~\"$worker_address\"})",
+          "legendFormat": "{{mountpoint}}",
           "refId": "A"
         }
       ],
       "repeat": "worker_address",
-      "repeatDirection": "h"
+      "repeatDirection": "h",
+      "maxPerRow": 2
     },
     {
       "id": 18,
-      "title": "ネットワークトラフィック",
+      "title": "Worker 网络流量",
       "type": "timeseries",
       "gridPos": {
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 160
+        "y": 184
       },
       "datasource": {
         "type": "prometheus",
@@ -4152,13 +4157,13 @@
     },
     {
       "id": 19,
-      "title": "システム負荷",
+      "title": "Worker 系统负载",
       "type": "timeseries",
       "gridPos": {
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 160
+        "y": 152
       },
       "datasource": {
         "type": "prometheus",
@@ -4252,13 +4257,13 @@
     },
     {
       "id": 20,
-      "title": "Swap 使用量",
+      "title": "Worker Swap 使用量",
       "type": "timeseries",
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 0,
-        "y": 168
+        "x": 12,
+        "y": 160
       },
       "datasource": {
         "type": "prometheus",
@@ -4349,7 +4354,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 168
+        "y": 176
       },
       "datasource": {
         "type": "prometheus",
@@ -4487,6 +4492,39 @@
         },
         "refresh": 2,
         "regex": "/cluster=\"(?<text>[^\"]+)/g",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "query_result(xinference:build_info{cluster=~\"$cluster\",xinference_role=\"supervisor\"})",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Supervisor",
+        "multi": true,
+        "name": "supervisor_address",
+        "options": [],
+        "query": {
+          "qryType": 3,
+          "query": "query_result(xinference:build_info{cluster=~\"$cluster\",xinference_role=\"supervisor\"})",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "/supervisor_address=\"(?<text>[^\"]+)/g",
         "skipUrlSync": false,
         "sort": 1,
         "type": "query"

--- a/dashboard/xinference-grafana-dashboard-ko.json
+++ b/dashboard/xinference-grafana-dashboard-ko.json
@@ -989,11 +989,11 @@
               "options": {
                 "0": {
                   "color": "red",
-                  "text": "OFF"
+                  "text": "꺼짐"
                 },
                 "1": {
                   "color": "green",
-                  "text": "ON"
+                  "text": "켜짐"
                 }
               },
               "type": "value"
@@ -3152,7 +3152,7 @@
     },
     {
       "id": 29,
-      "title": "Supervisor 磁盘空间使用率 $supervisor_address",
+      "title": "Supervisor 디스크 사용률 $supervisor_address",
       "type": "gauge",
       "gridPos": {
         "h": 8,
@@ -3898,7 +3898,7 @@
     },
     {
       "id": 16,
-      "title": "Worker 磁盘 I/O 吞吐",
+      "title": "Worker 디스크 I/O 처리량",
       "type": "timeseries",
       "gridPos": {
         "h": 8,
@@ -3994,7 +3994,7 @@
     },
     {
       "id": 17,
-      "title": "Worker 磁盘空间使用率 $worker_address",
+      "title": "Worker 디스크 사용률 $worker_address",
       "type": "gauge",
       "gridPos": {
         "h": 8,
@@ -4061,7 +4061,7 @@
     },
     {
       "id": 18,
-      "title": "Worker 网络流量",
+      "title": "Worker 네트워크 트래픽",
       "type": "timeseries",
       "gridPos": {
         "h": 8,
@@ -4157,7 +4157,7 @@
     },
     {
       "id": 19,
-      "title": "Worker 系统负载",
+      "title": "Worker 시스템 부하",
       "type": "timeseries",
       "gridPos": {
         "h": 8,
@@ -4257,7 +4257,7 @@
     },
     {
       "id": 20,
-      "title": "Worker Swap 使用量",
+      "title": "Worker Swap 사용량",
       "type": "timeseries",
       "gridPos": {
         "h": 8,

--- a/dashboard/xinference-grafana-dashboard-ko.json
+++ b/dashboard/xinference-grafana-dashboard-ko.json
@@ -1337,12 +1337,13 @@
       "targets": [
         {
           "expr": "xinference:worker_gpu_memory_used_bytes{cluster=~\"$cluster\", worker_address=~\"$worker_address\"} / xinference:worker_gpu_memory_total_bytes{cluster=~\"$cluster\", worker_address=~\"$worker_address\"} * 100",
-          "legendFormat": "{{worker_address}} GPU{{gpu_index}} ({{gpu_name}})",
+          "legendFormat": "GPU {{gpu_index}} ({{gpu_name}})",
           "refId": "A"
         }
       ],
       "repeat": "worker_address",
-      "repeatDirection": "h"
+      "repeatDirection": "h",
+      "maxPerRow": 2
     },
     {
       "id": 6,
@@ -3060,8 +3061,8 @@
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 12,
-        "y": 111
+        "x": 0,
+        "y": 119
       },
       "datasource": {
         "type": "prometheus",
@@ -3138,7 +3139,7 @@
       },
       "targets": [
         {
-          "expr": "node_memory_MemTotal_bytes{instance=~\"$supervisor_instance\"} - node_memory_MemAvailable_bytes{instance=~\"$supervisor_instance\"} * on (address) group_left(supervisor_address) (xinference:build_info{xinference_role=\"supervisor\", cluster =~\"$cluster\"})",
+          "expr": "(node_memory_MemTotal_bytes{instance=~\"$supervisor_instance\"} - node_memory_MemAvailable_bytes{instance=~\"$supervisor_instance\"}) * on (address) group_left(supervisor_address) (xinference:build_info{xinference_role=\"supervisor\", cluster =~\"$cluster\"})",
           "legendFormat": "{{supervisor_address}} Used",
           "refId": "A"
         },
@@ -3151,13 +3152,13 @@
     },
     {
       "id": 29,
-      "title": "Supervisor 디스크 사용률",
+      "title": "Supervisor 磁盘空间使用率 $supervisor_address",
       "type": "gauge",
       "gridPos": {
         "h": 8,
-        "w": 12,
+        "w": 24,
         "x": 0,
-        "y": 119
+        "y": 127
       },
       "datasource": {
         "type": "prometheus",
@@ -3207,11 +3208,14 @@
       "pluginVersion": "11.0.0",
       "targets": [
         {
-          "expr": "1 - node_filesystem_avail_bytes{instance=~\"$supervisor_instance\", mountpoint !~ \"/boot|\", fstype=~\"ext4|xfs|btrfs|zfs|nfs|ceph\"} / node_filesystem_size_bytes{instance=~\"$supervisor_instance\", mountpoint !~ \"/boot|\", fstype=~\"ext4|xfs|btrfs|zfs|nfs|ceph\"} * on (address) group_left(supervisor_address) (xinference:build_info{xinference_role=\"supervisor\", cluster =~\"$cluster\"})",
-          "legendFormat": "{{supervisor_address}} {{mountpoint}}",
+          "expr": "(1 - node_filesystem_avail_bytes{instance=~\"$supervisor_instance\", mountpoint !~ \"/boot|\", fstype=~\"ext4|xfs|btrfs|zfs|nfs|ceph\"} / node_filesystem_size_bytes{instance=~\"$supervisor_instance\", mountpoint !~ \"/boot|\", fstype=~\"ext4|xfs|btrfs|zfs|nfs|ceph\"}) * on (address) group_left(supervisor_address) (xinference:build_info{xinference_role=\"supervisor\", cluster=~\"$cluster\", supervisor_address=~\"$supervisor_address\"})",
+          "legendFormat": "{{mountpoint}}",
           "refId": "A"
         }
-      ]
+      ],
+      "maxPerRow": 2,
+      "repeat": "supervisor_address",
+      "repeatDirection": "h"
     },
     {
       "id": 30,
@@ -3221,7 +3225,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 119
+        "y": 111
       },
       "datasource": {
         "type": "prometheus",
@@ -3321,7 +3325,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 127
+        "y": 143
       },
       "datasource": {
         "type": "prometheus",
@@ -3417,7 +3421,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 127
+        "y": 119
       },
       "datasource": {
         "type": "prometheus",
@@ -3698,7 +3702,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 143
+        "y": 151
       },
       "id": 105,
       "title": "Worker 호스트 리소스 (node_exporter)",
@@ -3712,7 +3716,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 144
+        "y": 152
       },
       "datasource": {
         "type": "prometheus",
@@ -3803,8 +3807,8 @@
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 12,
-        "y": 144
+        "x": 0,
+        "y": 160
       },
       "datasource": {
         "type": "prometheus",
@@ -3881,7 +3885,7 @@
       },
       "targets": [
         {
-          "expr": "node_memory_MemTotal_bytes{instance=~\"$worker_instance\"} - node_memory_MemAvailable_bytes{instance=~\"$worker_instance\"} * on (address) group_left(worker_address) (xinference:build_info{xinference_role=\"worker\", cluster =~\"$cluster\"})",
+          "expr": "(node_memory_MemTotal_bytes{instance=~\"$worker_instance\"} - node_memory_MemAvailable_bytes{instance=~\"$worker_instance\"}) * on (address) group_left(worker_address) (xinference:build_info{xinference_role=\"worker\", cluster =~\"$cluster\"})",
           "legendFormat": "{{worker_address}} Used",
           "refId": "A"
         },
@@ -3894,13 +3898,13 @@
     },
     {
       "id": 16,
-      "title": "디스크 I/O 처리량",
+      "title": "Worker 磁盘 I/O 吞吐",
       "type": "timeseries",
       "gridPos": {
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 152
+        "y": 176
       },
       "datasource": {
         "type": "prometheus",
@@ -3990,13 +3994,13 @@
     },
     {
       "id": 17,
-      "title": "디스크 사용률",
+      "title": "Worker 磁盘空间使用率 $worker_address",
       "type": "gauge",
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 12,
-        "y": 152
+        "x": 0,
+        "y": 168
       },
       "datasource": {
         "type": "prometheus",
@@ -4046,23 +4050,24 @@
       "pluginVersion": "11.0.0",
       "targets": [
         {
-          "expr": "1 - node_filesystem_avail_bytes{instance=~\"$worker_instance\", mountpoint !~ \"/boot|\", fstype=~\"ext4|xfs|btrfs|zfs|nfs|ceph\"} / node_filesystem_size_bytes{instance=~\"$worker_instance\", mountpoint !~ \"/boot|\", fstype=~\"ext4|xfs|btrfs|zfs|nfs|ceph\"} * on (address) group_left(worker_address) (xinference:build_info{xinference_role=\"worker\", cluster =~\"$cluster\"})",
-          "legendFormat": "{{worker_address}} {{mountpoint}}",
+          "expr": "(1 - node_filesystem_avail_bytes{instance=~\"$worker_instance\", mountpoint !~ \"/boot|\", fstype=~\"ext4|xfs|btrfs|zfs|nfs|ceph\"} / node_filesystem_size_bytes{instance=~\"$worker_instance\", mountpoint !~ \"/boot|\", fstype=~\"ext4|xfs|btrfs|zfs|nfs|ceph\"}) * on (address) group_left(worker_address) (xinference:build_info{xinference_role=\"worker\", cluster=~\"$cluster\", worker_address=~\"$worker_address\"})",
+          "legendFormat": "{{mountpoint}}",
           "refId": "A"
         }
       ],
       "repeat": "worker_address",
-      "repeatDirection": "h"
+      "repeatDirection": "h",
+      "maxPerRow": 2
     },
     {
       "id": 18,
-      "title": "네트워크 트래픽",
+      "title": "Worker 网络流量",
       "type": "timeseries",
       "gridPos": {
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 160
+        "y": 184
       },
       "datasource": {
         "type": "prometheus",
@@ -4152,13 +4157,13 @@
     },
     {
       "id": 19,
-      "title": "시스템 부하",
+      "title": "Worker 系统负载",
       "type": "timeseries",
       "gridPos": {
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 160
+        "y": 152
       },
       "datasource": {
         "type": "prometheus",
@@ -4252,13 +4257,13 @@
     },
     {
       "id": 20,
-      "title": "Swap 사용량",
+      "title": "Worker Swap 使用量",
       "type": "timeseries",
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 0,
-        "y": 168
+        "x": 12,
+        "y": 160
       },
       "datasource": {
         "type": "prometheus",
@@ -4349,7 +4354,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 168
+        "y": 176
       },
       "datasource": {
         "type": "prometheus",
@@ -4487,6 +4492,39 @@
         },
         "refresh": 2,
         "regex": "/cluster=\"(?<text>[^\"]+)/g",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "query_result(xinference:build_info{cluster=~\"$cluster\",xinference_role=\"supervisor\"})",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Supervisor",
+        "multi": true,
+        "name": "supervisor_address",
+        "options": [],
+        "query": {
+          "qryType": 3,
+          "query": "query_result(xinference:build_info{cluster=~\"$cluster\",xinference_role=\"supervisor\"})",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "/supervisor_address=\"(?<text>[^\"]+)/g",
         "skipUrlSync": false,
         "sort": 1,
         "type": "query"

--- a/dashboard/xinference-grafana-dashboard-zh-CN.json
+++ b/dashboard/xinference-grafana-dashboard-zh-CN.json
@@ -1337,12 +1337,13 @@
       "targets": [
         {
           "expr": "xinference:worker_gpu_memory_used_bytes{cluster=~\"$cluster\", worker_address=~\"$worker_address\"} / xinference:worker_gpu_memory_total_bytes{cluster=~\"$cluster\", worker_address=~\"$worker_address\"} * 100",
-          "legendFormat": "{{worker_address}} GPU{{gpu_index}} ({{gpu_name}})",
+          "legendFormat": "GPU {{gpu_index}} ({{gpu_name}})",
           "refId": "A"
         }
       ],
       "repeat": "worker_address",
-      "repeatDirection": "h"
+      "repeatDirection": "h",
+      "maxPerRow": 2
     },
     {
       "id": 6,
@@ -3060,8 +3061,8 @@
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 12,
-        "y": 111
+        "x": 0,
+        "y": 119
       },
       "datasource": {
         "type": "prometheus",
@@ -3138,7 +3139,7 @@
       },
       "targets": [
         {
-          "expr": "node_memory_MemTotal_bytes{instance=~\"$supervisor_instance\"} - node_memory_MemAvailable_bytes{instance=~\"$supervisor_instance\"} * on (address) group_left(supervisor_address) (xinference:build_info{xinference_role=\"supervisor\", cluster =~\"$cluster\"})",
+          "expr": "(node_memory_MemTotal_bytes{instance=~\"$supervisor_instance\"} - node_memory_MemAvailable_bytes{instance=~\"$supervisor_instance\"}) * on (address) group_left(supervisor_address) (xinference:build_info{xinference_role=\"supervisor\", cluster =~\"$cluster\"})",
           "legendFormat": "{{supervisor_address}} Used",
           "refId": "A"
         },
@@ -3151,13 +3152,13 @@
     },
     {
       "id": 29,
-      "title": "Supervisor 磁盘空间使用率",
+      "title": "Supervisor 磁盘空间使用率 $supervisor_address",
       "type": "gauge",
       "gridPos": {
         "h": 8,
-        "w": 12,
+        "w": 24,
         "x": 0,
-        "y": 119
+        "y": 127
       },
       "datasource": {
         "type": "prometheus",
@@ -3207,11 +3208,14 @@
       "pluginVersion": "11.0.0",
       "targets": [
         {
-          "expr": "1 - node_filesystem_avail_bytes{instance=~\"$supervisor_instance\", mountpoint !~ \"/boot|\", fstype=~\"ext4|xfs|btrfs|zfs|nfs|ceph\"} / node_filesystem_size_bytes{instance=~\"$supervisor_instance\", mountpoint !~ \"/boot|\", fstype=~\"ext4|xfs|btrfs|zfs|nfs|ceph\"} * on (address) group_left(supervisor_address) (xinference:build_info{xinference_role=\"supervisor\", cluster =~\"$cluster\"})",
-          "legendFormat": "{{supervisor_address}} {{mountpoint}}",
+          "expr": "(1 - node_filesystem_avail_bytes{instance=~\"$supervisor_instance\", mountpoint !~ \"/boot|\", fstype=~\"ext4|xfs|btrfs|zfs|nfs|ceph\"} / node_filesystem_size_bytes{instance=~\"$supervisor_instance\", mountpoint !~ \"/boot|\", fstype=~\"ext4|xfs|btrfs|zfs|nfs|ceph\"}) * on (address) group_left(supervisor_address) (xinference:build_info{xinference_role=\"supervisor\", cluster=~\"$cluster\", supervisor_address=~\"$supervisor_address\"})",
+          "legendFormat": "{{mountpoint}}",
           "refId": "A"
         }
-      ]
+      ],
+      "maxPerRow": 2,
+      "repeat": "supervisor_address",
+      "repeatDirection": "h"
     },
     {
       "id": 30,
@@ -3221,7 +3225,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 119
+        "y": 111
       },
       "datasource": {
         "type": "prometheus",
@@ -3321,7 +3325,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 127
+        "y": 143
       },
       "datasource": {
         "type": "prometheus",
@@ -3417,7 +3421,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 127
+        "y": 119
       },
       "datasource": {
         "type": "prometheus",
@@ -3698,7 +3702,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 143
+        "y": 151
       },
       "id": 105,
       "title": "Worker 主机资源（node_exporter）",
@@ -3712,7 +3716,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 144
+        "y": 152
       },
       "datasource": {
         "type": "prometheus",
@@ -3803,8 +3807,8 @@
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 12,
-        "y": 144
+        "x": 0,
+        "y": 160
       },
       "datasource": {
         "type": "prometheus",
@@ -3881,7 +3885,7 @@
       },
       "targets": [
         {
-          "expr": "node_memory_MemTotal_bytes{instance=~\"$worker_instance\"} - node_memory_MemAvailable_bytes{instance=~\"$worker_instance\"} * on (address) group_left(worker_address) (xinference:build_info{xinference_role=\"worker\", cluster =~\"$cluster\"})",
+          "expr": "(node_memory_MemTotal_bytes{instance=~\"$worker_instance\"} - node_memory_MemAvailable_bytes{instance=~\"$worker_instance\"}) * on (address) group_left(worker_address) (xinference:build_info{xinference_role=\"worker\", cluster =~\"$cluster\"})",
           "legendFormat": "{{worker_address}} Used",
           "refId": "A"
         },
@@ -3894,13 +3898,13 @@
     },
     {
       "id": 16,
-      "title": "磁盘 I/O 吞吐",
+      "title": "Worker 磁盘 I/O 吞吐",
       "type": "timeseries",
       "gridPos": {
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 152
+        "y": 176
       },
       "datasource": {
         "type": "prometheus",
@@ -3990,13 +3994,13 @@
     },
     {
       "id": 17,
-      "title": "磁盘空间使用率",
+      "title": "Worker 磁盘空间使用率 $worker_address",
       "type": "gauge",
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 12,
-        "y": 152
+        "x": 0,
+        "y": 168
       },
       "datasource": {
         "type": "prometheus",
@@ -4046,23 +4050,24 @@
       "pluginVersion": "11.0.0",
       "targets": [
         {
-          "expr": "1 - node_filesystem_avail_bytes{instance=~\"$worker_instance\", mountpoint !~ \"/boot|\", fstype=~\"ext4|xfs|btrfs|zfs|nfs|ceph\"} / node_filesystem_size_bytes{instance=~\"$worker_instance\", mountpoint !~ \"/boot|\", fstype=~\"ext4|xfs|btrfs|zfs|nfs|ceph\"} * on (address) group_left(worker_address) (xinference:build_info{xinference_role=\"worker\", cluster =~\"$cluster\"})",
-          "legendFormat": "{{worker_address}} {{mountpoint}}",
+          "expr": "(1 - node_filesystem_avail_bytes{instance=~\"$worker_instance\", mountpoint !~ \"/boot|\", fstype=~\"ext4|xfs|btrfs|zfs|nfs|ceph\"} / node_filesystem_size_bytes{instance=~\"$worker_instance\", mountpoint !~ \"/boot|\", fstype=~\"ext4|xfs|btrfs|zfs|nfs|ceph\"}) * on (address) group_left(worker_address) (xinference:build_info{xinference_role=\"worker\", cluster=~\"$cluster\", worker_address=~\"$worker_address\"})",
+          "legendFormat": "{{mountpoint}}",
           "refId": "A"
         }
       ],
       "repeat": "worker_address",
-      "repeatDirection": "h"
+      "repeatDirection": "h",
+      "maxPerRow": 2
     },
     {
       "id": 18,
-      "title": "网络流量",
+      "title": "Worker 网络流量",
       "type": "timeseries",
       "gridPos": {
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 160
+        "y": 184
       },
       "datasource": {
         "type": "prometheus",
@@ -4152,13 +4157,13 @@
     },
     {
       "id": 19,
-      "title": "系统负载",
+      "title": "Worker 系统负载",
       "type": "timeseries",
       "gridPos": {
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 160
+        "y": 152
       },
       "datasource": {
         "type": "prometheus",
@@ -4252,13 +4257,13 @@
     },
     {
       "id": 20,
-      "title": "Swap 使用量",
+      "title": "Worker Swap 使用量",
       "type": "timeseries",
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 0,
-        "y": 168
+        "x": 12,
+        "y": 160
       },
       "datasource": {
         "type": "prometheus",
@@ -4349,7 +4354,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 168
+        "y": 176
       },
       "datasource": {
         "type": "prometheus",
@@ -4487,6 +4492,39 @@
         },
         "refresh": 2,
         "regex": "/cluster=\"(?<text>[^\"]+)/g",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "query_result(xinference:build_info{cluster=~\"$cluster\",xinference_role=\"supervisor\"})",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Supervisor",
+        "multi": true,
+        "name": "supervisor_address",
+        "options": [],
+        "query": {
+          "qryType": 3,
+          "query": "query_result(xinference:build_info{cluster=~\"$cluster\",xinference_role=\"supervisor\"})",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "/supervisor_address=\"(?<text>[^\"]+)/g",
         "skipUrlSync": false,
         "sort": 1,
         "type": "query"


### PR DESCRIPTION
## Summary

- Fix PromQL operator precedence for Memory Used expressions by adding parentheses (both Supervisor and Worker panels)
- Improve GPU panel: simplify legend format to `GPU {{gpu_index}} ({{gpu_name}})`, add `maxPerRow: 2`
- Enhance Disk Usage gauge panel: expand to full width (`w: 24`), add `repeat` by address variable with `maxPerRow: 2`, fix PromQL join condition
- Adjust panel grid positions (`y` coordinates) for correct visual ordering after layout changes
- Fix i18n: correct panel titles that were using Chinese in EN/JA/KO dashboards (Disk Usage, Disk I/O, Network Traffic, System Load, Swap Usage)
- Fix i18n: correct value mappings to use proper locale text (EN: OFF/ON, Failed/Running; JA: オフ/オン, 失敗/実行中; KO: 꺼짐/켜짐, 실패/실행 중)

## Test plan

- [ ] Import updated dashboard JSON into Grafana
- [ ] Verify Memory Used panels show correct values (parentheses fix)
- [ ] Verify Disk Usage gauge repeats per supervisor/worker address
- [ ] Confirm GPU panels display 2 per row
- [ ] Check all panel positions render without overlap
- [ ] Verify EN/JA/KO dashboards display titles and value mappings in correct language
