### PR TITLE
feat: add Qwen3.6-27B model support (pytorch + FP8)

### DIFF
--- a/xinference/model/llm/llm_family.json
+++ b/xinference/model/llm/llm_family.json
@@ -30252,6 +30252,42 @@
     ],
     "model_specs": [
       {
+        "model_size_in_billions": 27,
+        "model_format": "pytorch",
+        "model_src": {
+          "huggingface": {
+            "model_id": "Qwen/Qwen3.6-27B",
+            "quantizations": [
+              "none"
+            ]
+          },
+          "modelscope": {
+            "model_id": "Qwen/Qwen3.6-27B",
+            "quantizations": [
+              "none"
+            ]
+          }
+        }
+      },
+      {
+        "model_size_in_billions": 27,
+        "model_format": "fp8",
+        "model_src": {
+          "huggingface": {
+            "model_id": "Qwen/Qwen3.6-27B-FP8",
+            "quantizations": [
+              "FP8"
+            ]
+          },
+          "modelscope": {
+            "model_id": "Qwen/Qwen3.6-27B-FP8",
+            "quantizations": [
+              "FP8"
+            ]
+          }
+        }
+      },
+      {
         "model_size_in_billions": 35,
         "activated_size_in_billions": 3,
         "model_format": "pytorch",


### PR DESCRIPTION
## Summary

- Add Qwen3.6-27B (dense, BF16) and Qwen3.6-27B-FP8 model specs to the `qwen3.6` model family
- Both specs include HuggingFace and ModelScope sources
- Inserted before existing 35B-A3B (MoE) specs, ordered by model size ascending

## Changes

| File | Change |
|------|--------|
| `xinference/model/llm/llm_family.json` | Add 2 new specs (27B pytorch + 27B fp8) to `qwen3.6.model_specs` |

### New model specs

| Size | Format | HuggingFace | ModelScope |
|------|--------|-------------|------------|
| 27B | pytorch | `Qwen/Qwen3.6-27B` | `Qwen/Qwen3.6-27B` |
| 27B | fp8 | `Qwen/Qwen3.6-27B-FP8` | `Qwen/Qwen3.6-27B-FP8` |

Model abilities (chat, vision, tools, reasoning, hybrid), chat_template, stop tokens, and virtualenv config are inherited from the `qwen3.6` family definition.

## Test plan
- [ ] Verify `qwen3.6` 27B appears in xinference UI model list
- [ ] Launch 27B pytorch format and confirm download + load
- [ ] Launch 27B fp8 format and confirm download + load
- [ ] Send chat request and verify thinking mode (`<think>` tag) works
- [ ] Verify tool calling works
