### PR TITLE
feat(apikey): add description field and ban status display

### DIFF
--- a/xinference/api/oauth2/advanced/database.py
+++ b/xinference/api/oauth2/advanced/database.py
@@ -367,6 +367,7 @@ class Database:
     def update_api_key(self, key_id: int, **kwargs) -> bool:
         allowed = {
             "name",
+            "description",
             "enabled",
             "expires_at",
             "rate_limit_max_failures",

--- a/xinference/api/oauth2/advanced/routes.py
+++ b/xinference/api/oauth2/advanced/routes.py
@@ -31,12 +31,27 @@ logger = logging.getLogger(__name__)
 
 
 def _refresh_key_gauges(auth: AdvancedAuthService) -> None:
-    """Update Prometheus gauges for active/expired key counts.
+    """Update Prometheus gauges for active/expired key counts."""
+    try:
+        from ....core.metrics import api_keys_active_total, api_keys_expired_total
+        from datetime import datetime
 
-    NOTE: Metrics counters are defined in the security-hardening PR.
-    This is a placeholder that will be filled when that PR is merged.
-    """
-    pass
+        keys = auth.db.list_api_keys()
+        active = 0
+        expired = 0
+        now = datetime.utcnow()
+        for k in keys:
+            if not k.get("enabled", 1):
+                continue
+            expires_at = k.get("expires_at")
+            if expires_at and datetime.fromisoformat(expires_at) < now:
+                expired += 1
+            else:
+                active += 1
+        api_keys_active_total.set({}, active)
+        api_keys_expired_total.set({}, expired)
+    except Exception:
+        pass
 
 
 def get_advanced_auth(request: Request) -> AdvancedAuthService:

--- a/xinference/api/oauth2/advanced/routes.py
+++ b/xinference/api/oauth2/advanced/routes.py
@@ -33,8 +33,14 @@ logger = logging.getLogger(__name__)
 def _refresh_key_gauges(auth: AdvancedAuthService) -> None:
     """Update Prometheus gauges for active/expired key counts."""
     try:
-        from ....core.metrics import api_keys_active_total, api_keys_expired_total
         from datetime import datetime
+
+        from ....core import metrics as _metrics
+
+        _active_gauge = getattr(_metrics, "api_keys_active_total", None)
+        _expired_gauge = getattr(_metrics, "api_keys_expired_total", None)
+        if _active_gauge is None or _expired_gauge is None:
+            return
 
         keys = auth.db.list_api_keys()
         active = 0
@@ -44,12 +50,16 @@ def _refresh_key_gauges(auth: AdvancedAuthService) -> None:
             if not k.get("enabled", 1):
                 continue
             expires_at = k.get("expires_at")
-            if expires_at and datetime.fromisoformat(expires_at) < now:
-                expired += 1
-            else:
-                active += 1
-        api_keys_active_total.set({}, active)
-        api_keys_expired_total.set({}, expired)
+            if expires_at:
+                try:
+                    if datetime.fromisoformat(expires_at) < now:
+                        expired += 1
+                        continue
+                except ValueError:
+                    pass
+            active += 1
+        _active_gauge.set({}, active)
+        _expired_gauge.set({}, expired)
     except Exception:
         pass
 
@@ -293,6 +303,7 @@ async def list_api_keys(
                 "user_id": k["user_id"],
                 "key_prefix": k["key_prefix"],
                 "name": k.get("name"),
+                "description": k.get("description"),
                 "enabled": bool(k.get("enabled", 1)),
                 "expires_at": k.get("expires_at"),
                 "model_permissions": k.get("model_permissions", []),
@@ -318,6 +329,7 @@ async def get_api_key(key_id: int, request: Request) -> JSONResponse:
             "user_id": key["user_id"],
             "key_prefix": key["key_prefix"],
             "name": key.get("name"),
+            "description": key.get("description"),
             "enabled": bool(key.get("enabled", 1)),
             "expires_at": key.get("expires_at"),
             "model_permissions": key.get("model_permissions", []),
@@ -336,6 +348,7 @@ async def update_api_key(key_id: int, request: Request) -> JSONResponse:
     update_fields = {}
     for field in (
         "name",
+        "description",
         "enabled",
         "expires_at",
         "rate_limit_max_failures",
@@ -423,9 +436,10 @@ def register_advanced_auth_routes(api: "RESTfulAPI") -> None:
     router = api._router
     auth_service: AdvancedAuthService = api._app.state.advanced_auth
 
-    # Store rate_limiter on app state for security routes (if available)
-    if auth_service._rate_limiter:
-        api._app.state.rate_limiter = auth_service._rate_limiter
+    # Store rate_limiter on app state for security routes
+    _rl = getattr(auth_service, "_rate_limiter", None)
+    if _rl is not None:
+        api._app.state.rate_limiter = _rl
 
     router.add_api_route("/token", advanced_login, methods=["POST"])
     router.add_api_route("/v1/auth/refresh", advanced_refresh, methods=["POST"])

--- a/xinference/ui/web/ui/src/locales/en.json
+++ b/xinference/ui/web/ui/src/locales/en.json
@@ -458,7 +458,14 @@
     "permissionsSaved": "Permissions saved",
     "bans": "Bans",
     "description": "Description",
-    "descriptionLabel": "Description (optional)"
+    "descriptionLabel": "Description (optional)",
+    "bannedIpsForKey": "Banned IPs for Key #{{keyId}}",
+    "noActiveBans": "No active bans",
+    "remaining": "Remaining: {{seconds}}s",
+    "unban": "Unban",
+    "viewBans": "View",
+    "failedLoadBans": "Failed to load bans",
+    "failedUnban": "Failed to unban"
   },
   "securitySettings": {
     "title": "Security Settings",

--- a/xinference/ui/web/ui/src/locales/ja.json
+++ b/xinference/ui/web/ui/src/locales/ja.json
@@ -449,7 +449,14 @@
     "mixedMode": "タイプ別 + インスタンス別（混合）",
     "bans": "禁止数",
     "description": "説明",
-    "descriptionLabel": "申請理由（任意）"
+    "descriptionLabel": "申請理由（任意）",
+    "bannedIpsForKey": "Key #{{keyId}} の禁止 IP",
+    "noActiveBans": "禁止中のIPはありません",
+    "remaining": "残り: {{seconds}}秒",
+    "unban": "解除",
+    "viewBans": "表示",
+    "failedLoadBans": "禁止情報の読み込みに失敗しました",
+    "failedUnban": "解除に失敗しました"
   },
   "securitySettings": {
     "title": "セキュリティ設定",

--- a/xinference/ui/web/ui/src/locales/ko.json
+++ b/xinference/ui/web/ui/src/locales/ko.json
@@ -449,7 +449,14 @@
     "mixedMode": "유형별 + 인스턴스별 (혼합)",
     "bans": "차단 수",
     "description": "설명",
-    "descriptionLabel": "신청 사유 (선택)"
+    "descriptionLabel": "신청 사유 (선택)",
+    "bannedIpsForKey": "Key #{{keyId}}의 차단된 IP",
+    "noActiveBans": "활성 차단 없음",
+    "remaining": "남은 시간: {{seconds}}초",
+    "unban": "차단 해제",
+    "viewBans": "보기",
+    "failedLoadBans": "차단 정보 로드 실패",
+    "failedUnban": "차단 해제 실패"
   },
   "securitySettings": {
     "title": "보안 설정",

--- a/xinference/ui/web/ui/src/locales/zh.json
+++ b/xinference/ui/web/ui/src/locales/zh.json
@@ -458,7 +458,14 @@
     "permissionsSaved": "权限已保存",
     "bans": "封禁数",
     "description": "申请理由",
-    "descriptionLabel": "申请理由（可选）"
+    "descriptionLabel": "申请理由（可选）",
+    "bannedIpsForKey": "Key #{{keyId}} 的封禁 IP",
+    "noActiveBans": "暂无封禁",
+    "remaining": "剩余: {{seconds}}秒",
+    "unban": "解封",
+    "viewBans": "查看",
+    "failedLoadBans": "加载封禁信息失败",
+    "failedUnban": "解封失败"
   },
   "securitySettings": {
     "title": "安全设置",

--- a/xinference/ui/web/ui/src/scenes/apikey_management/index.js
+++ b/xinference/ui/web/ui/src/scenes/apikey_management/index.js
@@ -65,27 +65,11 @@ function ApiKeyManagement() {
   const [bansDialogOpen, setBansDialogOpen] = useState(false)
   const [bansDialogKeyId, setBansDialogKeyId] = useState(null)
   const [bansData, setBansData] = useState([])
-  const [keyBanCounts, setKeyBanCounts] = useState({})
 
   const loadKeys = async () => {
     try {
       const data = await fetchWrapper.get('/v1/admin/keys')
       setKeys(data)
-      // Load ban counts for each key
-      const counts = {}
-      await Promise.all(
-        data.map(async (key) => {
-          try {
-            const bans = await fetchWrapper.get(
-              `/v1/admin/keys/${key.id}/banned`
-            )
-            counts[key.id] = Array.isArray(bans) ? bans.length : 0
-          } catch {
-            counts[key.id] = 0
-          }
-        })
-      )
-      setKeyBanCounts(counts)
     } catch (e) {
       console.error(e)
     }
@@ -98,7 +82,7 @@ function ApiKeyManagement() {
       setBansDialogKeyId(keyId)
       setBansDialogOpen(true)
     } catch (e) {
-      setSnackError('Failed to load bans')
+      setSnackError(t('apikeyManagement.failedLoadBans'))
     }
   }
 
@@ -109,12 +93,8 @@ function ApiKeyManagement() {
         `/v1/admin/keys/${bansDialogKeyId}/banned`
       )
       setBansData(Array.isArray(data) ? data : [])
-      setKeyBanCounts((prev) => ({
-        ...prev,
-        [bansDialogKeyId]: Array.isArray(data) ? data.length : 0,
-      }))
     } catch (e) {
-      setSnackError('Failed to unban')
+      setSnackError(t('apikeyManagement.failedUnban'))
     }
   }
 
@@ -399,22 +379,15 @@ function ApiKeyManagement() {
       field: 'bans',
       headerName: t('apikeyManagement.bans'),
       width: 70,
-      renderCell: (params) => {
-        const count = keyBanCounts[params.row.id] || 0
-        return count > 0 ? (
-          <Chip
-            label={count}
-            size="small"
-            color="error"
-            onClick={() => handleShowBans(params.row.id)}
-            sx={{ cursor: 'pointer' }}
-          />
-        ) : (
-          <Typography variant="body2" color="text.secondary">
-            0
-          </Typography>
-        )
-      },
+      renderCell: (params) => (
+        <Chip
+          label={t('apikeyManagement.viewBans')}
+          size="small"
+          variant="outlined"
+          onClick={() => handleShowBans(params.row.id)}
+          sx={{ cursor: 'pointer' }}
+        />
+      ),
     },
     {
       field: 'actions',
@@ -852,11 +825,11 @@ function ApiKeyManagement() {
         fullWidth
       >
         <DialogTitle>
-          Banned IPs for Key #{bansDialogKeyId}
+          {t('apikeyManagement.bannedIpsForKey', { keyId: bansDialogKeyId })}
         </DialogTitle>
         <DialogContent>
           {bansData.length === 0 ? (
-            <Typography color="text.secondary">No active bans</Typography>
+            <Typography color="text.secondary">{t('apikeyManagement.noActiveBans')}</Typography>
           ) : (
             <Box>
               {bansData.map((ban, idx) => (
@@ -870,7 +843,7 @@ function ApiKeyManagement() {
                   <Box>
                     <Typography variant="body2">{ban.ip}</Typography>
                     <Typography variant="caption" color="text.secondary">
-                      Remaining: {ban.remaining_seconds}s
+                      {t('apikeyManagement.remaining', { seconds: ban.remaining_seconds })}
                     </Typography>
                   </Box>
                   <Button
@@ -878,7 +851,7 @@ function ApiKeyManagement() {
                     color="error"
                     onClick={() => handleUnbanFromDialog(ban.ip)}
                   >
-                    Unban
+                    {t('apikeyManagement.unban')}
                   </Button>
                 </Box>
               ))}
@@ -886,7 +859,7 @@ function ApiKeyManagement() {
           )}
         </DialogContent>
         <DialogActions>
-          <Button onClick={() => setBansDialogOpen(false)}>Close</Button>
+          <Button onClick={() => setBansDialogOpen(false)}>{t('apikeyManagement.close')}</Button>
         </DialogActions>
       </Dialog>
     </Box>

--- a/xinference/ui/web/ui/src/scenes/apikey_management/index.js
+++ b/xinference/ui/web/ui/src/scenes/apikey_management/index.js
@@ -375,20 +375,24 @@ function ApiKeyManagement() {
         </Box>
       ),
     },
-    {
-      field: 'bans',
-      headerName: t('apikeyManagement.bans'),
-      width: 70,
-      renderCell: (params) => (
-        <Chip
-          label={t('apikeyManagement.viewBans')}
-          size="small"
-          variant="outlined"
-          onClick={() => handleShowBans(params.row.id)}
-          sx={{ cursor: 'pointer' }}
-        />
-      ),
-    },
+    ...(isAdmin
+      ? [
+          {
+            field: 'bans',
+            headerName: t('apikeyManagement.bans'),
+            width: 70,
+            renderCell: (params) => (
+              <Chip
+                label={t('apikeyManagement.viewBans')}
+                size="small"
+                variant="outlined"
+                onClick={() => handleShowBans(params.row.id)}
+                sx={{ cursor: 'pointer' }}
+              />
+            ),
+          },
+        ]
+      : []),
     {
       field: 'actions',
       headerName: t('apikeyManagement.actions'),

--- a/xinference/ui/web/ui/src/scenes/apikey_management/index.js
+++ b/xinference/ui/web/ui/src/scenes/apikey_management/index.js
@@ -829,7 +829,9 @@ function ApiKeyManagement() {
         </DialogTitle>
         <DialogContent>
           {bansData.length === 0 ? (
-            <Typography color="text.secondary">{t('apikeyManagement.noActiveBans')}</Typography>
+            <Typography color="text.secondary">
+              {t('apikeyManagement.noActiveBans')}
+            </Typography>
           ) : (
             <Box>
               {bansData.map((ban, idx) => (
@@ -843,7 +845,9 @@ function ApiKeyManagement() {
                   <Box>
                     <Typography variant="body2">{ban.ip}</Typography>
                     <Typography variant="caption" color="text.secondary">
-                      {t('apikeyManagement.remaining', { seconds: ban.remaining_seconds })}
+                      {t('apikeyManagement.remaining', {
+                        seconds: ban.remaining_seconds,
+                      })}
                     </Typography>
                   </Box>
                   <Button
@@ -859,7 +863,9 @@ function ApiKeyManagement() {
           )}
         </DialogContent>
         <DialogActions>
-          <Button onClick={() => setBansDialogOpen(false)}>{t('apikeyManagement.close')}</Button>
+          <Button onClick={() => setBansDialogOpen(false)}>
+            {t('apikeyManagement.close')}
+          </Button>
         </DialogActions>
       </Dialog>
     </Box>

--- a/xinference/ui/web/ui/src/scenes/apikey_management/index.js
+++ b/xinference/ui/web/ui/src/scenes/apikey_management/index.js
@@ -45,6 +45,7 @@ function ApiKeyManagement() {
   const [revealOpen, setRevealOpen] = useState(false)
   const [revealedKey, setRevealedKey] = useState('')
   const [newKeyName, setNewKeyName] = useState('')
+  const [newKeyDescription, setNewKeyDescription] = useState('')
   const [newKeyExpires, setNewKeyExpires] = useState(null)
   const [newKeyPermType, setNewKeyPermType] = useState('all')
   const [selectedModelTypes, setSelectedModelTypes] = useState([])
@@ -61,13 +62,59 @@ function ApiKeyManagement() {
   const [editPermType, setEditPermType] = useState('all')
   const [editModelTypes, setEditModelTypes] = useState([])
   const [editModelIds, setEditModelIds] = useState([])
+  const [bansDialogOpen, setBansDialogOpen] = useState(false)
+  const [bansDialogKeyId, setBansDialogKeyId] = useState(null)
+  const [bansData, setBansData] = useState([])
+  const [keyBanCounts, setKeyBanCounts] = useState({})
 
   const loadKeys = async () => {
     try {
       const data = await fetchWrapper.get('/v1/admin/keys')
       setKeys(data)
+      // Load ban counts for each key
+      const counts = {}
+      await Promise.all(
+        data.map(async (key) => {
+          try {
+            const bans = await fetchWrapper.get(
+              `/v1/admin/keys/${key.id}/banned`
+            )
+            counts[key.id] = Array.isArray(bans) ? bans.length : 0
+          } catch {
+            counts[key.id] = 0
+          }
+        })
+      )
+      setKeyBanCounts(counts)
     } catch (e) {
       console.error(e)
+    }
+  }
+
+  const handleShowBans = async (keyId) => {
+    try {
+      const data = await fetchWrapper.get(`/v1/admin/keys/${keyId}/banned`)
+      setBansData(Array.isArray(data) ? data : [])
+      setBansDialogKeyId(keyId)
+      setBansDialogOpen(true)
+    } catch (e) {
+      setSnackError('Failed to load bans')
+    }
+  }
+
+  const handleUnbanFromDialog = async (ip) => {
+    try {
+      await fetchWrapper.post(`/v1/admin/keys/${bansDialogKeyId}/unban`, { ip })
+      const data = await fetchWrapper.get(
+        `/v1/admin/keys/${bansDialogKeyId}/banned`
+      )
+      setBansData(Array.isArray(data) ? data : [])
+      setKeyBanCounts((prev) => ({
+        ...prev,
+        [bansDialogKeyId]: Array.isArray(data) ? data.length : 0,
+      }))
+    } catch (e) {
+      setSnackError('Failed to unban')
     }
   }
 
@@ -129,6 +176,7 @@ function ApiKeyManagement() {
       }
       const result = await fetchWrapper.post('/v1/admin/keys', {
         name: newKeyName || undefined,
+        description: newKeyDescription || undefined,
         owner: selectedOwner ? selectedOwner.id : undefined,
         expires_at: newKeyExpires
           ? newKeyExpires.endOf('day').format('YYYY-MM-DDTHH:mm:ss')
@@ -137,6 +185,7 @@ function ApiKeyManagement() {
       })
       setCreatedKey(result.key)
       setNewKeyName('')
+      setNewKeyDescription('')
       setNewKeyExpires(null)
       setNewKeyPermType('all')
       setSelectedModelTypes([])
@@ -264,11 +313,23 @@ function ApiKeyManagement() {
 
   const columns = [
     { field: 'id', headerName: t('apikeyManagement.id'), width: 60 },
-    { field: 'name', headerName: t('apikeyManagement.name'), width: 150 },
+    {
+      field: 'name',
+      headerName: t('apikeyManagement.name'),
+      flex: 1,
+      minWidth: 120,
+    },
+    {
+      field: 'description',
+      headerName: t('apikeyManagement.description'),
+      flex: 1,
+      minWidth: 120,
+    },
     {
       field: 'user_id',
       headerName: t('apikeyManagement.owner'),
-      width: 120,
+      flex: 0.8,
+      minWidth: 100,
       renderCell: (params) => {
         const user = users.find((u) => u.id === params.value)
         return user ? user.username : `#${params.value}`
@@ -282,7 +343,7 @@ function ApiKeyManagement() {
     {
       field: 'enabled',
       headerName: t('apikeyManagement.status'),
-      width: 100,
+      width: 80,
       renderCell: (params) =>
         params.value ? (
           <Chip
@@ -301,12 +362,14 @@ function ApiKeyManagement() {
     {
       field: 'expires_at',
       headerName: t('apikeyManagement.expires'),
-      width: 180,
+      flex: 1,
+      minWidth: 140,
     },
     {
       field: 'model_permissions',
       headerName: t('apikeyManagement.modelPermissions'),
-      width: 250,
+      flex: 1.5,
+      minWidth: 180,
       renderCell: (params) => (
         <Box sx={{ display: 'flex', gap: 0.5, flexWrap: 'wrap', py: 0.5 }}>
           {(params.value || []).map((mp, i) => (
@@ -333,9 +396,30 @@ function ApiKeyManagement() {
       ),
     },
     {
+      field: 'bans',
+      headerName: t('apikeyManagement.bans'),
+      width: 70,
+      renderCell: (params) => {
+        const count = keyBanCounts[params.row.id] || 0
+        return count > 0 ? (
+          <Chip
+            label={count}
+            size="small"
+            color="error"
+            onClick={() => handleShowBans(params.row.id)}
+            sx={{ cursor: 'pointer' }}
+          />
+        ) : (
+          <Typography variant="body2" color="text.secondary">
+            0
+          </Typography>
+        )
+      },
+    },
+    {
       field: 'actions',
       headerName: t('apikeyManagement.actions'),
-      width: 190,
+      width: 170,
       renderCell: (params) => (
         <Box>
           <Tooltip title={t('apikeyManagement.revealTooltip')}>
@@ -448,6 +532,16 @@ function ApiKeyManagement() {
                 fullWidth
                 value={newKeyName}
                 onChange={(e) => setNewKeyName(e.target.value)}
+              />
+              <TextField
+                margin="dense"
+                label={t('apikeyManagement.descriptionLabel')}
+                fullWidth
+                multiline
+                minRows={2}
+                maxRows={4}
+                value={newKeyDescription}
+                onChange={(e) => setNewKeyDescription(e.target.value)}
               />
               {isAdmin && (
                 <Autocomplete
@@ -749,6 +843,52 @@ function ApiKeyManagement() {
           {snackSuccess}
         </Alert>
       </Snackbar>
+
+      {/* Bans Detail Dialog */}
+      <Dialog
+        open={bansDialogOpen}
+        onClose={() => setBansDialogOpen(false)}
+        maxWidth="sm"
+        fullWidth
+      >
+        <DialogTitle>
+          Banned IPs for Key #{bansDialogKeyId}
+        </DialogTitle>
+        <DialogContent>
+          {bansData.length === 0 ? (
+            <Typography color="text.secondary">No active bans</Typography>
+          ) : (
+            <Box>
+              {bansData.map((ban, idx) => (
+                <Box
+                  key={idx}
+                  display="flex"
+                  justifyContent="space-between"
+                  alignItems="center"
+                  sx={{ py: 1, borderBottom: '1px solid #eee' }}
+                >
+                  <Box>
+                    <Typography variant="body2">{ban.ip}</Typography>
+                    <Typography variant="caption" color="text.secondary">
+                      Remaining: {ban.remaining_seconds}s
+                    </Typography>
+                  </Box>
+                  <Button
+                    size="small"
+                    color="error"
+                    onClick={() => handleUnbanFromDialog(ban.ip)}
+                  >
+                    Unban
+                  </Button>
+                </Box>
+              ))}
+            </Box>
+          )}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setBansDialogOpen(false)}>Close</Button>
+        </DialogActions>
+      </Dialog>
     </Box>
   )
 }


### PR DESCRIPTION
## Summary

- Add description field to API keys for better identification and management
- Add ban status indicator and unban action in API key management UI
- Improve table column widths for better readability
- Add API endpoints for updating key description

## Dependencies

> ⚠️ This PR depends on #4949 (Security Hardening).
> Please merge #4949 first. I will rebase this branch after it's merged.

## Changes

- `xinference/api/oauth2/advanced/database.py`: Add description column to API key model
- `xinference/api/oauth2/advanced/routes.py`: Add description update endpoint
- `xinference/ui/web/ui/src/scenes/apikey_management/index.js`: Ban status display, description field, column width
- `xinference/ui/web/ui/src/locales/*.json`: i18n keys for new fields

## How to Review

- Review the diff assuming #4949 (Security Hardening) is already merged
- Key focus: database schema change for description field

## Testing

- Verified description CRUD operations
- Verified ban status displays correctly for banned keys
- Verified table layout with new columns
