### PR TITLE
BLD: Split Docker builds into separate jobs

### DIFF
--- a/.github/workflows/docker-cd.yaml
+++ b/.github/workflows/docker-cd.yaml
@@ -80,7 +80,7 @@ jobs:
 
   build-gpu:
     name: Build GPU Docker image
-    needs: check-release-permission
+    needs: build-aarch64
     timeout-minutes: 240
     runs-on: self-hosted
     permissions:
@@ -136,7 +136,7 @@ jobs:
 
   build-cpu:
     name: Build CPU Docker image
-    needs: check-release-permission
+    needs: build-gpu
     timeout-minutes: 240
     runs-on: self-hosted
     permissions:
@@ -192,7 +192,7 @@ jobs:
 
   tag-latest:
     name: Tag latest Docker images
-    needs: [build-aarch64, build-gpu, build-cpu]
+    needs: build-cpu
     timeout-minutes: 60
     runs-on: self-hosted
     permissions:

--- a/.github/workflows/docker-cd.yaml
+++ b/.github/workflows/docker-cd.yaml
@@ -240,3 +240,63 @@ jobs:
           docker system prune -af --volumes || true
           docker builder prune -af || true
           docker buildx prune -af || true
+
+  notify-failure:
+    name: Open issue for Docker CD failure
+    needs: [build-aarch64, build-gpu, build-cpu, tag-latest]
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    if: ${{ always() && github.repository == 'xorbitsai/inference' && contains(needs.*.result, 'failure') }}
+    steps:
+      - name: Create or update failure issue
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        with:
+          script: |
+            const needs = JSON.parse(process.env.NEEDS_JSON);
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const refName = context.ref.replace(/^refs\/heads\//, '').replace(/^refs\/tags\//, '');
+            const title = `[Docker CD] Failure on ${refName}`;
+            const jobResults = Object.entries(needs)
+              .map(([job, info]) => `- ${job}: ${info.result}`)
+              .join('\n');
+            const body = [
+              'Docker CD failed.',
+              '',
+              `- Workflow: ${context.workflow}`,
+              `- Run: ${runUrl}`,
+              `- Event: ${context.eventName}`,
+              `- Ref: ${context.ref}`,
+              `- SHA: ${context.sha}`,
+              `- Actor: ${context.actor}`,
+              '',
+              'Job results:',
+              jobResults,
+            ].join('\n');
+
+            const { data: existingIssues } = await github.rest.search.issuesAndPullRequests({
+              q: `repo:${context.repo.owner}/${context.repo.repo} is:issue is:open in:title "${title.replace(/"/g, '\\"')}"`,
+              per_page: 1,
+            });
+
+            if (existingIssues.items.length > 0) {
+              const issue = existingIssues.items[0];
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body,
+              });
+              core.info(`Updated existing issue #${issue.number}`);
+              return;
+            }
+
+            const { data: issue } = await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body,
+            });
+            core.info(`Created issue #${issue.number}`);

--- a/.github/workflows/docker-cd.yaml
+++ b/.github/workflows/docker-cd.yaml
@@ -22,15 +22,13 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/check-release-permission
 
-  build:
+  build-aarch64:
+    name: Build aarch64 Docker image
     needs: check-release-permission
     timeout-minutes: 240
     runs-on: self-hosted
     permissions:
       contents: read
-    strategy:
-      matrix:
-        python-version: [ "3.10" ]
     steps:
       - name: Check out code
         uses: actions/checkout@v3
@@ -44,55 +42,201 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
-      - name: Build and push Docker image
+      - name: Clean docker image cache before build
+        shell: bash
+        if: ${{ github.repository == 'xorbitsai/inference' }}
+        run: |
+          docker system df || true
+          docker system prune -af --volumes || true
+          docker builder prune -af || true
+          docker buildx prune -af || true
+
+      - name: Build and push aarch64 Docker image
         shell: bash
         if: ${{ github.repository == 'xorbitsai/inference' }}
         env:
           DOCKER_ORG: ${{ secrets.DOCKERHUB_USERNAME }}
-          PY_VERSION: ${{ matrix.python-version }}
         run: |
           if [[ "$GITHUB_REF" =~ ^"refs/tags/" ]]; then
-            export GIT_TAG=$(echo "$GITHUB_REF" | sed -e "s/refs\/tags\///g")
-          fi
-
-          docker system prune -f -a
-
-          if [[ -n "$GIT_TAG" ]]; then
-            BRANCHES="$GIT_TAG"
-            echo "Will handle tag $BRANCHES"
+            IMAGE_TAG="${GITHUB_REF#refs/tags/}"
+            echo "Will handle tag $IMAGE_TAG"
           else
-            MAINBRANCH=$(git rev-parse --abbrev-ref HEAD)
-            BRANCHES="$MAINBRANCH"
-          fi
-          
-          for branch in $BRANCHES; do
-            if [[ -n "$GIT_TAG" ]]; then
-              export IMAGE_TAG="$GIT_TAG"
-            else
-              git checkout $branch
-              export IMAGE_TAG="nightly-$branch"
-            fi
-            docker buildx build --platform linux/arm64 --load -t "$DOCKER_ORG/xinference:${IMAGE_TAG}-aarch64" --progress=plain -f xinference/deploy/docker/Dockerfile.aarch64 .
-            docker push "$DOCKER_ORG/xinference:${IMAGE_TAG}-aarch64"
-            docker build -t "$DOCKER_ORG/xinference:${IMAGE_TAG}" --progress=plain -f xinference/deploy/docker/Dockerfile .
-            docker push "$DOCKER_ORG/xinference:${IMAGE_TAG}"
-            docker build -t "$DOCKER_ORG/xinference:${IMAGE_TAG}-cpu" --progress=plain -f xinference/deploy/docker/Dockerfile.cpu .
-            docker push "$DOCKER_ORG/xinference:${IMAGE_TAG}-cpu"
-            echo "XINFERENCE_IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_ENV
-          done
-          
-          if [[ -n "$GIT_TAG" ]]; then
-            docker tag "$DOCKER_ORG/xinference:${GIT_TAG}" "$DOCKER_ORG/xinference:latest"
-            docker push "$DOCKER_ORG/xinference:latest"
-            docker tag "$DOCKER_ORG/xinference:${GIT_TAG}-cpu" "$DOCKER_ORG/xinference:latest-cpu"
-            docker push "$DOCKER_ORG/xinference:latest-cpu"
-            docker tag "$DOCKER_ORG/xinference:${GIT_TAG}-aarch64" "$DOCKER_ORG/xinference:latest-aarch64"
-            docker push "$DOCKER_ORG/xinference:latest-aarch64"
-            echo "XINFERENCE_GIT_TAG=${GIT_TAG}" >> $GITHUB_ENV
+            BRANCH="${GITHUB_REF_NAME:-$(git rev-parse --abbrev-ref HEAD)}"
+            git checkout "$BRANCH"
+            IMAGE_TAG="nightly-$BRANCH"
           fi
 
-      - name: Clean docker image cache
+          docker buildx build --platform linux/arm64 --load -t "$DOCKER_ORG/xinference:${IMAGE_TAG}-aarch64" --progress=plain -f xinference/deploy/docker/Dockerfile.aarch64 .
+          docker push "$DOCKER_ORG/xinference:${IMAGE_TAG}-aarch64"
+
+      - name: Clean docker image cache after build
+        shell: bash
+        if: ${{ always() && github.repository == 'xorbitsai/inference' }}
+        run: |
+          docker system df || true
+          docker system prune -af --volumes || true
+          docker builder prune -af || true
+          docker buildx prune -af || true
+
+  build-gpu:
+    name: Build GPU Docker image
+    needs: check-release-permission
+    timeout-minutes: 240
+    runs-on: self-hosted
+    permissions:
+      contents: read
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Clean docker image cache before build
         shell: bash
         if: ${{ github.repository == 'xorbitsai/inference' }}
         run: |
-          docker system prune -f -a
+          docker system df || true
+          docker system prune -af --volumes || true
+          docker builder prune -af || true
+          docker buildx prune -af || true
+
+      - name: Build and push GPU Docker image
+        shell: bash
+        if: ${{ github.repository == 'xorbitsai/inference' }}
+        env:
+          DOCKER_ORG: ${{ secrets.DOCKERHUB_USERNAME }}
+        run: |
+          if [[ "$GITHUB_REF" =~ ^"refs/tags/" ]]; then
+            IMAGE_TAG="${GITHUB_REF#refs/tags/}"
+            echo "Will handle tag $IMAGE_TAG"
+          else
+            BRANCH="${GITHUB_REF_NAME:-$(git rev-parse --abbrev-ref HEAD)}"
+            git checkout "$BRANCH"
+            IMAGE_TAG="nightly-$BRANCH"
+          fi
+
+          docker build -t "$DOCKER_ORG/xinference:${IMAGE_TAG}" --progress=plain -f xinference/deploy/docker/Dockerfile .
+          docker push "$DOCKER_ORG/xinference:${IMAGE_TAG}"
+
+      - name: Clean docker image cache after build
+        shell: bash
+        if: ${{ always() && github.repository == 'xorbitsai/inference' }}
+        run: |
+          docker system df || true
+          docker system prune -af --volumes || true
+          docker builder prune -af || true
+          docker buildx prune -af || true
+
+  build-cpu:
+    name: Build CPU Docker image
+    needs: check-release-permission
+    timeout-minutes: 240
+    runs-on: self-hosted
+    permissions:
+      contents: read
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Clean docker image cache before build
+        shell: bash
+        if: ${{ github.repository == 'xorbitsai/inference' }}
+        run: |
+          docker system df || true
+          docker system prune -af --volumes || true
+          docker builder prune -af || true
+          docker buildx prune -af || true
+
+      - name: Build and push CPU Docker image
+        shell: bash
+        if: ${{ github.repository == 'xorbitsai/inference' }}
+        env:
+          DOCKER_ORG: ${{ secrets.DOCKERHUB_USERNAME }}
+        run: |
+          if [[ "$GITHUB_REF" =~ ^"refs/tags/" ]]; then
+            IMAGE_TAG="${GITHUB_REF#refs/tags/}"
+            echo "Will handle tag $IMAGE_TAG"
+          else
+            BRANCH="${GITHUB_REF_NAME:-$(git rev-parse --abbrev-ref HEAD)}"
+            git checkout "$BRANCH"
+            IMAGE_TAG="nightly-$BRANCH"
+          fi
+
+          docker build -t "$DOCKER_ORG/xinference:${IMAGE_TAG}-cpu" --progress=plain -f xinference/deploy/docker/Dockerfile.cpu .
+          docker push "$DOCKER_ORG/xinference:${IMAGE_TAG}-cpu"
+
+      - name: Clean docker image cache after build
+        shell: bash
+        if: ${{ always() && github.repository == 'xorbitsai/inference' }}
+        run: |
+          docker system df || true
+          docker system prune -af --volumes || true
+          docker builder prune -af || true
+          docker buildx prune -af || true
+
+  tag-latest:
+    name: Tag latest Docker images
+    needs: [build-aarch64, build-gpu, build-cpu]
+    timeout-minutes: 60
+    runs-on: self-hosted
+    permissions:
+      contents: read
+    if: ${{ startsWith(github.ref, 'refs/tags/') && github.repository == 'xorbitsai/inference' }}
+    steps:
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Clean docker image cache before tagging
+        shell: bash
+        run: |
+          docker system df || true
+          docker system prune -af --volumes || true
+          docker builder prune -af || true
+          docker buildx prune -af || true
+
+      - name: Push latest tags
+        shell: bash
+        env:
+          DOCKER_ORG: ${{ secrets.DOCKERHUB_USERNAME }}
+        run: |
+          GIT_TAG="${GITHUB_REF#refs/tags/}"
+
+          docker pull "$DOCKER_ORG/xinference:${GIT_TAG}"
+          docker tag "$DOCKER_ORG/xinference:${GIT_TAG}" "$DOCKER_ORG/xinference:latest"
+          docker push "$DOCKER_ORG/xinference:latest"
+
+          docker pull "$DOCKER_ORG/xinference:${GIT_TAG}-cpu"
+          docker tag "$DOCKER_ORG/xinference:${GIT_TAG}-cpu" "$DOCKER_ORG/xinference:latest-cpu"
+          docker push "$DOCKER_ORG/xinference:latest-cpu"
+
+          docker pull "$DOCKER_ORG/xinference:${GIT_TAG}-aarch64"
+          docker tag "$DOCKER_ORG/xinference:${GIT_TAG}-aarch64" "$DOCKER_ORG/xinference:latest-aarch64"
+          docker push "$DOCKER_ORG/xinference:latest-aarch64"
+
+      - name: Clean docker image cache after tagging
+        shell: bash
+        if: ${{ always() }}
+        run: |
+          docker system df || true
+          docker system prune -af --volumes || true
+          docker builder prune -af || true
+          docker buildx prune -af || true


### PR DESCRIPTION
## Summary
- Split Docker CD image publishing into separate aarch64, GPU, and CPU build jobs while keeping the original sequential order.
- Add per-job Docker cache cleanup before and after each build.
- Move latest tag publishing into a separate job that runs after all image builds succeed.
- Open or update a GitHub issue automatically when Docker CD image publishing fails.

## Tests
- python yaml.safe_load for .github/workflows/docker-cd.yaml
- git diff --check