### PR TITLE
fix: Fix tool_call messages handling in utils.py

### DIFF
--- a/xinference/model/llm/tests/test_utils.py
+++ b/xinference/model/llm/tests/test_utils.py
@@ -46,6 +46,50 @@ def filter_ids_and_created(data):
     return data
 
 
+def test_transform_messages_preserves_tool_call_fields():
+    mixin = ChatModelMixin()
+    messages = [
+        {"role": "user", "content": "Hi"},
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "id": "call_bed4c5f1",
+                    "function": {
+                        "arguments": '{"file_path": "README*"}',
+                        "name": "view_file_in_detail",
+                    },
+                    "type": "function",
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "content": "Tool execute results: file not found: README*",
+            "tool_call_id": "call_bed4c5f1",
+        },
+    ]
+
+    transformed = mixin._transform_messages(messages)
+
+    assert transformed[0] == {
+        "role": "user",
+        "content": [{"type": "text", "text": "Hi"}],
+    }
+    assert transformed[1] == {
+        "role": "assistant",
+        "content": None,
+        "tool_calls": messages[1]["tool_calls"],
+    }
+    assert transformed[2] == {
+        "role": "tool",
+        "content": [
+            {"type": "text", "text": "Tool execute results: file not found: README*"}
+        ],
+        "tool_call_id": "call_bed4c5f1",
+    }
+
+
 def test_post_process_completion_chunk_without_thinking():
     mixin = ChatModelMixin()
     mixin.tool_parser = QwenToolParser()

--- a/xinference/model/llm/utils.py
+++ b/xinference/model/llm/utils.py
@@ -785,8 +785,7 @@ class ChatModelMixin:
         transformed_messages = []
         for msg in messages:
             new_content = []
-            role = msg["role"]
-            content = msg["content"]
+            content = msg.get("content")
             if isinstance(content, str):
                 new_content.append({"type": "text", "text": content})
             elif isinstance(content, List):
@@ -810,7 +809,8 @@ class ChatModelMixin:
                             "Unknown message type, message: %s, this message may be ignored",
                             messages,
                         )
-            new_message = {"role": role, "content": new_content}
+            new_message = dict(msg)
+            new_message["content"] = new_content if new_content else None
             transformed_messages.append(new_message)
 
         return transformed_messages

--- a/xinference/model/llm/utils.py
+++ b/xinference/model/llm/utils.py
@@ -807,7 +807,7 @@ class ChatModelMixin:
                     else:
                         logger.warning(
                             "Unknown message type, message: %s, this message may be ignored",
-                            messages,
+                            msg,
                         )
             new_message = dict(msg)
             new_message["content"] = new_content if new_content else None


### PR DESCRIPTION
Part of #4914 .

Code to reproduce:

```
......
user_msg = "Hi"

result = client.chat.completions.create(
    messages=[
        {"role": "user", "content": user_msg},
        {"role": "assistant", "tool_calls":[
            {
                "id":"call_bed4c5f1-5f3a-485b-bc77-2b3324391c3f",
                "function":{
                    "arguments":"{\"file_path\": \"README*\", \"show_line_numbers\": false}",
                    "name":"view_file_in_detail"
                },
                "type":"function"
            }
        ]},
        {"role":"tool", "content": "Tool execute results: file not found: README*","tool_call_id":"call_bed4c5f1-5f3a-485b-bc77-2b3324391c3f"}
    ],
    model=LLM_MODEL,
)

print(result.model_dump_json())
```