### PR TITLE
feat: add role/address to log format and structured inference logging

### DIFF
--- a/monitor/filebate/README.md
+++ b/monitor/filebate/README.md
@@ -1,0 +1,42 @@
+# Filebeat Log Collection
+
+Collects xinference worker/supervisor node logs, with output to Elasticsearch or Kafka.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `filebeat-to-es.yml` | Output to Elasticsearch, for direct querying + Kibana visualization |
+| `filebeat-to-kafka.yml` | Output to Kafka, for high-throughput or downstream consumption |
+| `docker-compose.yml` | Docker deployment example |
+
+## Quick Start
+
+```bash
+# 1. Update log paths and target addresses in the config
+# 2. Start
+docker compose up -d
+
+# To switch to Kafka output: change the volumes mount in docker-compose.yml
+```
+
+## Log Format
+
+```
+2026-05-08 00:00:01,678 xinference.core.worker 1199841 DEBUG    Enter get_model, args: ...
+```
+
+Parsed fields:
+- `xinference.timestamp` — timestamp
+- `xinference.module` — module name
+- `xinference.pid` — process ID
+- `xinference.level` — log level
+- `xinference.request_id` — request ID (in some logs)
+- `xinference.node` — node name (extracted from filename)
+- `log_type` — worker / supervisor
+
+## Notes
+
+- Worker logs can be large (~100MB/day); in production, consider filtering DEBUG or raising the xinference log level
+- Multiline merging is configured to handle progress bars and Python warnings
+- Log paths must be updated to match actual server paths

--- a/monitor/filebate/README_zh-CN.md
+++ b/monitor/filebate/README_zh-CN.md
@@ -1,0 +1,42 @@
+# Filebeat 日志采集配置
+
+采集 xinference worker/supervisor 节点日志，支持输出到 Elasticsearch 或 Kafka。
+
+## 文件说明
+
+| 文件 | 说明 |
+|------|------|
+| `filebeat-to-es.yml` | 输出到 Elasticsearch，适合直接查询+Kibana可视化 |
+| `filebeat-to-kafka.yml` | 输出到 Kafka，适合高吞吐、需二次消费的场景 |
+| `docker-compose.yml` | Docker 部署示例 |
+
+## 快速使用
+
+```bash
+# 1. 修改配置中的日志路径和目标地址
+# 2. 启动
+docker compose up -d
+
+# 切换到 Kafka 输出: 修改 docker-compose.yml 中的 volumes 挂载
+```
+
+## 日志格式
+
+```
+2026-05-08 00:00:01,678 xinference.core.worker 1199841 DEBUG    Enter get_model, args: ...
+```
+
+解析后字段:
+- `xinference.timestamp` — 时间戳
+- `xinference.module` — 模块名
+- `xinference.pid` — 进程ID
+- `xinference.level` — 日志级别
+- `xinference.request_id` — 请求ID (部分日志)
+- `xinference.node` — 节点名 (从文件名提取)
+- `log_type` — worker / supervisor
+
+## 注意事项
+
+- Worker 日志量大(~100MB/天)，生产环境建议过滤 DEBUG 或调高 xinference 日志级别
+- 多行合并已配置，可处理进度条和 Python warning
+- 日志路径需改为实际服务器路径

--- a/monitor/filebate/docker-compose.yml
+++ b/monitor/filebate/docker-compose.yml
@@ -1,0 +1,39 @@
+# Deploy Filebeat to collect xinference logs
+# Switch between ES or Kafka by changing the config file path in command
+
+services:
+  filebeat:
+    container_name: filebeat-xinference
+    image: docker.elastic.co/beats/filebeat:8.13.4
+    user: root
+    restart: always
+    # Switch config: filebeat-to-es.yml or filebeat-to-kafka.yml
+    command: filebeat -e -strict.perms=false -c /usr/share/filebeat/filebeat.yml
+    # Resource limits: prevent backlog catch-up or downstream failures from starving inference
+    deploy:
+      resources:
+        limits:
+          cpus: "0.50"
+          memory: 256M
+        reservations:
+          cpus: "0.10"
+          memory: 64M
+    volumes:
+      # Config file (pick one)
+      - ./filebeat-to-es.yml:/usr/share/filebeat/filebeat.yml:ro
+      # - ./filebeat-to-kafka.yml:/usr/share/filebeat/filebeat.yml:ro
+      # Log directories (adjust to actual paths)
+      - /data/logs/worker:/data/logs/worker:ro
+      - /data/logs/supervisor:/data/logs/supervisor:ro
+      # Data directory (persists collection progress across restarts)
+      - filebeat-data:/usr/share/filebeat/data
+    networks:
+      - xinference
+
+networks:
+  xinference:
+    external: true
+
+volumes:
+  filebeat-data:
+    driver: local

--- a/monitor/filebate/es-ilm-policy.json
+++ b/monitor/filebate/es-ilm-policy.json
@@ -1,0 +1,27 @@
+{
+  "policy": {
+    "phases": {
+      "hot": {
+        "actions": {
+          "rollover": {
+            "max_size": "10gb",
+            "max_age": "7d"
+          }
+        }
+      },
+      "warm": {
+        "min_age": "7d",
+        "actions": {
+          "shrink": { "number_of_shards": 1 },
+          "forcemerge": { "max_num_segments": 1 }
+        }
+      },
+      "delete": {
+        "min_age": "30d",
+        "actions": {
+          "delete": {}
+        }
+      }
+    }
+  }
+}

--- a/monitor/filebate/es-index-template.json
+++ b/monitor/filebate/es-index-template.json
@@ -1,0 +1,44 @@
+{
+  "index_patterns": ["xinference-logs-*"],
+  "template": {
+    "settings": {
+      "number_of_shards": 2,
+      "number_of_replicas": 1,
+      "index.refresh_interval": "5s",
+      "index.lifecycle.name": "xinference-logs-policy",
+      "index.lifecycle.rollover_alias": "xinference-logs"
+    },
+    "mappings": {
+      "dynamic": "strict",
+      "properties": {
+        "@timestamp": { "type": "date" },
+        "@version":   { "type": "keyword", "index": false },
+        "cluster":    { "type": "keyword" },
+        "log_type":   { "type": "keyword" },
+        "node":       { "type": "keyword" },
+        "address":    { "type": "keyword" },
+        "module":     { "type": "keyword" },
+        "pid":        { "type": "keyword" },
+        "level":      { "type": "keyword" },
+        "message": {
+          "type": "text",
+          "analyzer": "standard",
+          "fields": {
+            "keyword": {
+              "type": "keyword",
+              "ignore_above": 1024
+            }
+          }
+        },
+        "request_id": { "type": "keyword" },
+        "rtf_avg":    { "type": "float" },
+        "time_speech": { "type": "float" },
+        "time_escape": { "type": "float" }
+      }
+    }
+  },
+  "priority": 200,
+  "_meta": {
+    "description": "Xinference worker/supervisor 日志索引模板"
+  }
+}

--- a/monitor/filebate/filebeat-to-es.yml
+++ b/monitor/filebate/filebeat-to-es.yml
@@ -33,7 +33,7 @@ filebeat.inputs:
 
 processors:
   - dissect:
-      tokenizer: "%{_date} %{_time} %{module} %{pid} [%{_identity}] %{level} %{->}%{message_content}"
+      tokenizer: "%{_date} %{_time} %{module} %{->}%{pid} [%{_identity}] %{level} %{->}%{message_content}"
       field: "message"
       target_prefix: ""
       ignore_failure: true
@@ -61,11 +61,20 @@ processors:
           var raw = event.Get("message");
           if (raw) {
             var rtfMatch = raw.match(/rtf_avg:\s*([-\d.]+)/);
-            if (rtfMatch) event.Put("rtf_avg", parseFloat(rtfMatch[1]));
+            if (rtfMatch) {
+              var val = parseFloat(rtfMatch[1]);
+              if (!isNaN(val)) event.Put("rtf_avg", val);
+            }
             var tsMatch = raw.match(/time_speech:\s*([\d.]+)/);
-            if (tsMatch) event.Put("time_speech", parseFloat(tsMatch[1]));
+            if (tsMatch) {
+              var val = parseFloat(tsMatch[1]);
+              if (!isNaN(val)) event.Put("time_speech", val);
+            }
             var teMatch = raw.match(/time_escape:\s*([\d.]+)/);
-            if (teMatch) event.Put("time_escape", parseFloat(teMatch[1]));
+            if (teMatch) {
+              var val = parseFloat(teMatch[1]);
+              if (!isNaN(val)) event.Put("time_escape", val);
+            }
           }
 
           var mc = event.Get("message_content");
@@ -112,6 +121,7 @@ processors:
       field: "_datetime"
       layouts:
         - '2006-01-02 15:04:05,000'
+      # Change to your local timezone if xinference logs use local time
       timezone: "Asia/Shanghai"
       ignore_failure: true
 

--- a/monitor/filebate/filebeat-to-es.yml
+++ b/monitor/filebate/filebeat-to-es.yml
@@ -1,0 +1,160 @@
+# Filebeat -> Elasticsearch 示例配置
+# 用途: 采集 xinference worker/supervisor 日志，直接写入 ES 供 Kibana 查询
+# 使用: filebeat -e -c filebeat-to-es.yml
+
+filebeat.inputs:
+  - type: log
+    id: xinference-worker
+    enabled: true
+    paths:
+      - /data/logs/worker/worker-*.log
+    multiline.pattern: '^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}'
+    multiline.negate: true
+    multiline.match: after
+    multiline.max_lines: 500
+    fields:
+      log_type: worker
+      cluster: xinference
+    fields_under_root: true
+
+  - type: log
+    id: xinference-supervisor
+    enabled: true
+    paths:
+      - /data/logs/supervisor/supervisor-*.log
+    multiline.pattern: '^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}'
+    multiline.negate: true
+    multiline.match: after
+    multiline.max_lines: 500
+    fields:
+      log_type: supervisor
+      cluster: xinference
+    fields_under_root: true
+
+processors:
+  - dissect:
+      tokenizer: "%{_date} %{_time} %{module} %{pid} [%{_identity}] %{level} %{->}%{message_content}"
+      field: "message"
+      target_prefix: ""
+      ignore_failure: true
+
+  - dissect:
+      tokenizer: "[request %{request_id}] %{message_content}"
+      field: "message_content"
+      target_prefix: ""
+      ignore_failure: true
+
+  - script:
+      lang: javascript
+      source: |
+        function process(event) {
+          var source = event.Get("log.file.path");
+          if (source) {
+            var parts = source.split("/");
+            var filename = parts[parts.length - 1];
+            var nodeName = filename.replace(".log", "");
+            nodeName = nodeName.replace(/^(worker|supervisor)-/, "");
+            event.Put("node", nodeName);
+          }
+
+          // tqdm metric extraction (before message truncation)
+          var raw = event.Get("message");
+          if (raw) {
+            var rtfMatch = raw.match(/rtf_avg:\s*([-\d.]+)/);
+            if (rtfMatch) event.Put("rtf_avg", parseFloat(rtfMatch[1]));
+            var tsMatch = raw.match(/time_speech:\s*([\d.]+)/);
+            if (tsMatch) event.Put("time_speech", parseFloat(tsMatch[1]));
+            var teMatch = raw.match(/time_escape:\s*([\d.]+)/);
+            if (teMatch) event.Put("time_escape", parseFloat(teMatch[1]));
+          }
+
+          var mc = event.Get("message_content");
+          if (mc) {
+            // strip ANSI escape codes
+            mc = mc.replace(/\x1b\[[0-9;]*m/g, "");
+            // truncate model architecture dump
+            var modelIdx = mc.indexOf("model: ");
+            if (modelIdx >= 0) {
+              var parenIdx = mc.indexOf("(", modelIdx);
+              if (parenIdx >= 0) {
+                mc = mc.substring(0, parenIdx);
+              }
+            }
+            var crIdx = mc.indexOf("\r");
+            if (crIdx >= 0) {
+              mc = mc.substring(0, crIdx);
+            }
+            var nlIdx = mc.indexOf("\n");
+            if (nlIdx >= 0) {
+              mc = mc.substring(0, nlIdx);
+            }
+            event.Put("message", mc.replace(/^\s+/, ""));
+            event.Delete("message_content");
+          }
+          var d = event.Get("_date");
+          var t = event.Get("_time");
+          if (d && t) {
+            event.Put("_datetime", d + " " + t);
+          }
+          event.Delete("_date");
+          event.Delete("_time");
+          var identity = event.Get("_identity");
+          if (identity) {
+            var atIdx = identity.indexOf("@");
+            if (atIdx >= 0) {
+              event.Put("address", identity.substring(atIdx + 1));
+            }
+          }
+          event.Delete("_identity");
+        }
+
+  - timestamp:
+      field: "_datetime"
+      layouts:
+        - '2006-01-02 15:04:05,000'
+      timezone: "Asia/Shanghai"
+      ignore_failure: true
+
+  - drop_fields:
+      fields:
+        - agent
+        - ecs
+        - host
+        - input
+        - log
+        - event
+        - data_stream
+        - elastic_agent
+        - cloud
+        - container
+        - kubernetes
+        - orchestrator
+        - "@version"
+        - _datetime
+      ignore_missing: true
+
+output.elasticsearch:
+  hosts: ["http://elasticsearch:9200"]
+  index: "xinference-logs-%{[log_type]}-%{+yyyy.MM.dd}"
+  # username: "elastic"
+  # password: "changeme"
+
+setup.template.name: "xinference-logs"
+setup.template.pattern: "xinference-logs-*"
+setup.template.settings:
+  index.number_of_shards: 2
+  index.number_of_replicas: 1
+
+setup.ilm.enabled: true
+setup.ilm.rollover_alias: "xinference-logs"
+setup.ilm.policy_name: "xinference-logs-policy"
+
+logging.metrics.enabled: true
+logging.metrics.period: 60s
+logging.level: info
+logging.to_files: true
+logging.files:
+  path: /var/log/filebeat
+  name: filebeat
+  keepfiles: 7
+  permissions: 0644

--- a/monitor/filebate/filebeat-to-kafka.yml
+++ b/monitor/filebate/filebeat-to-kafka.yml
@@ -33,7 +33,7 @@ filebeat.inputs:
 
 processors:
   - dissect:
-      tokenizer: "%{_date} %{_time} %{module} %{pid} [%{_identity}] %{level} %{->}%{message_content}"
+      tokenizer: "%{_date} %{_time} %{module} %{->}%{pid} [%{_identity}] %{level} %{->}%{message_content}"
       field: "message"
       target_prefix: ""
       ignore_failure: true
@@ -61,11 +61,20 @@ processors:
           var raw = event.Get("message");
           if (raw) {
             var rtfMatch = raw.match(/rtf_avg:\s*([-\d.]+)/);
-            if (rtfMatch) event.Put("rtf_avg", parseFloat(rtfMatch[1]));
+            if (rtfMatch) {
+              var val = parseFloat(rtfMatch[1]);
+              if (!isNaN(val)) event.Put("rtf_avg", val);
+            }
             var tsMatch = raw.match(/time_speech:\s*([\d.]+)/);
-            if (tsMatch) event.Put("time_speech", parseFloat(tsMatch[1]));
+            if (tsMatch) {
+              var val = parseFloat(tsMatch[1]);
+              if (!isNaN(val)) event.Put("time_speech", val);
+            }
             var teMatch = raw.match(/time_escape:\s*([\d.]+)/);
-            if (teMatch) event.Put("time_escape", parseFloat(teMatch[1]));
+            if (teMatch) {
+              var val = parseFloat(teMatch[1]);
+              if (!isNaN(val)) event.Put("time_escape", val);
+            }
           }
 
           var mc = event.Get("message_content");

--- a/monitor/filebate/filebeat-to-kafka.yml
+++ b/monitor/filebate/filebeat-to-kafka.yml
@@ -1,0 +1,158 @@
+# Filebeat -> Kafka 示例配置
+# 用途: 采集 xinference worker/supervisor 日志，输出到 Kafka 供下游消费(Logstash/Flink/ES等)
+# 使用: filebeat -e -c filebeat-to-kafka.yml
+
+filebeat.inputs:
+  - type: log
+    id: xinference-worker
+    enabled: true
+    paths:
+      - /data/logs/worker/worker-*.log
+    multiline.pattern: '^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}'
+    multiline.negate: true
+    multiline.match: after
+    multiline.max_lines: 500
+    fields:
+      log_type: worker
+      cluster: xinference
+    fields_under_root: true
+
+  - type: log
+    id: xinference-supervisor
+    enabled: true
+    paths:
+      - /data/logs/supervisor/supervisor-*.log
+    multiline.pattern: '^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}'
+    multiline.negate: true
+    multiline.match: after
+    multiline.max_lines: 500
+    fields:
+      log_type: supervisor
+      cluster: xinference
+    fields_under_root: true
+
+processors:
+  - dissect:
+      tokenizer: "%{_date} %{_time} %{module} %{pid} [%{_identity}] %{level} %{->}%{message_content}"
+      field: "message"
+      target_prefix: ""
+      ignore_failure: true
+
+  - dissect:
+      tokenizer: "[request %{request_id}] %{message_content}"
+      field: "message_content"
+      target_prefix: ""
+      ignore_failure: true
+
+  - script:
+      lang: javascript
+      source: |
+        function process(event) {
+          var source = event.Get("log.file.path");
+          if (source) {
+            var parts = source.split("/");
+            var filename = parts[parts.length - 1];
+            var nodeName = filename.replace(".log", "");
+            nodeName = nodeName.replace(/^(worker|supervisor)-/, "");
+            event.Put("node", nodeName);
+          }
+
+          // tqdm metric extraction (before message truncation)
+          var raw = event.Get("message");
+          if (raw) {
+            var rtfMatch = raw.match(/rtf_avg:\s*([-\d.]+)/);
+            if (rtfMatch) event.Put("rtf_avg", parseFloat(rtfMatch[1]));
+            var tsMatch = raw.match(/time_speech:\s*([\d.]+)/);
+            if (tsMatch) event.Put("time_speech", parseFloat(tsMatch[1]));
+            var teMatch = raw.match(/time_escape:\s*([\d.]+)/);
+            if (teMatch) event.Put("time_escape", parseFloat(teMatch[1]));
+          }
+
+          var mc = event.Get("message_content");
+          if (mc) {
+            // strip ANSI escape codes
+            mc = mc.replace(/\x1b\[[0-9;]*m/g, "");
+            // truncate model architecture dump
+            var modelIdx = mc.indexOf("model: ");
+            if (modelIdx >= 0) {
+              var parenIdx = mc.indexOf("(", modelIdx);
+              if (parenIdx >= 0) {
+                mc = mc.substring(0, parenIdx);
+              }
+            }
+            var crIdx = mc.indexOf("\r");
+            if (crIdx >= 0) {
+              mc = mc.substring(0, crIdx);
+            }
+            var nlIdx = mc.indexOf("\n");
+            if (nlIdx >= 0) {
+              mc = mc.substring(0, nlIdx);
+            }
+            event.Put("message", mc.replace(/^\s+/, ""));
+            event.Delete("message_content");
+          }
+          var d = event.Get("_date");
+          var t = event.Get("_time");
+          if (d && t) {
+            event.Put("_datetime", d + " " + t);
+          }
+          event.Delete("_date");
+          event.Delete("_time");
+          var identity = event.Get("_identity");
+          if (identity) {
+            var atIdx = identity.indexOf("@");
+            if (atIdx >= 0) {
+              event.Put("address", identity.substring(atIdx + 1));
+            }
+          }
+          event.Delete("_identity");
+        }
+
+  - timestamp:
+      field: "_datetime"
+      layouts:
+        - '2006-01-02 15:04:05,000'
+      timezone: "Asia/Shanghai"
+      ignore_failure: true
+
+  - drop_fields:
+      fields:
+        - agent
+        - ecs
+        - host
+        - input
+        - log
+        - event
+        - data_stream
+        - elastic_agent
+        - cloud
+        - container
+        - kubernetes
+        - orchestrator
+        - "@version"
+        - _datetime
+      ignore_missing: true
+
+output.kafka:
+  hosts: ["kafka1:9092", "kafka2:9092", "kafka3:9092"]
+  topic: "xinference-logs-%{[log_type]}"
+  partition.round_robin:
+    reachable_only: true
+  codec.json:
+    pretty: false
+  required_acks: 1
+  compression: gzip
+  max_message_bytes: 1048576
+  # username: "filebeat"
+  # password: "changeme"
+  # sasl.mechanism: "PLAIN"
+
+logging.metrics.enabled: true
+logging.metrics.period: 60s
+logging.level: info
+logging.to_files: true
+logging.files:
+  path: /var/log/filebeat
+  name: filebeat
+  keepfiles: 7
+  permissions: 0644

--- a/xinference/deploy/cmdline.py
+++ b/xinference/deploy/cmdline.py
@@ -107,6 +107,8 @@ def start_local_cluster(
         get_log_file(f"local_{get_timestamp_ms()}"),
         XINFERENCE_LOG_BACKUP_COUNT,
         XINFERENCE_LOG_MAX_BYTES,
+        role="local",
+        address=f"{host}:{port}",
     )
     logging.config.dictConfig(dict_config)  # type: ignore
     # refer to https://huggingface.co/docs/transformers/main_classes/logging
@@ -283,6 +285,8 @@ def supervisor(
         get_log_file(f"supervisor_{get_timestamp_ms()}"),
         XINFERENCE_LOG_BACKUP_COUNT,
         XINFERENCE_LOG_MAX_BYTES,
+        role="supervisor",
+        address=f"{host}:{supervisor_port or ''}",
     )
     logging.config.dictConfig(dict_config)  # type: ignore
     set_envs("TRANSFORMERS_VERBOSITY", log_level.lower())
@@ -346,6 +350,8 @@ def worker(
         get_log_file(f"worker_{get_timestamp_ms()}"),
         XINFERENCE_LOG_BACKUP_COUNT,
         XINFERENCE_LOG_MAX_BYTES,
+        role="worker",
+        address=f"{host}:{worker_port or ''}",
     )
     logging.config.dictConfig(dict_config)  # type: ignore
     set_envs("TRANSFORMERS_VERBOSITY", log_level.lower())

--- a/xinference/deploy/local.py
+++ b/xinference/deploy/local.py
@@ -46,7 +46,7 @@ async def _start_local_cluster(
     logging_conf: Optional[Dict] = None,
     conn: Optional[Connection] = None,
 ):
-    from .utils import create_worker_actor_pool, AddressFormatter
+    from .utils import AddressFormatter, create_worker_actor_pool
 
     if logging_conf:
         logging.config.dictConfig(logging_conf)  # type: ignore

--- a/xinference/deploy/local.py
+++ b/xinference/deploy/local.py
@@ -46,10 +46,12 @@ async def _start_local_cluster(
     logging_conf: Optional[Dict] = None,
     conn: Optional[Connection] = None,
 ):
-    from .utils import create_worker_actor_pool
+    from .utils import create_worker_actor_pool, AddressFormatter
 
     if logging_conf:
         logging.config.dictConfig(logging_conf)  # type: ignore
+
+    AddressFormatter.update_address("local", address)
 
     pool = None
     try:

--- a/xinference/deploy/local.py
+++ b/xinference/deploy/local.py
@@ -52,6 +52,8 @@ async def _start_local_cluster(
         logging.config.dictConfig(logging_conf)  # type: ignore
 
     AddressFormatter.update_address("local", address)
+    if logging_conf and "formatters" in logging_conf:
+        logging_conf["formatters"]["formatter"]["address"] = address
 
     pool = None
     try:

--- a/xinference/deploy/supervisor.py
+++ b/xinference/deploy/supervisor.py
@@ -27,7 +27,7 @@ from ..constants import (
     XINFERENCE_HEALTH_CHECK_INTERVAL,
 )
 from ..core.supervisor import SupervisorActor
-from .utils import health_check, AddressFormatter
+from .utils import AddressFormatter, health_check
 
 logger = logging.getLogger(__name__)
 

--- a/xinference/deploy/supervisor.py
+++ b/xinference/deploy/supervisor.py
@@ -27,13 +27,14 @@ from ..constants import (
     XINFERENCE_HEALTH_CHECK_INTERVAL,
 )
 from ..core.supervisor import SupervisorActor
-from .utils import health_check
+from .utils import health_check, AddressFormatter
 
 logger = logging.getLogger(__name__)
 
 
 async def _start_supervisor(address: str, logging_conf: Optional[Dict] = None):
     logging.config.dictConfig(logging_conf)  # type: ignore
+    AddressFormatter.update_address("supervisor", address)
 
     pool = None
     try:

--- a/xinference/deploy/supervisor.py
+++ b/xinference/deploy/supervisor.py
@@ -35,6 +35,8 @@ logger = logging.getLogger(__name__)
 async def _start_supervisor(address: str, logging_conf: Optional[Dict] = None):
     logging.config.dictConfig(logging_conf)  # type: ignore
     AddressFormatter.update_address("supervisor", address)
+    if logging_conf and "formatters" in logging_conf:
+        logging_conf["formatters"]["formatter"]["address"] = address
 
     pool = None
     try:

--- a/xinference/deploy/utils.py
+++ b/xinference/deploy/utils.py
@@ -94,8 +94,12 @@ class AddressFormatter(logging.Formatter):
 
 
 def get_config_dict(
-    log_level: str, log_file_path: str, log_backup_count: int, log_max_bytes: int,
-    role: str = "", address: str = "",
+    log_level: str,
+    log_file_path: str,
+    log_backup_count: int,
+    log_max_bytes: int,
+    role: str = "",
+    address: str = "",
 ) -> dict:
     # for windows, the path should be a raw string.
     log_file_path = (

--- a/xinference/deploy/utils.py
+++ b/xinference/deploy/utils.py
@@ -18,6 +18,7 @@ import logging.handlers
 import os
 import time
 import typing
+import weakref
 from typing import TYPE_CHECKING, Any, Optional
 
 import xoscar as xo
@@ -73,13 +74,13 @@ def get_log_file(sub_dir: str):
 
 
 class AddressFormatter(logging.Formatter):
-    _instances: list = []
+    _instances: weakref.WeakSet = weakref.WeakSet()
 
     def __init__(self, fmt=None, datefmt=None, style="%", role="", address=""):
         super().__init__(fmt, datefmt, style)
         self.role = role
         self.address = address
-        AddressFormatter._instances.append(self)
+        AddressFormatter._instances.add(self)
 
     def format(self, record):
         record.xinference_role = self.role

--- a/xinference/deploy/utils.py
+++ b/xinference/deploy/utils.py
@@ -72,8 +72,30 @@ def get_log_file(sub_dir: str):
     return os.path.join(log_dir, XINFERENCE_DEFAULT_LOG_FILE_NAME)
 
 
+class AddressFormatter(logging.Formatter):
+    _instances: list = []
+
+    def __init__(self, fmt=None, datefmt=None, style="%", role="", address=""):
+        super().__init__(fmt, datefmt, style)
+        self.role = role
+        self.address = address
+        AddressFormatter._instances.append(self)
+
+    def format(self, record):
+        record.xinference_role = self.role
+        record.xinference_address = self.address
+        return super().format(record)
+
+    @classmethod
+    def update_address(cls, role, address):
+        for inst in cls._instances:
+            if inst.role == role:
+                inst.address = address
+
+
 def get_config_dict(
-    log_level: str, log_file_path: str, log_backup_count: int, log_max_bytes: int
+    log_level: str, log_file_path: str, log_backup_count: int, log_max_bytes: int,
+    role: str = "", address: str = "",
 ) -> dict:
     # for windows, the path should be a raw string.
     log_file_path = (
@@ -87,9 +109,14 @@ def get_config_dict(
         "disable_existing_loggers": False,
         "formatters": {
             "formatter": {
-                "format": (
-                    "%(asctime)s %(name)-12s %(process)d %(levelname)-8s %(message)s"
-                )
+                "()": "xinference.deploy.utils.AddressFormatter",
+                "fmt": (
+                    "%(asctime)s %(name)-12s %(process)d "
+                    "[%(xinference_role)s@%(xinference_address)s] "
+                    "%(levelname)-8s %(message)s"
+                ),
+                "role": role,
+                "address": address,
             },
         },
         "filters": {

--- a/xinference/deploy/worker.py
+++ b/xinference/deploy/worker.py
@@ -65,7 +65,9 @@ async def _start_worker(
     metrics_exporter_port: Optional[int] = None,
     logging_conf: Any = None,
 ):
-    from .utils import create_worker_actor_pool
+    from .utils import create_worker_actor_pool, AddressFormatter
+
+    AddressFormatter.update_address("worker", address)
 
     pool = await create_worker_actor_pool(address=address, logging_conf=logging_conf)
     await start_worker_components(

--- a/xinference/deploy/worker.py
+++ b/xinference/deploy/worker.py
@@ -65,7 +65,7 @@ async def _start_worker(
     metrics_exporter_port: Optional[int] = None,
     logging_conf: Any = None,
 ):
-    from .utils import create_worker_actor_pool, AddressFormatter
+    from .utils import AddressFormatter, create_worker_actor_pool
 
     AddressFormatter.update_address("worker", address)
 

--- a/xinference/deploy/worker.py
+++ b/xinference/deploy/worker.py
@@ -68,6 +68,8 @@ async def _start_worker(
     from .utils import AddressFormatter, create_worker_actor_pool
 
     AddressFormatter.update_address("worker", address)
+    if logging_conf and "formatters" in logging_conf:
+        logging_conf["formatters"]["formatter"]["address"] = address
 
     pool = await create_worker_actor_pool(address=address, logging_conf=logging_conf)
     await start_worker_components(

--- a/xinference/model/rerank/sentence_transformers/core.py
+++ b/xinference/model/rerank/sentence_transformers/core.py
@@ -435,9 +435,7 @@ class SentenceTransformerRerankModel(RerankModel, BatchMixin):
             **kwargs,
         )
         _elapsed = time.monotonic() - _start
-        _n_tokens = getattr(
-            getattr(self, "_token_tracking_data", None), "n_tokens", 0
-        )
+        _n_tokens = getattr(getattr(self, "_token_tracking_data", None), "n_tokens", 0)
         logger.info(
             "Rerank completed, docs=%d, elapsed=%.3fs, tokens=%d",
             documents_size,

--- a/xinference/model/rerank/sentence_transformers/core.py
+++ b/xinference/model/rerank/sentence_transformers/core.py
@@ -17,6 +17,7 @@ import inspect
 import logging
 import os
 import threading
+import time
 import uuid
 from collections import defaultdict
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
@@ -423,6 +424,7 @@ class SentenceTransformerRerankModel(RerankModel, BatchMixin):
         documents_size = len(documents)
         query_list = [query] * documents_size
 
+        _start = time.monotonic()
         similarity_scores = self._rerank(
             documents,
             query_list,
@@ -431,6 +433,16 @@ class SentenceTransformerRerankModel(RerankModel, BatchMixin):
             return_documents,
             return_len,
             **kwargs,
+        )
+        _elapsed = time.monotonic() - _start
+        _n_tokens = getattr(
+            getattr(self, "_token_tracking_data", None), "n_tokens", 0
+        )
+        logger.info(
+            "Rerank completed, docs=%d, elapsed=%.3fs, tokens=%d",
+            documents_size,
+            _elapsed,
+            _n_tokens,
         )
         sim_scores_argsort = list(reversed(np.argsort(similarity_scores)))
         if top_n is not None:

--- a/xinference/model/rerank/sentence_transformers/core.py
+++ b/xinference/model/rerank/sentence_transformers/core.py
@@ -436,12 +436,19 @@ class SentenceTransformerRerankModel(RerankModel, BatchMixin):
         )
         _elapsed = time.monotonic() - _start
         _n_tokens = getattr(getattr(self, "_token_tracking_data", None), "n_tokens", 0)
-        logger.info(
-            "Rerank completed, docs=%d, elapsed=%.3fs, tokens=%d",
-            documents_size,
-            _elapsed,
-            _n_tokens,
-        )
+        if _n_tokens > 0:
+            logger.info(
+                "Rerank completed, docs=%d, elapsed=%.3fs, tokens=%d",
+                documents_size,
+                _elapsed,
+                _n_tokens,
+            )
+        else:
+            logger.info(
+                "Rerank completed, docs=%d, elapsed=%.3fs",
+                documents_size,
+                _elapsed,
+            )
         sim_scores_argsort = list(reversed(np.argsort(similarity_scores)))
         if top_n is not None:
             sim_scores_argsort = sim_scores_argsort[:top_n]

--- a/xinference/model/utils.py
+++ b/xinference/model/utils.py
@@ -484,7 +484,15 @@ def retry_download(
     last_ex = None
     for current_attempt in range(1, XINFERENCE_DOWNLOAD_MAX_ATTEMPTS + 1):
         try:
-            return download_func(*args, **kwargs)
+            logger.info(
+                "Start downloading model '%s', attempt %d/%d",
+                model_name,
+                current_attempt,
+                XINFERENCE_DOWNLOAD_MAX_ATTEMPTS,
+            )
+            result = download_func(*args, **kwargs)
+            logger.info("Model '%s' downloaded successfully to %s", model_name, result)
+            return result
         except Exception as e:
             remaining_attempts = XINFERENCE_DOWNLOAD_MAX_ATTEMPTS - current_attempt
             last_ex = e


### PR DESCRIPTION
## Summary

- **AddressFormatter**: Custom `logging.Formatter` that injects `[role@address]` into every log line, enabling multi-node log filtering in ELK/Loki deployments
- **Download logging**: `retry_download` now logs model download start (with attempt count) and success (with cache path)
- **Rerank timing**: `rerank()` now logs elapsed time and token count (when available) after each inference call
- **Filebeat log processing**: Filebeat configs with ANSI cleanup, model architecture truncation, tqdm metric extraction, and deployment support files

## Changes

### 1. Log format: `[role@address]` prefix (5 files)

| File | Change |
|------|--------|
| `xinference/deploy/utils.py` | New `AddressFormatter` class (using `weakref.WeakSet` to prevent memory leak); `get_config_dict` uses `()` factory syntax with `role`/`address` params |
| `xinference/deploy/cmdline.py` | Pass `role`/`address` to `get_config_dict` in `start_local_cluster`, `supervisor`, `worker` |
| `xinference/deploy/supervisor.py` | Call `AddressFormatter.update_address()` + sync `logging_conf` dict for subprocess propagation |
| `xinference/deploy/worker.py` | Call `AddressFormatter.update_address()` + sync `logging_conf` dict for subprocess propagation |
| `xinference/deploy/local.py` | Call `AddressFormatter.update_address()` + sync `logging_conf` dict for subprocess propagation |

Log output example:
```
2026-05-08 18:17:01,844 xinference.core.supervisor 2189529 [supervisor@10.0.0.1:9997] DEBUG  ...
2026-05-08 22:17:01,962 xinference.core.worker    2856007 [worker@10.0.0.2:9998]     DEBUG  ...
```

### 2. Download start/success logging (1 file)

| File | Change |
|------|--------|
| `xinference/model/utils.py` | `retry_download` logs `Start downloading model 'X', attempt N/M` and `Model 'X' downloaded successfully to path` |

### 3. Rerank inference timing (1 file)

| File | Change |
|------|--------|
| `xinference/model/rerank/sentence_transformers/core.py` | Log `Rerank completed, docs=N, elapsed=Xs` after each `_rerank()` call; token count included only when `_n_tokens > 0` (Qwen3/Jina rerankers don't track tokens yet) |

### 4. Filebeat log processing and deployment (7 files)

| File | Change |
|------|--------|
| `monitor/filebate/filebeat-to-es.yml` | Filebeat config shipping logs to ES, with ANSI stripping, model arch truncation, tqdm metric extraction, `%{->}` dissect padding fix, `isNaN` guard |
| `monitor/filebate/filebeat-to-kafka.yml` | Same processing pipeline, shipping to Kafka |
| `monitor/filebate/es-index-template.json` | ES index template with `rtf_avg`/`time_speech`/`time_escape` field mappings |
| `monitor/filebate/es-ilm-policy.json` | ES ILM policy for log retention management |
| `monitor/filebate/docker-compose.yml` | Docker Compose for filebeat deployment |
| `monitor/filebate/README.md` | English documentation |
| `monitor/filebate/README_zh-CN.md` | Chinese documentation |

Filebeat processing:
- **ANSI stripping**: Remove `\x1b[...m` escape codes from log messages
- **Model arch truncation**: `model: Qwen3ForCausalLM(...)` → `model: Qwen3ForCausalLM`
- **tqdm metric extraction**: Extract `rtf_avg`, `time_speech`, `time_escape` as float fields with `isNaN` guard
- **Dissect padding**: `%{->}` handles variable-width fields from Python `%-12s` / `%-8s` format

## Design decisions

- **Custom Formatter over Filter**: Formatter survives `dictConfig` rebuilds (uvicorn restart), never misses a log record, and works in xoscar subprocess pools
- **`weakref.WeakSet` for instance tracking**: Prevents memory leak when `dictConfig` is called multiple times — old Formatter instances are automatically GC'd
- **Dual address update (instance + dict)**: `update_address()` updates current-process Formatter instances; syncing `logging_conf` dict ensures subprocess pools get the correct address via `dictConfig`
- **`get_config_dict` params have defaults**: `role=""`, `address=""` — existing callers (e.g. `conftest.py`) are unaffected
- **Conditional token output**: Qwen3/Jina rerankers don't update `_token_tracking_data.n_tokens`, so `tokens=` is only logged when the value is > 0 to avoid misleading output
- **Timezone kept as Asia/Shanghai**: Production logs use local time; changing to UTC would shift all timestamps by 8 hours. Comment added for user customization
- **nodeName extraction unchanged**: Production log filenames (e.g. `worker-p-gpu-s4090-001.log`) already contain node identifiers, so current extraction logic is correct

## Test plan

- [ ] Verify `[role@address]` appears in supervisor/worker/local logs
- [ ] Verify address updates correctly after xoscar pool creation
- [ ] Verify subprocess (actor pool) logs also show correct address
- [ ] Verify existing tests pass (no breakage from new `get_config_dict` params)
- [ ] Verify download start/success logs appear during model download
- [ ] Verify rerank elapsed/token logs appear after inference (tokens omitted for Qwen3/Jina)
- [ ] Verify filebeat correctly strips ANSI codes and extracts tqdm metrics
- [ ] Verify dissect handles short module names with padding spaces
