### PR TITLE
fix: upgrade TTFT metric to Histogram with stream label and add non-stream TTFT recording

### DIFF
--- a/xinference/core/metrics.py
+++ b/xinference/core/metrics.py
@@ -31,13 +31,14 @@ DEFAULT_METRICS_SERVER_LOG_LEVEL = "warning"
 # ===========================================================================
 # Worker-side inference metrics (LLM only)
 # ===========================================================================
-generate_throughput = Gauge(
-    "xinference:generate_tokens_per_s",
-    "Generate throughput in tokens/s (LLM only).",
+generate_tokens_total = Counter(
+    "xinference:generate_tokens_total",
+    "Total number of generated tokens (LLM only).",
 )
-time_to_first_token = Gauge(
-    "xinference:time_to_first_token_ms",
-    "First token latency in ms (LLM only).",
+time_to_first_token_seconds = Histogram(
+    "xinference:time_to_first_token_seconds",
+    "Time to first token in seconds (LLM only).",
+    buckets=(0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, float("inf")),
 )
 input_tokens_total_counter = Counter(
     "xinference:input_tokens_total_counter",

--- a/xinference/core/model.py
+++ b/xinference/core/model.py
@@ -133,7 +133,10 @@ def request_limit(fn):
             await self.record_metrics(
                 "model_request_total",
                 "add",
-                {"labels": {**self._metrics_labels, "stream": stream_label}, "value": 1},
+                {
+                    "labels": {**self._metrics_labels, "stream": stream_label},
+                    "value": 1,
+                },
             )
             if _is_stream:
                 # stream case, let client call model_ref to decrease self._serve_count
@@ -560,7 +563,10 @@ class ModelActor(xo.StatelessActor, CancelMixin):
                 coro = self.record_metrics(
                     "time_to_first_token_seconds",
                     "observe",
-                    {"labels": {**self._metrics_labels, "stream": "true"}, "value": time_to_first_token / 1000},
+                    {
+                        "labels": {**self._metrics_labels, "stream": "true"},
+                        "value": time_to_first_token / 1000,
+                    },
                 )
                 asyncio.run_coroutine_threadsafe(coro, loop=self._loop)
             if self._loop is not None and final_usage is not None:
@@ -599,7 +605,10 @@ class ModelActor(xo.StatelessActor, CancelMixin):
                     self.record_metrics(
                         "time_to_first_token_seconds",
                         "observe",
-                        {"labels": {**self._metrics_labels, "stream": "true"}, "value": time_to_first_token / 1000},
+                        {
+                            "labels": {**self._metrics_labels, "stream": "true"},
+                            "value": time_to_first_token / 1000,
+                        },
                     )
                 )
             if final_usage is not None:
@@ -805,7 +814,10 @@ class ModelActor(xo.StatelessActor, CancelMixin):
                 await self.record_metrics(
                     "time_to_first_token_seconds",
                     "observe",
-                    {"labels": {**self._metrics_labels, "stream": "false"}, "value": time.time() - start_time},
+                    {
+                        "labels": {**self._metrics_labels, "stream": "false"},
+                        "value": time.time() - start_time,
+                    },
                 )
 
     async def abort_request(

--- a/xinference/core/model.py
+++ b/xinference/core/model.py
@@ -95,16 +95,14 @@ def request_limit(fn):
         logger.debug(
             f"Request {fn.__name__}, current serve request count: {self._serve_count}, request limit: {self._request_limits} for the model {self.model_uid()}"
         )
-        # Count every incoming request (including those rejected by rate limit)
-        await self.record_metrics(
-            "model_request_total",
-            "add",
-            {"labels": self._metrics_labels, "value": 1},
-        )
         if 1 + self._serve_count <= self._request_limits:
             self._serve_count += 1
         else:
-            # Rate-limited requests count as errors
+            await self.record_metrics(
+                "model_request_total",
+                "add",
+                {"labels": {**self._metrics_labels, "stream": "unknown"}, "value": 1},
+            )
             await self.record_metrics(
                 "model_request_errors_total",
                 "add",
@@ -128,9 +126,16 @@ def request_limit(fn):
             raise
         finally:
             duration = time.time() - start_time
-            if ret is not None and (
+            _is_stream = ret is not None and (
                 inspect.isasyncgen(ret) or inspect.isgenerator(ret)
-            ):
+            )
+            stream_label = "true" if _is_stream else "false"
+            await self.record_metrics(
+                "model_request_total",
+                "add",
+                {"labels": {**self._metrics_labels, "stream": stream_label}, "value": 1},
+            )
+            if _is_stream:
                 # stream case, let client call model_ref to decrease self._serve_count
                 pass
             else:
@@ -361,14 +366,13 @@ class ModelActor(xo.StatelessActor, CancelMixin):
                 )
             )
         if completion_tokens > 0:
-            generate_throughput = completion_tokens / duration
             coros.append(
                 self.record_metrics(
-                    "generate_throughput",
-                    "set",
+                    "generate_tokens_total",
+                    "add",
                     {
                         "labels": self._metrics_labels,
-                        "value": generate_throughput,
+                        "value": completion_tokens,
                     },
                 )
             )
@@ -554,9 +558,9 @@ class ModelActor(xo.StatelessActor, CancelMixin):
         finally:
             if self._loop is not None and time_to_first_token is not None:
                 coro = self.record_metrics(
-                    "time_to_first_token",
-                    "set",
-                    {"labels": self._metrics_labels, "value": time_to_first_token},
+                    "time_to_first_token_seconds",
+                    "observe",
+                    {"labels": {**self._metrics_labels, "stream": "true"}, "value": time_to_first_token / 1000},
                 )
                 asyncio.run_coroutine_threadsafe(coro, loop=self._loop)
             if self._loop is not None and final_usage is not None:
@@ -593,9 +597,9 @@ class ModelActor(xo.StatelessActor, CancelMixin):
             if time_to_first_token is not None:
                 coros.append(
                     self.record_metrics(
-                        "time_to_first_token",
-                        "set",
-                        {"labels": self._metrics_labels, "value": time_to_first_token},
+                        "time_to_first_token_seconds",
+                        "observe",
+                        {"labels": {**self._metrics_labels, "stream": "true"}, "value": time_to_first_token / 1000},
                     )
                 )
             if final_usage is not None:
@@ -606,7 +610,10 @@ class ModelActor(xo.StatelessActor, CancelMixin):
                         prompt_tokens=final_usage["prompt_tokens"],
                     )
                 )
-            await asyncio.gather(*coros)
+            try:
+                await asyncio.gather(*coros)
+            except Exception:
+                logger.exception("Failed to record metrics in _to_async_gen finally")
 
     async def _handle_pending_requests(self):
         logger.info("Start requests handler.")
@@ -794,6 +801,11 @@ class ModelActor(xo.StatelessActor, CancelMixin):
                     time.time() - start_time,
                     completion_tokens,
                     prompt_tokens,
+                )
+                await self.record_metrics(
+                    "time_to_first_token_seconds",
+                    "observe",
+                    {"labels": {**self._metrics_labels, "stream": "false"}, "value": time.time() - start_time},
                 )
 
     async def abort_request(


### PR DESCRIPTION
## Summary

- Replace `generate_throughput` Gauge (`xinference:generate_tokens_per_s`) with `generate_tokens_total` Counter (`xinference:generate_tokens_total`) for accurate cumulative token counting instead of point-in-time throughput
- Replace `time_to_first_token` Gauge (`xinference:time_to_first_token_ms`, milliseconds) with `time_to_first_token_seconds` Histogram (`xinference:time_to_first_token_seconds`, seconds) with proper buckets `(0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, +Inf)` for percentile queries
- Add `stream` label (`"true"` / `"false"` / `"unknown"`) to `model_request_total` Counter and `time_to_first_token_seconds` Histogram to distinguish streaming vs non-streaming request patterns
- Record TTFT for non-stream requests in `chat()` finally block (TTFT = total request duration), fixing the issue where TTFT was only recorded for streaming requests
- Move `model_request_total` counting from pre-execution to post-execution in `request_limit` decorator, so the `stream` label reflects actual response type rather than a guess
- Add exception protection to `asyncio.gather` in `_to_async_gen` finally block to prevent metric recording failures from swallowing generator errors

## Why

1. **TTFT Grafana panel shows "No data"**: TTFT was only recorded in streaming paths (`_to_generator` / `_to_async_gen`). Non-stream requests (the majority in production) produced no TTFT data at all.
2. **Stream vs non-stream value ranges differ by 10x+**: Streaming TTFT is typically 0.1–2s (prefill + first token), while non-stream TTFT equals full inference time (1–30s+). Mixing them makes averages meaningless and alerting impossible.
3. **Gauge → Histogram**: A Gauge only stores the last value, making `rate()` queries unreliable. A Histogram supports `histogram_quantile()` for p50/p95/p99 and proper `rate()` aggregation.
4. **Gauge → Counter for token generation**: `generate_throughput` (tokens/s Gauge) was a point-in-time snapshot that got overwritten per request. `generate_tokens_total` (Counter) enables accurate `rate()` queries for sustained throughput monitoring.

## Changes

| File | What changed |
|------|-------------|
| `xinference/core/metrics.py` | Replace `generate_throughput` Gauge → `generate_tokens_total` Counter; replace `time_to_first_token` Gauge → `time_to_first_token_seconds` Histogram with buckets |
| `xinference/core/model.py` | Add `stream` label to `model_request_total` and TTFT; record non-stream TTFT in `chat()` finally; replace `generate_throughput.set()` → `generate_tokens_total.add()`; add try/except around `asyncio.gather` in `_to_async_gen` |

## Dashboard query examples

```promql
# Streaming TTFT p95
histogram_quantile(0.95, rate(xinference:time_to_first_token_seconds_bucket{stream="true"}[5m]))

# Non-stream response time p95
histogram_quantile(0.95, rate(xinference:time_to_first_token_seconds_bucket{stream="false"}[5m]))

# Stream vs non-stream request ratio
xinference:model_request_total{stream="true"} / ignoring(stream) group_left sum by (model_name) (xinference:model_request_total)

# Token generation throughput (tokens/s)
rate(xinference:generate_tokens_total[5m])
```

## Test plan

- [ ] Deploy to test environment, send non-stream requests → verify `time_to_first_token_seconds` with `stream="false"` appears in `/metrics`
- [ ] Send stream requests → verify `time_to_first_token_seconds` with `stream="true"` appears in `/metrics`
- [ ] Verify `model_request_total` has correct `stream` label for both request types
- [ ] Verify `generate_tokens_total` counter increments correctly
- [ ] Trigger rate limit → verify `model_request_total{stream="unknown"}` is recorded
- [ ] Verify Grafana dashboard queries work with new metric names and labels
