### PR TITLE
fix(monitor): periodic refresh for security gauges and ban remaining API

### DIFF
--- a/xinference/api/oauth2/advanced/rate_limiter.py
+++ b/xinference/api/oauth2/advanced/rate_limiter.py
@@ -144,6 +144,22 @@ class RateLimiter:
                 del self._key_records[(ip, key_id)]
             return False
 
+    def get_ip_ban_remaining(self, ip: str) -> int:
+        with self._lock:
+            rec = self._ip_records.get(ip)
+            if not rec or not rec.banned_until:
+                return 0
+            remaining = rec.banned_until - time.time()
+            return max(0, int(remaining))
+
+    def get_key_ban_remaining(self, ip: str, key_id: int) -> int:
+        with self._lock:
+            rec = self._key_records.get((ip, key_id))
+            if not rec or not rec.banned_until:
+                return 0
+            remaining = rec.banned_until - time.time()
+            return max(0, int(remaining))
+
     def record_key_failure(
         self, ip: str, key_id: int, config: Optional[RateLimitConfig] = None
     ) -> None:

--- a/xinference/api/restful_api.py
+++ b/xinference/api/restful_api.py
@@ -586,7 +586,7 @@ class RESTfulAPI(CancelMixin):
         """Periodically refresh Supervisor-side Prometheus Gauges (every 15s)."""
         import asyncio
 
-        from ..core.metrics import update_cluster_metrics
+        from ..core.metrics import update_cluster_metrics, update_security_gauges
 
         while True:
             try:
@@ -599,6 +599,8 @@ class RESTfulAPI(CancelMixin):
                     models_data,
                     supervisor_address=self._supervisor_address,
                 )
+                if self._advanced_auth_service:
+                    update_security_gauges(self._advanced_auth_service)
             except Exception:
                 logger.warning("Failed to update cluster metrics", exc_info=True)
 

--- a/xinference/core/metrics.py
+++ b/xinference/core/metrics.py
@@ -524,10 +524,14 @@ def update_security_gauges(auth_service) -> None:
             if not k.get("enabled", 1):
                 continue
             expires_at = k.get("expires_at")
-            if expires_at and datetime.fromisoformat(expires_at) < now:
-                expired += 1
-            else:
-                active += 1
+            if expires_at:
+                try:
+                    if datetime.fromisoformat(expires_at) < now:
+                        expired += 1
+                        continue
+                except ValueError:
+                    continue
+            active += 1
         api_keys_active_total.set({}, active)
         api_keys_expired_total.set({}, expired)
     except Exception:

--- a/xinference/core/metrics.py
+++ b/xinference/core/metrics.py
@@ -507,6 +507,54 @@ def update_cluster_metrics(
     _prev_status_labels = cur_status_labels
 
 
+def update_security_gauges(auth_service) -> None:
+    """Refresh security-related Prometheus gauges (API key counts + ban counts).
+
+    Called periodically from the metrics update loop to ensure gauges always
+    have a value, regardless of whether CRUD or ban events have occurred.
+    """
+    from datetime import datetime
+
+    try:
+        keys = auth_service._db.list_api_keys()
+        active = 0
+        expired = 0
+        now = datetime.utcnow()
+        for k in keys:
+            if not k.get("enabled", 1):
+                continue
+            expires_at = k.get("expires_at")
+            if expires_at and datetime.fromisoformat(expires_at) < now:
+                expired += 1
+            else:
+                active += 1
+        api_keys_active_total.set({}, active)
+        api_keys_expired_total.set({}, expired)
+    except Exception:
+        pass
+
+    try:
+        import time as _time
+
+        rate_limiter = auth_service._rate_limiter
+        if rate_limiter:
+            now_ts = _time.time()
+            ip_count = sum(
+                1
+                for r in rate_limiter._ip_records.values()
+                if r.banned_until and r.banned_until > now_ts
+            )
+            key_count = sum(
+                1
+                for r in rate_limiter._key_records.values()
+                if r.banned_until and r.banned_until > now_ts
+            )
+            banned_ips_total.set({}, ip_count)
+            banned_keys_total.set({}, key_count)
+    except Exception:
+        pass
+
+
 def launch_metrics_export_server(q, host=None, port=None):
     # Remove Supervisor-only metrics from Worker's Registry to avoid
     # empty HELP/TYPE headers on the Worker /metrics endpoint.

--- a/xinference/core/metrics.py
+++ b/xinference/core/metrics.py
@@ -538,17 +538,18 @@ def update_security_gauges(auth_service) -> None:
 
         rate_limiter = auth_service._rate_limiter
         if rate_limiter:
-            now_ts = _time.time()
-            ip_count = sum(
-                1
-                for r in rate_limiter._ip_records.values()
-                if r.banned_until and r.banned_until > now_ts
-            )
-            key_count = sum(
-                1
-                for r in rate_limiter._key_records.values()
-                if r.banned_until and r.banned_until > now_ts
-            )
+            with rate_limiter._lock:
+                now_ts = _time.time()
+                ip_count = sum(
+                    1
+                    for r in rate_limiter._ip_records.values()
+                    if r.banned_until and r.banned_until > now_ts
+                )
+                key_count = sum(
+                    1
+                    for r in rate_limiter._key_records.values()
+                    if r.banned_until and r.banned_until > now_ts
+                )
             banned_ips_total.set({}, ip_count)
             banned_keys_total.set({}, key_count)
     except Exception:


### PR DESCRIPTION
## Summary
- Add `update_security_gauges()` to periodically refresh `api_keys_active_total`, `api_keys_expired_total`, `banned_ips_total`, and `banned_keys_total` in the existing 15s metrics update loop
- Previously these gauges only had values when triggered by CRUD or ban events; after a restart they showed no data
- Add `get_ip_ban_remaining()` and `get_key_ban_remaining()` methods to RateLimiter for querying remaining ban duration

## Test plan
- [ ] Start xinference with advanced auth enabled, verify all 4 gauges have values within 15s without any CRUD/ban events
- [ ] Create/expire API keys → verify `api_keys_active_total` and `api_keys_expired_total` update correctly
- [ ] Trigger IP/key ban → verify `banned_ips_total` and `banned_keys_total` reflect correct counts
- [ ] Restart service → verify gauges recover values within 15s
