### PR TITLE
feat: backport monitoring metrics and fix stream label / serve_count bugs

### DIFF
--- a/xinference/api/restful_api.py
+++ b/xinference/api/restful_api.py
@@ -929,7 +929,8 @@ class RESTfulAPI(CancelMixin):
                     yield dict(data=json.dumps({"error": str(ex)}))
                     return
                 finally:
-                    await model.decrease_serve_count()
+                    if iterator is not None:
+                        await model.decrease_serve_count()
 
             return EventSourceResponse(
                 stream_results(), ping=XINFERENCE_SSE_PING_ATTEMPTS_SECONDS
@@ -1063,7 +1064,8 @@ class RESTfulAPI(CancelMixin):
                     yield dict(data=json.dumps({"error": str(ex)}))
                     return
                 finally:
-                    await model.decrease_serve_count()
+                    if iterator is not None:
+                        await model.decrease_serve_count()
 
             return EventSourceResponse(
                 stream_results(), ping=XINFERENCE_SSE_PING_ATTEMPTS_SECONDS
@@ -2137,7 +2139,8 @@ class RESTfulAPI(CancelMixin):
                     yield dict(data=json.dumps({"error": str(ex)}))
                     return
                 finally:
-                    await model.decrease_serve_count()
+                    if iterator is not None:
+                        await model.decrease_serve_count()
 
             return EventSourceResponse(
                 stream_results(), ping=XINFERENCE_SSE_PING_ATTEMPTS_SECONDS

--- a/xinference/api/restful_api.py
+++ b/xinference/api/restful_api.py
@@ -274,7 +274,7 @@ class RESTfulAPI(CancelMixin):
             # Only remove MetricsMiddleware's HTTP counters to avoid duplicates
             # on restart; preserve xinference:* custom metrics registered at
             # module level in metrics.py.
-            from xinference.core.metrics import _WORKER_ONLY_METRICS
+            from ..core.metrics import _WORKER_ONLY_METRICS
 
             for collector in list(REGISTRY.get_all()):
                 if not collector.name.startswith("xinference:"):
@@ -930,7 +930,14 @@ class RESTfulAPI(CancelMixin):
                     return
                 finally:
                     if iterator is not None:
-                        await model.decrease_serve_count()
+                        from xoscar.api import IteratorWrapper
+
+                        if (
+                            inspect.isasyncgen(iterator)
+                            or inspect.isgenerator(iterator)
+                            or isinstance(iterator, IteratorWrapper)
+                        ):
+                            await model.decrease_serve_count()
 
             return EventSourceResponse(
                 stream_results(), ping=XINFERENCE_SSE_PING_ATTEMPTS_SECONDS
@@ -1065,7 +1072,14 @@ class RESTfulAPI(CancelMixin):
                     return
                 finally:
                     if iterator is not None:
-                        await model.decrease_serve_count()
+                        from xoscar.api import IteratorWrapper
+
+                        if (
+                            inspect.isasyncgen(iterator)
+                            or inspect.isgenerator(iterator)
+                            or isinstance(iterator, IteratorWrapper)
+                        ):
+                            await model.decrease_serve_count()
 
             return EventSourceResponse(
                 stream_results(), ping=XINFERENCE_SSE_PING_ATTEMPTS_SECONDS
@@ -2140,7 +2154,14 @@ class RESTfulAPI(CancelMixin):
                     return
                 finally:
                     if iterator is not None:
-                        await model.decrease_serve_count()
+                        from xoscar.api import IteratorWrapper
+
+                        if (
+                            inspect.isasyncgen(iterator)
+                            or inspect.isgenerator(iterator)
+                            or isinstance(iterator, IteratorWrapper)
+                        ):
+                            await model.decrease_serve_count()
 
             return EventSourceResponse(
                 stream_results(), ping=XINFERENCE_SSE_PING_ATTEMPTS_SECONDS

--- a/xinference/api/restful_api.py
+++ b/xinference/api/restful_api.py
@@ -274,8 +274,12 @@ class RESTfulAPI(CancelMixin):
             # Only remove MetricsMiddleware's HTTP counters to avoid duplicates
             # on restart; preserve xinference:* custom metrics registered at
             # module level in metrics.py.
+            from xinference.core.metrics import _WORKER_ONLY_METRICS
+
             for collector in list(REGISTRY.get_all()):
                 if not collector.name.startswith("xinference:"):
+                    REGISTRY.deregister(collector.name)
+                elif collector.name in _WORKER_ONLY_METRICS:
                     REGISTRY.deregister(collector.name)
             self._app.add_middleware(MetricsMiddleware)
             self._app.include_router(self._router)

--- a/xinference/api/routers/admin.py
+++ b/xinference/api/routers/admin.py
@@ -255,10 +255,15 @@ async def get_progress(
 
 
 async def get_ui_config() -> JSONResponse:
+    grafana_datasource = os.environ.get("XINFERENCE_GRAFANA_DATASOURCE", "")
     return JSONResponse(
         content={
             "grafana_url": os.environ.get("XINFERENCE_GRAFANA_URL", ""),
-            "grafana_datasource": os.environ.get("XINFERENCE_GRAFANA_DATASOURCE", ""),
+            "grafana_datasource": grafana_datasource,
+            "grafana_alert_datasource": os.environ.get(
+                "XINFERENCE_GRAFANA_ALERT_DATASOURCE", ""
+            )
+            or grafana_datasource,
             "grafana_dashboard_uid": os.environ.get(
                 "XINFERENCE_GRAFANA_DASHBOARD_UID", "xinference-overview"
             ),

--- a/xinference/core/metrics.py
+++ b/xinference/core/metrics.py
@@ -88,6 +88,10 @@ model_request_limit_gauge = Gauge(
     "xinference:model_request_limit",
     "Maximum concurrent request limit for the model.",
 )
+model_last_load_duration_seconds = Gauge(
+    "xinference:model_last_load_duration_seconds",
+    "Duration of the last model load in seconds.",
+)
 
 # ===========================================================================
 # Supervisor-side cluster / worker / model info metrics
@@ -168,6 +172,22 @@ _SUPERVISOR_ONLY_METRICS = {
 }
 
 # ---------------------------------------------------------------------------
+# Worker-only metric names — removed from Supervisor Registry at startup
+# ---------------------------------------------------------------------------
+_WORKER_ONLY_METRICS = {
+    "xinference:generate_tokens_total",
+    "xinference:input_tokens_total_counter",
+    "xinference:output_tokens_total_counter",
+    "xinference:model_request_total",
+    "xinference:model_request_errors_total",
+    "xinference:model_request_duration_seconds",
+    "xinference:model_serve_count",
+    "xinference:model_request_limit",
+    "xinference:time_to_first_token_seconds",
+    "xinference:model_last_load_duration_seconds",
+}
+
+# ---------------------------------------------------------------------------
 # Stale-label tracking sets for update_cluster_metrics()
 # ---------------------------------------------------------------------------
 _prev_worker_labels: Set[Tuple[str, ...]] = set()
@@ -180,7 +200,12 @@ _prev_gpu_binding_labels: Set[Tuple[str, ...]] = set()
 def record_metrics(name, op, kwargs):
     collector = globals().get(name)
     if collector is not None:
-        getattr(collector, op)(**kwargs)
+        try:
+            getattr(collector, op)(**kwargs)
+        except Exception:
+            logger.exception(
+                "Failed to record metric %s.%s with kwargs=%s", name, op, kwargs
+            )
 
 
 def set_build_info(

--- a/xinference/core/model.py
+++ b/xinference/core/model.py
@@ -273,13 +273,23 @@ class ModelActor(xo.StatelessActor, CancelMixin):
         self._worker_ref = None
         self._progress_tracker_ref = None
         self._serve_count = 0
+        model_type = self._model_description.get("model_type", "unknown")
+        if model_type in ("audio", "video"):
+            engine_label = ""
+            format_label = ""
+        elif model_type == "image":
+            engine_label = model_engine or ""
+            format_label = ""
+        else:
+            engine_label = model_engine or "unknown"
+            format_label = self._model_description.get("model_format", "unknown")
         self._metrics_labels = {
-            "type": self._model_description.get("model_type", "unknown"),
+            "type": model_type,
             "model": self.model_uid(),
             "model_name": self._model_description.get("model_name", "unknown"),
-            "engine": model_engine or "unknown",
+            "engine": engine_label,
             "node": self._worker_address,
-            "format": self._model_description.get("model_format", "unknown"),
+            "format": format_label,
             "quantization": self._model_description.get("quantization", "none"),
             "gpu_index": ",".join(
                 str(a) for a in (self._model_description.get("accelerators") or [])
@@ -1021,6 +1031,7 @@ class ModelActor(xo.StatelessActor, CancelMixin):
                 )
         raise AttributeError(f"Model {self._model.model_spec} is not for txt2img.")
 
+    @request_limit
     @log_async(
         logger=logger,
         ignore_kwargs=["image"],
@@ -1073,6 +1084,7 @@ class ModelActor(xo.StatelessActor, CancelMixin):
                 )
         raise AttributeError(f"Model {self._model.model_spec} is not for img2img.")
 
+    @request_limit
     @log_async(
         logger=logger,
         ignore_kwargs=["image"],
@@ -1110,6 +1122,7 @@ class ModelActor(xo.StatelessActor, CancelMixin):
             f"Model {self._model.model_spec} is not for creating image."
         )
 
+    @request_limit
     @log_async(
         logger=logger,
         ignore_kwargs=["image"],

--- a/xinference/core/model.py
+++ b/xinference/core/model.py
@@ -36,6 +36,7 @@ from typing import (
 
 import sse_starlette.sse
 import xoscar as xo
+from xoscar.api import IteratorWrapper
 
 from ..constants import (
     XINFERENCE_DEFAULT_CANCEL_BLOCK_DURATION,
@@ -127,7 +128,9 @@ def request_limit(fn):
         finally:
             duration = time.time() - start_time
             _is_stream = ret is not None and (
-                inspect.isasyncgen(ret) or inspect.isgenerator(ret)
+                inspect.isasyncgen(ret)
+                or inspect.isgenerator(ret)
+                or isinstance(ret, IteratorWrapper)
             )
             stream_label = "true" if _is_stream else "false"
             await self.record_metrics(

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -2119,7 +2119,19 @@ class WorkerActor(xo.StatelessActor):
 
                 with progressor:
                     try:
+                        _load_start = time.time()
                         await model_ref.load()
+                        _load_duration = time.time() - _load_start
+                        from .metrics import model_last_load_duration_seconds
+
+                        model_last_load_duration_seconds.set(
+                            {
+                                "model_name": model_name,
+                                "model_type": model_type,
+                                "worker_address": self.address,
+                            },
+                            _load_duration,
+                        )
                     except xo.ServerClosed:
                         check_cancel()
                         raise

--- a/xinference/ui/web/ui/src/components/grafanaUtils.js
+++ b/xinference/ui/web/ui/src/components/grafanaUtils.js
@@ -1,19 +1,23 @@
 /**
  * Build Grafana iframe URL for the full dashboard (kiosk mode).
  */
-export const buildGrafanaUrl = (config, theme = 'light') => {
+export const buildGrafanaUrl = (config, theme = 'light', from = 'now-1h', to = 'now') => {
   const {
     grafana_url,
     grafana_dashboard_uid,
     grafana_datasource,
+    grafana_alert_datasource,
     cluster_name,
   } = config
   if (!grafana_url) return null
 
-  let url = `${grafana_url}/d/${grafana_dashboard_uid}?orgId=1&kiosk=tv&theme=${theme}`
+  let url = `${grafana_url}/d/${grafana_dashboard_uid}?orgId=1&kiosk&theme=${theme}&from=${from}&to=${to}`
 
   if (grafana_datasource) {
     url += `&var-datasource=${encodeURIComponent(grafana_datasource)}`
+  }
+  if (grafana_alert_datasource) {
+    url += `&var-alert_datasource=${encodeURIComponent(grafana_alert_datasource)}`
   }
   if (cluster_name) {
     url += `&var-cluster=${encodeURIComponent(cluster_name)}`
@@ -29,20 +33,26 @@ export const buildGrafanaPanelUrl = (
   config,
   panelId,
   modelName,
-  theme = 'light'
+  theme = 'light',
+  from = 'now-1h',
+  to = 'now'
 ) => {
   const {
     grafana_url,
     grafana_dashboard_uid,
     grafana_datasource,
+    grafana_alert_datasource,
     cluster_name,
   } = config
   if (!grafana_url) return null
 
-  let url = `${grafana_url}/d-solo/${grafana_dashboard_uid}?orgId=1&theme=${theme}&panelId=${panelId}`
+  let url = `${grafana_url}/d-solo/${grafana_dashboard_uid}?orgId=1&kiosk&theme=${theme}&panelId=${panelId}&from=${from}&to=${to}`
 
   if (grafana_datasource) {
     url += `&var-datasource=${encodeURIComponent(grafana_datasource)}`
+  }
+  if (grafana_alert_datasource) {
+    url += `&var-alert_datasource=${encodeURIComponent(grafana_alert_datasource)}`
   }
   if (cluster_name) {
     url += `&var-cluster=${encodeURIComponent(cluster_name)}`

--- a/xinference/ui/web/ui/src/components/grafanaUtils.js
+++ b/xinference/ui/web/ui/src/components/grafanaUtils.js
@@ -1,7 +1,12 @@
 /**
  * Build Grafana iframe URL for the full dashboard (kiosk mode).
  */
-export const buildGrafanaUrl = (config, theme = 'light', from = 'now-1h', to = 'now') => {
+export const buildGrafanaUrl = (
+  config,
+  theme = 'light',
+  from = 'now-1h',
+  to = 'now'
+) => {
   const {
     grafana_url,
     grafana_dashboard_uid,

--- a/xinference/ui/web/ui/src/components/grafanaUtils.js
+++ b/xinference/ui/web/ui/src/components/grafanaUtils.js
@@ -22,7 +22,9 @@ export const buildGrafanaUrl = (
     url += `&var-datasource=${encodeURIComponent(grafana_datasource)}`
   }
   if (grafana_alert_datasource) {
-    url += `&var-alert_datasource=${encodeURIComponent(grafana_alert_datasource)}`
+    url += `&var-alert_datasource=${encodeURIComponent(
+      grafana_alert_datasource
+    )}`
   }
   if (cluster_name) {
     url += `&var-cluster=${encodeURIComponent(cluster_name)}`
@@ -57,7 +59,9 @@ export const buildGrafanaPanelUrl = (
     url += `&var-datasource=${encodeURIComponent(grafana_datasource)}`
   }
   if (grafana_alert_datasource) {
-    url += `&var-alert_datasource=${encodeURIComponent(grafana_alert_datasource)}`
+    url += `&var-alert_datasource=${encodeURIComponent(
+      grafana_alert_datasource
+    )}`
   }
   if (cluster_name) {
     url += `&var-cluster=${encodeURIComponent(cluster_name)}`


### PR DESCRIPTION
## Summary

- **Monitoring metrics backport (2.7.0 → 2.8.0)**: Restores 5 customized metric changes that were overwritten during the 2.8.0 upgrade:
  - `model_last_load_duration_seconds` Gauge with load timing in worker
  - `_WORKER_ONLY_METRICS` set + Supervisor-side deregister to avoid empty HELP/TYPE headers
  - image/audio/video engine/format label differentiation (empty labels instead of "unknown")
  - `grafana_alert_datasource` in UI config API + grafanaUtils.js URL params
  - `@request_limit` decorator on `image_to_image`, `inpainting`, `ocr` methods
  - Exception protection for `record_metrics`

- **Stream label fix**: `request_limit` decorator now recognizes xoscar `IteratorWrapper` as a stream type, fixing `stream="true"` label never being recorded for LLM requests

- **serve_count double-decrement fix**: Added stream type detection guard (`isasyncgen`/`isgenerator`/`IteratorWrapper`) to 3 `stream_results()` finally blocks, ensuring `decrease_serve_count()` is only called when the decorator has deferred the decrement to the caller. This prevents `model_serve_count` from going negative in two scenarios:
  - `model.chat()` fails before iterator is assigned (`iterator is None`)
  - `model.chat()` returns a non-stream value on `stream=True` path (iterator is not a generator/IteratorWrapper)

## Test plan

- [ ] Deploy and verify `model_last_load_duration_seconds` is reported after model load
- [ ] Verify Supervisor `/metrics` endpoint no longer shows worker-only metric HELP/TYPE headers
- [ ] Send stream + non-stream LLM requests, confirm `model_request_total{stream="true"}` and `stream="false"` are both recorded correctly
- [ ] Verify `model_serve_count` stays ≥ 0 after failed stream requests
- [ ] Verify `grafana_alert_datasource` appears in `/v1/cluster/ui_config` response
- [ ] Verify image/audio model metrics show empty engine/format labels instead of "unknown"
