### PR TITLE
feat: add modular vLLM post-install patch framework with hybrid KV cache fix

### DIFF
--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -2069,7 +2069,7 @@ class WorkerActor(xo.StatelessActor):
                         virtual_env_packages,
                         model_engine,
                         model_name=model_name,
-                        architectures=model.model_family._resolve_architectures(),
+                        architectures=getattr(model.model_family, '_resolve_architectures', lambda: None)(),
                     )
                     launch_info.virtual_env_manager = virtual_env_manager
 

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -2069,7 +2069,9 @@ class WorkerActor(xo.StatelessActor):
                         virtual_env_packages,
                         model_engine,
                         model_name=model_name,
-                        architectures=getattr(model.model_family, '_resolve_architectures', lambda: None)(),
+                        architectures=getattr(
+                            model.model_family, "_resolve_architectures", lambda: None
+                        )(),
                     )
                     launch_info.virtual_env_manager = virtual_env_manager
 

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -1677,6 +1677,8 @@ class WorkerActor(xo.StatelessActor):
         settings: Optional[VirtualEnvSettings],
         virtual_env_packages: Optional[List[str]],
         model_engine: Optional[str],
+        model_name: Optional[str] = None,
+        model_family: Optional[str] = None,
     ):
         engine_defaults: List[str] = []
         if (
@@ -1804,6 +1806,19 @@ class WorkerActor(xo.StatelessActor):
         )
         with _exclusive_venv_path_lock(str(virtual_env_manager.env_path)):
             virtual_env_manager.install_packages(packages, **conf, **variables)
+
+        # Apply engine-specific post-install patches
+        if model_engine and model_engine.lower() == "vllm":
+            try:
+                from xinference.model.llm.vllm.patches import apply_vllm_patches
+            except ImportError:
+                pass
+            else:
+                apply_vllm_patches(
+                    env_path=str(virtual_env_manager.env_path),
+                    model_name=model_name,
+                    model_family=model_family,
+                )
 
     async def _get_progressor(self, request_id: str):
         from .progress_tracker import Progressor, ProgressTrackerActor
@@ -2053,6 +2068,8 @@ class WorkerActor(xo.StatelessActor):
                         model.model_family.virtualenv,
                         virtual_env_packages,
                         model_engine,
+                        model_name=model_name,
+                        model_family=model.model_family.model_name,
                     )
                     launch_info.virtual_env_manager = virtual_env_manager
 

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -1678,7 +1678,7 @@ class WorkerActor(xo.StatelessActor):
         virtual_env_packages: Optional[List[str]],
         model_engine: Optional[str],
         model_name: Optional[str] = None,
-        model_family: Optional[str] = None,
+        architectures: Optional[List[str]] = None,
     ):
         engine_defaults: List[str] = []
         if (
@@ -1817,7 +1817,7 @@ class WorkerActor(xo.StatelessActor):
                 apply_vllm_patches(
                     env_path=str(virtual_env_manager.env_path),
                     model_name=model_name,
-                    model_family=model_family,
+                    architectures=architectures,
                 )
 
     async def _get_progressor(self, request_id: str):
@@ -2069,7 +2069,7 @@ class WorkerActor(xo.StatelessActor):
                         virtual_env_packages,
                         model_engine,
                         model_name=model_name,
-                        model_family=model.model_family.model_name,
+                        architectures=model.model_family._resolve_architectures(),
                     )
                     launch_info.virtual_env_manager = virtual_env_manager
 

--- a/xinference/model/llm/vllm/patches/__init__.py
+++ b/xinference/model/llm/vllm/patches/__init__.py
@@ -4,6 +4,7 @@ vLLM post-install patches registry.
 Patches are auto-discovered: any module in this package that exposes a
 top-level ``PATCH`` attribute (instance of VllmPatch) is registered automatically.
 """
+
 import importlib
 import logging
 import pkgutil

--- a/xinference/model/llm/vllm/patches/__init__.py
+++ b/xinference/model/llm/vllm/patches/__init__.py
@@ -1,0 +1,56 @@
+"""
+vLLM post-install patches registry.
+
+Patches are auto-discovered: any module in this package that exposes a
+top-level ``PATCH`` attribute (instance of VllmPatch) is registered automatically.
+"""
+import importlib
+import logging
+import pkgutil
+from typing import List, Optional
+
+from ._base import VllmPatch
+
+logger = logging.getLogger(__name__)
+
+# Auto-discover patch modules
+_PATCHES: List[VllmPatch] = []
+for _info in pkgutil.iter_modules(__path__):
+    if _info.name.startswith("_"):
+        continue
+    _mod = importlib.import_module(f".{_info.name}", __name__)
+    if hasattr(_mod, "PATCH"):
+        _PATCHES.append(_mod.PATCH)
+
+
+def apply_vllm_patches(
+    env_path: str,
+    model_name: Optional[str] = None,
+    model_family: Optional[str] = None,
+) -> None:
+    """
+    Apply applicable vLLM patches for the given model.
+
+    Args:
+        env_path: Path to the virtual environment root.
+        model_name: Model name (for logging).
+        model_family: Model family string, used to filter patches.
+    """
+    for patch in _PATCHES:
+        if patch.model_families and model_family:
+            if model_family.lower() not in patch.model_families:
+                logger.debug(
+                    "Skipping patch '%s' (not applicable to %s)",
+                    patch.name,
+                    model_family,
+                )
+                continue
+
+        try:
+            applied = patch.fn(env_path)
+            if applied:
+                logger.info(
+                    "Applied patch '%s' for %s", patch.name, model_name or "unknown"
+                )
+        except Exception:
+            logger.exception("Failed to apply patch '%s'", patch.name)

--- a/xinference/model/llm/vllm/patches/__init__.py
+++ b/xinference/model/llm/vllm/patches/__init__.py
@@ -27,7 +27,7 @@ for _info in pkgutil.iter_modules(__path__):
 def apply_vllm_patches(
     env_path: str,
     model_name: Optional[str] = None,
-    model_family: Optional[str] = None,
+    architectures: Optional[List[str]] = None,
 ) -> None:
     """
     Apply applicable vLLM patches for the given model.
@@ -35,15 +35,14 @@ def apply_vllm_patches(
     Args:
         env_path: Path to the virtual environment root.
         model_name: Model name (for logging).
-        model_family: Model family string, used to filter patches.
+        architectures: Model architecture list, used to filter patches.
     """
     for patch in _PATCHES:
-        if patch.model_families and model_family:
-            if model_family.lower() not in patch.model_families:
+        if patch.architectures and architectures:
+            if not any(arch in patch.architectures for arch in architectures):
                 logger.debug(
-                    "Skipping patch '%s' (not applicable to %s)",
+                    "Skipping patch '%s' (architecture not matched)",
                     patch.name,
-                    model_family,
                 )
                 continue
 

--- a/xinference/model/llm/vllm/patches/_base.py
+++ b/xinference/model/llm/vllm/patches/_base.py
@@ -14,12 +14,12 @@ class VllmPatch:
         fn: Callable(env_path) -> bool. Returns True if patch was applied.
         description: What the patch fixes.
         removal_condition: When this patch should be deleted.
-        model_families: Set of model families this patch applies to.
-                        None means apply to all vLLM models.
+        architectures: Set of model architectures this patch applies to.
+                       None means apply to all vLLM models.
     """
 
     name: str
     fn: Callable[[str], bool]
     description: str
     removal_condition: str
-    model_families: Optional[Set[str]] = None
+    architectures: Optional[Set[str]] = None

--- a/xinference/model/llm/vllm/patches/_base.py
+++ b/xinference/model/llm/vllm/patches/_base.py
@@ -1,0 +1,24 @@
+"""Base dataclass for vLLM patches."""
+from dataclasses import dataclass
+from typing import Callable, Optional, Set
+
+
+@dataclass
+class VllmPatch:
+    """
+    Describes a post-install patch for vLLM.
+
+    Attributes:
+        name: Unique identifier for the patch.
+        fn: Callable(env_path) -> bool. Returns True if patch was applied.
+        description: What the patch fixes.
+        removal_condition: When this patch should be deleted.
+        model_families: Set of model families this patch applies to.
+                        None means apply to all vLLM models.
+    """
+
+    name: str
+    fn: Callable[[str], bool]
+    description: str
+    removal_condition: str
+    model_families: Optional[Set[str]] = None

--- a/xinference/model/llm/vllm/patches/_base.py
+++ b/xinference/model/llm/vllm/patches/_base.py
@@ -1,4 +1,5 @@
 """Base dataclass for vLLM patches."""
+
 from dataclasses import dataclass
 from typing import Callable, Optional, Set
 

--- a/xinference/model/llm/vllm/patches/hybrid_kv_cache_page_size.py
+++ b/xinference/model/llm/vllm/patches/hybrid_kv_cache_page_size.py
@@ -8,6 +8,7 @@ Solution: Replace the hard error with LCM-based padding.
 
 Removal condition: vLLM merges fix for vllm-project/vllm#37121 / #38041.
 """
+
 import glob
 import logging
 import os
@@ -47,10 +48,15 @@ def _get_vllm_site_packages_path(env_path: str) -> Optional[str]:
             continue
         try:
             result = subprocess.run(
-                [python_bin, "-c",
-                 "import importlib.util; spec = importlib.util.find_spec('vllm'); "
-                 "print(spec.submodule_search_locations[0]) if spec else exit(1)"],
-                capture_output=True, text=True, timeout=10,
+                [
+                    python_bin,
+                    "-c",
+                    "import importlib.util; spec = importlib.util.find_spec('vllm'); "
+                    "print(spec.submodule_search_locations[0]) if spec else exit(1)",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=10,
             )
             if result.returncode == 0:
                 vllm_path = result.stdout.strip()

--- a/xinference/model/llm/vllm/patches/hybrid_kv_cache_page_size.py
+++ b/xinference/model/llm/vllm/patches/hybrid_kv_cache_page_size.py
@@ -191,5 +191,8 @@ PATCH = VllmPatch(
     fn=patch_kv_cache_hybrid_page_size,
     description="LCM-based padding for hybrid attention KV cache page sizes",
     removal_condition="vLLM merges fix for vllm-project/vllm#37121 / #38041",
-    architectures={"Qwen3_5MoeForConditionalGeneration"},
+    architectures={
+        "Qwen3_5MoeForConditionalGeneration",
+        "Qwen3_5ForConditionalGeneration",
+    },
 )

--- a/xinference/model/llm/vllm/patches/hybrid_kv_cache_page_size.py
+++ b/xinference/model/llm/vllm/patches/hybrid_kv_cache_page_size.py
@@ -1,0 +1,189 @@
+"""
+Fix hybrid attention KV cache page size for Qwen3.5/3.6 MoE models.
+
+Problem: vLLM 0.20.x raises NotImplementedError when page sizes across
+different layer types are not evenly divisible.
+
+Solution: Replace the hard error with LCM-based padding.
+
+Removal condition: vLLM merges fix for vllm-project/vllm#37121 / #38041.
+"""
+import glob
+import logging
+import os
+from typing import Optional
+
+from ._base import VllmPatch
+
+logger = logging.getLogger(__name__)
+
+# Original code to match (the problematic raise)
+_KV_CACHE_ORIGINAL = """\
+            if max_page_size % layer_page_size != 0:
+                raise NotImplementedError(
+                    "The page size of the layer is not divisible by the "
+                    "maximum page size. Cannot unify by adjusting block_size."
+                )
+            ratio = max_page_size // layer_page_size
+            new_block_size = layer_spec.block_size * ratio
+            new_spec = replace(layer_spec, block_size=new_block_size)
+            assert new_spec.page_size_bytes == max_page_size
+            new_kv_cache_spec[layer_name] = new_spec
+    return new_kv_cache_spec"""
+
+# Marker to detect already-patched files
+_KV_CACHE_PATCHED_MARKER = "# [xinference-patch] hybrid KV cache LCM padding"
+
+
+def _get_vllm_site_packages_path(env_path: str) -> Optional[str]:
+    """Find the vLLM installation path within a virtual environment."""
+    import subprocess
+
+    # Method 1: use the venv's own Python to locate vllm precisely
+    # This handles .pth injected parent site-packages and uv-managed envs
+    for python_name in ("python3", "python"):
+        python_bin = os.path.join(env_path, "bin", python_name)
+        if not os.path.exists(python_bin):
+            continue
+        try:
+            result = subprocess.run(
+                [python_bin, "-c",
+                 "import importlib.util; spec = importlib.util.find_spec('vllm'); "
+                 "print(spec.submodule_search_locations[0]) if spec else exit(1)"],
+                capture_output=True, text=True, timeout=10,
+            )
+            if result.returncode == 0:
+                vllm_path = result.stdout.strip()
+                if os.path.isdir(vllm_path):
+                    return vllm_path
+        except Exception:
+            pass
+
+    # Method 2: fallback to glob pattern (standard venv layout)
+    patterns = [
+        os.path.join(env_path, "lib", "python*", "site-packages", "vllm"),
+        os.path.join(env_path, "Lib", "site-packages", "vllm"),  # Windows
+    ]
+    for pattern in patterns:
+        matches = glob.glob(pattern)
+        if matches:
+            return matches[0]
+
+    return None
+
+
+def patch_kv_cache_hybrid_page_size(env_path: str) -> bool:
+    """
+    Patch vLLM's unify_kv_cache_spec_page_size for hybrid attention models.
+
+    Returns:
+        True if patch was applied, False if skipped.
+    """
+    vllm_path = _get_vllm_site_packages_path(env_path)
+    if not vllm_path:
+        logger.debug("vLLM not found in %s, skipping KV cache patch", env_path)
+        return False
+
+    target_file = os.path.join(vllm_path, "v1", "core", "kv_cache_utils.py")
+    if not os.path.exists(target_file):
+        logger.debug("kv_cache_utils.py not found at %s, skipping", target_file)
+        return False
+
+    with open(target_file, "r") as f:
+        content = f.read()
+
+    # Already patched?
+    if _KV_CACHE_PATCHED_MARKER in content:
+        logger.debug("KV cache hybrid patch already applied in %s", env_path)
+        return False
+
+    # Check if the original problematic code exists
+    if _KV_CACHE_ORIGINAL not in content:
+        logger.debug(
+            "Original KV cache code not found (may be a newer vLLM with official fix), "
+            "skipping patch for %s",
+            env_path,
+        )
+        return False
+
+    # Apply patch
+    patched_section = f"""\
+            {_KV_CACHE_PATCHED_MARKER}
+            # Check if all smaller pages divide max evenly
+            smaller_sizes = sorted(
+                ps for ps in page_sizes if ps < max_page_size
+            )
+            if all(max_page_size % ps == 0 for ps in smaller_sizes):
+                target_page_size = max_page_size
+            else:
+                # Hybrid model: use LCM-based padding
+                # Reference: vllm-project/vllm#40128
+                import math as _math
+                smaller_lcm = _math.lcm(*smaller_sizes)
+                target_page_size = (
+                    (max_page_size + smaller_lcm - 1) // smaller_lcm
+                ) * smaller_lcm
+                logger.info(
+                    "Hybrid KV cache: padding max page size %d -> %d "
+                    "(LCM=%d, overhead=%.3f%%)",
+                    max_page_size,
+                    target_page_size,
+                    smaller_lcm,
+                    (target_page_size - max_page_size) / max_page_size * 100,
+                )
+
+            new_kv_cache_spec = {{}}
+            for layer_name, layer_spec in kv_cache_spec.items():
+                layer_page = layer_spec.page_size_bytes
+                if layer_page == target_page_size:
+                    new_kv_cache_spec[layer_name] = layer_spec
+                elif (
+                    layer_page < target_page_size
+                    and target_page_size % layer_page == 0
+                ):
+                    ratio = target_page_size // layer_page
+                    new_block_size = layer_spec.block_size * ratio
+                    new_spec = replace(layer_spec, block_size=new_block_size)
+                    assert new_spec.page_size_bytes == target_page_size
+                    new_kv_cache_spec[layer_name] = new_spec
+                else:
+                    try:
+                        new_spec = replace(
+                            layer_spec, page_size_padded=target_page_size
+                        )
+                    except TypeError:
+                        raise NotImplementedError(
+                            f"Cannot pad page size for "
+                            f"{{type(layer_spec).__name__}}: "
+                            f"page_size_padded not supported. "
+                            f"layer_page={{layer_page}}, "
+                            f"target={{target_page_size}}"
+                        )
+                    assert new_spec.page_size_bytes == target_page_size
+                    new_kv_cache_spec[layer_name] = new_spec
+    return new_kv_cache_spec"""
+
+    new_content = content.replace(_KV_CACHE_ORIGINAL, patched_section)
+
+    if new_content == content:
+        logger.warning("KV cache patch replacement failed for %s", env_path)
+        return False
+
+    with open(target_file, "w") as f:
+        f.write(new_content)
+
+    logger.info(
+        "Applied hybrid KV cache patch to %s (vllm-project/vllm#37121)",
+        target_file,
+    )
+    return True
+
+
+# --- Registration ---
+PATCH = VllmPatch(
+    name="hybrid_kv_cache_page_size",
+    fn=patch_kv_cache_hybrid_page_size,
+    description="LCM-based padding for hybrid attention KV cache page sizes",
+    removal_condition="vLLM merges fix for vllm-project/vllm#37121 / #38041",
+    model_families={"qwen3.5", "qwen3.6", "qwen3.6-moe"},
+)

--- a/xinference/model/llm/vllm/patches/hybrid_kv_cache_page_size.py
+++ b/xinference/model/llm/vllm/patches/hybrid_kv_cache_page_size.py
@@ -191,5 +191,5 @@ PATCH = VllmPatch(
     fn=patch_kv_cache_hybrid_page_size,
     description="LCM-based padding for hybrid attention KV cache page sizes",
     removal_condition="vLLM merges fix for vllm-project/vllm#37121 / #38041",
-    model_families={"qwen3.5", "qwen3.6", "qwen3.6-moe"},
+    architectures={"Qwen3_5MoeForConditionalGeneration"},
 )


### PR DESCRIPTION
## Summary

- Add `xinference/model/llm/vllm/patches/` module with auto-discovery registry for applying post-install patches to vLLM site-packages
- Implement hybrid KV cache page size patch (LCM-based padding) for Qwen3.5/3.6/3.6-MoE models, working around [vllm-project/vllm#37121](https://github.com/vllm-project/vllm/issues/37121)
- Use subprocess-based vLLM path resolution to correctly handle uv-managed virtual environments and `.pth`-injected parent site-packages
- Filter patches by model **architectures** (not model names), automatically covering fine-tuned and custom-registered models

## Motivation

Qwen3.5/3.6 models use hybrid attention (linear_attention + full_attention) with non-divisible KV cache page sizes. vLLM 0.20.x raises `NotImplementedError` during `unify_kv_cache_spec_page_size()`. The official fix (vllm-project/vllm#40128) has not been merged.

Previous monkey-patching approach fails because vLLM's EngineCore uses `spawn` multiprocessing (due to CUDA initialization), which doesn't inherit in-memory patches. File-level patching solves this by modifying the source directly in site-packages.

## Design

```
xinference/model/llm/vllm/patches/
├── __init__.py                          # Auto-discovery registry + apply_vllm_patches()
├── _base.py                             # VllmPatch dataclass
└── hybrid_kv_cache_page_size.py         # Qwen3.5/3.6 KV cache patch
```

- **Auto-discovery**: `pkgutil.iter_modules` scans for modules exposing `PATCH` attribute
- **Architecture filtering**: Each patch declares `architectures` set; uses `_resolve_architectures()` to cover fine-tuned models that inherit from built-in families
- **Idempotent**: Marker-based detection prevents double-patching
- **Subprocess path resolution**: Uses venv's own Python interpreter to locate vLLM via `importlib.util.find_spec`, handling `.pth` injections and uv-managed envs
- **Fallback**: Glob pattern for standard venv layouts

## Changes

| File | Change |
|------|--------|
| `xinference/model/llm/vllm/patches/__init__.py` | New: registry + entry point |
| `xinference/model/llm/vllm/patches/_base.py` | New: VllmPatch dataclass |
| `xinference/model/llm/vllm/patches/hybrid_kv_cache_page_size.py` | New: KV cache patch with subprocess path resolution |
| `xinference/core/worker.py` | Add `model_name`/`architectures` params to `_prepare_virtual_env`, call `apply_vllm_patches` after install |

## Removal condition

When vLLM officially merges the hybrid KV cache fix (tracking: vllm-project/vllm#37121, #38041), delete the patch file. The framework (`__init__.py`, `_base.py`) can remain for future patches or be removed entirely (worker.py has `ImportError` guard).

## Test plan

- [ ] Deploy Qwen3.6-35B-A3B-FP8 with vLLM 0.20.x on multi-GPU worker
- [ ] Verify worker logs show: `Applied hybrid KV cache patch to .../kv_cache_utils.py`
- [ ] Verify logs show: `Hybrid KV cache: padding max page size 1073152 -> 1081344`
- [ ] Verify no `NotImplementedError` during model initialization
- [ ] Verify non-hybrid models (e.g., Qwen2.5) are unaffected (patch skipped)
- [ ] Verify fine-tuned model with `model_family="qwen3.6"` gets patch applied via architecture inheritance
