### PR TITLE
Draft: parse tool_calls arguments

### DIFF
--- a/xinference/model/llm/tests/test_utils.py
+++ b/xinference/model/llm/tests/test_utils.py
@@ -79,7 +79,16 @@ def test_transform_messages_preserves_tool_call_fields():
     assert transformed[1] == {
         "role": "assistant",
         "content": None,
-        "tool_calls": messages[1]["tool_calls"],
+        "tool_calls": [
+            {
+                "id": "call_bed4c5f1",
+                "function": {
+                    "arguments": {"file_path": "README*"},
+                    "name": "view_file_in_detail",
+                },
+                "type": "function",
+            }
+        ],
     }
     assert transformed[2] == {
         "role": "tool",

--- a/xinference/model/llm/utils.py
+++ b/xinference/model/llm/utils.py
@@ -811,6 +811,22 @@ class ChatModelMixin:
                         )
             new_message = dict(msg)
             new_message["content"] = new_content if new_content else None
+            # Parse JSON-encoded arguments in tool_calls to dicts,
+            # so Jinja2 templates can iterate them with |items.
+            if new_message.get("tool_calls"):
+                tool_calls = []
+                for tc in new_message["tool_calls"]:
+                    tc = dict(tc)
+                    func = tc.get("function")
+                    if func and isinstance(func.get("arguments"), str):
+                        func = dict(func)
+                        try:
+                            func["arguments"] = json.loads(func["arguments"])
+                        except (json.JSONDecodeError, TypeError):
+                            pass
+                        tc["function"] = func
+                    tool_calls.append(tc)
+                new_message["tool_calls"] = tool_calls
             transformed_messages.append(new_message)
 
         return transformed_messages

--- a/xinference/model/llm/utils.py
+++ b/xinference/model/llm/utils.py
@@ -818,7 +818,9 @@ class ChatModelMixin:
                 for tc in new_message["tool_calls"]:
                     tc = dict(tc)
                     func = tc.get("function")
-                    if isinstance(func, dict) and isinstance(func.get("arguments"), str):
+                    if isinstance(func, dict) and isinstance(
+                        func.get("arguments"), str
+                    ):
                         func = dict(func)
                         try:
                             parsed_args = json.loads(func["arguments"])

--- a/xinference/model/llm/utils.py
+++ b/xinference/model/llm/utils.py
@@ -818,10 +818,12 @@ class ChatModelMixin:
                 for tc in new_message["tool_calls"]:
                     tc = dict(tc)
                     func = tc.get("function")
-                    if func and isinstance(func.get("arguments"), str):
+                    if isinstance(func, dict) and isinstance(func.get("arguments"), str):
                         func = dict(func)
                         try:
-                            func["arguments"] = json.loads(func["arguments"])
+                            parsed_args = json.loads(func["arguments"])
+                            if isinstance(parsed_args, dict):
+                                func["arguments"] = parsed_args
                         except (json.JSONDecodeError, TypeError):
                             pass
                         tc["function"] = func


### PR DESCRIPTION
Add parsing for JSON-encoded arguments in tool_calls. Tested with [open-zread](https://github.com/bb-boy680/open-zread) and Qwen3.5 models.

Close #4914 .

Note: This is a draft PR and it works on my computer. I hope the subsequent modifications can be made by the official maintainers.

## TODO

I made a quick investigation in `llm_family.json` and it seemed that there are four kinds of handling logics in chat templates:

| accept | template | models |
| --- | --- | -------- |
| both | `tool_call.arguments \| tojson` | `DianJin-R1-32B`, `HuatuoGPT-o1-70B`, `InternVL3-78B`, `Ovis2-34B`, `QwQ-32B`, `XiYanSQL-QwenCoder-32B`, `Fin-R1`, `Qwen1.5-Chat`, `Qwen2-Instruct`, `Qwen2.5-Coder-32B-Instruct`, `Qwen2.5-Instruct`, `GPT-OSS`, `KAT-V1-40B`, `DeepSeek-V3.1` |
| both | `{%- set arguments = tool['function']['arguments'] %}{%- if arguments is not string %}...` | `DeepSeek-R1-0528`, `Qwen3`, `Qwen3-Instruct`, `Qwen3-Thinking`, `Baichuan-M2-32B`, `Qwen3-VL-Instruct`, `Qwen3-VL-Thinking`, `Qwen3-Next-Instruct`, `Qwen3-Next-Thinking`, `Qwen3-Omni-Instruct`, `Qwen3-Omni-Thinking`, `DeepSeek-V3.2`, `Kimi-K2.5` |
| `arguments` as string | `'\n' + tool['function']['arguments'] + '\n'` | `DeepSeek-Prover-V2-7B`, `DeepSeek-V2.5`, `DeepSeek-V3-0324`, `DeepSeek-R1`, `DeepSeek-R1-0528-Qwen3-8B`, `DeepSeek-R1-Distill-Llama-8B`, `DeepSeek-R1-Distill-Qwen-32B`, `Skywork-OR1-7B`, `QwenLong-L1-32B` |
| `arguments` as dict | `{%- for arg_name, arg_val in tool_call.arguments \| items %}` | `Llama-3.1-70B-Instruct`, `Qwen3-Coder`, `GLM-4.5`, `GLM-4.5V`, `Seed-OSS-36B-Instruct`, `MiniMax-M2`, `GLM-4.6`, `GLM-4.7`, `GLM-4.7-Flash`, `MiniMax-M2.5`, `GLM-5`, `Qwen3.5`, `Qwen3.6`, `MiniMax-M2.7`, `GLM-5.1` |

So models that treat arguments as string will be unable to handling function callings if this PR is merged but the chat template remains the same.