### PR TITLE
feat: add Log Center UI with Elasticsearch integration

### DIFF
--- a/xinference/api/routers/admin.py
+++ b/xinference/api/routers/admin.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 import signal
 from typing import TYPE_CHECKING, Any
 
+import aiohttp
 from fastapi import Depends, HTTPException, Query, Request, Security
 
 from ..._version import get_versions
@@ -284,8 +286,6 @@ async def search_logs(
     size: int = 200,
     page_from: int = 0,
 ) -> JSONResponse:
-    import aiohttp
-
     es_url = os.environ.get("XINFERENCE_ES_URL", "")
     if not es_url:
         raise HTTPException(status_code=503, detail="Elasticsearch is not configured")
@@ -356,10 +356,11 @@ async def search_logs(
                         status_code=502, detail="Elasticsearch query failed"
                     )
                 data = await resp.json()
-    except aiohttp.ClientError as e:
-        logger.error("ES connection error: %s", e)
+    except (aiohttp.ClientError, asyncio.TimeoutError) as e:
+        logger.error("ES connection error or timeout: %s", e)
         raise HTTPException(
-            status_code=502, detail="Failed to connect to Elasticsearch"
+            status_code=502,
+            detail="Failed to connect to Elasticsearch or query timed out",
         )
 
     hits = [hit["_source"] for hit in data.get("hits", {}).get("hits", [])]

--- a/xinference/api/routers/admin.py
+++ b/xinference/api/routers/admin.py
@@ -268,8 +268,86 @@ async def get_ui_config() -> JSONResponse:
                 "XINFERENCE_GRAFANA_DASHBOARD_UID", "xinference-overview"
             ),
             "cluster_name": os.environ.get("XINFERENCE_CLUSTER_NAME", ""),
+            "es_enabled": bool(os.environ.get("XINFERENCE_ES_URL", "")),
         }
     )
+
+
+async def search_logs(
+    q: str = "",
+    level: str = "",
+    module: str = "",
+    node: str = "",
+    log_type: str = "",
+    time_from: str = "now-1h",
+    time_to: str = "now",
+    size: int = 200,
+    page_from: int = 0,
+) -> JSONResponse:
+    import aiohttp
+
+    es_url = os.environ.get("XINFERENCE_ES_URL", "")
+    if not es_url:
+        raise HTTPException(status_code=503, detail="Elasticsearch is not configured")
+
+    es_index = os.environ.get("XINFERENCE_ES_INDEX", "xinference-logs-*")
+    es_auth = os.environ.get("XINFERENCE_ES_AUTH", "")
+
+    size = max(1, min(size, 500))
+    page_from = max(0, min(page_from, 10000))
+
+    must = []
+    filter_clauses = [{"range": {"@timestamp": {"gte": time_from, "lte": time_to}}}]
+
+    if q:
+        must.append(
+            {"simple_query_string": {"query": q, "fields": ["message"], "default_operator": "AND"}}
+        )
+
+    for field, value in [("level", level), ("module", module), ("node", node), ("log_type", log_type)]:
+        if value:
+            terms = [v.strip() for v in value.split(",") if v.strip()]
+            if terms:
+                filter_clauses.append({"terms": {field: terms}})
+
+    body = {
+        "query": {"bool": {"must": must, "filter": filter_clauses}},
+        "sort": [{"@timestamp": "desc"}],
+        "from": page_from,
+        "size": size,
+        "_source": {"excludes": ["@version"]},
+    }
+
+    headers = {"Content-Type": "application/json"}
+    auth = None
+    if es_auth:
+        if es_auth.startswith("ApiKey "):
+            headers["Authorization"] = es_auth
+        else:
+            parts = es_auth.split(":", 1)
+            if len(parts) == 2:
+                auth = aiohttp.BasicAuth(parts[0], parts[1])
+
+    url = f"{es_url.rstrip('/')}/{es_index}/_search"
+
+    try:
+        timeout = aiohttp.ClientTimeout(total=10)
+        async with aiohttp.ClientSession(timeout=timeout, auth=auth) as session:
+            async with session.post(url, json=body, headers=headers) as resp:
+                if resp.status != 200:
+                    text = await resp.text()
+                    logger.error("ES query failed: status=%d body=%s", resp.status, text[:500])
+                    raise HTTPException(status_code=502, detail="Elasticsearch query failed")
+                data = await resp.json()
+    except aiohttp.ClientError as e:
+        logger.error("ES connection error: %s", e)
+        raise HTTPException(status_code=502, detail="Failed to connect to Elasticsearch")
+
+    hits = [hit["_source"] for hit in data.get("hits", {}).get("hits", [])]
+    total_value = data.get("hits", {}).get("total", {})
+    total = total_value.get("value", 0) if isinstance(total_value, dict) else total_value
+
+    return JSONResponse(content={"hits": hits, "total": total})
 
 
 # --- Route registration ---
@@ -365,4 +443,11 @@ def register_routes(api: "RESTfulAPI") -> None:
         get_progress,
         methods=["GET"],
         dependencies=([Security(auth, scopes=["models:read"])] if is_auth else None),
+    )
+
+    router.add_api_route(
+        "/v1/cluster/logs",
+        search_logs,
+        methods=["GET"],
+        dependencies=([Security(auth, scopes=["admin"])] if is_auth else None),
     )

--- a/xinference/api/routers/admin.py
+++ b/xinference/api/routers/admin.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import os
 import signal
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from fastapi import Depends, HTTPException, Query, Request, Security
 
@@ -297,20 +297,33 @@ async def search_logs(
     page_from = max(0, min(page_from, 10000))
 
     must = []
-    filter_clauses = [{"range": {"@timestamp": {"gte": time_from, "lte": time_to}}}]
+    filter_clauses: list[dict[str, Any]] = [
+        {"range": {"@timestamp": {"gte": time_from, "lte": time_to}}}
+    ]
 
     if q:
         must.append(
-            {"simple_query_string": {"query": q, "fields": ["message"], "default_operator": "AND"}}
+            {
+                "simple_query_string": {
+                    "query": q,
+                    "fields": ["message"],
+                    "default_operator": "AND",
+                }
+            }
         )
 
-    for field, value in [("level", level), ("module", module), ("node", node), ("log_type", log_type)]:
+    for field, value in [
+        ("level", level),
+        ("module", module),
+        ("node", node),
+        ("log_type", log_type),
+    ]:
         if value:
             terms = [v.strip() for v in value.split(",") if v.strip()]
             if terms:
                 filter_clauses.append({"terms": {field: terms}})
 
-    body = {
+    body: dict[str, Any] = {
         "query": {"bool": {"must": must, "filter": filter_clauses}},
         "sort": [{"@timestamp": "desc"}],
         "from": page_from,
@@ -336,16 +349,24 @@ async def search_logs(
             async with session.post(url, json=body, headers=headers) as resp:
                 if resp.status != 200:
                     text = await resp.text()
-                    logger.error("ES query failed: status=%d body=%s", resp.status, text[:500])
-                    raise HTTPException(status_code=502, detail="Elasticsearch query failed")
+                    logger.error(
+                        "ES query failed: status=%d body=%s", resp.status, text[:500]
+                    )
+                    raise HTTPException(
+                        status_code=502, detail="Elasticsearch query failed"
+                    )
                 data = await resp.json()
     except aiohttp.ClientError as e:
         logger.error("ES connection error: %s", e)
-        raise HTTPException(status_code=502, detail="Failed to connect to Elasticsearch")
+        raise HTTPException(
+            status_code=502, detail="Failed to connect to Elasticsearch"
+        )
 
     hits = [hit["_source"] for hit in data.get("hits", {}).get("hits", [])]
     total_value = data.get("hits", {}).get("total", {})
-    total = total_value.get("value", 0) if isinstance(total_value, dict) else total_value
+    total = (
+        total_value.get("value", 0) if isinstance(total_value, dict) else total_value
+    )
 
     return JSONResponse(content={"hits": hits, "total": total})
 

--- a/xinference/api/routers/admin.py
+++ b/xinference/api/routers/admin.py
@@ -294,7 +294,7 @@ async def search_logs(
     es_auth = os.environ.get("XINFERENCE_ES_AUTH", "")
 
     size = max(1, min(size, 500))
-    page_from = max(0, min(page_from, 10000))
+    page_from = max(0, min(page_from, 10000 - size))
 
     must = []
     filter_clauses: list[dict[str, Any]] = [

--- a/xinference/ui/web/ui/src/components/MenuSide.js
+++ b/xinference/ui/web/ui/src/components/MenuSide.js
@@ -45,7 +45,10 @@ const MenuSide = () => {
 
   useEffect(() => {
     fetch(endPoint + '/v1/cluster/ui_config')
-      .then((res) => res.json())
+      .then((res) => {
+        if (!res.ok) throw new Error('Network response was not ok')
+        return res.json()
+      })
       .then((data) => setEsEnabled(data.es_enabled || false))
       .catch(() => setEsEnabled(false))
   }, [endPoint])

--- a/xinference/ui/web/ui/src/components/MenuSide.js
+++ b/xinference/ui/web/ui/src/components/MenuSide.js
@@ -1,5 +1,6 @@
 import {
   AddBoxOutlined,
+  ArticleOutlined,
   ChevronRightOutlined,
   DescriptionOutlined,
   DnsOutlined,
@@ -22,11 +23,12 @@ import {
   Typography,
   useTheme,
 } from '@mui/material'
-import { useEffect, useState } from 'react'
+import { useContext, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 
 import icon from '../media/icon.webp'
+import { ApiContext } from './apiContext'
 import ThemeButton from './themeButton'
 import TranslateButton from './translateButton'
 import VersionLabel from './versionLabel'
@@ -38,6 +40,15 @@ const MenuSide = () => {
     `${Math.min(Math.max(window.innerWidth * 0.2, 287), 320)}px`
   )
   const { i18n, t } = useTranslation()
+  const { endPoint } = useContext(ApiContext)
+  const [esEnabled, setEsEnabled] = useState(false)
+
+  useEffect(() => {
+    fetch(endPoint + '/v1/cluster/ui_config')
+      .then((res) => res.json())
+      .then((data) => setEsEnabled(data.es_enabled || false))
+      .catch(() => setEsEnabled(false))
+  }, [endPoint])
 
   const navItems = [
     {
@@ -87,6 +98,17 @@ const MenuSide = () => {
       action: 'navigate',
       path: '/monitoring',
     },
+    ...(esEnabled
+      ? [
+          {
+            text: 'logs',
+            label: t('menu.logs'),
+            icon: <ArticleOutlined />,
+            action: 'navigate',
+            path: '/logs',
+          },
+        ]
+      : []),
     {
       text: 'documentation',
       label: t('menu.documentation'),

--- a/xinference/ui/web/ui/src/locales/en.json
+++ b/xinference/ui/web/ui/src/locales/en.json
@@ -5,6 +5,7 @@
     "registerModel": "Register Model",
     "clusterInfo": "Cluster Information",
     "monitoring": "Monitoring",
+    "logs": "Log Center",
     "xagent": "Build AI Agents with Xagent",
     "contactUs": "Contact Us",
     "documentation": "Documentation",
@@ -315,5 +316,30 @@
     "to": "To",
     "applyTimeRange": "Apply time range",
     "manualRefresh": "Refresh dashboard"
+  },
+  "logs": {
+    "notConfigured": "Log query not configured. Please set XINFERENCE_ES_URL environment variable.",
+    "searchPlaceholder": "Search logs...",
+    "allNodes": "All Nodes",
+    "time": "Time",
+    "level": "Level",
+    "node": "Node",
+    "message": "Message",
+    "fullMessage": "Full Message",
+    "noLogs": "No logs found",
+    "refresh": "Refresh",
+    "totalHits": "Total: {{count}}",
+    "prevPage": "Previous",
+    "nextPage": "Next",
+    "detail": {
+      "module": "Module",
+      "pid": "PID",
+      "request_id": "Request ID",
+      "address": "Address",
+      "log_type": "Log Type",
+      "rtf_avg": "RTF Average",
+      "time_speech": "Speech Time",
+      "time_escape": "Process Time"
+    }
   }
 }

--- a/xinference/ui/web/ui/src/locales/ja.json
+++ b/xinference/ui/web/ui/src/locales/ja.json
@@ -5,6 +5,7 @@
     "registerModel": "モデル登録",
     "clusterInfo": "クラスター情報",
     "monitoring": "モニタリング",
+    "logs": "ログセンター",
     "xagent": "XagentでAIエージェントを構築",
     "contactUs": "お問い合わせ",
     "documentation": "ドキュメント",
@@ -315,5 +316,30 @@
     "to": "終了",
     "applyTimeRange": "時間範囲を適用",
     "manualRefresh": "ダッシュボードを更新"
+  },
+  "logs": {
+    "notConfigured": "ログクエリが設定されていません。XINFERENCE_ES_URL 環境変数を設定してください。",
+    "searchPlaceholder": "ログを検索...",
+    "allNodes": "全ノード",
+    "time": "時刻",
+    "level": "レベル",
+    "node": "ノード",
+    "message": "メッセージ",
+    "fullMessage": "完全なメッセージ",
+    "noLogs": "ログが見つかりません",
+    "refresh": "更新",
+    "totalHits": "合計: {{count}} 件",
+    "prevPage": "前へ",
+    "nextPage": "次へ",
+    "detail": {
+      "module": "モジュール",
+      "pid": "PID",
+      "request_id": "リクエストID",
+      "address": "アドレス",
+      "log_type": "ログタイプ",
+      "rtf_avg": "RTF平均",
+      "time_speech": "音声時間",
+      "time_escape": "処理時間"
+    }
   }
 }

--- a/xinference/ui/web/ui/src/locales/ko.json
+++ b/xinference/ui/web/ui/src/locales/ko.json
@@ -5,6 +5,7 @@
     "registerModel": "모델 등록",
     "clusterInfo": "클러스터 정보",
     "monitoring": "모니터링",
+    "logs": "로그 센터",
     "xagent": "Xagent로 AI 에이전트 구축",
     "contactUs": "문의하기",
     "documentation": "문서",
@@ -315,5 +316,30 @@
     "to": "종료",
     "applyTimeRange": "시간 범위 적용",
     "manualRefresh": "대시보드 새로고침"
+  },
+  "logs": {
+    "notConfigured": "로그 조회가 구성되지 않았습니다. XINFERENCE_ES_URL 환경 변수를 설정하세요.",
+    "searchPlaceholder": "로그 검색...",
+    "allNodes": "전체 노드",
+    "time": "시간",
+    "level": "레벨",
+    "node": "노드",
+    "message": "메시지",
+    "fullMessage": "전체 메시지",
+    "noLogs": "로그를 찾을 수 없습니다",
+    "refresh": "새로고침",
+    "totalHits": "총 {{count}} 건",
+    "prevPage": "이전",
+    "nextPage": "다음",
+    "detail": {
+      "module": "모듈",
+      "pid": "PID",
+      "request_id": "요청 ID",
+      "address": "주소",
+      "log_type": "로그 유형",
+      "rtf_avg": "RTF 평균",
+      "time_speech": "음성 시간",
+      "time_escape": "처리 시간"
+    }
   }
 }

--- a/xinference/ui/web/ui/src/locales/zh.json
+++ b/xinference/ui/web/ui/src/locales/zh.json
@@ -5,6 +5,7 @@
     "registerModel": "注册模型",
     "clusterInfo": "集群信息",
     "monitoring": "监控中心",
+    "logs": "日志中心",
     "xagent": "使用 Xagent 构建 AI 智能体",
     "contactUs": "联系我们",
     "documentation": "文档",
@@ -315,5 +316,30 @@
     "to": "结束",
     "applyTimeRange": "应用时间范围",
     "manualRefresh": "刷新仪表板"
+  },
+  "logs": {
+    "notConfigured": "日志查询未配置，请设置 XINFERENCE_ES_URL 环境变量。",
+    "searchPlaceholder": "搜索日志...",
+    "allNodes": "全部节点",
+    "time": "时间",
+    "level": "级别",
+    "node": "节点",
+    "message": "消息",
+    "fullMessage": "完整消息",
+    "noLogs": "未找到日志",
+    "refresh": "刷新",
+    "totalHits": "共 {{count}} 条",
+    "prevPage": "上一页",
+    "nextPage": "下一页",
+    "detail": {
+      "module": "模块",
+      "pid": "进程 ID",
+      "request_id": "请求 ID",
+      "address": "地址",
+      "log_type": "日志类型",
+      "rtf_avg": "RTF 均值",
+      "time_speech": "语音时长",
+      "time_escape": "处理耗时"
+    }
   }
 }

--- a/xinference/ui/web/ui/src/router/index.js
+++ b/xinference/ui/web/ui/src/router/index.js
@@ -7,6 +7,7 @@ import Layout from '../scenes/_layout'
 import ClusterInfo from '../scenes/cluster_info'
 import LaunchModel from '../scenes/launch_model'
 import Login from '../scenes/login/login'
+import Logs from '../scenes/logs'
 import Monitoring from '../scenes/monitoring'
 import RegisterModel from '../scenes/register_model'
 import RunningModels from '../scenes/running_models'
@@ -68,6 +69,10 @@ const routes = [
       {
         path: 'monitoring',
         element: <Monitoring />,
+      },
+      {
+        path: 'logs',
+        element: <Logs />,
       },
     ],
   },

--- a/xinference/ui/web/ui/src/scenes/logs/index.js
+++ b/xinference/ui/web/ui/src/scenes/logs/index.js
@@ -1,0 +1,597 @@
+import 'dayjs/locale/ja'
+import 'dayjs/locale/ko'
+import 'dayjs/locale/zh-cn'
+
+import {
+  AccessTime,
+  ExpandMore as ExpandMoreIcon,
+  Refresh as RefreshIcon,
+  Search as SearchIcon,
+} from '@mui/icons-material'
+import {
+  Box,
+  Button,
+  Chip,
+  Collapse,
+  Divider,
+  FormControl,
+  IconButton,
+  InputAdornment,
+  MenuItem,
+  MenuList,
+  Popover,
+  Select,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TextField,
+  Toolbar,
+  Tooltip,
+  Typography,
+} from '@mui/material'
+import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs'
+import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker'
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider'
+import React, { useCallback, useContext, useEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { ApiContext } from '../../components/apiContext'
+
+const FONT_SIZE = '0.813rem'
+
+const DAYJS_LOCALE_MAP = { en: 'en', zh: 'zh-cn', ja: 'ja', ko: 'ko' }
+
+const LEVELS = ['ERROR', 'WARNING', 'INFO', 'DEBUG']
+const LOG_TYPES = ['worker', 'supervisor']
+
+const TIME_RANGES = [
+  { labelKey: 'monitoring.time.15m', from: 'now-15m', to: 'now' },
+  { labelKey: 'monitoring.time.1h', from: 'now-1h', to: 'now' },
+  { labelKey: 'monitoring.time.6h', from: 'now-6h', to: 'now' },
+  { labelKey: 'monitoring.time.24h', from: 'now-24h', to: 'now' },
+  { labelKey: 'monitoring.time.2d', from: 'now-2d', to: 'now' },
+  { labelKey: 'monitoring.time.7d', from: 'now-7d', to: 'now' },
+]
+
+const PAGE_SIZE = 200
+
+const DATE_TIME_SLOT_PROPS = {
+  textField: {
+    size: 'small',
+    fullWidth: true,
+    sx: {
+      '& .MuiInputBase-input': { fontSize: FONT_SIZE },
+      '& .MuiInputLabel-root': { fontSize: FONT_SIZE },
+    },
+  },
+  popper: {
+    sx: {
+      '& .MuiDayCalendar-weekDayLabel': { fontSize: FONT_SIZE },
+      '& .MuiPickersDay-root': { fontSize: FONT_SIZE },
+    },
+  },
+}
+
+const PICKER_LOCALE_TEXT = {
+  en: { okButtonLabel: 'OK', cancelButtonLabel: 'Cancel' },
+  zh: { okButtonLabel: '确定', cancelButtonLabel: '取消' },
+  ja: { okButtonLabel: '確定', cancelButtonLabel: 'キャンセル' },
+  ko: { okButtonLabel: '확인', cancelButtonLabel: '취소' },
+}
+
+const LEVEL_COLORS = {
+  ERROR: 'error.main',
+  WARNING: 'warning.main',
+  DEBUG: 'text.disabled',
+}
+
+function HighlightText({ text, keyword }) {
+  if (!keyword || !text) return text || ''
+  const escaped = keyword.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const parts = text.split(new RegExp(`(${escaped})`, 'gi'))
+  return parts.map((part, i) =>
+    part.toLowerCase() === keyword.toLowerCase() ? (
+      <mark key={i} style={{ background: '#ffe082', padding: 0 }}>
+        {part}
+      </mark>
+    ) : (
+      part
+    )
+  )
+}
+
+function DetailRow({ row }) {
+  const { t } = useTranslation()
+  const fields = [
+    ['module', row.module],
+    ['pid', row.pid],
+    ['request_id', row.request_id],
+    ['address', row.address],
+    ['log_type', row.log_type],
+    ['rtf_avg', row.rtf_avg],
+    ['time_speech', row.time_speech],
+    ['time_escape', row.time_escape],
+  ].filter(([, v]) => v !== undefined && v !== null && v !== '')
+
+  return (
+    <Box sx={{ p: 2, display: 'flex', flexWrap: 'wrap', gap: 2 }}>
+      {fields.map(([key, val]) => (
+        <Box key={key} sx={{ minWidth: 180 }}>
+          <Typography variant="caption" color="text.secondary">
+            {t(`logs.detail.${key}`, key)}
+          </Typography>
+          <Typography variant="body2" sx={{ fontSize: FONT_SIZE, wordBreak: 'break-all' }}>
+            {String(val)}
+          </Typography>
+        </Box>
+      ))}
+    </Box>
+  )
+}
+
+const Logs = () => {
+  const { endPoint } = useContext(ApiContext)
+  const { t, i18n } = useTranslation()
+  const dayjsLocale = DAYJS_LOCALE_MAP[(i18n.language || 'en').split('-')[0]] || 'en'
+
+  const [esEnabled, setEsEnabled] = useState(null)
+  const [logs, setLogs] = useState([])
+  const [total, setTotal] = useState(0)
+  const [loading, setLoading] = useState(false)
+
+  const [searchText, setSearchText] = useState('')
+  const [appliedSearch, setAppliedSearch] = useState('')
+  const [selectedLevels, setSelectedLevels] = useState([])
+  const [selectedLogType, setSelectedLogType] = useState('')
+  const [selectedNode, setSelectedNode] = useState('')
+  const [nodes, setNodes] = useState([])
+  const [pageFrom, setPageFrom] = useState(0)
+  const [expandedRow, setExpandedRow] = useState(null)
+
+  const [timeRange, setTimeRange] = useState({ from: 'now-1h', to: 'now' })
+  const [timeRangeLabel, setTimeRangeLabel] = useState('monitoring.time.1h')
+  const [customDisplay, setCustomDisplay] = useState('')
+  const [customFrom, setCustomFrom] = useState(null)
+  const [customTo, setCustomTo] = useState(null)
+  const [timeAnchor, setTimeAnchor] = useState(null)
+
+  const debounceRef = useRef(null)
+
+  useEffect(() => {
+    fetch(endPoint + '/v1/cluster/ui_config')
+      .then((res) => res.json())
+      .then((data) => setEsEnabled(data.es_enabled || false))
+      .catch(() => setEsEnabled(false))
+  }, [endPoint])
+
+  useEffect(() => {
+    if (!esEnabled) return
+    const token = sessionStorage.getItem('token')
+    const headers = { 'Content-Type': 'application/json' }
+    if (token) headers['Authorization'] = `Bearer ${token}`
+    fetch(endPoint + '/v1/cluster/info', { headers })
+      .then((res) => res.json())
+      .then((data) => {
+        const nodeSet = new Set()
+        if (Array.isArray(data)) {
+          data.forEach((item) => {
+            if (item.node) nodeSet.add(item.node)
+          })
+        }
+        setNodes([...nodeSet])
+      })
+      .catch(() => setNodes([]))
+  }, [endPoint, esEnabled])
+
+  const fetchLogs = useCallback(() => {
+    if (!esEnabled) return
+    setLoading(true)
+    const params = new URLSearchParams()
+    if (appliedSearch) params.set('q', appliedSearch)
+    if (selectedLevels.length) params.set('level', selectedLevels.join(','))
+    if (selectedLogType) params.set('log_type', selectedLogType)
+    if (selectedNode) params.set('node', selectedNode)
+    params.set('time_from', timeRange.from)
+    params.set('time_to', timeRange.to)
+    params.set('size', String(PAGE_SIZE))
+    params.set('page_from', String(pageFrom))
+
+    const token = sessionStorage.getItem('token')
+    const headers = { 'Content-Type': 'application/json' }
+    if (token) headers['Authorization'] = `Bearer ${token}`
+
+    fetch(endPoint + '/v1/cluster/logs?' + params.toString(), { headers })
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`)
+        return res.json()
+      })
+      .then((data) => {
+        setLogs(data.hits || [])
+        setTotal(data.total || 0)
+      })
+      .catch((err) => {
+        console.error('Failed to fetch logs:', err)
+        setLogs([])
+        setTotal(0)
+      })
+      .finally(() => setLoading(false))
+  }, [endPoint, esEnabled, appliedSearch, selectedLevels, selectedLogType, selectedNode, timeRange, pageFrom])
+
+  useEffect(() => {
+    fetchLogs()
+  }, [fetchLogs])
+
+  const handleSearchChange = (e) => {
+    const val = e.target.value
+    setSearchText(val)
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+    debounceRef.current = setTimeout(() => {
+      setAppliedSearch(val)
+      setPageFrom(0)
+    }, 500)
+  }
+
+  const handleSearchKeyDown = (e) => {
+    if (e.key === 'Enter') {
+      if (debounceRef.current) clearTimeout(debounceRef.current)
+      setAppliedSearch(searchText)
+      setPageFrom(0)
+    }
+  }
+
+  const toggleLevel = (level) => {
+    setSelectedLevels((prev) =>
+      prev.includes(level) ? prev.filter((l) => l !== level) : [...prev, level]
+    )
+    setPageFrom(0)
+  }
+
+  const handleQuickRange = (item) => {
+    setTimeRange({ from: item.from, to: item.to })
+    setTimeRangeLabel(item.labelKey)
+    setCustomDisplay('')
+    setTimeAnchor(null)
+    setPageFrom(0)
+  }
+
+  const handleApplyAbsolute = () => {
+    if (
+      customFrom &&
+      customTo &&
+      customFrom.isValid() &&
+      customTo.isValid() &&
+      customTo.isAfter(customFrom)
+    ) {
+      const fromMs = customFrom.valueOf()
+      const toMs = customTo.valueOf()
+      setTimeRange({ from: String(fromMs), to: String(toMs) })
+      setTimeRangeLabel(null)
+      setCustomDisplay(
+        `${customFrom.format('YYYY-MM-DD HH:mm')} ~ ${customTo.format('YYYY-MM-DD HH:mm')}`
+      )
+      setTimeAnchor(null)
+      setPageFrom(0)
+    }
+  }
+
+  const totalPages = Math.ceil(total / PAGE_SIZE)
+  const currentPage = Math.floor(pageFrom / PAGE_SIZE) + 1
+
+  if (esEnabled === null) return null
+
+  if (!esEnabled) {
+    return (
+      <Box display="flex" justifyContent="center" alignItems="center" height="calc(100vh - 64px)">
+        <Typography variant="h6" color="text.secondary">
+          {t('logs.notConfigured')}
+        </Typography>
+      </Box>
+    )
+  }
+
+  const formatTime = (ts) => {
+    if (!ts) return ''
+    const d = new Date(ts)
+    return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })
+  }
+
+  return (
+    <Box sx={{ width: '100%', height: 'calc(100vh - 64px)', display: 'flex', flexDirection: 'column' }}>
+      {/* Toolbar */}
+      <Toolbar
+        variant="dense"
+        sx={{ minHeight: 48, px: 2, gap: 1, borderBottom: 1, borderColor: 'divider', flexWrap: 'wrap' }}
+      >
+        {/* Search */}
+        <TextField
+          size="small"
+          placeholder={t('logs.searchPlaceholder')}
+          value={searchText}
+          onChange={handleSearchChange}
+          onKeyDown={handleSearchKeyDown}
+          sx={{ 'width': 240, '& .MuiInputBase-input': { fontSize: FONT_SIZE } }}
+          InputProps={{
+            startAdornment: (
+              <InputAdornment position="start">
+                <SearchIcon fontSize="small" />
+              </InputAdornment>
+            ),
+          }}
+        />
+
+        {/* Level Chips */}
+        <Box sx={{ display: 'flex', gap: 0.5 }}>
+          {LEVELS.map((level) => (
+            <Chip
+              key={level}
+              label={level}
+              size="small"
+              variant={selectedLevels.includes(level) ? 'filled' : 'outlined'}
+              color={level === 'ERROR' ? 'error' : level === 'WARNING' ? 'warning' : 'default'}
+              onClick={() => toggleLevel(level)}
+              sx={{ fontSize: FONT_SIZE }}
+            />
+          ))}
+        </Box>
+
+        {/* Log Type Chips */}
+        <Box sx={{ display: 'flex', gap: 0.5 }}>
+          {LOG_TYPES.map((lt) => (
+            <Chip
+              key={lt}
+              label={lt}
+              size="small"
+              variant={selectedLogType === lt ? 'filled' : 'outlined'}
+              onClick={() => {
+                setSelectedLogType((prev) => (prev === lt ? '' : lt))
+                setPageFrom(0)
+              }}
+              sx={{ fontSize: FONT_SIZE }}
+            />
+          ))}
+        </Box>
+
+        {/* Node Select */}
+        {nodes.length > 0 && (
+          <FormControl size="small" sx={{ minWidth: 140 }}>
+            <Select
+              value={selectedNode}
+              onChange={(e) => {
+                setSelectedNode(e.target.value)
+                setPageFrom(0)
+              }}
+              displayEmpty
+              sx={{ fontSize: FONT_SIZE }}
+            >
+              <MenuItem value="" sx={{ fontSize: FONT_SIZE }}>
+                {t('logs.allNodes')}
+              </MenuItem>
+              {nodes.map((n) => (
+                <MenuItem key={n} value={n} sx={{ fontSize: FONT_SIZE }}>
+                  {n}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        )}
+
+        <Box sx={{ flex: 1 }} />
+
+        {/* Time Range */}
+        <Button
+          size="small"
+          color="inherit"
+          startIcon={<AccessTime fontSize="small" />}
+          onClick={(e) => setTimeAnchor(e.currentTarget)}
+          sx={{ textTransform: 'none', fontSize: FONT_SIZE }}
+        >
+          {timeRangeLabel ? t(timeRangeLabel) : customDisplay}
+        </Button>
+        <Popover
+          anchorEl={timeAnchor}
+          open={Boolean(timeAnchor)}
+          onClose={() => setTimeAnchor(null)}
+          anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+          transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+        >
+          <Box sx={{ display: 'flex', width: 480, maxHeight: 400 }}>
+            <Box sx={{ width: 240, p: 2, display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+              <Typography variant="subtitle2" color="text.secondary" sx={{ fontSize: FONT_SIZE }}>
+                {t('monitoring.absoluteRange')}
+              </Typography>
+              <LocalizationProvider
+                dateAdapter={AdapterDayjs}
+                adapterLocale={dayjsLocale}
+                localeText={
+                  PICKER_LOCALE_TEXT[(i18n.language || 'en').split('-')[0]] || PICKER_LOCALE_TEXT.en
+                }
+              >
+                <DateTimePicker
+                  label={t('monitoring.from')}
+                  value={customFrom}
+                  onChange={(v) => setCustomFrom(v)}
+                  ampm={false}
+                  slotProps={DATE_TIME_SLOT_PROPS}
+                />
+                <DateTimePicker
+                  label={t('monitoring.to')}
+                  value={customTo}
+                  onChange={(v) => setCustomTo(v)}
+                  ampm={false}
+                  slotProps={DATE_TIME_SLOT_PROPS}
+                />
+              </LocalizationProvider>
+              <Button
+                variant="contained"
+                size="small"
+                onClick={handleApplyAbsolute}
+                disabled={!customFrom || !customTo}
+                fullWidth
+                sx={{ fontSize: FONT_SIZE }}
+              >
+                {t('monitoring.applyTimeRange')}
+              </Button>
+            </Box>
+            <Divider orientation="vertical" flexItem />
+            <Box sx={{ width: 240, overflow: 'auto' }}>
+              <MenuList dense disablePadding>
+                {TIME_RANGES.map((item) => (
+                  <MenuItem
+                    key={item.labelKey}
+                    selected={item.labelKey === timeRangeLabel}
+                    onClick={() => handleQuickRange(item)}
+                    sx={{ fontSize: FONT_SIZE }}
+                  >
+                    {t(item.labelKey)}
+                  </MenuItem>
+                ))}
+              </MenuList>
+            </Box>
+          </Box>
+        </Popover>
+
+        {/* Refresh */}
+        <Tooltip title={t('logs.refresh')}>
+          <IconButton size="small" color="inherit" onClick={fetchLogs}>
+            <RefreshIcon fontSize="small" />
+          </IconButton>
+        </Tooltip>
+      </Toolbar>
+
+      {/* Log Table */}
+      <TableContainer sx={{ flex: 1, overflow: 'auto' }}>
+        <Table size="small" stickyHeader>
+          <TableHead>
+            <TableRow>
+              <TableCell sx={{ width: 32, fontSize: FONT_SIZE }} />
+              <TableCell sx={{ width: 100, fontSize: FONT_SIZE }}>{t('logs.time')}</TableCell>
+              <TableCell sx={{ width: 80, fontSize: FONT_SIZE }}>{t('logs.level')}</TableCell>
+              <TableCell sx={{ width: 160, fontSize: FONT_SIZE }}>{t('logs.node')}</TableCell>
+              <TableCell sx={{ fontSize: FONT_SIZE }}>{t('logs.message')}</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {logs.map((row, idx) => {
+              const isExpanded = expandedRow === idx
+              return (
+                <React.Fragment key={idx}>
+                  <TableRow
+                    hover
+                    sx={{ 'cursor': 'pointer', '& > *': { borderBottom: isExpanded ? 'none' : undefined } }}
+                    onClick={() => setExpandedRow(isExpanded ? null : idx)}
+                  >
+                    <TableCell sx={{ fontSize: FONT_SIZE, p: 0.5 }}>
+                      <ExpandMoreIcon
+                        fontSize="small"
+                        sx={{
+                          transform: isExpanded ? 'rotate(180deg)' : 'none',
+                          transition: 'transform 0.2s',
+                        }}
+                      />
+                    </TableCell>
+                    <TableCell sx={{ fontSize: FONT_SIZE, whiteSpace: 'nowrap' }}>
+                      {formatTime(row['@timestamp'])}
+                    </TableCell>
+                    <TableCell sx={{ fontSize: FONT_SIZE }}>
+                      <Typography
+                        component="span"
+                        sx={{
+                          fontSize: FONT_SIZE,
+                          fontWeight: 600,
+                          color: LEVEL_COLORS[row.level] || 'text.primary',
+                        }}
+                      >
+                        {row.level}
+                      </Typography>
+                    </TableCell>
+                    <TableCell sx={{ fontSize: FONT_SIZE }}>{row.node}</TableCell>
+                    <TableCell
+                      sx={{
+                        fontSize: FONT_SIZE,
+                        maxWidth: 0,
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                      }}
+                    >
+                      <HighlightText text={row.message} keyword={appliedSearch} />
+                    </TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell sx={{ p: 0 }} colSpan={5}>
+                      <Collapse in={isExpanded} timeout="auto" unmountOnExit>
+                        <DetailRow row={row} />
+                        {row.message && (
+                          <Box sx={{ px: 2, pb: 2 }}>
+                            <Typography variant="caption" color="text.secondary">
+                              {t('logs.fullMessage')}
+                            </Typography>
+                            <Typography
+                              variant="body2"
+                              sx={{
+                                fontSize: FONT_SIZE,
+                                whiteSpace: 'pre-wrap',
+                                wordBreak: 'break-all',
+                                mt: 0.5,
+                                p: 1,
+                                bgcolor: 'action.hover',
+                                borderRadius: 1,
+                              }}
+                            >
+                              <HighlightText text={row.message} keyword={appliedSearch} />
+                            </Typography>
+                          </Box>
+                        )}
+                      </Collapse>
+                    </TableCell>
+                  </TableRow>
+                </React.Fragment>
+              )
+            })}
+            {!loading && logs.length === 0 && (
+              <TableRow>
+                <TableCell colSpan={5} align="center" sx={{ py: 4 }}>
+                  <Typography color="text.secondary">{t('logs.noLogs')}</Typography>
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </TableContainer>
+
+      {/* Pagination */}
+      <Toolbar
+        variant="dense"
+        sx={{ minHeight: 40, px: 2, justifyContent: 'flex-end', gap: 1, borderTop: 1, borderColor: 'divider' }}
+      >
+        <Typography variant="body2" sx={{ fontSize: FONT_SIZE }}>
+          {t('logs.totalHits', { count: total })}
+        </Typography>
+        <Button
+          size="small"
+          disabled={pageFrom === 0}
+          onClick={() => setPageFrom(Math.max(0, pageFrom - PAGE_SIZE))}
+          sx={{ fontSize: FONT_SIZE, textTransform: 'none' }}
+        >
+          {t('logs.prevPage')}
+        </Button>
+        <Typography variant="body2" sx={{ fontSize: FONT_SIZE }}>
+          {currentPage} / {totalPages || 1}
+        </Typography>
+        <Button
+          size="small"
+          disabled={pageFrom + PAGE_SIZE >= total || pageFrom + PAGE_SIZE > 10000}
+          onClick={() => setPageFrom(pageFrom + PAGE_SIZE)}
+          sx={{ fontSize: FONT_SIZE, textTransform: 'none' }}
+        >
+          {t('logs.nextPage')}
+        </Button>
+      </Toolbar>
+    </Box>
+  )
+}
+
+export default Logs

--- a/xinference/ui/web/ui/src/scenes/logs/index.js
+++ b/xinference/ui/web/ui/src/scenes/logs/index.js
@@ -35,7 +35,13 @@ import {
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs'
 import { DateTimePicker } from '@mui/x-date-pickers/DateTimePicker'
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider'
-import React, { useCallback, useContext, useEffect, useRef, useState } from 'react'
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { ApiContext } from '../../components/apiContext'
@@ -123,7 +129,10 @@ function DetailRow({ row }) {
           <Typography variant="caption" color="text.secondary">
             {t(`logs.detail.${key}`, key)}
           </Typography>
-          <Typography variant="body2" sx={{ fontSize: FONT_SIZE, wordBreak: 'break-all' }}>
+          <Typography
+            variant="body2"
+            sx={{ fontSize: FONT_SIZE, wordBreak: 'break-all' }}
+          >
             {String(val)}
           </Typography>
         </Box>
@@ -135,7 +144,8 @@ function DetailRow({ row }) {
 const Logs = () => {
   const { endPoint } = useContext(ApiContext)
   const { t, i18n } = useTranslation()
-  const dayjsLocale = DAYJS_LOCALE_MAP[(i18n.language || 'en').split('-')[0]] || 'en'
+  const dayjsLocale =
+    DAYJS_LOCALE_MAP[(i18n.language || 'en').split('-')[0]] || 'en'
 
   const [esEnabled, setEsEnabled] = useState(null)
   const [logs, setLogs] = useState([])
@@ -221,7 +231,16 @@ const Logs = () => {
         setTotal(0)
       })
       .finally(() => setLoading(false))
-  }, [endPoint, esEnabled, appliedSearch, selectedLevels, selectedLogType, selectedNode, timeRange, pageFrom])
+  }, [
+    endPoint,
+    esEnabled,
+    appliedSearch,
+    selectedLevels,
+    selectedLogType,
+    selectedNode,
+    timeRange,
+    pageFrom,
+  ])
 
   useEffect(() => {
     fetchLogs()
@@ -273,7 +292,9 @@ const Logs = () => {
       setTimeRange({ from: String(fromMs), to: String(toMs) })
       setTimeRangeLabel(null)
       setCustomDisplay(
-        `${customFrom.format('YYYY-MM-DD HH:mm')} ~ ${customTo.format('YYYY-MM-DD HH:mm')}`
+        `${customFrom.format('YYYY-MM-DD HH:mm')} ~ ${customTo.format(
+          'YYYY-MM-DD HH:mm'
+        )}`
       )
       setTimeAnchor(null)
       setPageFrom(0)
@@ -287,7 +308,12 @@ const Logs = () => {
 
   if (!esEnabled) {
     return (
-      <Box display="flex" justifyContent="center" alignItems="center" height="calc(100vh - 64px)">
+      <Box
+        display="flex"
+        justifyContent="center"
+        alignItems="center"
+        height="calc(100vh - 64px)"
+      >
         <Typography variant="h6" color="text.secondary">
           {t('logs.notConfigured')}
         </Typography>
@@ -309,11 +335,25 @@ const Logs = () => {
   }
 
   return (
-    <Box sx={{ width: '100%', height: 'calc(100vh - 64px)', display: 'flex', flexDirection: 'column' }}>
+    <Box
+      sx={{
+        width: '100%',
+        height: 'calc(100vh - 64px)',
+        display: 'flex',
+        flexDirection: 'column',
+      }}
+    >
       {/* Toolbar */}
       <Toolbar
         variant="dense"
-        sx={{ minHeight: 48, px: 2, gap: 1, borderBottom: 1, borderColor: 'divider', flexWrap: 'wrap' }}
+        sx={{
+          minHeight: 48,
+          px: 2,
+          gap: 1,
+          borderBottom: 1,
+          borderColor: 'divider',
+          flexWrap: 'wrap',
+        }}
       >
         {/* Search */}
         <TextField
@@ -322,7 +362,10 @@ const Logs = () => {
           value={searchText}
           onChange={handleSearchChange}
           onKeyDown={handleSearchKeyDown}
-          sx={{ 'width': 240, '& .MuiInputBase-input': { fontSize: FONT_SIZE } }}
+          sx={{
+            'width': 240,
+            '& .MuiInputBase-input': { fontSize: FONT_SIZE },
+          }}
           InputProps={{
             startAdornment: (
               <InputAdornment position="start">
@@ -340,7 +383,13 @@ const Logs = () => {
               label={level}
               size="small"
               variant={selectedLevels.includes(level) ? 'filled' : 'outlined'}
-              color={level === 'ERROR' ? 'error' : level === 'WARNING' ? 'warning' : 'default'}
+              color={
+                level === 'ERROR'
+                  ? 'error'
+                  : level === 'WARNING'
+                  ? 'warning'
+                  : 'default'
+              }
               onClick={() => toggleLevel(level)}
               sx={{ fontSize: FONT_SIZE }}
             />
@@ -408,15 +457,28 @@ const Logs = () => {
           transformOrigin={{ vertical: 'top', horizontal: 'right' }}
         >
           <Box sx={{ display: 'flex', width: 480, maxHeight: 400 }}>
-            <Box sx={{ width: 240, p: 2, display: 'flex', flexDirection: 'column', gap: 1.5 }}>
-              <Typography variant="subtitle2" color="text.secondary" sx={{ fontSize: FONT_SIZE }}>
+            <Box
+              sx={{
+                width: 240,
+                p: 2,
+                display: 'flex',
+                flexDirection: 'column',
+                gap: 1.5,
+              }}
+            >
+              <Typography
+                variant="subtitle2"
+                color="text.secondary"
+                sx={{ fontSize: FONT_SIZE }}
+              >
                 {t('monitoring.absoluteRange')}
               </Typography>
               <LocalizationProvider
                 dateAdapter={AdapterDayjs}
                 adapterLocale={dayjsLocale}
                 localeText={
-                  PICKER_LOCALE_TEXT[(i18n.language || 'en').split('-')[0]] || PICKER_LOCALE_TEXT.en
+                  PICKER_LOCALE_TEXT[(i18n.language || 'en').split('-')[0]] ||
+                  PICKER_LOCALE_TEXT.en
                 }
               >
                 <DateTimePicker
@@ -477,10 +539,18 @@ const Logs = () => {
           <TableHead>
             <TableRow>
               <TableCell sx={{ width: 32, fontSize: FONT_SIZE }} />
-              <TableCell sx={{ width: 150, fontSize: FONT_SIZE }}>{t('logs.time')}</TableCell>
-              <TableCell sx={{ width: 80, fontSize: FONT_SIZE }}>{t('logs.level')}</TableCell>
-              <TableCell sx={{ width: 160, fontSize: FONT_SIZE }}>{t('logs.node')}</TableCell>
-              <TableCell sx={{ fontSize: FONT_SIZE }}>{t('logs.message')}</TableCell>
+              <TableCell sx={{ width: 150, fontSize: FONT_SIZE }}>
+                {t('logs.time')}
+              </TableCell>
+              <TableCell sx={{ width: 80, fontSize: FONT_SIZE }}>
+                {t('logs.level')}
+              </TableCell>
+              <TableCell sx={{ width: 160, fontSize: FONT_SIZE }}>
+                {t('logs.node')}
+              </TableCell>
+              <TableCell sx={{ fontSize: FONT_SIZE }}>
+                {t('logs.message')}
+              </TableCell>
             </TableRow>
           </TableHead>
           <TableBody>
@@ -490,7 +560,12 @@ const Logs = () => {
                 <React.Fragment key={idx}>
                   <TableRow
                     hover
-                    sx={{ 'cursor': 'pointer', '& > *': { borderBottom: isExpanded ? 'none' : undefined } }}
+                    sx={{
+                      'cursor': 'pointer',
+                      '& > *': {
+                        borderBottom: isExpanded ? 'none' : undefined,
+                      },
+                    }}
                     onClick={() => setExpandedRow(isExpanded ? null : idx)}
                   >
                     <TableCell sx={{ fontSize: FONT_SIZE, p: 0.5 }}>
@@ -502,7 +577,9 @@ const Logs = () => {
                         }}
                       />
                     </TableCell>
-                    <TableCell sx={{ fontSize: FONT_SIZE, whiteSpace: 'nowrap' }}>
+                    <TableCell
+                      sx={{ fontSize: FONT_SIZE, whiteSpace: 'nowrap' }}
+                    >
                       {formatTime(row['@timestamp'])}
                     </TableCell>
                     <TableCell sx={{ fontSize: FONT_SIZE }}>
@@ -517,7 +594,9 @@ const Logs = () => {
                         {row.level}
                       </Typography>
                     </TableCell>
-                    <TableCell sx={{ fontSize: FONT_SIZE }}>{row.node}</TableCell>
+                    <TableCell sx={{ fontSize: FONT_SIZE }}>
+                      {row.node}
+                    </TableCell>
                     <TableCell
                       sx={{
                         fontSize: FONT_SIZE,
@@ -527,7 +606,10 @@ const Logs = () => {
                         whiteSpace: 'nowrap',
                       }}
                     >
-                      <HighlightText text={row.message} keyword={appliedSearch} />
+                      <HighlightText
+                        text={row.message}
+                        keyword={appliedSearch}
+                      />
                     </TableCell>
                   </TableRow>
                   <TableRow>
@@ -536,7 +618,10 @@ const Logs = () => {
                         <DetailRow row={row} />
                         {row.message && (
                           <Box sx={{ px: 2, pb: 2 }}>
-                            <Typography variant="caption" color="text.secondary">
+                            <Typography
+                              variant="caption"
+                              color="text.secondary"
+                            >
                               {t('logs.fullMessage')}
                             </Typography>
                             <Typography
@@ -551,7 +636,10 @@ const Logs = () => {
                                 borderRadius: 1,
                               }}
                             >
-                              <HighlightText text={row.message} keyword={appliedSearch} />
+                              <HighlightText
+                                text={row.message}
+                                keyword={appliedSearch}
+                              />
                             </Typography>
                           </Box>
                         )}
@@ -564,7 +652,9 @@ const Logs = () => {
             {!loading && logs.length === 0 && (
               <TableRow>
                 <TableCell colSpan={5} align="center" sx={{ py: 4 }}>
-                  <Typography color="text.secondary">{t('logs.noLogs')}</Typography>
+                  <Typography color="text.secondary">
+                    {t('logs.noLogs')}
+                  </Typography>
                 </TableCell>
               </TableRow>
             )}
@@ -575,7 +665,14 @@ const Logs = () => {
       {/* Pagination */}
       <Toolbar
         variant="dense"
-        sx={{ minHeight: 40, px: 2, justifyContent: 'flex-end', gap: 1, borderTop: 1, borderColor: 'divider' }}
+        sx={{
+          minHeight: 40,
+          px: 2,
+          justifyContent: 'flex-end',
+          gap: 1,
+          borderTop: 1,
+          borderColor: 'divider',
+        }}
       >
         <Typography variant="body2" sx={{ fontSize: FONT_SIZE }}>
           {t('logs.totalHits', { count: total })}
@@ -593,7 +690,9 @@ const Logs = () => {
         </Typography>
         <Button
           size="small"
-          disabled={pageFrom + PAGE_SIZE >= total || pageFrom + PAGE_SIZE > 10000}
+          disabled={
+            pageFrom + PAGE_SIZE >= total || pageFrom + PAGE_SIZE > 10000
+          }
           onClick={() => setPageFrom(pageFrom + PAGE_SIZE)}
           sx={{ fontSize: FONT_SIZE, textTransform: 'none' }}
         >

--- a/xinference/ui/web/ui/src/scenes/logs/index.js
+++ b/xinference/ui/web/ui/src/scenes/logs/index.js
@@ -162,7 +162,10 @@ const Logs = () => {
 
   useEffect(() => {
     fetch(endPoint + '/v1/cluster/ui_config')
-      .then((res) => res.json())
+      .then((res) => {
+        if (!res.ok) throw new Error('Network response was not ok')
+        return res.json()
+      })
       .then((data) => setEsEnabled(data.es_enabled || false))
       .catch(() => setEsEnabled(false))
   }, [endPoint])
@@ -295,7 +298,14 @@ const Logs = () => {
   const formatTime = (ts) => {
     if (!ts) return ''
     const d = new Date(ts)
-    return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })
+    return d.toLocaleString([], {
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      hour12: false,
+    })
   }
 
   return (
@@ -467,7 +477,7 @@ const Logs = () => {
           <TableHead>
             <TableRow>
               <TableCell sx={{ width: 32, fontSize: FONT_SIZE }} />
-              <TableCell sx={{ width: 100, fontSize: FONT_SIZE }}>{t('logs.time')}</TableCell>
+              <TableCell sx={{ width: 150, fontSize: FONT_SIZE }}>{t('logs.time')}</TableCell>
               <TableCell sx={{ width: 80, fontSize: FONT_SIZE }}>{t('logs.level')}</TableCell>
               <TableCell sx={{ width: 160, fontSize: FONT_SIZE }}>{t('logs.node')}</TableCell>
               <TableCell sx={{ fontSize: FONT_SIZE }}>{t('logs.message')}</TableCell>


### PR DESCRIPTION
## Summary

- Add backend `GET /v1/cluster/logs` API that proxies Elasticsearch queries via `aiohttp` (compatible with ES 7.x/8.x/9.x, zero new Python dependencies)
- Add `es_enabled` field to `ui_config` response, controlled by `XINFERENCE_ES_URL` environment variable
- Add new **Log Center** page (`/#/logs`) with full-text search, log level/type/node filtering, time range picker, pagination, and search keyword highlighting
- Conditionally show "Log Center" sidebar menu item only when ES is configured
- Add i18n support for en/zh/ja/ko

## Changes

### Backend (`xinference/api/routers/admin.py`)
- `get_ui_config()`: added `es_enabled` field based on `XINFERENCE_ES_URL`
- New `search_logs()` handler: builds parameterized ES `bool` query (prevents injection), supports `q`/`level`/`module`/`node`/`log_type`/`time_from`/`time_to`/`size`/`page_from` params, 10s timeout, Basic Auth / API Key auth
- Route registration: `GET /v1/cluster/logs` with `admin` scope

### Frontend
- **New file** `scenes/logs/index.js`: Log Center page with toolbar (search, level chips, log type chips, node select, time range popover, refresh), MUI Table with expandable detail rows, `from/size` pagination, `<mark>` search highlighting
- `router/index.js`: added `/logs` route
- `components/MenuSide.js`: added `ArticleOutlined` icon, `ApiContext` import, `esEnabled` state fetched from `ui_config`, conditional "Log Center" menu item
- `locales/{en,zh,ja,ko}.json`: added `menu.logs` and `logs.*` i18n keys

### Environment Variables
| Variable | Description | Example |
|----------|-------------|---------|
| `XINFERENCE_ES_URL` | Elasticsearch URL | `http://es:9200` |
| `XINFERENCE_ES_INDEX` | Log index pattern | `xinference-logs-*` |
| `XINFERENCE_ES_AUTH` | Auth (optional): `user:pass` or `ApiKey <base64>` | `elastic:changeme` |

## Test plan
- [ ] Set `XINFERENCE_ES_URL` and verify "Log Center" menu item appears
- [ ] Without `XINFERENCE_ES_URL`, verify menu item is hidden
- [ ] Test full-text search, level/type/node filtering, time range selection
- [ ] Test pagination (prev/next), search highlight in message column
- [ ] Test expandable row detail (module, pid, request_id, etc.)
- [ ] Verify admin auth is enforced on `/v1/cluster/logs`
- [ ] Test with ES 7.x and 8.x for compatibility

