### PR TITLE
fix(ci): harden gen docs workflow

### DIFF
--- a/.github/scripts/validate_gen_docs_pr.py
+++ b/.github/scripts/validate_gen_docs_pr.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.request
+from pathlib import Path
+
+
+MODEL_SPEC_FILES = (
+    "xinference/model/llm/llm_family.json",
+    "xinference/model/embedding/model_spec.json",
+    "xinference/model/rerank/model_spec.json",
+    "xinference/model/image/model_spec.json",
+    "xinference/model/audio/model_spec.json",
+    "xinference/model/video/model_spec.json",
+)
+
+SAFE_MODEL_NAME = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+def _next_link(link_header):
+    links = {}
+    for part in link_header.split(","):
+        if 'rel="' not in part:
+            continue
+        url_part, rel_part = part.split(";", 1)
+        rel = rel_part.split('rel="', 1)[1].split('"', 1)[0]
+        links[rel] = url_part.strip()[1:-1]
+    return links.get("next")
+
+
+def validate_changed_files():
+    token = os.environ["GITHUB_TOKEN"]
+    next_url = os.environ["PR_FILES_URL"] + "?per_page=100"
+    changed = []
+
+    while next_url:
+        req = urllib.request.Request(
+            next_url,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {token}",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+        )
+        with urllib.request.urlopen(req) as resp:
+            for item in json.load(resp):
+                changed.append(item["filename"])
+                if "previous_filename" in item:
+                    changed.append(item["previous_filename"])
+            next_url = _next_link(resp.headers.get("Link", ""))
+
+    unexpected = sorted(set(changed) - set(MODEL_SPEC_FILES))
+    if unexpected:
+        print("Unexpected PR file changes are not allowed:")
+        for filename in unexpected:
+            print(f"- {filename}")
+        return 1
+
+    if not changed:
+        print("No changed files found for PR.")
+        return 1
+
+    print("Changed files are limited to the allowed model spec JSON files.")
+    return 0
+
+
+def _visit_model_names(value, source, unsafe):
+    if isinstance(value, dict):
+        model_name = value.get("model_name")
+        if model_name is not None:
+            if not isinstance(model_name, str) or not SAFE_MODEL_NAME.fullmatch(
+                model_name
+            ):
+                unsafe.append((source, model_name))
+        for child in value.values():
+            _visit_model_names(child, source, unsafe)
+    elif isinstance(value, list):
+        for child in value:
+            _visit_model_names(child, source, unsafe)
+
+
+def validate_model_names(workspace):
+    unsafe = []
+    for spec_file in MODEL_SPEC_FILES:
+        path = workspace / spec_file
+        with path.open() as fp:
+            _visit_model_names(json.load(fp), spec_file, unsafe)
+
+    if unsafe:
+        print("Unsafe model_name values are not allowed:")
+        for source, model_name in unsafe:
+            print(f"- {source}: {model_name!r}")
+        return 1
+
+    print("Model names are safe for generated documentation paths.")
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("changed-files")
+    model_names = subparsers.add_parser("model-names")
+    model_names.add_argument("workspace", type=Path)
+    args = parser.parse_args()
+
+    if args.command == "changed-files":
+        return validate_changed_files()
+    if args.command == "model-names":
+        return validate_model_names(args.workspace)
+    raise AssertionError(args.command)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/pr_auto_run_gen_docs.yaml
+++ b/.github/workflows/pr_auto_run_gen_docs.yaml
@@ -13,13 +13,28 @@ on:
 
 permissions:
   contents: write
-  pull-requests: write
+  pull-requests: read
 
 jobs:
   run-gen-docs-and-commit:
     if: startsWith(github.event.pull_request.head.ref, 'chore/models-sync/')
     runs-on: ubuntu-latest
     steps:
+      - name: Validate PR metadata
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+        run: |
+          set -euo pipefail
+          if ! printf '%s' "$HEAD_REF" | grep -Eq '^chore/models-sync/[A-Za-z0-9._/-]+$'; then
+            echo "Unsafe branch name: $HEAD_REF"
+            exit 1
+          fi
+          if ! printf '%s' "$HEAD_REPO" | grep -Eq '^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$'; then
+            echo "Unsafe repository name: $HEAD_REPO"
+            exit 1
+          fi
+
       - name: Checkout base branch (trusted code)
         uses: actions/checkout@v4
         with:
@@ -50,6 +65,15 @@ jobs:
           fi
           echo "run=true" >> $GITHUB_OUTPUT
 
+      - name: Validate changed files
+        if: steps.decide.outputs.run == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_FILES_URL: ${{ github.event.pull_request.url }}/files
+        run: |
+          set -euo pipefail
+          python base/.github/scripts/validate_gen_docs_pr.py changed-files
+
       - name: Set up Python
         if: steps.decide.outputs.run == 'true'
         uses: actions/setup-python@v5
@@ -61,51 +85,98 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install jinja2
-          python -m pip install "xinference[doc]"
+          python -m pip install "./base[doc]"
 
-      - name: Run gen_docs.py (from base branch ONLY)
+      - name: Prepare sanitized gen_docs workspace
         if: steps.decide.outputs.run == 'true'
         run: |
-          echo "[Debug] CWD: $(pwd)"
+          set -euo pipefail
+          rm -rf gen-docs-work
+          cp -a base gen-docs-work
 
-          # IMPORTANT: Only execute gen_docs.py from base branch (trusted)
-          # We use PR's data files but base branch's code and templates
-          if [ -f "base/doc/source/gen_docs.py" ]; then
-            echo "Running gen_docs.py from base branch on PR data"
-            cd pr
-            # Copy templates from base (they should be in the same relative location)
-            if [ -d "../base/doc/source/templates" ]; then
-              mkdir -p doc/source
-              cp -r ../base/doc/source/templates doc/source/
+          for file in \
+            xinference/model/llm/llm_family.json \
+            xinference/model/embedding/model_spec.json \
+            xinference/model/rerank/model_spec.json \
+            xinference/model/image/model_spec.json \
+            xinference/model/audio/model_spec.json \
+            xinference/model/video/model_spec.json
+          do
+            if [ -e "pr/$file" ]; then
+              if [ -L "pr/$file" ]; then
+                echo "Refusing symlinked PR data file: $file"
+                exit 1
+              fi
+              cp "pr/$file" "gen-docs-work/$file"
             fi
-            # Execute gen_docs.py from base branch
-            python ../base/doc/source/gen_docs.py
-          elif [ -f "base/gen_docs.py" ]; then
-            echo "Running gen_docs.py from base root"
-            cd pr
-            python ../base/gen_docs.py
-          else
-            echo "gen_docs.py not found in base branch, skipping."
-          fi
+          done
 
-      - name: Stage and commit changes
+      - name: Validate model names
+        if: steps.decide.outputs.run == 'true'
+        run: |
+          set -euo pipefail
+          python base/.github/scripts/validate_gen_docs_pr.py model-names gen-docs-work
+
+      - name: Run gen_docs.py from sanitized workspace
+        if: steps.decide.outputs.run == 'true'
+        working-directory: gen-docs-work/doc/source
+        run: |
+          set -euo pipefail
+          python gen_docs.py
+
+      - name: Copy generated docs back to PR checkout
+        if: steps.decide.outputs.run == 'true'
+        run: |
+          set -euo pipefail
+          for path in \
+            doc/source/models/builtin \
+            doc/source/getting_started/installation.rst \
+            doc/source/user_guide/backends.rst \
+            doc/source/user_guide/metrics.rst
+          do
+            if [ -e "gen-docs-work/$path" ]; then
+              mkdir -p "pr/$(dirname "$path")"
+              rm -rf "pr/$path"
+              cp -a "gen-docs-work/$path" "pr/$path"
+            fi
+          done
+
+      - name: Stage and validate generated changes
         if: steps.decide.outputs.run == 'true'
         working-directory: pr
         run: |
+          set -euo pipefail
           echo "[Debug] Before staging:" && git status --porcelain
 
           echo "[Debug] check-ignore for generated file:"
           git check-ignore -v doc/source/_generated/auto_generated.txt || echo "Not ignored"
-          git add -A
-          git add -f doc/source/_generated || true
+          git add -A -- \
+            doc/source/models/builtin \
+            doc/source/getting_started/installation.rst \
+            doc/source/user_guide/backends.rst \
+            doc/source/user_guide/metrics.rst
 
           echo "[Debug] After staging:" && git status --porcelain
           echo "[Debug] Staged diff:" && git diff --cached --name-status || true
 
+          unexpected="$(git diff --cached --name-only | grep -Ev '^(doc/source/models/builtin/|doc/source/getting_started/installation\.rst$|doc/source/user_guide/backends\.rst$|doc/source/user_guide/metrics\.rst$)' || true)"
+          if [ -n "$unexpected" ]; then
+            echo "Unexpected generated changes:"
+            printf '%s\n' "$unexpected"
+            exit 1
+          fi
+
+          unsafe_generated_names="$(git diff --cached --name-only -- doc/source/models/builtin | grep -Ev '^doc/source/models/builtin/(llm|embedding|rerank|image|audio|video)/([A-Za-z0-9._-]+|index)\.rst$' || true)"
+          if [ -n "$unsafe_generated_names" ]; then
+            echo "Unsafe generated documentation paths:"
+            printf '%s\n' "$unsafe_generated_names"
+            exit 1
+          fi
+
           if ! git diff --cached --quiet; then
             git config user.name "github-actions[bot]"
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git commit -m "chore(docs): auto-run gen_docs.py"
+            git commit -m "chore(docs): auto-run gen_docs.py [skip ci]"
           else
             echo "No changes to commit."
           fi
@@ -124,28 +195,10 @@ jobs:
           echo "Pushing changes to same-repo PR..."
           git push origin "HEAD:${HEAD_REF}" || echo "No changes to push."
 
-      - name: Push to fork PR
+      - name: Skip fork PR push
         env:
-          PUSH_TOKEN: ${{ secrets.PUSH_TOKEN }}
-          HEAD_REF: ${{ github.event.pull_request.head.ref }}
           HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
         if: steps.decide.outputs.run == 'true' && github.event.pull_request.head.repo.full_name != github.repository
-        working-directory: pr
         run: |
-          if ! printf '%s' "$HEAD_REF" | grep -Eq '^chore/models-sync/[A-Za-z0-9._/-]+$'; then
-            echo "Unsafe branch name: $HEAD_REF"
-            exit 1
-          fi
-          if ! printf '%s' "$HEAD_REPO" | grep -Eq '^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$'; then
-            echo "Unsafe repository name: $HEAD_REPO"
-            exit 1
-          fi
-          if [ -z "$PUSH_TOKEN" ]; then
-            echo "Missing secrets.PUSH_TOKEN; cannot push to fork. Skipping push."
-            echo "Please ask maintainer to run gen_docs.py manually."
-            exit 0
-          fi
-          echo "Pushing changes to fork PR..."
-          # Set remote for fork repository
-          git remote add fork "https://x-access-token:${PUSH_TOKEN}@github.com/${HEAD_REPO}.git"
-          git push fork "HEAD:${HEAD_REF}" || echo "No changes to push."
+          echo "Skipping automatic docs push to fork PR: $HEAD_REPO"
+          echo "Please ask a maintainer to run gen_docs.py manually or open a same-repository chore/models-sync branch."


### PR DESCRIPTION
## Summary

- validate PR metadata and changed files before running the gen_docs workflow
- run gen_docs from a sanitized base-branch workspace with only allowed PR JSON inputs copied in
- validate generated docs paths before committing and skip automatic fork PR push

Fixes #4912

## Validation

- Parsed .github/workflows/pr_auto_run_gen_docs.yaml with PyYAML
- Ran git diff --check
- Verified staging only includes generated docs paths in a local git simulation
- Tested the workflow end-to-end in rogercloud/inference#1: Auto run gen_docs.py and commit changes to PR completed successfully