### PR TITLE
fix: differentiate jina-embeddings v3/v4 task parameter handling

### DIFF
--- a/xinference/model/embedding/sentence_transformers/core.py
+++ b/xinference/model/embedding/sentence_transformers/core.py
@@ -28,47 +28,61 @@ from ..core import EmbeddingModel, EmbeddingModelFamilyV2, EmbeddingSpecV1
 logger = logging.getLogger(__name__)
 SENTENCE_TRANSFORMER_MODEL_LIST: List[str] = []
 
-# Jina embeddings v4 supported task types and their mapping to
-# SentenceTransformer prompt_name values.
-# The official Jina AI API supports "retrieval.passage", "retrieval.query",
-# "text-matching", and "code" as task values.  Xinference previously only
-# accepted the coarser "retrieval" (mapped to no prompt), losing the
-# query/passage distinction.  This mapping restores full compatibility with
-# the Jina API while keeping backward compatibility for "retrieval".
-JINA_V4_TASK_TO_PROMPT_NAME: Dict[str, str] = {
+# jina-embeddings-v3: 使用标准 SentenceTransformer prompt_name 机制
+# v3 的 model.prompts 字典 keys 为点分格式: "retrieval.passage", "retrieval.query", etc.
+JINA_V3_TASK_TO_PROMPT_NAME: Dict[str, str] = {
     "retrieval.passage": "retrieval.passage",
     "retrieval.query": "retrieval.query",
-    "text-matching": "text-matching",
-    "code": "code",
-    # Backward-compatible alias: plain "retrieval" defaults to passage encoding
     "retrieval": "retrieval.passage",
+    "passage": "retrieval.passage",
+    "query": "retrieval.query",
+    "document": "document",
 }
 
-# Models that support Jina-style dot-notation task types.
-JINA_TASK_SUPPORTED_MODELS = {
-    "jina-embeddings-v4",
-    "jina-embeddings-v3",
+# jina-embeddings-v4: 使用自定义 forward() 消费 task 参数，不走 prompt_name 机制
+# 此集合仅用于校验合法性，task 值直接传给 model.forward()
+JINA_V4_VALID_TASKS = {
+    "retrieval.passage",
+    "retrieval.query",
+    "retrieval",
+    "text-matching",
+    "code",
+    "passage",
+    "query",
+    "document",
 }
 
 
-def _resolve_jina_task(model_name: str, task: Optional[str]) -> Optional[str]:
-    """Resolve a Jina API ``task`` value to a SentenceTransformer ``prompt_name``.
+def _resolve_jina_task(
+    model_name: str, task: Optional[str]
+) -> Tuple[Optional[str], Optional[str]]:
+    """Resolve Jina API task parameter.
 
-    Returns ``None`` when the model is not a Jina task-aware model or when no
-    task is provided, so callers can fall through to the default behaviour.
+    Returns:
+        (prompt_name, task_passthrough)
+        - v3: (prompt_name, None) — 使用 prompt_name 机制查找 prompt 模板
+        - v4: (None, task) — 将 task 直传给 model.forward()
+        - 其他模型: (None, None)
     """
     if task is None:
-        return None
-    # Only apply the mapping for known Jina task-aware models.
-    if not any(name in model_name.lower() for name in JINA_TASK_SUPPORTED_MODELS):
-        return None
-    prompt_name = JINA_V4_TASK_TO_PROMPT_NAME.get(task)
-    if prompt_name is None:
-        valid = sorted(JINA_V4_TASK_TO_PROMPT_NAME.keys())
-        raise ValueError(
-            f"Invalid task: {task}. Must be one of {valid} " f"for model {model_name}."
-        )
-    return prompt_name
+        return None, None
+    model_lower = model_name.lower()
+    if "jina-embeddings-v3" in model_lower:
+        prompt_name = JINA_V3_TASK_TO_PROMPT_NAME.get(task)
+        if prompt_name is None:
+            valid = sorted(JINA_V3_TASK_TO_PROMPT_NAME.keys())
+            raise ValueError(
+                f"Invalid task: {task}. Must be one of {valid} for model {model_name}."
+            )
+        return prompt_name, None
+    elif "jina-embeddings-v4" in model_lower:
+        if task not in JINA_V4_VALID_TASKS:
+            valid = sorted(JINA_V4_VALID_TASKS)
+            raise ValueError(
+                f"Invalid task: {task}. Must be one of {valid} for model {model_name}."
+            )
+        return None, task
+    return None, None
 
 
 def _build_encode_kwargs(
@@ -225,9 +239,14 @@ class SentenceTransformerEmbeddingModel(EmbeddingModel, BatchMixin):
         sentences = self._fix_langchain_openai_inputs(sentences)
         model_uid = kwargs.pop("model_uid", None)
 
-        # Resolve Jina-style task parameter to a SentenceTransformer prompt_name.
+        # Resolve Jina-style task parameter.
         task = kwargs.pop("task", None)
-        jina_prompt_name = _resolve_jina_task(self._model_name, task)
+        jina_prompt_name, jina_task_passthrough = _resolve_jina_task(
+            self._model_name, task
+        )
+        # v4: 将 task 放回 kwargs，让 model.forward() 消费
+        if jina_task_passthrough is not None:
+            kwargs["task"] = jina_task_passthrough
 
         from sentence_transformers import SentenceTransformer
 

--- a/xinference/model/embedding/sentence_transformers/core.py
+++ b/xinference/model/embedding/sentence_transformers/core.py
@@ -28,8 +28,8 @@ from ..core import EmbeddingModel, EmbeddingModelFamilyV2, EmbeddingSpecV1
 logger = logging.getLogger(__name__)
 SENTENCE_TRANSFORMER_MODEL_LIST: List[str] = []
 
-# jina-embeddings-v3: 使用标准 SentenceTransformer prompt_name 机制
-# v3 的 model.prompts 字典 keys 为点分格式: "retrieval.passage", "retrieval.query", etc.
+# jina-embeddings-v3: uses standard SentenceTransformer prompt_name mechanism
+# v3 model.prompts keys use dot-notation: "retrieval.passage", "retrieval.query", etc.
 JINA_V3_TASK_TO_PROMPT_NAME: Dict[str, str] = {
     "retrieval.passage": "retrieval.passage",
     "retrieval.query": "retrieval.query",
@@ -39,8 +39,8 @@ JINA_V3_TASK_TO_PROMPT_NAME: Dict[str, str] = {
     "document": "document",
 }
 
-# jina-embeddings-v4: 使用自定义 forward() 消费 task 参数，不走 prompt_name 机制
-# 此集合仅用于校验合法性，task 值直接传给 model.forward()
+# jina-embeddings-v4: custom forward() consumes task param directly, bypasses prompt_name
+# This set is only for validation; task value is passed directly to model.forward()
 JINA_V4_VALID_TASKS = {
     "retrieval.passage",
     "retrieval.query",
@@ -60,9 +60,9 @@ def _resolve_jina_task(
 
     Returns:
         (prompt_name, task_passthrough)
-        - v3: (prompt_name, None) — 使用 prompt_name 机制查找 prompt 模板
-        - v4: (None, task) — 将 task 直传给 model.forward()
-        - 其他模型: (None, None)
+        - v3: (prompt_name, None) — uses prompt_name to look up prompt template
+        - v4: (None, task) — passes task directly to model.forward()
+        - other models: (None, None)
     """
     if task is None:
         return None, None
@@ -244,7 +244,7 @@ class SentenceTransformerEmbeddingModel(EmbeddingModel, BatchMixin):
         jina_prompt_name, jina_task_passthrough = _resolve_jina_task(
             self._model_name, task
         )
-        # v4: 将 task 放回 kwargs，让 model.forward() 消费
+        # v4: put task back into kwargs for model.forward() to consume
         if jina_task_passthrough is not None:
             kwargs["task"] = jina_task_passthrough
 

--- a/xinference/model/embedding/sentence_transformers/tests/test_jina_task_mapping.py
+++ b/xinference/model/embedding/sentence_transformers/tests/test_jina_task_mapping.py
@@ -13,19 +13,18 @@
 # limitations under the License.
 
 """
-Tests for Jina embeddings v4 task parameter mapping.
+Tests for Jina embeddings v3/v4 task parameter mapping.
 
-Verifies that the Jina-style ``task`` parameter (e.g. ``retrieval.passage``,
-``retrieval.query``) is correctly resolved to SentenceTransformer
-``prompt_name`` values, ensuring API compatibility with the official Jina AI
-API.
+Verifies that the Jina-style ``task`` parameter is correctly resolved:
+- v3: maps to SentenceTransformer ``prompt_name`` (dot-notation keys)
+- v4: passes task through to ``model.forward()``
 """
 
 import pytest
 
 from ..core import (
-    JINA_TASK_SUPPORTED_MODELS,
-    JINA_V4_TASK_TO_PROMPT_NAME,
+    JINA_V3_TASK_TO_PROMPT_NAME,
+    JINA_V4_VALID_TASKS,
     _resolve_jina_task,
 )
 
@@ -34,86 +33,106 @@ from ..core import (
 # ---------------------------------------------------------------------------
 
 
-class TestResolveJinaTask:
-    """Tests for the _resolve_jina_task helper."""
-
-    # -- Valid task values for jina-embeddings-v4 --
+class TestResolveJinaTaskV4:
+    """Tests for v4: returns (None, task) — task passthrough to forward()."""
 
     def test_retrieval_passage(self):
-        result = _resolve_jina_task("jina-embeddings-v4", "retrieval.passage")
-        assert result == "retrieval.passage"
+        prompt_name, task = _resolve_jina_task("jina-embeddings-v4", "retrieval.passage")
+        assert prompt_name is None
+        assert task == "retrieval.passage"
 
     def test_retrieval_query(self):
-        result = _resolve_jina_task("jina-embeddings-v4", "retrieval.query")
-        assert result == "retrieval.query"
+        prompt_name, task = _resolve_jina_task("jina-embeddings-v4", "retrieval.query")
+        assert prompt_name is None
+        assert task == "retrieval.query"
 
     def test_text_matching(self):
-        result = _resolve_jina_task("jina-embeddings-v4", "text-matching")
-        assert result == "text-matching"
+        prompt_name, task = _resolve_jina_task("jina-embeddings-v4", "text-matching")
+        assert prompt_name is None
+        assert task == "text-matching"
 
     def test_code(self):
-        result = _resolve_jina_task("jina-embeddings-v4", "code")
-        assert result == "code"
+        prompt_name, task = _resolve_jina_task("jina-embeddings-v4", "code")
+        assert prompt_name is None
+        assert task == "code"
 
-    # -- Backward compatibility: plain "retrieval" maps to "retrieval.passage" --
-
-    def test_retrieval_backward_compat(self):
-        result = _resolve_jina_task("jina-embeddings-v4", "retrieval")
-        assert result == "retrieval.passage"
-
-    # -- jina-embeddings-v3 is also supported --
-
-    def test_jina_v3_retrieval_passage(self):
-        result = _resolve_jina_task("jina-embeddings-v3", "retrieval.passage")
-        assert result == "retrieval.passage"
-
-    def test_jina_v3_retrieval_query(self):
-        result = _resolve_jina_task("jina-embeddings-v3", "retrieval.query")
-        assert result == "retrieval.query"
-
-    def test_jina_v3_text_matching(self):
-        result = _resolve_jina_task("jina-embeddings-v3", "text-matching")
-        assert result == "text-matching"
-
-    def test_jina_v3_code(self):
-        result = _resolve_jina_task("jina-embeddings-v3", "code")
-        assert result == "code"
-
-    # -- None task returns None (no-op) --
-
-    def test_none_task_returns_none(self):
-        result = _resolve_jina_task("jina-embeddings-v4", None)
-        assert result is None
-
-    # -- Non-Jina model returns None regardless of task value --
-
-    def test_non_jina_model_returns_none(self):
-        result = _resolve_jina_task("bge-small-en-v1.5", "retrieval.passage")
-        assert result is None
-
-    def test_non_jina_model_with_none_task(self):
-        result = _resolve_jina_task("bge-small-en-v1.5", None)
-        assert result is None
-
-    # -- Invalid task raises ValueError --
+    def test_retrieval_passthrough(self):
+        """Plain 'retrieval' is passed through as-is for v4."""
+        prompt_name, task = _resolve_jina_task("jina-embeddings-v4", "retrieval")
+        assert prompt_name is None
+        assert task == "retrieval"
 
     def test_invalid_task_raises(self):
         with pytest.raises(ValueError, match="Invalid task"):
             _resolve_jina_task("jina-embeddings-v4", "nonexistent-task")
 
-    def test_invalid_task_message_contains_valid_options(self):
-        with pytest.raises(ValueError, match="retrieval.passage"):
-            _resolve_jina_task("jina-embeddings-v4", "bad")
 
-    # -- Case sensitivity: model name matching is case-insensitive --
+class TestResolveJinaTaskV3:
+    """Tests for v3: returns (prompt_name, None) — uses prompt_name mechanism."""
 
-    def test_case_insensitive_model_name(self):
-        result = _resolve_jina_task("Jina-Embeddings-V4", "retrieval.query")
-        assert result == "retrieval.query"
+    def test_retrieval_passage(self):
+        prompt_name, task = _resolve_jina_task("jina-embeddings-v3", "retrieval.passage")
+        assert prompt_name == "retrieval.passage"
+        assert task is None
 
-    def test_uppercase_model_name(self):
-        result = _resolve_jina_task("JINA-EMBEDDINGS-V4", "code")
-        assert result == "code"
+    def test_retrieval_query(self):
+        prompt_name, task = _resolve_jina_task("jina-embeddings-v3", "retrieval.query")
+        assert prompt_name == "retrieval.query"
+        assert task is None
+
+    def test_retrieval_backward_compat(self):
+        """Plain 'retrieval' maps to 'retrieval.passage' for v3."""
+        prompt_name, task = _resolve_jina_task("jina-embeddings-v3", "retrieval")
+        assert prompt_name == "retrieval.passage"
+        assert task is None
+
+    def test_passage_alias(self):
+        prompt_name, task = _resolve_jina_task("jina-embeddings-v3", "passage")
+        assert prompt_name == "retrieval.passage"
+        assert task is None
+
+    def test_query_alias(self):
+        prompt_name, task = _resolve_jina_task("jina-embeddings-v3", "query")
+        assert prompt_name == "retrieval.query"
+        assert task is None
+
+    def test_document(self):
+        prompt_name, task = _resolve_jina_task("jina-embeddings-v3", "document")
+        assert prompt_name == "document"
+        assert task is None
+
+    def test_invalid_task_raises(self):
+        with pytest.raises(ValueError, match="Invalid task"):
+            _resolve_jina_task("jina-embeddings-v3", "nonexistent-task")
+
+
+class TestResolveJinaTaskGeneral:
+    """Tests for general behavior: None task, non-Jina models, case sensitivity."""
+
+    def test_none_task_returns_none_none(self):
+        prompt_name, task = _resolve_jina_task("jina-embeddings-v4", None)
+        assert prompt_name is None
+        assert task is None
+
+    def test_non_jina_model_returns_none_none(self):
+        prompt_name, task = _resolve_jina_task("bge-small-en-v1.5", "retrieval.passage")
+        assert prompt_name is None
+        assert task is None
+
+    def test_non_jina_model_with_none_task(self):
+        prompt_name, task = _resolve_jina_task("bge-small-en-v1.5", None)
+        assert prompt_name is None
+        assert task is None
+
+    def test_case_insensitive_model_name_v4(self):
+        prompt_name, task = _resolve_jina_task("Jina-Embeddings-V4", "retrieval.query")
+        assert prompt_name is None
+        assert task == "retrieval.query"
+
+    def test_case_insensitive_model_name_v3(self):
+        prompt_name, task = _resolve_jina_task("Jina-Embeddings-V3", "retrieval.query")
+        assert prompt_name == "retrieval.query"
+        assert task is None
 
 
 # ---------------------------------------------------------------------------
@@ -121,31 +140,36 @@ class TestResolveJinaTask:
 # ---------------------------------------------------------------------------
 
 
-class TestJinaTaskMappingTable:
-    """Verify the JINA_V4_TASK_TO_PROMPT_NAME mapping is complete."""
+class TestJinaMappingTables:
+    """Verify mapping tables are complete and correct."""
 
-    EXPECTED_TASKS = {
-        "retrieval.passage",
-        "retrieval.query",
-        "text-matching",
-        "code",
-        "retrieval",
-    }
+    def test_v3_table_has_expected_keys(self):
+        expected = {
+            "retrieval.passage",
+            "retrieval.query",
+            "retrieval",
+            "passage",
+            "query",
+            "document",
+        }
+        assert expected == set(JINA_V3_TASK_TO_PROMPT_NAME.keys())
 
-    def test_all_expected_tasks_present(self):
-        assert self.EXPECTED_TASKS == set(JINA_V4_TASK_TO_PROMPT_NAME.keys())
+    def test_v4_valid_tasks_has_expected_values(self):
+        expected = {
+            "retrieval.passage",
+            "retrieval.query",
+            "retrieval",
+            "text-matching",
+            "code",
+            "passage",
+            "query",
+            "document",
+        }
+        assert expected == JINA_V4_VALID_TASKS
 
-    def test_supported_models_contains_v4(self):
-        assert "jina-embeddings-v4" in JINA_TASK_SUPPORTED_MODELS
+    def test_v3_retrieval_alias_maps_to_retrieval_passage(self):
+        assert JINA_V3_TASK_TO_PROMPT_NAME["retrieval"] == "retrieval.passage"
 
-    def test_supported_models_contains_v3(self):
-        assert "jina-embeddings-v3" in JINA_TASK_SUPPORTED_MODELS
-
-    def test_retrieval_alias_maps_to_passage(self):
-        """Plain 'retrieval' should default to 'retrieval.passage' for backward compat."""
-        assert JINA_V4_TASK_TO_PROMPT_NAME["retrieval"] == "retrieval.passage"
-
-    def test_each_dotted_task_maps_to_itself(self):
-        """retrieval.passage -> retrieval.passage, retrieval.query -> retrieval.query, etc."""
-        for task in ("retrieval.passage", "retrieval.query", "text-matching", "code"):
-            assert JINA_V4_TASK_TO_PROMPT_NAME[task] == task
+    def test_v3_dotted_tasks_map_to_themselves(self):
+        for task in ("retrieval.passage", "retrieval.query"):
+            assert JINA_V3_TASK_TO_PROMPT_NAME[task] == task

--- a/xinference/model/embedding/sentence_transformers/tests/test_jina_task_mapping.py
+++ b/xinference/model/embedding/sentence_transformers/tests/test_jina_task_mapping.py
@@ -22,11 +22,7 @@ Verifies that the Jina-style ``task`` parameter is correctly resolved:
 
 import pytest
 
-from ..core import (
-    JINA_V3_TASK_TO_PROMPT_NAME,
-    JINA_V4_VALID_TASKS,
-    _resolve_jina_task,
-)
+from ..core import JINA_V3_TASK_TO_PROMPT_NAME, JINA_V4_VALID_TASKS, _resolve_jina_task
 
 # ---------------------------------------------------------------------------
 # _resolve_jina_task unit tests
@@ -37,7 +33,9 @@ class TestResolveJinaTaskV4:
     """Tests for v4: returns (None, task) — task passthrough to forward()."""
 
     def test_retrieval_passage(self):
-        prompt_name, task = _resolve_jina_task("jina-embeddings-v4", "retrieval.passage")
+        prompt_name, task = _resolve_jina_task(
+            "jina-embeddings-v4", "retrieval.passage"
+        )
         assert prompt_name is None
         assert task == "retrieval.passage"
 
@@ -71,7 +69,9 @@ class TestResolveJinaTaskV3:
     """Tests for v3: returns (prompt_name, None) — uses prompt_name mechanism."""
 
     def test_retrieval_passage(self):
-        prompt_name, task = _resolve_jina_task("jina-embeddings-v3", "retrieval.passage")
+        prompt_name, task = _resolve_jina_task(
+            "jina-embeddings-v3", "retrieval.passage"
+        )
         assert prompt_name == "retrieval.passage"
         assert task is None
 


### PR DESCRIPTION
## Summary

- Fix jina-embeddings-v4 "Task must be specified" error by passing `task` through to `model.forward()` instead of popping it
- Fix jina-embeddings-v3 "Prompt name 'passage' not found" error by using correct dot-notation prompt keys
- Split the shared `JINA_V4_TASK_TO_PROMPT_NAME` into separate `JINA_V3_TASK_TO_PROMPT_NAME` and `JINA_V4_VALID_TASKS`

## Root Cause

PR #4788 introduced `kwargs.pop("task")` + a single mapping table for both v3 and v4, but:
- **v4** uses a custom `model.forward(features, task=...)` — popping `task` from kwargs broke it
- **v3** uses standard SentenceTransformer `prompt_name` mechanism with dot-notation keys (`"retrieval.passage"`, not `"passage"`)

## Changes

| File | Change |
|------|--------|
| `xinference/model/embedding/sentence_transformers/core.py` | Replace shared mapping with v3/v4-specific logic; `_resolve_jina_task` now returns `(prompt_name, task_passthrough)` tuple |
| `.../tests/test_jina_task_mapping.py` | Rewrite tests for new tuple return and separate v3/v4 behavior |

## Behavior

| Model | API `task` | Handling |
|-------|-----------|----------|
| v3 | `retrieval.passage` | `encode(prompt_name="retrieval.passage")` |
| v3 | `retrieval` | `encode(prompt_name="retrieval.passage")` (backward compat alias) |
| v4 | `retrieval.passage` | `model.forward(features, task="retrieval.passage")` |
| v4 | `retrieval` | `model.forward(features, task="retrieval")` |
| other | any | no-op (task ignored) |

## Test plan

- [ ] `pytest xinference/model/embedding/sentence_transformers/tests/test_jina_task_mapping.py` passes
- [ ] Deploy jina-embeddings-v4 with `task="retrieval.passage"` → 200 OK
- [ ] Deploy jina-embeddings-v3 with `task="retrieval.passage"` → 200 OK
- [ ] Non-Jina models unaffected
