### PR TITLE
feat: add Prometheus alert rules for cluster monitoring

### DIFF
--- a/monitor/alert/README.md
+++ b/monitor/alert/README.md
@@ -1,0 +1,92 @@
+# Xinference Alert Rules
+
+Prometheus alert rules for monitoring Xinference cluster health.
+
+## Files
+
+| File | Language |
+|------|----------|
+| `rules.yml` | English |
+| `rules-zh-CN.yml` | 中文 |
+| `rules-ja.yml` | 日本語 |
+| `rules-ko.yml` | 한국어 |
+
+All files share the same alert expressions and thresholds — only `summary` and `description` annotations are localized.
+
+## Alert Rules
+
+### GPUMemoryHigh
+
+- **Severity**: critical
+- **Condition**: GPU memory usage > 90% for 5 minutes
+- **Expression**: `xinference:worker_gpu_memory_used_bytes / xinference:worker_gpu_memory_total_bytes > 0.9`
+
+### ModelRequestErrorRateHigh
+
+- **Severity**: warning
+- **Condition**: Model request error rate > 5% for 3 minutes
+- **Expression**: `rate(xinference:model_request_errors_total[5m]) / rate(xinference:model_request_total[5m]) > 0.05`
+
+### TTFTHigh
+
+- **Severity**: warning
+- **Condition**: Time to first token > 10 seconds for 3 minutes
+- **Expression**: `rate(xinference:time_to_first_token_seconds_sum[5m]) / rate(xinference:time_to_first_token_seconds_count[5m]) > 10`
+
+### WorkerOffline
+
+- **Severity**: critical
+- **Condition**: Online worker count < 1 for 2 minutes
+- **Expression**: `xinference:workers_total < 1`
+
+### DiskSpaceLow
+
+- **Severity**: critical
+- **Condition**: Disk available space < 10% for 5 minutes
+- **Expression**: `(node_filesystem_avail_bytes / node_filesystem_size_bytes) < 0.1`
+
+### RequestQueueBacklog
+
+- **Severity**: warning
+- **Condition**: Pending requests > 10 for 3 minutes
+- **Expression**: `xinference:model_pending_requests > 10`
+
+### ModelLoadSlow
+
+- **Severity**: warning
+- **Condition**: Model load time > 5 minutes
+- **Expression**: `xinference:model_last_load_duration_seconds > 300`
+
+## Usage
+
+Add the rule file to your Prometheus configuration:
+
+```yaml
+# prometheus.yml
+rule_files:
+  - "/path/to/monitor/alert/rules.yml"
+```
+
+Reload Prometheus to apply:
+
+```bash
+curl -X POST http://localhost:9090/-/reload
+```
+
+## Alertmanager Integration
+
+Configure Alertmanager to route alerts by severity:
+
+```yaml
+# alertmanager.yml
+route:
+  group_by: ['alertname']
+  receiver: default
+  routes:
+    - match:
+        severity: critical
+      receiver: critical-channel
+    - match:
+        severity: warning
+      receiver: warning-channel
+```

--- a/monitor/alert/README_zh-CN.md
+++ b/monitor/alert/README_zh-CN.md
@@ -1,0 +1,92 @@
+# Xinference 告警规则
+
+用于监控 Xinference 集群健康状态的 Prometheus 告警规则。
+
+## 文件说明
+
+| 文件 | 语言 |
+|------|------|
+| `rules.yml` | English |
+| `rules-zh-CN.yml` | 中文 |
+| `rules-ja.yml` | 日本語 |
+| `rules-ko.yml` | 한국어 |
+
+所有文件使用相同的告警表达式和阈值，仅 `summary` 和 `description` 注解做了本地化翻译。
+
+## 告警规则
+
+### GPUMemoryHigh — GPU 显存使用率过高
+
+- **级别**: critical（严重）
+- **条件**: GPU 显存使用率 > 90%，持续 5 分钟
+- **表达式**: `xinference:worker_gpu_memory_used_bytes / xinference:worker_gpu_memory_total_bytes > 0.9`
+
+### ModelRequestErrorRateHigh — 模型请求错误率过高
+
+- **级别**: warning（警告）
+- **条件**: 模型请求错误率 > 5%，持续 3 分钟
+- **表达式**: `rate(xinference:model_request_errors_total[5m]) / rate(xinference:model_request_total[5m]) > 0.05`
+
+### TTFTHigh — 首 Token 延迟过高
+
+- **级别**: warning（警告）
+- **条件**: 首 Token 延迟 > 10 秒，持续 3 分钟
+- **表达式**: `rate(xinference:time_to_first_token_seconds_sum[5m]) / rate(xinference:time_to_first_token_seconds_count[5m]) > 10`
+
+### WorkerOffline — Worker 节点离线
+
+- **级别**: critical（严重）
+- **条件**: 在线 Worker 数量 < 1，持续 2 分钟
+- **表达式**: `xinference:workers_total < 1`
+
+### DiskSpaceLow — 磁盘空间不足
+
+- **级别**: critical（严重）
+- **条件**: 磁盘可用空间 < 10%，持续 5 分钟
+- **表达式**: `(node_filesystem_avail_bytes / node_filesystem_size_bytes) < 0.1`
+
+### RequestQueueBacklog — 请求队列积压
+
+- **级别**: warning（警告）
+- **条件**: 排队请求数 > 10，持续 3 分钟
+- **表达式**: `xinference:model_pending_requests > 10`
+
+### ModelLoadSlow — 模型加载缓慢
+
+- **级别**: warning（警告）
+- **条件**: 模型加载耗时 > 5 分钟
+- **表达式**: `xinference:model_last_load_duration_seconds > 300`
+
+## 使用方法
+
+在 Prometheus 配置中添加规则文件：
+
+```yaml
+# prometheus.yml
+rule_files:
+  - "/path/to/monitor/alert/rules-zh-CN.yml"
+```
+
+重新加载 Prometheus 使配置生效：
+
+```bash
+curl -X POST http://localhost:9090/-/reload
+```
+
+## Alertmanager 集成
+
+配置 Alertmanager 按告警级别进行路由分发：
+
+```yaml
+# alertmanager.yml
+route:
+  group_by: ['alertname']
+  receiver: default
+  routes:
+    - match:
+        severity: critical
+      receiver: critical-channel
+    - match:
+        severity: warning
+      receiver: warning-channel
+```

--- a/monitor/alert/rules-ja.yml
+++ b/monitor/alert/rules-ja.yml
@@ -1,0 +1,65 @@
+groups:
+  - name: xinference-alert-rule
+    rules:
+      - alert: GPUMemoryHigh
+        expr: xinference:worker_gpu_memory_used_bytes / xinference:worker_gpu_memory_total_bytes > 0.9
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "GPU メモリ使用率が 90% を超過"
+          description: "Worker {{ $labels.worker_address }} GPU {{ $labels.gpu_index }} メモリ使用率 {{ $value | humanizePercentage }}、5 分間継続。"
+
+      - alert: ModelRequestErrorRateHigh
+        expr: rate(xinference:model_request_errors_total[5m]) / rate(xinference:model_request_total[5m]) > 0.05
+        for: 3m
+        labels:
+          severity: warning
+        annotations:
+          summary: "モデルリクエストエラー率が 5% を超過"
+          description: "モデル {{ $labels.model }} エラー率 {{ $value | humanizePercentage }}、3 分間継続。"
+
+      - alert: TTFTHigh
+        expr: rate(xinference:time_to_first_token_seconds_sum[5m]) / rate(xinference:time_to_first_token_seconds_count[5m]) > 10
+        for: 3m
+        labels:
+          severity: warning
+        annotations:
+          summary: "初回トークン遅延が 10 秒を超過"
+          description: "モデル {{ $labels.model }} TTFT {{ $value }}ms、3 分間継続。"
+
+      - alert: WorkerOffline
+        expr: xinference:workers_total < 1
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Worker ノードがオフライン"
+          description: "現在のオンライン Worker 数 {{ $value }}、期待値を下回っています。"
+
+      - alert: DiskSpaceLow
+        expr: (node_filesystem_avail_bytes / node_filesystem_size_bytes) < 0.1
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "ディスク空き容量が 10% 未満"
+          description: "ノード {{ $labels.instance }} マウントポイント {{ $labels.mountpoint }} 残り容量 {{ $value | humanizePercentage }}。"
+
+      - alert: RequestQueueBacklog
+        expr: xinference:model_pending_requests > 10
+        for: 3m
+        labels:
+          severity: warning
+        annotations:
+          summary: "モデルリクエストキューが滞留"
+          description: "モデル {{ $labels.model }} 待機リクエスト数 {{ $value }}、3 分間継続。"
+
+      - alert: ModelLoadSlow
+        expr: xinference:model_last_load_duration_seconds > 300
+        for: 0m
+        labels:
+          severity: warning
+        annotations:
+          summary: "モデルロード時間が 5 分を超過"
+          description: "モデル {{ $labels.model_name }} 直近の平均ロード時間 {{ $value | humanizeDuration }}。"

--- a/monitor/alert/rules-ko.yml
+++ b/monitor/alert/rules-ko.yml
@@ -1,0 +1,65 @@
+groups:
+  - name: xinference-alert-rule
+    rules:
+      - alert: GPUMemoryHigh
+        expr: xinference:worker_gpu_memory_used_bytes / xinference:worker_gpu_memory_total_bytes > 0.9
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "GPU 메모리 사용률 90% 초과"
+          description: "Worker {{ $labels.worker_address }} GPU {{ $labels.gpu_index }} 메모리 사용률 {{ $value | humanizePercentage }}, 5분간 지속."
+
+      - alert: ModelRequestErrorRateHigh
+        expr: rate(xinference:model_request_errors_total[5m]) / rate(xinference:model_request_total[5m]) > 0.05
+        for: 3m
+        labels:
+          severity: warning
+        annotations:
+          summary: "모델 요청 오류율 5% 초과"
+          description: "모델 {{ $labels.model }} 오류율 {{ $value | humanizePercentage }}, 3분간 지속."
+
+      - alert: TTFTHigh
+        expr: rate(xinference:time_to_first_token_seconds_sum[5m]) / rate(xinference:time_to_first_token_seconds_count[5m]) > 10
+        for: 3m
+        labels:
+          severity: warning
+        annotations:
+          summary: "첫 토큰 지연 시간 10초 초과"
+          description: "모델 {{ $labels.model }} TTFT {{ $value }}ms, 3분간 지속."
+
+      - alert: WorkerOffline
+        expr: xinference:workers_total < 1
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Worker 노드 오프라인"
+          description: "현재 온라인 Worker 수 {{ $value }}, 예상치보다 낮음."
+
+      - alert: DiskSpaceLow
+        expr: (node_filesystem_avail_bytes / node_filesystem_size_bytes) < 0.1
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "디스크 공간 10% 미만"
+          description: "노드 {{ $labels.instance }} 마운트 포인트 {{ $labels.mountpoint }} 잔여 공간 {{ $value | humanizePercentage }}."
+
+      - alert: RequestQueueBacklog
+        expr: xinference:model_pending_requests > 10
+        for: 3m
+        labels:
+          severity: warning
+        annotations:
+          summary: "모델 요청 대기열 적체"
+          description: "모델 {{ $labels.model }} 대기 요청 수 {{ $value }}, 3분간 지속."
+
+      - alert: ModelLoadSlow
+        expr: xinference:model_last_load_duration_seconds > 300
+        for: 0m
+        labels:
+          severity: warning
+        annotations:
+          summary: "모델 로딩 시간 5분 초과"
+          description: "모델 {{ $labels.model_name }} 최근 평균 로딩 시간 {{ $value | humanizeDuration }}."

--- a/monitor/alert/rules-zh-CN.yml
+++ b/monitor/alert/rules-zh-CN.yml
@@ -1,0 +1,65 @@
+groups:
+  - name: xinference-alert-rule
+    rules:
+      - alert: GPUMemoryHigh
+        expr: xinference:worker_gpu_memory_used_bytes / xinference:worker_gpu_memory_total_bytes > 0.9
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "GPU 显存使用率超过 90%"
+          description: "Worker {{ $labels.worker_address }} GPU {{ $labels.gpu_index }} 显存使用率 {{ $value | humanizePercentage }}，持续 5 分钟。"
+
+      - alert: ModelRequestErrorRateHigh
+        expr: rate(xinference:model_request_errors_total[5m]) / rate(xinference:model_request_total[5m]) > 0.05
+        for: 3m
+        labels:
+          severity: warning
+        annotations:
+          summary: "模型请求错误率超过 5%"
+          description: "模型 {{ $labels.model }} 错误率 {{ $value | humanizePercentage }}，持续 3 分钟。"
+
+      - alert: TTFTHigh
+        expr: rate(xinference:time_to_first_token_seconds_sum[5m]) / rate(xinference:time_to_first_token_seconds_count[5m]) > 10
+        for: 3m
+        labels:
+          severity: warning
+        annotations:
+          summary: "首 Token 延迟超过 10 秒"
+          description: "模型 {{ $labels.model }} TTFT {{ $value }}ms，持续 3 分钟。"
+
+      - alert: WorkerOffline
+        expr: xinference:workers_total < 1
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Worker 节点离线"
+          description: "当前在线 Worker 数量 {{ $value }}，低于预期。"
+
+      - alert: DiskSpaceLow
+        expr: (node_filesystem_avail_bytes / node_filesystem_size_bytes) < 0.1
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "磁盘空间不足 10%"
+          description: "节点 {{ $labels.instance }} 挂载点 {{ $labels.mountpoint }} 剩余空间 {{ $value | humanizePercentage }}。"
+
+      - alert: RequestQueueBacklog
+        expr: xinference:model_pending_requests > 10
+        for: 3m
+        labels:
+          severity: warning
+        annotations:
+          summary: "模型请求队列积压"
+          description: "模型 {{ $labels.model }} 排队请求数 {{ $value }}，持续 3 分钟。"
+
+      - alert: ModelLoadSlow
+        expr: xinference:model_last_load_duration_seconds > 300
+        for: 0m
+        labels:
+          severity: warning
+        annotations:
+          summary: "模型加载耗时超过 5 分钟"
+          description: "模型 {{ $labels.model_name }} 最近加载平均耗时 {{ $value | humanizeDuration }}。"

--- a/monitor/alert/rules.yml
+++ b/monitor/alert/rules.yml
@@ -1,0 +1,65 @@
+groups:
+  - name: xinference-alert-rule
+    rules:
+      - alert: GPUMemoryHigh
+        expr: xinference:worker_gpu_memory_used_bytes / xinference:worker_gpu_memory_total_bytes > 0.9
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "GPU memory usage exceeds 90%"
+          description: "Worker {{ $labels.worker_address }} GPU {{ $labels.gpu_index }} memory usage {{ $value | humanizePercentage }}, lasting 5 minutes."
+
+      - alert: ModelRequestErrorRateHigh
+        expr: rate(xinference:model_request_errors_total[5m]) / rate(xinference:model_request_total[5m]) > 0.05
+        for: 3m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Model request error rate exceeds 5%"
+          description: "Model {{ $labels.model }} error rate {{ $value | humanizePercentage }}, lasting 3 minutes."
+
+      - alert: TTFTHigh
+        expr: rate(xinference:time_to_first_token_seconds_sum[5m]) / rate(xinference:time_to_first_token_seconds_count[5m]) > 10
+        for: 3m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Time to first token exceeds 10 seconds"
+          description: "Model {{ $labels.model }} TTFT {{ $value }}ms, lasting 3 minutes."
+
+      - alert: WorkerOffline
+        expr: xinference:workers_total < 1
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Worker node offline"
+          description: "Current online worker count {{ $value }}, below expected."
+
+      - alert: DiskSpaceLow
+        expr: (node_filesystem_avail_bytes / node_filesystem_size_bytes) < 0.1
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Disk space below 10%"
+          description: "Node {{ $labels.instance }} mountpoint {{ $labels.mountpoint }} remaining space {{ $value | humanizePercentage }}."
+
+      - alert: RequestQueueBacklog
+        expr: xinference:model_pending_requests > 10
+        for: 3m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Model request queue backlog"
+          description: "Model {{ $labels.model }} pending requests {{ $value }}, lasting 3 minutes."
+
+      - alert: ModelLoadSlow
+        expr: xinference:model_last_load_duration_seconds > 300
+        for: 0m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Model load time exceeds 5 minutes"
+          description: "Model {{ $labels.model_name }} recent average load time {{ $value | humanizeDuration }}."


### PR DESCRIPTION
## Summary

- Add predefined Prometheus alert rules for monitoring Xinference cluster health
- 7 alert rules: GPUMemoryHigh, ModelRequestErrorRateHigh, TTFTHigh, WorkerOffline, DiskSpaceLow, RequestQueueBacklog, ModelLoadSlow
- Localized rule files for English, Chinese, Japanese, and Korean
- Include README with usage guide and Alertmanager integration example

## Alert Rules

| Alert | Severity | Condition |
|-------|----------|-----------|
| GPUMemoryHigh | critical | GPU memory > 90% for 5m |
| ModelRequestErrorRateHigh | warning | Error rate > 5% for 3m |
| TTFTHigh | warning | TTFT > 10s for 3m |
| WorkerOffline | critical | Workers < 1 for 2m |
| DiskSpaceLow | critical | Disk < 10% for 5m |
| RequestQueueBacklog | warning | Pending > 10 for 3m |
| ModelLoadSlow | warning | Load time > 5min |

## Test plan

- [ ] Validate YAML syntax for all rule files
- [ ] Verify alert expressions against Xinference metric names
- [ ] Test rule loading in Prometheus
