### PR TITLE
feat: add page titles to Monitoring and Log Center pages

### DIFF
--- a/xinference/ui/web/ui/src/scenes/logs/index.js
+++ b/xinference/ui/web/ui/src/scenes/logs/index.js
@@ -310,14 +310,25 @@ const Logs = () => {
   if (!esEnabled) {
     return (
       <Box
-        display="flex"
-        justifyContent="center"
-        alignItems="center"
-        height="calc(100vh - 64px)"
+        sx={{
+          width: '100%',
+          height: 'calc(100vh - 64px)',
+          padding: '20px 20px 0 20px',
+          display: 'flex',
+          flexDirection: 'column',
+        }}
       >
-        <Typography variant="h6" color="text.secondary">
-          {t('logs.notConfigured')}
-        </Typography>
+        <Title title={t('menu.logs')} />
+        <Box
+          display="flex"
+          justifyContent="center"
+          alignItems="center"
+          sx={{ flex: 1 }}
+        >
+          <Typography variant="h6" color="text.secondary">
+            {t('logs.notConfigured')}
+          </Typography>
+        </Box>
       </Box>
     )
   }

--- a/xinference/ui/web/ui/src/scenes/logs/index.js
+++ b/xinference/ui/web/ui/src/scenes/logs/index.js
@@ -45,6 +45,7 @@ import React, {
 import { useTranslation } from 'react-i18next'
 
 import { ApiContext } from '../../components/apiContext'
+import Title from '../../components/Title'
 
 const FONT_SIZE = '0.813rem'
 
@@ -339,10 +340,12 @@ const Logs = () => {
       sx={{
         width: '100%',
         height: 'calc(100vh - 64px)',
+        padding: '20px 20px 0 20px',
         display: 'flex',
         flexDirection: 'column',
       }}
     >
+      <Title title={t('menu.logs')} />
       {/* Toolbar */}
       <Toolbar
         variant="dense"

--- a/xinference/ui/web/ui/src/scenes/monitoring/index.js
+++ b/xinference/ui/web/ui/src/scenes/monitoring/index.js
@@ -165,14 +165,25 @@ const Monitoring = () => {
   if (!config || !config.grafana_url) {
     return (
       <Box
-        display="flex"
-        justifyContent="center"
-        alignItems="center"
-        height="calc(100vh - 64px)"
+        sx={{
+          width: '100%',
+          height: 'calc(100vh - 64px)',
+          padding: '20px 20px 0 20px',
+          display: 'flex',
+          flexDirection: 'column',
+        }}
       >
-        <Typography variant="h6" color="text.secondary">
-          {t('monitoring.notConfigured')}
-        </Typography>
+        <Title title={t('menu.monitoring')} />
+        <Box
+          display="flex"
+          justifyContent="center"
+          alignItems="center"
+          sx={{ flex: 1 }}
+        >
+          <Typography variant="h6" color="text.secondary">
+            {t('monitoring.notConfigured')}
+          </Typography>
+        </Box>
       </Box>
     )
   }

--- a/xinference/ui/web/ui/src/scenes/monitoring/index.js
+++ b/xinference/ui/web/ui/src/scenes/monitoring/index.js
@@ -25,6 +25,7 @@ import { useTranslation } from 'react-i18next'
 import { ApiContext } from '../../components/apiContext'
 import { buildGrafanaUrl } from '../../components/grafanaUtils'
 import { useThemeContext } from '../../components/themeContext'
+import Title from '../../components/Title'
 
 const FONT_SIZE = '0.813rem'
 
@@ -190,10 +191,12 @@ const Monitoring = () => {
       sx={{
         width: '100%',
         height: 'calc(100vh - 64px)',
+        padding: '20px 20px 0 20px',
         display: 'flex',
         flexDirection: 'column',
       }}
     >
+      <Title title={t('menu.monitoring')} />
       {/* Toolbar */}
       <Toolbar
         variant="dense"


### PR DESCRIPTION
## Summary
- Add `<Title>` component to Monitoring and Log Center pages to align with standard UI page layout
- Add consistent `padding: '20px 20px 0 20px'` to outer Box of both pages
- Uses existing i18n keys (`menu.monitoring`, `menu.logs`), no new translations needed

## Test plan
- [ ] Monitoring page shows "Monitoring" title at top (or localized equivalent)
- [ ] Log Center page shows "Log Center" title at top (or localized equivalent)
- [ ] Title style matches other pages (e.g., Cluster Information) — h2 bold with bottom margin
- [ ] Content has proper 20px padding from edges, consistent with other pages
- [ ] Switching languages updates the page titles correctly (en/zh/ja/ko)
