### PR TITLE
fix(venv): evaluate CUDA version markers dynamically

### DIFF
--- a/xinference/core/utils.py
+++ b/xinference/core/utils.py
@@ -374,12 +374,12 @@ def filter_virtualenv_packages_by_markers(
                 return False
 
         if op_versions := re.findall(
-            r"cuda_version\s*([<>=!]+)\s*['\"]([^'\"]+)['\"]", marker
+            r"cuda_version\s*([<>=!~]+)\s*['\"]([^'\"]+)['\"]", marker
         ):
             if not cuda_version:
                 return False
             if not all(
-                check_marker(op_version, {"cuda_version": cuda_version})
+                check_marker(op_version, "cuda_version", cuda_version)
                 for op_version in op_versions
             ):
                 return False
@@ -497,22 +497,16 @@ class CancelMixin:
             )
 
 
-def check_marker(op_version: Tuple[str, str], package_version: Dict[str, str]) -> bool:
-    package_name = "unknown"
-    p_version = "unknown"
-
+def check_marker(
+    op_version: Tuple[str, str], package_name: str, package_version: str
+) -> bool:
     try:
-        if len(package_version) != 1:
-            raise ValueError(
-                f"Expected exactly one package version, got {package_version}"
-            )
         op, version = op_version
-        package_name, p_version = next(iter(package_version.items()))
         marker_str = f'python_full_version {op} "{version}"'
-        env = {"python_full_version": p_version}
+        env = {"python_full_version": package_version}
         return Marker(marker_str).evaluate(env)
     except Exception as e:
         logger.warning(
-            f"Failed to evaluate {package_name} version marker {op_version} against {p_version}: {e}"
+            f"Failed to evaluate {package_name} version marker {op_version} against {package_version}: {e}"
         )
         return False

--- a/xinference/core/utils.py
+++ b/xinference/core/utils.py
@@ -373,11 +373,9 @@ def filter_virtualenv_packages_by_markers(
             ):
                 return False
 
-        def parse_all_cuda_markers(s):
-            pattern = r"cuda_version\s*([<>=!]+)\s*['\"]([^'\"]+)['\"]"
-            return re.findall(pattern, s)
-
-        if op_versions := parse_all_cuda_markers(marker):
+        if op_versions := re.findall(
+            r"cuda_version\s*([<>=!]+)\s*['\"]([^'\"]+)['\"]", marker
+        ):
             if not cuda_version:
                 return False
             if not all(
@@ -499,6 +497,12 @@ class CancelMixin:
 
 
 def check_marker(op_version: Tuple[str, str], package_version: str) -> bool:
-    marker_str = f'extra {op_version[0]} "{op_version[1]}"'
-    env = {"extra": package_version}
-    return Marker(marker_str).evaluate(env)
+    try:
+        marker_str = f'extra {op_version[0]} "{op_version[1]}"'
+        env = {"extra": package_version}
+        return Marker(marker_str).evaluate(env)
+    except Exception as e:
+        logger.warning(
+            f"Failed to evaluate CUDA version marker {op_version} against {package_version}: {e}"
+        )
+        return False

--- a/xinference/core/utils.py
+++ b/xinference/core/utils.py
@@ -379,7 +379,8 @@ def filter_virtualenv_packages_by_markers(
             if not cuda_version:
                 return False
             if not all(
-                check_marker(op_version, cuda_version) for op_version in op_versions
+                check_marker(op_version, {"cuda_version": cuda_version})
+                for op_version in op_versions
             ):
                 return False
         if (
@@ -496,13 +497,22 @@ class CancelMixin:
             )
 
 
-def check_marker(op_version: Tuple[str, str], package_version: str) -> bool:
+def check_marker(op_version: Tuple[str, str], package_version: Dict[str, str]) -> bool:
+    package_name = "unknown"
+    p_version = "unknown"
+
     try:
-        marker_str = f'extra {op_version[0]} "{op_version[1]}"'
-        env = {"extra": package_version}
+        if len(package_version) != 1:
+            raise ValueError(
+                f"Expected exactly one package version, got {package_version}"
+            )
+        op, version = op_version
+        package_name, p_version = next(iter(package_version.items()))
+        marker_str = f'python_full_version {op} "{version}"'
+        env = {"python_full_version": p_version}
         return Marker(marker_str).evaluate(env)
     except Exception as e:
         logger.warning(
-            f"Failed to evaluate CUDA version marker {op_version} against {package_version}: {e}"
+            f"Failed to evaluate {package_name} version marker {op_version} against {p_version}: {e}"
         )
         return False

--- a/xinference/core/utils.py
+++ b/xinference/core/utils.py
@@ -16,6 +16,7 @@ import logging
 import os
 import platform
 import random
+import re
 import string
 import uuid
 import weakref
@@ -23,6 +24,7 @@ from enum import Enum
 from typing import Any, Dict, Generator, List, Optional, Tuple, Union
 
 import orjson
+from packaging.markers import Marker
 from packaging.requirements import Requirement
 
 from .._compat import BaseModel
@@ -370,11 +372,22 @@ def filter_virtualenv_packages_by_markers(
                 and f"#model_engine# == '{engine_value}'" not in marker
             ):
                 return False
-        if 'cuda_version == "13.0"' in marker and cuda_version != "13.0":
+
+        def parse_all_cuda_markers(s):
+            pattern = r'cuda_version\s*([<>=!]+)\s*"([^"]+)"'
+            return re.findall(pattern, s)
+
+        if (
+            cuda_version
+            and (op_versions := parse_all_cuda_markers(marker))
+            and any(
+                [
+                    check_marker(op_version, cuda_version) is False
+                    for op_version in op_versions
+                ]
+            )
+        ):
             return False
-        if 'cuda_version < "13.0"' in marker:
-            if not cuda_version or cuda_version == "13.0":
-                return False
         if (
             'platform_machine == "x86_64"' in marker
             and platform.machine().lower() != "x86_64"
@@ -487,3 +500,9 @@ class CancelMixin:
             self._running_tasks[request_id] = asyncio.create_task(
                 block_task(), name=self._CANCEL_TASK_NAME
             )
+
+
+def check_marker(op_version: Tuple[str, str], package_version: str) -> bool:
+    marker_str = f'extra {op_version[0]} "{op_version[1]}"'
+    env = {"extra": package_version}
+    return Marker(marker_str).evaluate(env)

--- a/xinference/core/utils.py
+++ b/xinference/core/utils.py
@@ -374,7 +374,7 @@ def filter_virtualenv_packages_by_markers(
                 return False
 
         if op_versions := re.findall(
-            r"cuda_version\s*([<>=!~]+)\s*['\"]([^'\"]+)['\"]", marker
+            r"\bcuda_version\b\s*([<>=!~]+)\s*['\"]([^'\"]+)['\"]", marker
         ):
             if not cuda_version:
                 return False

--- a/xinference/core/utils.py
+++ b/xinference/core/utils.py
@@ -374,17 +374,14 @@ def filter_virtualenv_packages_by_markers(
                 return False
 
         def parse_all_cuda_markers(s):
-            pattern = r'cuda_version\s*([<>=!]+)\s*"([^"]+)"'
+            pattern = r"cuda_version\s*([<>=!]+)\s*['\"]([^'\"]+)['\"]"
             return re.findall(pattern, s)
 
         if op_versions := parse_all_cuda_markers(marker):
             if not cuda_version:
                 return False
-            if any(
-                [
-                    check_marker(op_version, cuda_version) is False
-                    for op_version in op_versions
-                ]
+            if not all(
+                check_marker(op_version, cuda_version) for op_version in op_versions
             ):
                 return False
         if (

--- a/xinference/core/utils.py
+++ b/xinference/core/utils.py
@@ -377,17 +377,16 @@ def filter_virtualenv_packages_by_markers(
             pattern = r'cuda_version\s*([<>=!]+)\s*"([^"]+)"'
             return re.findall(pattern, s)
 
-        if (
-            cuda_version
-            and (op_versions := parse_all_cuda_markers(marker))
-            and any(
+        if op_versions := parse_all_cuda_markers(marker):
+            if not cuda_version:
+                return False
+            if any(
                 [
                     check_marker(op_version, cuda_version) is False
                     for op_version in op_versions
                 ]
-            )
-        ):
-            return False
+            ):
+                return False
         if (
             'platform_machine == "x86_64"' in marker
             and platform.machine().lower() != "x86_64"


### PR DESCRIPTION
The current cuda_version check is fixed, change it to a dynamic check.