### PR TITLE
fix(vllm): set quantization="fp8" when model_format is fp8

### DIFF
--- a/xinference/model/llm/vllm/core.py
+++ b/xinference/model/llm/vllm/core.py
@@ -883,8 +883,10 @@ class VLLMModel(LLM):
 
         if "model_quantization" in model_config:
             model_config["quantization"] = model_config.pop("model_quantization")
-        elif self.model_spec.model_format == "fp8":
-            model_config.setdefault("quantization", "fp8")
+
+        if self.model_spec.model_format == "fp8":
+            if model_config.get("quantization") in (None, "none"):
+                model_config["quantization"] = "fp8"
         else:
             model_config.setdefault("quantization", None)
         model_config.setdefault("max_model_len", None)

--- a/xinference/model/llm/vllm/core.py
+++ b/xinference/model/llm/vllm/core.py
@@ -883,6 +883,8 @@ class VLLMModel(LLM):
 
         if "model_quantization" in model_config:
             model_config["quantization"] = model_config.pop("model_quantization")
+        elif self.model_spec.model_format == "fp8":
+            model_config.setdefault("quantization", "fp8")
         else:
             model_config.setdefault("quantization", None)
         model_config.setdefault("max_model_len", None)


### PR DESCRIPTION
## Summary

- When `model_format` is `"fp8"`, explicitly set `quantization="fp8"` in the vLLM engine config to prevent OOM from BF16 full-precision loading.

## Background

vLLM 0.21.0 no longer auto-detects FP8 quantization from `config.json` for certain multi-modal architectures (e.g. `Qwen3_5ForConditionalGeneration`). Without explicit `--quantization fp8`, a 27B FP8 model attempts to load in BF16 (~27 GiB), causing OOM on 24 GiB GPUs.

The fix adds an `elif self.model_spec.model_format == "fp8"` branch in `_sanitize_model_config` so the quantization parameter is correctly passed through.

## Test plan

- [ ] Deploy an FP8 model (e.g. Qwen3.6-27B FP8) via xinference with vLLM engine
- [ ] Verify vLLM receives `quantization: fp8` in its config (visible in startup logs)
- [ ] Confirm model loads at ~14 GiB/GPU instead of OOM
