### PR TITLE
fix(auth): return specific error messages for expired/disabled API keys

### DIFF
--- a/xinference/api/oauth2/advanced/auth_service.py
+++ b/xinference/api/oauth2/advanced/auth_service.py
@@ -437,7 +437,20 @@ class AdvancedAuthService:
                         )
                     except ImportError:
                         pass
-                raise credentials_exception
+                if (
+                    api_key_entry.expires_at
+                    and datetime.utcnow() > api_key_entry.expires_at
+                ):
+                    raise HTTPException(
+                        status_code=status.HTTP_401_UNAUTHORIZED,
+                        detail="API key has expired",
+                        headers={"WWW-Authenticate": authenticate_value},
+                    )
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail="API key is disabled",
+                    headers={"WWW-Authenticate": authenticate_value},
+                )
 
             # Check (IP, Key) ban
             if (

--- a/xinference/api/oauth2/advanced/auth_service.py
+++ b/xinference/api/oauth2/advanced/auth_service.py
@@ -437,10 +437,7 @@ class AdvancedAuthService:
                         )
                     except ImportError:
                         pass
-                if (
-                    api_key_entry.expires_at
-                    and datetime.utcnow() > api_key_entry.expires_at
-                ):
+                if _status == "key_expired":
                     raise HTTPException(
                         status_code=status.HTTP_401_UNAUTHORIZED,
                         detail="API key has expired",


### PR DESCRIPTION
## Summary
- Return `401 API key has expired` when an expired API key is used, instead of the generic "Could not validate credentials"
- Return `401 API key is disabled` when a disabled API key is used
- Improves user experience by clearly indicating why authentication failed

## Test plan
- [ ] Use an expired API key → verify response is `401` with detail `"API key has expired"`
- [ ] Use a disabled API key → verify response is `401` with detail `"API key is disabled"`
- [ ] Use a valid API key → verify normal behavior unchanged
- [ ] Use an invalid/unknown API key → verify still returns generic credentials error
