### PR TITLE
feat(logs): Kibana-style enhancements for Log Center

### DIFF
--- a/xinference/api/routers/admin.py
+++ b/xinference/api/routers/admin.py
@@ -340,7 +340,7 @@ async def search_logs(
                 continue
             op = token[0]
             field_name = token[1:sep]
-            field_value = token[sep + 1:]
+            field_value = token[sep + 1 :]
             if not _FIELD_NAME_RE.match(field_name) or not field_value:
                 continue
             if field_name in _TEXT_FIELDS:
@@ -353,7 +353,9 @@ async def search_logs(
                 must_not.append(clause)
 
     body: dict[str, Any] = {
-        "query": {"bool": {"must": must, "filter": filter_clauses, "must_not": must_not}},
+        "query": {
+            "bool": {"must": must, "filter": filter_clauses, "must_not": must_not}
+        },
         "sort": [{"@timestamp": "desc"}],
         "from": page_from,
         "size": size,
@@ -468,15 +470,27 @@ async def search_logs_context(
             async with session.post(url, json=older_body, headers=headers) as resp:
                 if resp.status != 200:
                     text = await resp.text()
-                    logger.error("ES context older query failed: status=%d body=%s", resp.status, text[:500])
-                    raise HTTPException(status_code=502, detail="Elasticsearch query failed")
+                    logger.error(
+                        "ES context older query failed: status=%d body=%s",
+                        resp.status,
+                        text[:500],
+                    )
+                    raise HTTPException(
+                        status_code=502, detail="Elasticsearch query failed"
+                    )
                 older_data = await resp.json()
 
             async with session.post(url, json=newer_body, headers=headers) as resp:
                 if resp.status != 200:
                     text = await resp.text()
-                    logger.error("ES context newer query failed: status=%d body=%s", resp.status, text[:500])
-                    raise HTTPException(status_code=502, detail="Elasticsearch query failed")
+                    logger.error(
+                        "ES context newer query failed: status=%d body=%s",
+                        resp.status,
+                        text[:500],
+                    )
+                    raise HTTPException(
+                        status_code=502, detail="Elasticsearch query failed"
+                    )
                 newer_data = await resp.json()
     except (aiohttp.ClientError, asyncio.TimeoutError) as e:
         logger.error("ES connection error or timeout: %s", e)
@@ -485,8 +499,12 @@ async def search_logs_context(
             detail="Failed to connect to Elasticsearch or query timed out",
         )
 
-    older_hits_raw = [hit["_source"] for hit in older_data.get("hits", {}).get("hits", [])]
-    newer_hits_raw = [hit["_source"] for hit in newer_data.get("hits", {}).get("hits", [])]
+    older_hits_raw = [
+        hit["_source"] for hit in older_data.get("hits", {}).get("hits", [])
+    ]
+    newer_hits_raw = [
+        hit["_source"] for hit in newer_data.get("hits", {}).get("hits", [])
+    ]
 
     has_more_older = len(older_hits_raw) > size
     has_more_newer = len(newer_hits_raw) > size
@@ -494,13 +512,15 @@ async def search_logs_context(
     older_hits = older_hits_raw[:size]
     newer_hits = newer_hits_raw[:size]
 
-    return JSONResponse(content={
-        "older": older_hits,
-        "newer": newer_hits,
-        "anchor_timestamp": timestamp,
-        "has_more_older": has_more_older,
-        "has_more_newer": has_more_newer,
-    })
+    return JSONResponse(
+        content={
+            "older": older_hits,
+            "newer": newer_hits,
+            "anchor_timestamp": timestamp,
+            "has_more_older": has_more_older,
+            "has_more_newer": has_more_newer,
+        }
+    )
 
 
 # --- Route registration ---

--- a/xinference/api/routers/admin.py
+++ b/xinference/api/routers/admin.py
@@ -286,7 +286,9 @@ async def search_logs(
     module: str = "",
     node: str = "",
     log_type: str = "",
-    filters: list[str] = Query([], description="Field filters, e.g. filters=+node:val1&filters=-level:val2"),
+    filters: list[str] = Query(
+        [], description="Field filters, e.g. filters=+node:val1&filters=-level:val2"
+    ),
     time_from: str = "now-1h",
     time_to: str = "now",
     size: int = 200,

--- a/xinference/api/routers/admin.py
+++ b/xinference/api/routers/admin.py
@@ -330,6 +330,7 @@ async def search_logs(
                 filter_clauses.append({"terms": {field: terms}})
 
     must_not: list[dict[str, Any]] = []
+    plus_filters: dict[str, list[str]] = {}
     if filters:
         for token in filters.split(","):
             token = token.strip()
@@ -343,14 +344,25 @@ async def search_logs(
             field_value = token[sep + 1 :]
             if not _FIELD_NAME_RE.match(field_name) or not field_value:
                 continue
-            if field_name in _TEXT_FIELDS:
-                clause = {"match_phrase": {field_name: field_value}}
-            else:
-                clause = {"term": {field_name: field_value}}
             if op == "+":
-                filter_clauses.append(clause)
+                plus_filters.setdefault(field_name, []).append(field_value)
             else:
-                must_not.append(clause)
+                if field_name in _TEXT_FIELDS:
+                    must_not.append({"match_phrase": {field_name: field_value}})
+                else:
+                    must_not.append({"term": {field_name: field_value}})
+
+    for field_name, values in plus_filters.items():
+        if field_name in _TEXT_FIELDS:
+            filter_clauses.append(
+                {
+                    "bool": {
+                        "should": [{"match_phrase": {field_name: v}} for v in values]
+                    }
+                }
+            )
+        else:
+            filter_clauses.append({"terms": {field_name: values}})
 
     body: dict[str, Any] = {
         "query": {
@@ -467,31 +479,27 @@ async def search_logs_context(
     try:
         timeout = aiohttp.ClientTimeout(total=10)
         async with aiohttp.ClientSession(timeout=timeout, auth=auth) as session:
-            async with session.post(url, json=older_body, headers=headers) as resp:
-                if resp.status != 200:
-                    text = await resp.text()
-                    logger.error(
-                        "ES context older query failed: status=%d body=%s",
-                        resp.status,
-                        text[:500],
-                    )
-                    raise HTTPException(
-                        status_code=502, detail="Elasticsearch query failed"
-                    )
-                older_data = await resp.json()
 
-            async with session.post(url, json=newer_body, headers=headers) as resp:
-                if resp.status != 200:
-                    text = await resp.text()
-                    logger.error(
-                        "ES context newer query failed: status=%d body=%s",
-                        resp.status,
-                        text[:500],
-                    )
-                    raise HTTPException(
-                        status_code=502, detail="Elasticsearch query failed"
-                    )
-                newer_data = await resp.json()
+            async def fetch(body: dict, name: str) -> dict:
+                async with session.post(url, json=body, headers=headers) as resp:
+                    if resp.status != 200:
+                        text = await resp.text()
+                        logger.error(
+                            "ES context %s query failed: status=%d body=%s",
+                            name,
+                            resp.status,
+                            text[:500],
+                        )
+                        raise HTTPException(
+                            status_code=502,
+                            detail="Elasticsearch query failed",
+                        )
+                    return await resp.json()
+
+            older_data, newer_data = await asyncio.gather(
+                fetch(older_body, "older"),
+                fetch(newer_body, "newer"),
+            )
     except (aiohttp.ClientError, asyncio.TimeoutError) as e:
         logger.error("ES connection error or timeout: %s", e)
         raise HTTPException(

--- a/xinference/api/routers/admin.py
+++ b/xinference/api/routers/admin.py
@@ -401,6 +401,108 @@ async def search_logs(
     return JSONResponse(content={"hits": hits, "total": total})
 
 
+async def search_logs_context(
+    timestamp: str = "",
+    size: int = 5,
+    node: str = "",
+) -> JSONResponse:
+    if not timestamp:
+        raise HTTPException(status_code=400, detail="timestamp is required")
+
+    es_url = os.environ.get("XINFERENCE_ES_URL", "")
+    if not es_url:
+        raise HTTPException(status_code=503, detail="Elasticsearch is not configured")
+
+    es_index = os.environ.get("XINFERENCE_ES_INDEX", "xinference-logs-*")
+    es_auth = os.environ.get("XINFERENCE_ES_AUTH", "")
+
+    size = max(1, min(size, 50))
+
+    node_filter: list[dict[str, Any]] = []
+    if node:
+        node_filter = [{"term": {"node": node}}]
+
+    older_body: dict[str, Any] = {
+        "query": {
+            "bool": {
+                "filter": [
+                    {"range": {"@timestamp": {"lt": timestamp}}},
+                    *node_filter,
+                ]
+            }
+        },
+        "sort": [{"@timestamp": "desc"}],
+        "size": size + 1,
+        "_source": {"excludes": ["@version"]},
+    }
+
+    newer_body: dict[str, Any] = {
+        "query": {
+            "bool": {
+                "filter": [
+                    {"range": {"@timestamp": {"gt": timestamp}}},
+                    *node_filter,
+                ]
+            }
+        },
+        "sort": [{"@timestamp": "asc"}],
+        "size": size + 1,
+        "_source": {"excludes": ["@version"]},
+    }
+
+    headers = {"Content-Type": "application/json"}
+    auth = None
+    if es_auth:
+        if es_auth.startswith("ApiKey "):
+            headers["Authorization"] = es_auth
+        else:
+            parts = es_auth.split(":", 1)
+            if len(parts) == 2:
+                auth = aiohttp.BasicAuth(parts[0], parts[1])
+
+    url = f"{es_url.rstrip('/')}/{es_index}/_search"
+
+    try:
+        timeout = aiohttp.ClientTimeout(total=10)
+        async with aiohttp.ClientSession(timeout=timeout, auth=auth) as session:
+            async with session.post(url, json=older_body, headers=headers) as resp:
+                if resp.status != 200:
+                    text = await resp.text()
+                    logger.error("ES context older query failed: status=%d body=%s", resp.status, text[:500])
+                    raise HTTPException(status_code=502, detail="Elasticsearch query failed")
+                older_data = await resp.json()
+
+            async with session.post(url, json=newer_body, headers=headers) as resp:
+                if resp.status != 200:
+                    text = await resp.text()
+                    logger.error("ES context newer query failed: status=%d body=%s", resp.status, text[:500])
+                    raise HTTPException(status_code=502, detail="Elasticsearch query failed")
+                newer_data = await resp.json()
+    except (aiohttp.ClientError, asyncio.TimeoutError) as e:
+        logger.error("ES connection error or timeout: %s", e)
+        raise HTTPException(
+            status_code=502,
+            detail="Failed to connect to Elasticsearch or query timed out",
+        )
+
+    older_hits_raw = [hit["_source"] for hit in older_data.get("hits", {}).get("hits", [])]
+    newer_hits_raw = [hit["_source"] for hit in newer_data.get("hits", {}).get("hits", [])]
+
+    has_more_older = len(older_hits_raw) > size
+    has_more_newer = len(newer_hits_raw) > size
+
+    older_hits = older_hits_raw[:size]
+    newer_hits = newer_hits_raw[:size]
+
+    return JSONResponse(content={
+        "older": older_hits,
+        "newer": newer_hits,
+        "anchor_timestamp": timestamp,
+        "has_more_older": has_more_older,
+        "has_more_newer": has_more_newer,
+    })
+
+
 # --- Route registration ---
 
 
@@ -499,6 +601,13 @@ def register_routes(api: "RESTfulAPI") -> None:
     router.add_api_route(
         "/v1/cluster/logs",
         search_logs,
+        methods=["GET"],
+        dependencies=([Security(auth, scopes=["admin"])] if is_auth else None),
+    )
+
+    router.add_api_route(
+        "/v1/cluster/logs/context",
+        search_logs_context,
         methods=["GET"],
         dependencies=([Security(auth, scopes=["admin"])] if is_auth else None),
     )

--- a/xinference/api/routers/admin.py
+++ b/xinference/api/routers/admin.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import re
 import signal
 from typing import TYPE_CHECKING, Any
 
@@ -275,12 +276,17 @@ async def get_ui_config() -> JSONResponse:
     )
 
 
+_FIELD_NAME_RE = re.compile(r"^[a-zA-Z0-9_.@]+$")
+_TEXT_FIELDS = {"message"}
+
+
 async def search_logs(
     q: str = "",
     level: str = "",
     module: str = "",
     node: str = "",
     log_type: str = "",
+    filters: str = "",
     time_from: str = "now-1h",
     time_to: str = "now",
     size: int = 200,
@@ -323,8 +329,31 @@ async def search_logs(
             if terms:
                 filter_clauses.append({"terms": {field: terms}})
 
+    must_not: list[dict[str, Any]] = []
+    if filters:
+        for token in filters.split(","):
+            token = token.strip()
+            if len(token) < 3 or token[0] not in ("+", "-"):
+                continue
+            sep = token.find(":", 1)
+            if sep < 0:
+                continue
+            op = token[0]
+            field_name = token[1:sep]
+            field_value = token[sep + 1:]
+            if not _FIELD_NAME_RE.match(field_name) or not field_value:
+                continue
+            if field_name in _TEXT_FIELDS:
+                clause = {"match_phrase": {field_name: field_value}}
+            else:
+                clause = {"term": {field_name: field_value}}
+            if op == "+":
+                filter_clauses.append(clause)
+            else:
+                must_not.append(clause)
+
     body: dict[str, Any] = {
-        "query": {"bool": {"must": must, "filter": filter_clauses}},
+        "query": {"bool": {"must": must, "filter": filter_clauses, "must_not": must_not}},
         "sort": [{"@timestamp": "desc"}],
         "from": page_from,
         "size": size,

--- a/xinference/api/routers/admin.py
+++ b/xinference/api/routers/admin.py
@@ -286,7 +286,7 @@ async def search_logs(
     module: str = "",
     node: str = "",
     log_type: str = "",
-    filters: str = "",
+    filters: list[str] = Query([], description="Field filters, e.g. filters=+node:val1&filters=-level:val2"),
     time_from: str = "now-1h",
     time_to: str = "now",
     size: int = 200,
@@ -331,26 +331,25 @@ async def search_logs(
 
     must_not: list[dict[str, Any]] = []
     plus_filters: dict[str, list[str]] = {}
-    if filters:
-        for token in filters.split(","):
-            token = token.strip()
-            if len(token) < 3 or token[0] not in ("+", "-"):
-                continue
-            sep = token.find(":", 1)
-            if sep < 0:
-                continue
-            op = token[0]
-            field_name = token[1:sep]
-            field_value = token[sep + 1 :]
-            if not _FIELD_NAME_RE.match(field_name) or not field_value:
-                continue
-            if op == "+":
-                plus_filters.setdefault(field_name, []).append(field_value)
+    for token in filters:
+        token = token.strip()
+        if len(token) < 3 or token[0] not in ("+", "-"):
+            continue
+        sep = token.find(":", 1)
+        if sep < 0:
+            continue
+        op = token[0]
+        field_name = token[1:sep]
+        field_value = token[sep + 1 :]
+        if not _FIELD_NAME_RE.match(field_name) or not field_value:
+            continue
+        if op == "+":
+            plus_filters.setdefault(field_name, []).append(field_value)
+        else:
+            if field_name in _TEXT_FIELDS:
+                must_not.append({"match_phrase": {field_name: field_value}})
             else:
-                if field_name in _TEXT_FIELDS:
-                    must_not.append({"match_phrase": {field_name: field_value}})
-                else:
-                    must_not.append({"term": {field_name: field_value}})
+                must_not.append({"term": {field_name: field_value}})
 
     for field_name, values in plus_filters.items():
         if field_name in _TEXT_FIELDS:

--- a/xinference/ui/web/ui/src/locales/en.json
+++ b/xinference/ui/web/ui/src/locales/en.json
@@ -350,7 +350,16 @@
       "filterFor": "Filter for value",
       "filterOut": "Filter out value",
       "copyJson": "Copy JSON",
-      "copied": "Copied!"
+      "copied": "Copied!",
+      "viewContext": "View surrounding documents",
+      "contextTitle": "Surrounding documents",
+      "loadNewer": "Load",
+      "loadOlder": "Load",
+      "newerDocs": "newer documents",
+      "olderDocs": "older documents",
+      "anchorRow": "Current document",
+      "contextError": "This feature requires a newer backend version.",
+      "contextFetchError": "Failed to load surrounding documents."
     }
   }
 }

--- a/xinference/ui/web/ui/src/locales/en.json
+++ b/xinference/ui/web/ui/src/locales/en.json
@@ -348,7 +348,9 @@
       "field": "Field",
       "value": "Value",
       "filterFor": "Filter for value",
-      "filterOut": "Filter out value"
+      "filterOut": "Filter out value",
+      "copyJson": "Copy JSON",
+      "copied": "Copied!"
     }
   }
 }

--- a/xinference/ui/web/ui/src/locales/en.json
+++ b/xinference/ui/web/ui/src/locales/en.json
@@ -341,7 +341,14 @@
       "log_type": "Log Type",
       "rtf_avg": "RTF Average",
       "time_speech": "Speech Time",
-      "time_escape": "Process Time"
+      "time_escape": "Process Time",
+      "tableTab": "Table",
+      "jsonTab": "JSON",
+      "action": "Action",
+      "field": "Field",
+      "value": "Value",
+      "filterFor": "Filter for value",
+      "filterOut": "Filter out value"
     }
   }
 }

--- a/xinference/ui/web/ui/src/locales/ja.json
+++ b/xinference/ui/web/ui/src/locales/ja.json
@@ -348,7 +348,9 @@
       "field": "フィールド",
       "value": "値",
       "filterFor": "この値でフィルター",
-      "filterOut": "この値を除外"
+      "filterOut": "この値を除外",
+      "copyJson": "JSONをコピー",
+      "copied": "コピーしました!"
     }
   }
 }

--- a/xinference/ui/web/ui/src/locales/ja.json
+++ b/xinference/ui/web/ui/src/locales/ja.json
@@ -341,7 +341,14 @@
       "log_type": "ログタイプ",
       "rtf_avg": "RTF平均",
       "time_speech": "音声時間",
-      "time_escape": "処理時間"
+      "time_escape": "処理時間",
+      "tableTab": "テーブル",
+      "jsonTab": "JSON",
+      "action": "操作",
+      "field": "フィールド",
+      "value": "値",
+      "filterFor": "この値でフィルター",
+      "filterOut": "この値を除外"
     }
   }
 }

--- a/xinference/ui/web/ui/src/locales/ja.json
+++ b/xinference/ui/web/ui/src/locales/ja.json
@@ -350,7 +350,16 @@
       "filterFor": "この値でフィルター",
       "filterOut": "この値を除外",
       "copyJson": "JSONをコピー",
-      "copied": "コピーしました!"
+      "copied": "コピーしました!",
+      "viewContext": "周辺ドキュメントを表示",
+      "contextTitle": "周辺ドキュメント",
+      "loadNewer": "読み込む",
+      "loadOlder": "読み込む",
+      "newerDocs": "件の新しいドキュメント",
+      "olderDocs": "件の古いドキュメント",
+      "anchorRow": "現在のドキュメント",
+      "contextError": "この機能にはバックエンドの更新が必要です。",
+      "contextFetchError": "周辺ドキュメントの読み込みに失敗しました。"
     }
   }
 }

--- a/xinference/ui/web/ui/src/locales/ko.json
+++ b/xinference/ui/web/ui/src/locales/ko.json
@@ -348,7 +348,9 @@
       "field": "필드",
       "value": "값",
       "filterFor": "이 값으로 필터",
-      "filterOut": "이 값 제외"
+      "filterOut": "이 값 제외",
+      "copyJson": "JSON 복사",
+      "copied": "복사됨!"
     }
   }
 }

--- a/xinference/ui/web/ui/src/locales/ko.json
+++ b/xinference/ui/web/ui/src/locales/ko.json
@@ -341,7 +341,14 @@
       "log_type": "로그 유형",
       "rtf_avg": "RTF 평균",
       "time_speech": "음성 시간",
-      "time_escape": "처리 시간"
+      "time_escape": "처리 시간",
+      "tableTab": "테이블",
+      "jsonTab": "JSON",
+      "action": "작업",
+      "field": "필드",
+      "value": "값",
+      "filterFor": "이 값으로 필터",
+      "filterOut": "이 값 제외"
     }
   }
 }

--- a/xinference/ui/web/ui/src/locales/ko.json
+++ b/xinference/ui/web/ui/src/locales/ko.json
@@ -350,7 +350,16 @@
       "filterFor": "이 값으로 필터",
       "filterOut": "이 값 제외",
       "copyJson": "JSON 복사",
-      "copied": "복사됨!"
+      "copied": "복사됨!",
+      "viewContext": "주변 문서 보기",
+      "contextTitle": "주변 문서",
+      "loadNewer": "불러오기",
+      "loadOlder": "불러오기",
+      "newerDocs": "최신 문서",
+      "olderDocs": "이전 문서",
+      "anchorRow": "현재 문서",
+      "contextError": "이 기능을 사용하려면 백엔드를 업데이트해야 합니다.",
+      "contextFetchError": "주변 문서를 불러오지 못했습니다."
     }
   }
 }

--- a/xinference/ui/web/ui/src/locales/zh.json
+++ b/xinference/ui/web/ui/src/locales/zh.json
@@ -348,7 +348,9 @@
       "field": "字段",
       "value": "值",
       "filterFor": "筛选该值",
-      "filterOut": "排除该值"
+      "filterOut": "排除该值",
+      "copyJson": "复制 JSON",
+      "copied": "已复制!"
     }
   }
 }

--- a/xinference/ui/web/ui/src/locales/zh.json
+++ b/xinference/ui/web/ui/src/locales/zh.json
@@ -341,7 +341,14 @@
       "log_type": "日志类型",
       "rtf_avg": "RTF 均值",
       "time_speech": "语音时长",
-      "time_escape": "处理耗时"
+      "time_escape": "处理耗时",
+      "tableTab": "表格",
+      "jsonTab": "JSON",
+      "action": "操作",
+      "field": "字段",
+      "value": "值",
+      "filterFor": "筛选该值",
+      "filterOut": "排除该值"
     }
   }
 }

--- a/xinference/ui/web/ui/src/locales/zh.json
+++ b/xinference/ui/web/ui/src/locales/zh.json
@@ -350,7 +350,16 @@
       "filterFor": "筛选该值",
       "filterOut": "排除该值",
       "copyJson": "复制 JSON",
-      "copied": "已复制!"
+      "copied": "已复制!",
+      "viewContext": "查看周围文档",
+      "contextTitle": "周围文档",
+      "loadNewer": "加载",
+      "loadOlder": "加载",
+      "newerDocs": "newer documents",
+      "olderDocs": "older documents",
+      "anchorRow": "当前文档",
+      "contextError": "该功能需要更新后端版本。",
+      "contextFetchError": "加载周围文档失败。"
     }
   }
 }

--- a/xinference/ui/web/ui/src/scenes/logs/index.js
+++ b/xinference/ui/web/ui/src/scenes/logs/index.js
@@ -848,12 +848,9 @@ const Logs = () => {
     params.set('time_to', timeRange.to)
     params.set('size', String(PAGE_SIZE))
     params.set('page_from', String(pageFrom))
-    if (fieldFilters.length) {
-      params.set(
-        'filters',
-        fieldFilters.map((f) => `${f.op}${f.key}:${String(f.value)}`).join(',')
-      )
-    }
+    fieldFilters.forEach((f) => {
+      params.append('filters', `${f.op}${f.key}:${String(f.value)}`)
+    })
 
     const token = sessionStorage.getItem('token')
     const headers = { 'Content-Type': 'application/json' }

--- a/xinference/ui/web/ui/src/scenes/logs/index.js
+++ b/xinference/ui/web/ui/src/scenes/logs/index.js
@@ -5,8 +5,10 @@ import 'dayjs/locale/zh-cn'
 import {
   AccessTime,
   AddCircleOutline,
+  ArticleOutlined,
   CalendarToday,
   Check as CheckIcon,
+  Close as CloseIcon,
   ContentCopy as ContentCopyIcon,
   ExpandMore as ExpandMoreIcon,
   Refresh as RefreshIcon,
@@ -19,7 +21,11 @@ import {
   Box,
   Button,
   Chip,
+  CircularProgress,
   Collapse,
+  Dialog,
+  DialogContent,
+  DialogTitle,
   Divider,
   FormControl,
   IconButton,
@@ -153,7 +159,7 @@ function formatFieldValue(value) {
   return String(value)
 }
 
-function DetailRow({ row, onFilter, fieldFilters, appliedSearch, selectedLevels, selectedLogType }) {
+function DetailRow({ row, onFilter, fieldFilters, appliedSearch, selectedLevels, selectedLogType, endPoint, onViewContext }) {
   const [tab, setTab] = useState(0)
   const [copied, setCopied] = useState(false)
   const copyTimerRef = useRef(null)
@@ -194,19 +200,40 @@ function DetailRow({ row, onFilter, fieldFilters, appliedSearch, selectedLevels,
     activeFilterMap.get('log_type').add(selectedLogType)
   }
 
+  const [contextOpen, setContextOpen] = useState(false)
+
+  const handleViewContext = (e) => {
+    e.stopPropagation()
+    if (onViewContext) {
+      onViewContext(row)
+    } else {
+      setContextOpen(true)
+    }
+  }
+
   return (
     <Box sx={{ px: 2, pb: 2 }}>
-      <Tabs
-        value={tab}
-        onChange={(_, v) => setTab(v)}
-        sx={{
-          'minHeight': 32,
-          '& .MuiTab-root': { minHeight: 32, fontSize: FONT_SIZE, textTransform: 'none', py: 0.5 },
-        }}
-      >
-        <Tab label={t('logs.detail.tableTab')} />
-        <Tab label={t('logs.detail.jsonTab')} />
-      </Tabs>
+      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <Tabs
+          value={tab}
+          onChange={(_, v) => setTab(v)}
+          sx={{
+            'minHeight': 32,
+            '& .MuiTab-root': { minHeight: 32, fontSize: FONT_SIZE, textTransform: 'none', py: 0.5 },
+          }}
+        >
+          <Tab label={t('logs.detail.tableTab')} />
+          <Tab label={t('logs.detail.jsonTab')} />
+        </Tabs>
+        <Button
+          size="small"
+          startIcon={<ArticleOutlined sx={{ fontSize: 16 }} />}
+          onClick={handleViewContext}
+          sx={{ fontSize: FONT_SIZE, textTransform: 'none', whiteSpace: 'nowrap' }}
+        >
+          {t('logs.detail.viewContext')}
+        </Button>
+      </Box>
       {tab === 0 ? (
         <Table size="small" sx={{ mt: 1 }}>
           <TableHead>
@@ -301,7 +328,273 @@ function DetailRow({ row, onFilter, fieldFilters, appliedSearch, selectedLevels,
           </pre>
         </Box>
       )}
+      {!onViewContext && (
+        <ContextDialog
+          open={contextOpen}
+          onClose={() => setContextOpen(false)}
+          anchorRow={row}
+          endPoint={endPoint}
+        />
+      )}
     </Box>
+  )
+}
+
+function ContextDialog({ open, onClose, anchorRow, endPoint }) {
+  const { t } = useTranslation()
+  const [currentAnchor, setCurrentAnchor] = useState(anchorRow)
+  const [olderSize, setOlderSize] = useState(5)
+  const [newerSize, setNewerSize] = useState(5)
+  const [olderLoadCount, setOlderLoadCount] = useState(5)
+  const [newerLoadCount, setNewerLoadCount] = useState(5)
+  const [older, setOlder] = useState([])
+  const [newer, setNewer] = useState([])
+  const [hasMoreOlder, setHasMoreOlder] = useState(false)
+  const [hasMoreNewer, setHasMoreNewer] = useState(false)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState(null)
+  const [expandedRow, setExpandedRow] = useState(null)
+  const [localFieldFilters, setLocalFieldFilters] = useState([])
+  const anchorRef = useRef(null)
+
+  useEffect(() => {
+    if (open && anchorRow) setCurrentAnchor(anchorRow)
+  }, [open, anchorRow])
+
+  const timestamp = currentAnchor ? currentAnchor['@timestamp'] : null
+
+  useEffect(() => {
+    if (!open || !timestamp) return
+    setLoading(true)
+    setError(null)
+
+    const params = new URLSearchParams()
+    params.set('timestamp', timestamp)
+    params.set('size', String(Math.max(olderSize, newerSize)))
+    if (currentAnchor.node) params.set('node', currentAnchor.node)
+
+    const token = sessionStorage.getItem('token')
+    const headers = { 'Content-Type': 'application/json' }
+    if (token) headers['Authorization'] = `Bearer ${token}`
+
+    fetch(endPoint + '/v1/cluster/logs/context?' + params.toString(), { headers })
+      .then((res) => {
+        if (res.status === 404) {
+          setError('notFound')
+          return null
+        }
+        if (!res.ok) throw new Error(`HTTP ${res.status}`)
+        return res.json()
+      })
+      .then((data) => {
+        if (!data) return
+        setOlder((data.older || []).slice(0, olderSize))
+        setNewer((data.newer || []).slice(0, newerSize))
+        setHasMoreOlder(data.has_more_older || false)
+        setHasMoreNewer(data.has_more_newer || false)
+      })
+      .catch(() => setError('fetchError'))
+      .finally(() => setLoading(false))
+  }, [open, timestamp, olderSize, newerSize, currentAnchor, endPoint])
+
+  useEffect(() => {
+    if (!loading && anchorRef.current) {
+      anchorRef.current.scrollIntoView({ block: 'center', behavior: 'smooth' })
+    }
+  }, [loading, older, newer])
+
+  const resetState = () => {
+    setOlderSize(5)
+    setNewerSize(5)
+    setOlderLoadCount(5)
+    setNewerLoadCount(5)
+    setOlder([])
+    setNewer([])
+    setError(null)
+    setExpandedRow(null)
+    setLocalFieldFilters([])
+  }
+
+  const handleClose = () => {
+    resetState()
+    onClose()
+  }
+
+  const handleSwitchAnchor = (row) => {
+    resetState()
+    setCurrentAnchor(row)
+  }
+
+  const handleLocalFilter = useCallback((key, value, op) => {
+    const valStr = String(value)
+    setLocalFieldFilters((prev) => {
+      const exists = prev.find((f) => f.key === key && f.value === valStr && f.op === op)
+      if (exists) return prev.filter((f) => f !== exists)
+      return [...prev, { key, value: valStr, op }]
+    })
+  }, [])
+
+  const clampCount = (val) => Math.max(1, Math.min(500, Number(val) || 1))
+
+  const formatTime = (ts) => {
+    if (!ts) return ''
+    const d = new Date(ts)
+    return d.toLocaleString([], {
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      hour12: false,
+    })
+  }
+
+  const colSpan = 5
+
+  const renderLoadBar = (direction) => {
+    const isNewer = direction === 'newer'
+    const count = isNewer ? newerLoadCount : olderLoadCount
+    const setCount = isNewer ? setNewerLoadCount : setOlderLoadCount
+    const setSize = isNewer ? setNewerSize : setOlderSize
+    const hasMore = isNewer ? hasMoreNewer : hasMoreOlder
+    if (!hasMore) return null
+    return (
+      <TableRow>
+        <TableCell colSpan={colSpan} sx={{ py: 0.5 }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <Button
+              size="small"
+              onClick={() => setSize((s) => s + clampCount(count))}
+              sx={{ fontSize: FONT_SIZE, textTransform: 'none' }}
+            >
+              {t(isNewer ? 'logs.detail.loadNewer' : 'logs.detail.loadOlder')}
+            </Button>
+            <TextField
+              size="small"
+              type="number"
+              value={count}
+              onChange={(e) => setCount(clampCount(e.target.value))}
+              onBlur={(e) => setCount(clampCount(e.target.value))}
+              inputProps={{ min: 1, max: 500, style: { fontSize: FONT_SIZE, width: 48, textAlign: 'center', padding: '2px 4px' } }}
+              sx={{ '& .MuiOutlinedInput-root': { height: 28 } }}
+            />
+            <Typography sx={{ fontSize: FONT_SIZE, color: 'text.secondary' }}>
+              {t(isNewer ? 'logs.detail.newerDocs' : 'logs.detail.olderDocs')}
+            </Typography>
+          </Box>
+        </TableCell>
+      </TableRow>
+    )
+  }
+
+  const renderContextRow = (row, rowKey, isAnchor) => {
+    const isExpanded = expandedRow === rowKey
+    return (
+      <React.Fragment key={rowKey}>
+        <TableRow
+          ref={isAnchor ? anchorRef : undefined}
+          sx={{
+            ...(isAnchor ? { bgcolor: '#e3f2fd' } : undefined),
+            'cursor': 'pointer',
+            '& > *': { borderBottom: isExpanded ? 'none' : undefined },
+          }}
+          hover={!isAnchor}
+          onClick={() => setExpandedRow(isExpanded ? null : rowKey)}
+        >
+          <TableCell sx={{ fontSize: FONT_SIZE, p: 0.5, width: 32 }}>
+            <ExpandMoreIcon
+              fontSize="small"
+              sx={{ transform: isExpanded ? 'rotate(180deg)' : 'none', transition: 'transform 0.2s' }}
+            />
+          </TableCell>
+          <TableCell sx={{ fontSize: FONT_SIZE, whiteSpace: 'nowrap' }}>
+            {formatTime(row['@timestamp'])}
+          </TableCell>
+          <TableCell sx={{ fontSize: FONT_SIZE }}>
+            <Typography
+              component="span"
+              sx={{ fontSize: FONT_SIZE, fontWeight: 600, color: LEVEL_COLORS[row.level] || 'text.primary' }}
+            >
+              {row.level}
+            </Typography>
+          </TableCell>
+          <TableCell sx={{ fontSize: FONT_SIZE }}>{row.node}</TableCell>
+          <TableCell
+            sx={{ fontSize: FONT_SIZE, maxWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+          >
+            {row.message}
+          </TableCell>
+        </TableRow>
+        <TableRow>
+          <TableCell sx={{ p: 0 }} colSpan={colSpan}>
+            <Collapse in={isExpanded} timeout="auto" unmountOnExit>
+              <DetailRow
+                row={row}
+                onFilter={handleLocalFilter}
+                fieldFilters={localFieldFilters}
+                appliedSearch=""
+                selectedLevels={[]}
+                selectedLogType=""
+                endPoint={endPoint}
+                onViewContext={handleSwitchAnchor}
+              />
+            </Collapse>
+          </TableCell>
+        </TableRow>
+      </React.Fragment>
+    )
+  }
+
+  const newerDesc = [...newer].reverse()
+
+  return (
+    <Dialog open={open} onClose={handleClose} fullWidth maxWidth="lg">
+      <DialogTitle sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', fontSize: FONT_SIZE, py: 1.5 }}>
+        {t('logs.detail.contextTitle')}
+        <IconButton size="small" onClick={handleClose}>
+          <CloseIcon fontSize="small" />
+        </IconButton>
+      </DialogTitle>
+      <DialogContent dividers sx={{ p: 0 }}>
+        {loading && (
+          <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+            <CircularProgress size={28} />
+          </Box>
+        )}
+        {error === 'notFound' && (
+          <Box sx={{ py: 4, textAlign: 'center' }}>
+            <Typography color="text.secondary">{t('logs.detail.contextError')}</Typography>
+          </Box>
+        )}
+        {error === 'fetchError' && (
+          <Box sx={{ py: 4, textAlign: 'center' }}>
+            <Typography color="error">{t('logs.detail.contextFetchError')}</Typography>
+          </Box>
+        )}
+        {!loading && !error && (
+          <TableContainer sx={{ maxHeight: '60vh' }}>
+            <Table size="small" stickyHeader>
+              <TableHead>
+                <TableRow>
+                  <TableCell sx={{ width: 32, fontSize: FONT_SIZE }} />
+                  <TableCell sx={{ width: 150, fontSize: FONT_SIZE }}>{t('logs.time')}</TableCell>
+                  <TableCell sx={{ width: 80, fontSize: FONT_SIZE }}>{t('logs.level')}</TableCell>
+                  <TableCell sx={{ width: 160, fontSize: FONT_SIZE }}>{t('logs.node')}</TableCell>
+                  <TableCell sx={{ fontSize: FONT_SIZE }}>{t('logs.message')}</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {renderLoadBar('newer')}
+                {newerDesc.map((row, idx) => renderContextRow(row, `newer-${idx}`, false))}
+                {currentAnchor && renderContextRow(currentAnchor, 'anchor', true)}
+                {older.map((row, idx) => renderContextRow(row, `older-${idx}`, false))}
+                {renderLoadBar('older')}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        )}
+      </DialogContent>
+    </Dialog>
   )
 }
 
@@ -863,7 +1156,7 @@ const Logs = () => {
                   <TableRow>
                     <TableCell sx={{ p: 0 }} colSpan={5}>
                       <Collapse in={isExpanded} timeout="auto" unmountOnExit>
-                        <DetailRow row={row} onFilter={handleFieldFilter} fieldFilters={fieldFilters} appliedSearch={appliedSearch} selectedLevels={selectedLevels} selectedLogType={selectedLogType} />
+                        <DetailRow row={row} onFilter={handleFieldFilter} fieldFilters={fieldFilters} appliedSearch={appliedSearch} selectedLevels={selectedLevels} selectedLogType={selectedLogType} endPoint={endPoint} />
                       </Collapse>
                     </TableCell>
                   </TableRow>

--- a/xinference/ui/web/ui/src/scenes/logs/index.js
+++ b/xinference/ui/web/ui/src/scenes/logs/index.js
@@ -6,6 +6,8 @@ import {
   AccessTime,
   AddCircleOutline,
   CalendarToday,
+  Check as CheckIcon,
+  ContentCopy as ContentCopyIcon,
   ExpandMore as ExpandMoreIcon,
   Refresh as RefreshIcon,
   RemoveCircleOutline,
@@ -102,6 +104,19 @@ const LEVEL_COLORS = {
   DEBUG: 'text.disabled',
 }
 
+function copyToClipboard(text) {
+  if (navigator.clipboard) {
+    return navigator.clipboard.writeText(text)
+  }
+  const textarea = document.createElement('textarea')
+  textarea.value = text
+  document.body.appendChild(textarea)
+  textarea.select()
+  document.execCommand('copy')
+  document.body.removeChild(textarea)
+  return Promise.resolve()
+}
+
 function HighlightText({ text, keywords }) {
   if (!text) return ''
   const validKeywords = (Array.isArray(keywords) ? keywords : [keywords]).filter(
@@ -140,7 +155,22 @@ function formatFieldValue(value) {
 
 function DetailRow({ row, onFilter, fieldFilters, appliedSearch, selectedLevels, selectedLogType }) {
   const [tab, setTab] = useState(0)
+  const [copied, setCopied] = useState(false)
+  const copyTimerRef = useRef(null)
   const { t } = useTranslation()
+
+  useEffect(() => {
+    return () => {
+      if (copyTimerRef.current) clearTimeout(copyTimerRef.current)
+    }
+  }, [])
+
+  const handleCopyJson = () => {
+    copyToClipboard(JSON.stringify(row, null, 2)).then(() => {
+      setCopied(true)
+      copyTimerRef.current = setTimeout(() => setCopied(false), 1500)
+    })
+  }
 
   const fields = Object.entries(row).filter(
     ([, v]) => v !== undefined && v !== null && v !== ''
@@ -254,8 +284,18 @@ function DetailRow({ row, onFilter, fieldFilters, appliedSearch, selectedLevels,
             borderRadius: 1,
             overflow: 'auto',
             maxHeight: 400,
+            position: 'relative',
           }}
         >
+          <Tooltip title={copied ? t('logs.detail.copied') : t('logs.detail.copyJson')}>
+            <IconButton
+              size="small"
+              onClick={handleCopyJson}
+              sx={{ position: 'absolute', top: 4, right: 4 }}
+            >
+              {copied ? <CheckIcon sx={{ fontSize: 16 }} /> : <ContentCopyIcon sx={{ fontSize: 16 }} />}
+            </IconButton>
+          </Tooltip>
           <pre style={{ margin: 0, fontSize: FONT_SIZE, fontFamily: 'monospace', whiteSpace: 'pre-wrap', wordBreak: 'break-all' }}>
             {JSON.stringify(row, null, 2)}
           </pre>

--- a/xinference/ui/web/ui/src/scenes/logs/index.js
+++ b/xinference/ui/web/ui/src/scenes/logs/index.js
@@ -125,11 +125,12 @@ function copyToClipboard(text) {
 
 function HighlightText({ text, keywords }) {
   if (!text) return ''
-  const validKeywords = (Array.isArray(keywords) ? keywords : [keywords]).filter(
-    (k) => k && typeof k === 'string' && k.trim()
-  )
+  const validKeywords = (
+    Array.isArray(keywords) ? keywords : [keywords]
+  ).filter((k) => k && typeof k === 'string' && k.trim())
   if (!validKeywords.length) return text
   const escaped = validKeywords
+    .sort((a, b) => b.length - a.length)
     .map((k) => k.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
     .join('|')
   const parts = String(text).split(new RegExp(`(${escaped})`, 'gi'))
@@ -159,7 +160,16 @@ function formatFieldValue(value) {
   return String(value)
 }
 
-function DetailRow({ row, onFilter, fieldFilters, appliedSearch, selectedLevels, selectedLogType, endPoint, onViewContext }) {
+function DetailRow({
+  row,
+  onFilter,
+  fieldFilters,
+  appliedSearch,
+  selectedLevels,
+  selectedLogType,
+  endPoint,
+  onViewContext,
+}) {
   const [tab, setTab] = useState(0)
   const [copied, setCopied] = useState(false)
   const copyTimerRef = useRef(null)
@@ -196,7 +206,8 @@ function DetailRow({ row, onFilter, fieldFilters, appliedSearch, selectedLevels,
     selectedLevels.forEach((v) => activeFilterMap.get('level').add(v))
   }
   if (selectedLogType) {
-    if (!activeFilterMap.has('log_type')) activeFilterMap.set('log_type', new Set())
+    if (!activeFilterMap.has('log_type'))
+      activeFilterMap.set('log_type', new Set())
     activeFilterMap.get('log_type').add(selectedLogType)
   }
 
@@ -213,13 +224,24 @@ function DetailRow({ row, onFilter, fieldFilters, appliedSearch, selectedLevels,
 
   return (
     <Box sx={{ px: 2, pb: 2 }}>
-      <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+        }}
+      >
         <Tabs
           value={tab}
           onChange={(_, v) => setTab(v)}
           sx={{
             'minHeight': 32,
-            '& .MuiTab-root': { minHeight: 32, fontSize: FONT_SIZE, textTransform: 'none', py: 0.5 },
+            '& .MuiTab-root': {
+              minHeight: 32,
+              fontSize: FONT_SIZE,
+              textTransform: 'none',
+              py: 0.5,
+            },
           }}
         >
           <Tab label={t('logs.detail.tableTab')} />
@@ -229,7 +251,11 @@ function DetailRow({ row, onFilter, fieldFilters, appliedSearch, selectedLevels,
           size="small"
           startIcon={<ArticleOutlined sx={{ fontSize: 16 }} />}
           onClick={handleViewContext}
-          sx={{ fontSize: FONT_SIZE, textTransform: 'none', whiteSpace: 'nowrap' }}
+          sx={{
+            fontSize: FONT_SIZE,
+            textTransform: 'none',
+            whiteSpace: 'nowrap',
+          }}
         >
           {t('logs.detail.viewContext')}
         </Button>
@@ -238,10 +264,14 @@ function DetailRow({ row, onFilter, fieldFilters, appliedSearch, selectedLevels,
         <Table size="small" sx={{ mt: 1 }}>
           <TableHead>
             <TableRow>
-              <TableCell sx={{ fontSize: FONT_SIZE, width: 80, fontWeight: 600 }}>
+              <TableCell
+                sx={{ fontSize: FONT_SIZE, width: 80, fontWeight: 600 }}
+              >
                 {t('logs.detail.action')}
               </TableCell>
-              <TableCell sx={{ fontSize: FONT_SIZE, width: 200, fontWeight: 600 }}>
+              <TableCell
+                sx={{ fontSize: FONT_SIZE, width: 200, fontWeight: 600 }}
+              >
                 {t('logs.detail.field')}
               </TableCell>
               <TableCell sx={{ fontSize: FONT_SIZE, fontWeight: 600 }}>
@@ -251,7 +281,9 @@ function DetailRow({ row, onFilter, fieldFilters, appliedSearch, selectedLevels,
           </TableHead>
           <TableBody>
             {fields.map(([key, val]) => {
-              const isFilterMatch = activeFilterMap.has(key) && activeFilterMap.get(key).has(String(val))
+              const isFilterMatch =
+                activeFilterMap.has(key) &&
+                activeFilterMap.get(key).has(String(val))
               const valueKeywords = []
               if (appliedSearch) valueKeywords.push(appliedSearch)
               if (isFilterMatch) valueKeywords.push(String(val))
@@ -287,15 +319,27 @@ function DetailRow({ row, onFilter, fieldFilters, appliedSearch, selectedLevels,
                     </Tooltip>
                   </TableCell>
                   <TableCell sx={{ fontSize: FONT_SIZE }}>
-                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                    <Box
+                      sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}
+                    >
                       <FieldTypeIcon fieldKey={key} value={val} />
-                      <HighlightText text={key} keywords={appliedSearch ? [appliedSearch] : []} />
+                      <HighlightText
+                        text={key}
+                        keywords={appliedSearch ? [appliedSearch] : []}
+                      />
                     </Box>
                   </TableCell>
                   <TableCell
-                    sx={{ fontSize: FONT_SIZE, wordBreak: 'break-all', fontFamily: 'monospace' }}
+                    sx={{
+                      fontSize: FONT_SIZE,
+                      wordBreak: 'break-all',
+                      fontFamily: 'monospace',
+                    }}
                   >
-                    <HighlightText text={formatFieldValue(val)} keywords={valueKeywords} />
+                    <HighlightText
+                      text={formatFieldValue(val)}
+                      keywords={valueKeywords}
+                    />
                   </TableCell>
                 </TableRow>
               )
@@ -314,16 +358,30 @@ function DetailRow({ row, onFilter, fieldFilters, appliedSearch, selectedLevels,
             position: 'relative',
           }}
         >
-          <Tooltip title={copied ? t('logs.detail.copied') : t('logs.detail.copyJson')}>
+          <Tooltip
+            title={copied ? t('logs.detail.copied') : t('logs.detail.copyJson')}
+          >
             <IconButton
               size="small"
               onClick={handleCopyJson}
               sx={{ position: 'absolute', top: 4, right: 4 }}
             >
-              {copied ? <CheckIcon sx={{ fontSize: 16 }} /> : <ContentCopyIcon sx={{ fontSize: 16 }} />}
+              {copied ? (
+                <CheckIcon sx={{ fontSize: 16 }} />
+              ) : (
+                <ContentCopyIcon sx={{ fontSize: 16 }} />
+              )}
             </IconButton>
           </Tooltip>
-          <pre style={{ margin: 0, fontSize: FONT_SIZE, fontFamily: 'monospace', whiteSpace: 'pre-wrap', wordBreak: 'break-all' }}>
+          <pre
+            style={{
+              margin: 0,
+              fontSize: FONT_SIZE,
+              fontFamily: 'monospace',
+              whiteSpace: 'pre-wrap',
+              wordBreak: 'break-all',
+            }}
+          >
             {JSON.stringify(row, null, 2)}
           </pre>
         </Box>
@@ -377,7 +435,9 @@ function ContextDialog({ open, onClose, anchorRow, endPoint }) {
     const headers = { 'Content-Type': 'application/json' }
     if (token) headers['Authorization'] = `Bearer ${token}`
 
-    fetch(endPoint + '/v1/cluster/logs/context?' + params.toString(), { headers })
+    fetch(endPoint + '/v1/cluster/logs/context?' + params.toString(), {
+      headers,
+    })
       .then((res) => {
         if (res.status === 404) {
           setError('notFound')
@@ -428,7 +488,9 @@ function ContextDialog({ open, onClose, anchorRow, endPoint }) {
   const handleLocalFilter = useCallback((key, value, op) => {
     const valStr = String(value)
     setLocalFieldFilters((prev) => {
-      const exists = prev.find((f) => f.key === key && f.value === valStr && f.op === op)
+      const exists = prev.find(
+        (f) => f.key === key && f.value === valStr && f.op === op
+      )
       if (exists) return prev.filter((f) => f !== exists)
       return [...prev, { key, value: valStr, op }]
     })
@@ -498,8 +560,19 @@ function ContextDialog({ open, onClose, anchorRow, endPoint }) {
               value={count}
               onChange={(e) => setCount(clampCount(e.target.value))}
               onBlur={(e) => setCount(clampCount(e.target.value))}
-              onKeyDown={(e) => { if (e.key === 'Enter') setSize((s) => s + clampCount(count)) }}
-              inputProps={{ min: 1, max: 500, style: { fontSize: FONT_SIZE, width: 48, textAlign: 'center', padding: '2px 4px' } }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') setSize((s) => s + clampCount(count))
+              }}
+              inputProps={{
+                min: 1,
+                max: 500,
+                style: {
+                  fontSize: FONT_SIZE,
+                  width: 48,
+                  textAlign: 'center',
+                  padding: '2px 4px',
+                },
+              }}
               sx={{ '& .MuiOutlinedInput-root': { height: 28 } }}
             />
             <Typography sx={{ fontSize: FONT_SIZE, color: 'text.secondary' }}>
@@ -528,7 +601,10 @@ function ContextDialog({ open, onClose, anchorRow, endPoint }) {
           <TableCell sx={{ fontSize: FONT_SIZE, p: 0.5, width: 32 }}>
             <ExpandMoreIcon
               fontSize="small"
-              sx={{ transform: isExpanded ? 'rotate(180deg)' : 'none', transition: 'transform 0.2s' }}
+              sx={{
+                transform: isExpanded ? 'rotate(180deg)' : 'none',
+                transition: 'transform 0.2s',
+              }}
             />
           </TableCell>
           <TableCell sx={{ fontSize: FONT_SIZE, whiteSpace: 'nowrap' }}>
@@ -537,14 +613,24 @@ function ContextDialog({ open, onClose, anchorRow, endPoint }) {
           <TableCell sx={{ fontSize: FONT_SIZE }}>
             <Typography
               component="span"
-              sx={{ fontSize: FONT_SIZE, fontWeight: 600, color: LEVEL_COLORS[row.level] || 'text.primary' }}
+              sx={{
+                fontSize: FONT_SIZE,
+                fontWeight: 600,
+                color: LEVEL_COLORS[row.level] || 'text.primary',
+              }}
             >
               {row.level}
             </Typography>
           </TableCell>
           <TableCell sx={{ fontSize: FONT_SIZE }}>{row.node}</TableCell>
           <TableCell
-            sx={{ fontSize: FONT_SIZE, maxWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+            sx={{
+              fontSize: FONT_SIZE,
+              maxWidth: 0,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
           >
             {row.message}
           </TableCell>
@@ -574,7 +660,15 @@ function ContextDialog({ open, onClose, anchorRow, endPoint }) {
 
   return (
     <Dialog open={open} onClose={handleClose} fullWidth maxWidth="lg">
-      <DialogTitle sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', fontSize: FONT_SIZE, py: 1.5 }}>
+      <DialogTitle
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          fontSize: FONT_SIZE,
+          py: 1.5,
+        }}
+      >
         {t('logs.detail.contextTitle')}
         <IconButton size="small" onClick={handleClose}>
           <CloseIcon fontSize="small" />
@@ -588,12 +682,16 @@ function ContextDialog({ open, onClose, anchorRow, endPoint }) {
         )}
         {error === 'notFound' && (
           <Box sx={{ py: 4, textAlign: 'center' }}>
-            <Typography color="text.secondary">{t('logs.detail.contextError')}</Typography>
+            <Typography color="text.secondary">
+              {t('logs.detail.contextError')}
+            </Typography>
           </Box>
         )}
         {error === 'fetchError' && (
           <Box sx={{ py: 4, textAlign: 'center' }}>
-            <Typography color="error">{t('logs.detail.contextFetchError')}</Typography>
+            <Typography color="error">
+              {t('logs.detail.contextFetchError')}
+            </Typography>
           </Box>
         )}
         {!loading && !error && (
@@ -614,11 +712,19 @@ function ContextDialog({ open, onClose, anchorRow, endPoint }) {
                 {localFieldFilters.map((f, i) => (
                   <Chip
                     key={`${f.op}${f.key}:${f.value}-${i}`}
-                    label={f.op === '-' ? `NOT ${f.key}: ${f.value}` : `${f.key}: ${f.value}`}
+                    label={
+                      f.op === '-'
+                        ? `NOT ${f.key}: ${f.value}`
+                        : `${f.key}: ${f.value}`
+                    }
                     size="small"
                     color={f.op === '-' ? 'error' : 'default'}
                     variant={f.op === '-' ? 'outlined' : 'filled'}
-                    onDelete={() => setLocalFieldFilters((prev) => prev.filter((_, idx) => idx !== i))}
+                    onDelete={() =>
+                      setLocalFieldFilters((prev) =>
+                        prev.filter((_, idx) => idx !== i)
+                      )
+                    }
                     sx={{ fontSize: FONT_SIZE }}
                   />
                 ))}
@@ -636,17 +742,30 @@ function ContextDialog({ open, onClose, anchorRow, endPoint }) {
                 <TableHead>
                   <TableRow>
                     <TableCell sx={{ width: 32, fontSize: FONT_SIZE }} />
-                    <TableCell sx={{ width: 150, fontSize: FONT_SIZE }}>{t('logs.time')}</TableCell>
-                    <TableCell sx={{ width: 80, fontSize: FONT_SIZE }}>{t('logs.level')}</TableCell>
-                    <TableCell sx={{ width: 160, fontSize: FONT_SIZE }}>{t('logs.node')}</TableCell>
-                    <TableCell sx={{ fontSize: FONT_SIZE }}>{t('logs.message')}</TableCell>
+                    <TableCell sx={{ width: 150, fontSize: FONT_SIZE }}>
+                      {t('logs.time')}
+                    </TableCell>
+                    <TableCell sx={{ width: 80, fontSize: FONT_SIZE }}>
+                      {t('logs.level')}
+                    </TableCell>
+                    <TableCell sx={{ width: 160, fontSize: FONT_SIZE }}>
+                      {t('logs.node')}
+                    </TableCell>
+                    <TableCell sx={{ fontSize: FONT_SIZE }}>
+                      {t('logs.message')}
+                    </TableCell>
                   </TableRow>
                 </TableHead>
                 <TableBody>
                   {renderLoadBar('newer')}
-                  {newerDesc.map((row, idx) => renderContextRow(row, `newer-${idx}`, false))}
-                  {currentAnchor && renderContextRow(currentAnchor, 'anchor', true)}
-                  {filteredOlder.map((row, idx) => renderContextRow(row, `older-${idx}`, false))}
+                  {newerDesc.map((row, idx) =>
+                    renderContextRow(row, `newer-${idx}`, false)
+                  )}
+                  {currentAnchor &&
+                    renderContextRow(currentAnchor, 'anchor', true)}
+                  {filteredOlder.map((row, idx) =>
+                    renderContextRow(row, `older-${idx}`, false)
+                  )}
                   {renderLoadBar('older')}
                 </TableBody>
               </Table>
@@ -732,9 +851,7 @@ const Logs = () => {
     if (fieldFilters.length) {
       params.set(
         'filters',
-        fieldFilters
-          .map((f) => `${f.op}${f.key}:${String(f.value)}`)
-          .join(',')
+        fieldFilters.map((f) => `${f.op}${f.key}:${String(f.value)}`).join(',')
       )
     }
 
@@ -1149,80 +1266,100 @@ const Logs = () => {
           <TableBody>
             {(() => {
               const levelFilterValues = [
-                ...fieldFilters.filter((f) => f.op === '+' && f.key === 'level').map((f) => f.value),
+                ...fieldFilters
+                  .filter((f) => f.op === '+' && f.key === 'level')
+                  .map((f) => f.value),
                 ...selectedLevels,
               ]
-              const nodeFilterValues = fieldFilters.filter((f) => f.op === '+' && f.key === 'node').map((f) => f.value)
-              const messageFilterValues = fieldFilters.filter((f) => f.op === '+' && f.key === 'message').map((f) => f.value)
+              const nodeFilterValues = fieldFilters
+                .filter((f) => f.op === '+' && f.key === 'node')
+                .map((f) => f.value)
+              const messageFilterValues = fieldFilters
+                .filter((f) => f.op === '+' && f.key === 'message')
+                .map((f) => f.value)
 
               return logs.map((row, idx) => {
-              const isExpanded = expandedRow === idx
-              return (
-                <React.Fragment key={idx}>
-                  <TableRow
-                    hover
-                    sx={{
-                      'cursor': 'pointer',
-                      '& > *': {
-                        borderBottom: isExpanded ? 'none' : undefined,
-                      },
-                    }}
-                    onClick={() => setExpandedRow(isExpanded ? null : idx)}
-                  >
-                    <TableCell sx={{ fontSize: FONT_SIZE, p: 0.5 }}>
-                      <ExpandMoreIcon
-                        fontSize="small"
-                        sx={{
-                          transform: isExpanded ? 'rotate(180deg)' : 'none',
-                          transition: 'transform 0.2s',
-                        }}
-                      />
-                    </TableCell>
-                    <TableCell
-                      sx={{ fontSize: FONT_SIZE, whiteSpace: 'nowrap' }}
+                const isExpanded = expandedRow === idx
+                return (
+                  <React.Fragment key={idx}>
+                    <TableRow
+                      hover
+                      sx={{
+                        'cursor': 'pointer',
+                        '& > *': {
+                          borderBottom: isExpanded ? 'none' : undefined,
+                        },
+                      }}
+                      onClick={() => setExpandedRow(isExpanded ? null : idx)}
                     >
-                      {formatTime(row['@timestamp'])}
-                    </TableCell>
-                    <TableCell sx={{ fontSize: FONT_SIZE }}>
-                      <Typography
-                        component="span"
+                      <TableCell sx={{ fontSize: FONT_SIZE, p: 0.5 }}>
+                        <ExpandMoreIcon
+                          fontSize="small"
+                          sx={{
+                            transform: isExpanded ? 'rotate(180deg)' : 'none',
+                            transition: 'transform 0.2s',
+                          }}
+                        />
+                      </TableCell>
+                      <TableCell
+                        sx={{ fontSize: FONT_SIZE, whiteSpace: 'nowrap' }}
+                      >
+                        {formatTime(row['@timestamp'])}
+                      </TableCell>
+                      <TableCell sx={{ fontSize: FONT_SIZE }}>
+                        <Typography
+                          component="span"
+                          sx={{
+                            fontSize: FONT_SIZE,
+                            fontWeight: 600,
+                            color: LEVEL_COLORS[row.level] || 'text.primary',
+                          }}
+                        >
+                          <HighlightText
+                            text={row.level}
+                            keywords={levelFilterValues}
+                          />
+                        </Typography>
+                      </TableCell>
+                      <TableCell sx={{ fontSize: FONT_SIZE }}>
+                        <HighlightText
+                          text={row.node}
+                          keywords={nodeFilterValues}
+                        />
+                      </TableCell>
+                      <TableCell
                         sx={{
                           fontSize: FONT_SIZE,
-                          fontWeight: 600,
-                          color: LEVEL_COLORS[row.level] || 'text.primary',
+                          maxWidth: 0,
+                          overflow: 'hidden',
+                          textOverflow: 'ellipsis',
+                          whiteSpace: 'nowrap',
                         }}
                       >
-                        <HighlightText text={row.level} keywords={levelFilterValues} />
-                      </Typography>
-                    </TableCell>
-                    <TableCell sx={{ fontSize: FONT_SIZE }}>
-                      <HighlightText text={row.node} keywords={nodeFilterValues} />
-                    </TableCell>
-                    <TableCell
-                      sx={{
-                        fontSize: FONT_SIZE,
-                        maxWidth: 0,
-                        overflow: 'hidden',
-                        textOverflow: 'ellipsis',
-                        whiteSpace: 'nowrap',
-                      }}
-                    >
-                      <HighlightText
-                        text={row.message}
-                        keywords={[appliedSearch, ...messageFilterValues]}
-                      />
-                    </TableCell>
-                  </TableRow>
-                  <TableRow>
-                    <TableCell sx={{ p: 0 }} colSpan={5}>
-                      <Collapse in={isExpanded} timeout="auto" unmountOnExit>
-                        <DetailRow row={row} onFilter={handleFieldFilter} fieldFilters={fieldFilters} appliedSearch={appliedSearch} selectedLevels={selectedLevels} selectedLogType={selectedLogType} endPoint={endPoint} />
-                      </Collapse>
-                    </TableCell>
-                  </TableRow>
-                </React.Fragment>
-              )
-            })
+                        <HighlightText
+                          text={row.message}
+                          keywords={[appliedSearch, ...messageFilterValues]}
+                        />
+                      </TableCell>
+                    </TableRow>
+                    <TableRow>
+                      <TableCell sx={{ p: 0 }} colSpan={5}>
+                        <Collapse in={isExpanded} timeout="auto" unmountOnExit>
+                          <DetailRow
+                            row={row}
+                            onFilter={handleFieldFilter}
+                            fieldFilters={fieldFilters}
+                            appliedSearch={appliedSearch}
+                            selectedLevels={selectedLevels}
+                            selectedLogType={selectedLogType}
+                            endPoint={endPoint}
+                          />
+                        </Collapse>
+                      </TableCell>
+                    </TableRow>
+                  </React.Fragment>
+                )
+              })
             })()}
             {!loading && logs.length === 0 && (
               <TableRow>

--- a/xinference/ui/web/ui/src/scenes/logs/index.js
+++ b/xinference/ui/web/ui/src/scenes/logs/index.js
@@ -436,6 +436,29 @@ function ContextDialog({ open, onClose, anchorRow, endPoint }) {
 
   const clampCount = (val) => Math.max(1, Math.min(500, Number(val) || 1))
 
+  const filterRows = (rows) => {
+    if (!localFieldFilters.length) return rows
+    const plusByKey = {}
+    const minusFilters = []
+    localFieldFilters.forEach((f) => {
+      if (f.op === '+') {
+        if (!plusByKey[f.key]) plusByKey[f.key] = []
+        plusByKey[f.key].push(f.value)
+      } else {
+        minusFilters.push(f)
+      }
+    })
+    return rows.filter((row) => {
+      for (const [key, values] of Object.entries(plusByKey)) {
+        if (!values.includes(String(row[key]))) return false
+      }
+      for (const f of minusFilters) {
+        if (String(row[f.key]) === f.value) return false
+      }
+      return true
+    })
+  }
+
   const formatTime = (ts) => {
     if (!ts) return ''
     const d = new Date(ts)
@@ -475,6 +498,7 @@ function ContextDialog({ open, onClose, anchorRow, endPoint }) {
               value={count}
               onChange={(e) => setCount(clampCount(e.target.value))}
               onBlur={(e) => setCount(clampCount(e.target.value))}
+              onKeyDown={(e) => { if (e.key === 'Enter') setSize((s) => s + clampCount(count)) }}
               inputProps={{ min: 1, max: 500, style: { fontSize: FONT_SIZE, width: 48, textAlign: 'center', padding: '2px 4px' } }}
               sx={{ '& .MuiOutlinedInput-root': { height: 28 } }}
             />
@@ -545,7 +569,8 @@ function ContextDialog({ open, onClose, anchorRow, endPoint }) {
     )
   }
 
-  const newerDesc = [...newer].reverse()
+  const newerDesc = filterRows([...newer].reverse())
+  const filteredOlder = filterRows(older)
 
   return (
     <Dialog open={open} onClose={handleClose} fullWidth maxWidth="lg">
@@ -572,26 +597,61 @@ function ContextDialog({ open, onClose, anchorRow, endPoint }) {
           </Box>
         )}
         {!loading && !error && (
-          <TableContainer sx={{ maxHeight: '60vh' }}>
-            <Table size="small" stickyHeader>
-              <TableHead>
-                <TableRow>
-                  <TableCell sx={{ width: 32, fontSize: FONT_SIZE }} />
-                  <TableCell sx={{ width: 150, fontSize: FONT_SIZE }}>{t('logs.time')}</TableCell>
-                  <TableCell sx={{ width: 80, fontSize: FONT_SIZE }}>{t('logs.level')}</TableCell>
-                  <TableCell sx={{ width: 160, fontSize: FONT_SIZE }}>{t('logs.node')}</TableCell>
-                  <TableCell sx={{ fontSize: FONT_SIZE }}>{t('logs.message')}</TableCell>
-                </TableRow>
-              </TableHead>
-              <TableBody>
-                {renderLoadBar('newer')}
-                {newerDesc.map((row, idx) => renderContextRow(row, `newer-${idx}`, false))}
-                {currentAnchor && renderContextRow(currentAnchor, 'anchor', true)}
-                {older.map((row, idx) => renderContextRow(row, `older-${idx}`, false))}
-                {renderLoadBar('older')}
-              </TableBody>
-            </Table>
-          </TableContainer>
+          <>
+            {localFieldFilters.length > 0 && (
+              <Box
+                sx={{
+                  display: 'flex',
+                  flexWrap: 'wrap',
+                  gap: 0.5,
+                  px: 2,
+                  py: 0.5,
+                  borderBottom: 1,
+                  borderColor: 'divider',
+                  alignItems: 'center',
+                }}
+              >
+                {localFieldFilters.map((f, i) => (
+                  <Chip
+                    key={`${f.op}${f.key}:${f.value}-${i}`}
+                    label={f.op === '-' ? `NOT ${f.key}: ${f.value}` : `${f.key}: ${f.value}`}
+                    size="small"
+                    color={f.op === '-' ? 'error' : 'default'}
+                    variant={f.op === '-' ? 'outlined' : 'filled'}
+                    onDelete={() => setLocalFieldFilters((prev) => prev.filter((_, idx) => idx !== i))}
+                    sx={{ fontSize: FONT_SIZE }}
+                  />
+                ))}
+                <Chip
+                  label={t('logs.clearFilters', 'Clear all')}
+                  size="small"
+                  variant="outlined"
+                  onClick={() => setLocalFieldFilters([])}
+                  sx={{ fontSize: FONT_SIZE }}
+                />
+              </Box>
+            )}
+            <TableContainer sx={{ maxHeight: '60vh' }}>
+              <Table size="small" stickyHeader>
+                <TableHead>
+                  <TableRow>
+                    <TableCell sx={{ width: 32, fontSize: FONT_SIZE }} />
+                    <TableCell sx={{ width: 150, fontSize: FONT_SIZE }}>{t('logs.time')}</TableCell>
+                    <TableCell sx={{ width: 80, fontSize: FONT_SIZE }}>{t('logs.level')}</TableCell>
+                    <TableCell sx={{ width: 160, fontSize: FONT_SIZE }}>{t('logs.node')}</TableCell>
+                    <TableCell sx={{ fontSize: FONT_SIZE }}>{t('logs.message')}</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {renderLoadBar('newer')}
+                  {newerDesc.map((row, idx) => renderContextRow(row, `newer-${idx}`, false))}
+                  {currentAnchor && renderContextRow(currentAnchor, 'anchor', true)}
+                  {filteredOlder.map((row, idx) => renderContextRow(row, `older-${idx}`, false))}
+                  {renderLoadBar('older')}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          </>
         )}
       </DialogContent>
     </Dialog>

--- a/xinference/ui/web/ui/src/scenes/logs/index.js
+++ b/xinference/ui/web/ui/src/scenes/logs/index.js
@@ -4,9 +4,14 @@ import 'dayjs/locale/zh-cn'
 
 import {
   AccessTime,
+  AddCircleOutline,
+  CalendarToday,
   ExpandMore as ExpandMoreIcon,
   Refresh as RefreshIcon,
+  RemoveCircleOutline,
   Search as SearchIcon,
+  Tag as TagIcon,
+  TextFields as TextFieldsIcon,
 } from '@mui/icons-material'
 import {
   Box,
@@ -21,12 +26,14 @@ import {
   MenuList,
   Popover,
   Select,
+  Tab,
   Table,
   TableBody,
   TableCell,
   TableContainer,
   TableHead,
   TableRow,
+  Tabs,
   TextField,
   Toolbar,
   Tooltip,
@@ -95,12 +102,19 @@ const LEVEL_COLORS = {
   DEBUG: 'text.disabled',
 }
 
-function HighlightText({ text, keyword }) {
-  if (!keyword || !text) return text || ''
-  const escaped = keyword.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-  const parts = text.split(new RegExp(`(${escaped})`, 'gi'))
+function HighlightText({ text, keywords }) {
+  if (!text) return ''
+  const validKeywords = (Array.isArray(keywords) ? keywords : [keywords]).filter(
+    (k) => k && typeof k === 'string' && k.trim()
+  )
+  if (!validKeywords.length) return text
+  const escaped = validKeywords
+    .map((k) => k.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+    .join('|')
+  const parts = String(text).split(new RegExp(`(${escaped})`, 'gi'))
+  const lowerSet = new Set(validKeywords.map((k) => k.toLowerCase()))
   return parts.map((part, i) =>
-    part.toLowerCase() === keyword.toLowerCase() ? (
+    lowerSet.has(part.toLowerCase()) ? (
       <mark key={i} style={{ background: '#ffe082', padding: 0 }}>
         {part}
       </mark>
@@ -110,34 +124,143 @@ function HighlightText({ text, keyword }) {
   )
 }
 
-function DetailRow({ row }) {
+function FieldTypeIcon({ fieldKey, value }) {
+  if (fieldKey === '@timestamp')
+    return <CalendarToday sx={{ fontSize: 14, color: 'text.disabled' }} />
+  if (typeof value === 'number')
+    return <TagIcon sx={{ fontSize: 14, color: 'text.disabled' }} />
+  return <TextFieldsIcon sx={{ fontSize: 14, color: 'text.disabled' }} />
+}
+
+function formatFieldValue(value) {
+  if (value === null || value === undefined) return '-'
+  if (typeof value === 'object') return JSON.stringify(value)
+  return String(value)
+}
+
+function DetailRow({ row, onFilter, fieldFilters, appliedSearch, selectedLevels, selectedLogType }) {
+  const [tab, setTab] = useState(0)
   const { t } = useTranslation()
-  const fields = [
-    ['module', row.module],
-    ['pid', row.pid],
-    ['request_id', row.request_id],
-    ['address', row.address],
-    ['log_type', row.log_type],
-    ['rtf_avg', row.rtf_avg],
-    ['time_speech', row.time_speech],
-    ['time_escape', row.time_escape],
-  ].filter(([, v]) => v !== undefined && v !== null && v !== '')
+
+  const fields = Object.entries(row).filter(
+    ([, v]) => v !== undefined && v !== null && v !== ''
+  )
+
+  const activeFilterMap = new Map()
+  if (fieldFilters) {
+    fieldFilters.forEach((f) => {
+      if (f.op === '+') {
+        if (!activeFilterMap.has(f.key)) activeFilterMap.set(f.key, new Set())
+        activeFilterMap.get(f.key).add(f.value)
+      }
+    })
+  }
+  if (selectedLevels && selectedLevels.length) {
+    if (!activeFilterMap.has('level')) activeFilterMap.set('level', new Set())
+    selectedLevels.forEach((v) => activeFilterMap.get('level').add(v))
+  }
+  if (selectedLogType) {
+    if (!activeFilterMap.has('log_type')) activeFilterMap.set('log_type', new Set())
+    activeFilterMap.get('log_type').add(selectedLogType)
+  }
 
   return (
-    <Box sx={{ p: 2, display: 'flex', flexWrap: 'wrap', gap: 2 }}>
-      {fields.map(([key, val]) => (
-        <Box key={key} sx={{ minWidth: 180 }}>
-          <Typography variant="caption" color="text.secondary">
-            {t(`logs.detail.${key}`, key)}
-          </Typography>
-          <Typography
-            variant="body2"
-            sx={{ fontSize: FONT_SIZE, wordBreak: 'break-all' }}
-          >
-            {String(val)}
-          </Typography>
+    <Box sx={{ px: 2, pb: 2 }}>
+      <Tabs
+        value={tab}
+        onChange={(_, v) => setTab(v)}
+        sx={{
+          'minHeight': 32,
+          '& .MuiTab-root': { minHeight: 32, fontSize: FONT_SIZE, textTransform: 'none', py: 0.5 },
+        }}
+      >
+        <Tab label={t('logs.detail.tableTab')} />
+        <Tab label={t('logs.detail.jsonTab')} />
+      </Tabs>
+      {tab === 0 ? (
+        <Table size="small" sx={{ mt: 1 }}>
+          <TableHead>
+            <TableRow>
+              <TableCell sx={{ fontSize: FONT_SIZE, width: 80, fontWeight: 600 }}>
+                {t('logs.detail.action')}
+              </TableCell>
+              <TableCell sx={{ fontSize: FONT_SIZE, width: 200, fontWeight: 600 }}>
+                {t('logs.detail.field')}
+              </TableCell>
+              <TableCell sx={{ fontSize: FONT_SIZE, fontWeight: 600 }}>
+                {t('logs.detail.value')}
+              </TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {fields.map(([key, val]) => {
+              const isFilterMatch = activeFilterMap.has(key) && activeFilterMap.get(key).has(String(val))
+              const valueKeywords = []
+              if (appliedSearch) valueKeywords.push(appliedSearch)
+              if (isFilterMatch) valueKeywords.push(String(val))
+
+              return (
+                <TableRow
+                  key={key}
+                  hover
+                  sx={isFilterMatch ? { bgcolor: '#fff8e1' } : undefined}
+                >
+                  <TableCell sx={{ fontSize: FONT_SIZE, p: 0.5 }}>
+                    <Tooltip title={t('logs.detail.filterFor')}>
+                      <IconButton
+                        size="small"
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          if (onFilter) onFilter(key, val, '+')
+                        }}
+                      >
+                        <AddCircleOutline sx={{ fontSize: 16 }} />
+                      </IconButton>
+                    </Tooltip>
+                    <Tooltip title={t('logs.detail.filterOut')}>
+                      <IconButton
+                        size="small"
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          if (onFilter) onFilter(key, val, '-')
+                        }}
+                      >
+                        <RemoveCircleOutline sx={{ fontSize: 16 }} />
+                      </IconButton>
+                    </Tooltip>
+                  </TableCell>
+                  <TableCell sx={{ fontSize: FONT_SIZE }}>
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                      <FieldTypeIcon fieldKey={key} value={val} />
+                      <HighlightText text={key} keywords={appliedSearch ? [appliedSearch] : []} />
+                    </Box>
+                  </TableCell>
+                  <TableCell
+                    sx={{ fontSize: FONT_SIZE, wordBreak: 'break-all', fontFamily: 'monospace' }}
+                  >
+                    <HighlightText text={formatFieldValue(val)} keywords={valueKeywords} />
+                  </TableCell>
+                </TableRow>
+              )
+            })}
+          </TableBody>
+        </Table>
+      ) : (
+        <Box
+          sx={{
+            mt: 1,
+            p: 1.5,
+            bgcolor: 'action.hover',
+            borderRadius: 1,
+            overflow: 'auto',
+            maxHeight: 400,
+          }}
+        >
+          <pre style={{ margin: 0, fontSize: FONT_SIZE, fontFamily: 'monospace', whiteSpace: 'pre-wrap', wordBreak: 'break-all' }}>
+            {JSON.stringify(row, null, 2)}
+          </pre>
         </Box>
-      ))}
+      )}
     </Box>
   )
 }
@@ -161,6 +284,7 @@ const Logs = () => {
   const [nodes, setNodes] = useState([])
   const [pageFrom, setPageFrom] = useState(0)
   const [expandedRow, setExpandedRow] = useState(null)
+  const [fieldFilters, setFieldFilters] = useState([])
 
   const [timeRange, setTimeRange] = useState({ from: 'now-1h', to: 'now' })
   const [timeRangeLabel, setTimeRangeLabel] = useState('monitoring.time.1h')
@@ -212,6 +336,14 @@ const Logs = () => {
     params.set('time_to', timeRange.to)
     params.set('size', String(PAGE_SIZE))
     params.set('page_from', String(pageFrom))
+    if (fieldFilters.length) {
+      params.set(
+        'filters',
+        fieldFilters
+          .map((f) => `${f.op}${f.key}:${String(f.value)}`)
+          .join(',')
+      )
+    }
 
     const token = sessionStorage.getItem('token')
     const headers = { 'Content-Type': 'application/json' }
@@ -241,6 +373,7 @@ const Logs = () => {
     selectedNode,
     timeRange,
     pageFrom,
+    fieldFilters,
   ])
 
   useEffect(() => {
@@ -301,6 +434,18 @@ const Logs = () => {
       setPageFrom(0)
     }
   }
+
+  const handleFieldFilter = useCallback((key, value, op) => {
+    const valStr = String(value)
+    setFieldFilters((prev) => {
+      const exists = prev.find(
+        (f) => f.key === key && f.value === valStr && f.op === op
+      )
+      if (exists) return prev.filter((f) => f !== exists)
+      return [...prev, { key, value: valStr, op }]
+    })
+    setPageFrom(0)
+  }, [])
 
   const totalPages = Math.ceil(total / PAGE_SIZE)
   const currentPage = Math.floor(pageFrom / PAGE_SIZE) + 1
@@ -547,6 +692,47 @@ const Logs = () => {
         </Tooltip>
       </Toolbar>
 
+      {/* Active Field Filters */}
+      {fieldFilters.length > 0 && (
+        <Box
+          sx={{
+            display: 'flex',
+            flexWrap: 'wrap',
+            gap: 0.5,
+            px: 2,
+            py: 0.5,
+            borderBottom: 1,
+            borderColor: 'divider',
+            alignItems: 'center',
+          }}
+        >
+          {fieldFilters.map((f, i) => (
+            <Chip
+              key={`${f.op}${f.key}:${f.value}-${i}`}
+              label={
+                f.op === '-'
+                  ? `NOT ${f.key}: ${f.value}`
+                  : `${f.key}: ${f.value}`
+              }
+              size="small"
+              color={f.op === '-' ? 'error' : 'default'}
+              variant={f.op === '-' ? 'outlined' : 'filled'}
+              onDelete={() =>
+                setFieldFilters((prev) => prev.filter((_, idx) => idx !== i))
+              }
+              sx={{ fontSize: FONT_SIZE }}
+            />
+          ))}
+          <Chip
+            label={t('logs.clearFilters', 'Clear all')}
+            size="small"
+            variant="outlined"
+            onClick={() => setFieldFilters([])}
+            sx={{ fontSize: FONT_SIZE }}
+          />
+        </Box>
+      )}
+
       {/* Log Table */}
       <TableContainer sx={{ flex: 1, overflow: 'auto' }}>
         <Table size="small" stickyHeader>
@@ -568,7 +754,15 @@ const Logs = () => {
             </TableRow>
           </TableHead>
           <TableBody>
-            {logs.map((row, idx) => {
+            {(() => {
+              const levelFilterValues = [
+                ...fieldFilters.filter((f) => f.op === '+' && f.key === 'level').map((f) => f.value),
+                ...selectedLevels,
+              ]
+              const nodeFilterValues = fieldFilters.filter((f) => f.op === '+' && f.key === 'node').map((f) => f.value)
+              const messageFilterValues = fieldFilters.filter((f) => f.op === '+' && f.key === 'message').map((f) => f.value)
+
+              return logs.map((row, idx) => {
               const isExpanded = expandedRow === idx
               return (
                 <React.Fragment key={idx}>
@@ -605,11 +799,11 @@ const Logs = () => {
                           color: LEVEL_COLORS[row.level] || 'text.primary',
                         }}
                       >
-                        {row.level}
+                        <HighlightText text={row.level} keywords={levelFilterValues} />
                       </Typography>
                     </TableCell>
                     <TableCell sx={{ fontSize: FONT_SIZE }}>
-                      {row.node}
+                      <HighlightText text={row.node} keywords={nodeFilterValues} />
                     </TableCell>
                     <TableCell
                       sx={{
@@ -622,47 +816,21 @@ const Logs = () => {
                     >
                       <HighlightText
                         text={row.message}
-                        keyword={appliedSearch}
+                        keywords={[appliedSearch, ...messageFilterValues]}
                       />
                     </TableCell>
                   </TableRow>
                   <TableRow>
                     <TableCell sx={{ p: 0 }} colSpan={5}>
                       <Collapse in={isExpanded} timeout="auto" unmountOnExit>
-                        <DetailRow row={row} />
-                        {row.message && (
-                          <Box sx={{ px: 2, pb: 2 }}>
-                            <Typography
-                              variant="caption"
-                              color="text.secondary"
-                            >
-                              {t('logs.fullMessage')}
-                            </Typography>
-                            <Typography
-                              variant="body2"
-                              sx={{
-                                fontSize: FONT_SIZE,
-                                whiteSpace: 'pre-wrap',
-                                wordBreak: 'break-all',
-                                mt: 0.5,
-                                p: 1,
-                                bgcolor: 'action.hover',
-                                borderRadius: 1,
-                              }}
-                            >
-                              <HighlightText
-                                text={row.message}
-                                keyword={appliedSearch}
-                              />
-                            </Typography>
-                          </Box>
-                        )}
+                        <DetailRow row={row} onFilter={handleFieldFilter} fieldFilters={fieldFilters} appliedSearch={appliedSearch} selectedLevels={selectedLevels} selectedLogType={selectedLogType} />
                       </Collapse>
                     </TableCell>
                   </TableRow>
                 </React.Fragment>
               )
-            })}
+            })
+            })()}
             {!loading && logs.length === 0 && (
               <TableRow>
                 <TableCell colSpan={5} align="center" sx={{ py: 4 }}>


### PR DESCRIPTION
## Summary

- **DetailRow refactor**: Three-column table (Action/Field/Value) with Table/JSON tabs, field-level filtering (`+`/`-` buttons), multi-keyword highlighting across collapsed and expanded rows, Level/LogType chip highlight sync
- **JSON copy button**: Clipboard API with `execCommand` fallback for HTTP environments, visual feedback with auto-reset
- **Surrounding documents view**: New `GET /v1/cluster/logs/context` backend API with dual ES queries; ContextDialog with editable load count, newest-first ordering, row expansion, isolated filter state, and in-dialog anchor switching
- **ContextDialog enhancements**: Enter key to trigger loading, filter chips bar with client-side data filtering (OR within same key, AND across keys), anchor row always visible
- **i18n**: 18 new keys across en/zh/ja/ko locales

## Test plan

- [ ] Expand a log row → verify three-column Table/JSON tabs render correctly
- [ ] Click `+`/`-` action buttons → verify filter chips appear in toolbar, data filters, and highlighting works in both collapsed and expanded rows
- [ ] Click Level/LogType chips → verify highlighting syncs in DetailRow
- [ ] Switch to JSON tab → verify copy button works (test in both HTTPS and HTTP)
- [ ] Click "View surrounding documents" → verify ContextDialog opens with correct anchor
- [ ] Edit load count and click Load / press Enter → verify newer/older documents load
- [ ] Click a row's "View surrounding documents" inside ContextDialog → verify anchor switches (no nested dialog)
- [ ] Use `+`/`-` filters inside ContextDialog → verify filter chips and data filtering work independently from main page
- [ ] Test with ES not configured → verify graceful 503 error
- [ ] Verify all 4 languages display correctly
