### PR TITLE
chattts: set weights_only=True for torch.load speaker embedding

### DIFF
--- a/xinference/model/audio/chattts.py
+++ b/xinference/model/audio/chattts.py
@@ -83,7 +83,7 @@ class ChatTTSModel:
                 assert self._model is not None
                 b = base64.b64decode(voice)
                 bio = BytesIO(b)
-                tensor = torch.load(bio, map_location="cpu")
+                tensor = torch.load(bio, map_location="cpu", weights_only=True)
                 rnd_spk_emb = self._model._encode_spk_emb(tensor)
                 logger.info("Speech by input speaker")
             except Exception as e:


### PR DESCRIPTION
### What

Set `weights_only=True` explicitly on the `torch.load` call that decodes the ChatTTS speaker-embedding tensor in `xinference/model/audio/chattts.py`.

### Why

PyTorch 2.6 changed the default of `torch.load` to `weights_only=True` and emits a `FutureWarning` when it is left unset. Setting it explicitly keeps the ChatTTS voice-embedding load path forward-compatible with newer torch releases and silences the deprecation warning. `weights_only=True` is sufficient here since the payload is a plain speaker-embedding tensor.

### Test

`torch.load(bio, map_location="cpu", weights_only=True)` loads the speaker-embedding tensor unchanged for valid inputs.

Signed-off-by: tonghuaroot <tonghuaroot@gmail.com>