### PR TITLE
feat(monitor): add per-model GPU memory usage metrics

### DIFF
--- a/xinference/core/metrics.py
+++ b/xinference/core/metrics.py
@@ -148,10 +148,6 @@ model_gpu_memory_used_bytes = Gauge(
     "xinference:model_gpu_memory_used_bytes",
     "Per-model GPU memory used in bytes (real-time, per process).",
 )
-model_gpu_memory_loaded_bytes = Gauge(
-    "xinference:model_gpu_memory_loaded_bytes",
-    "GPU memory consumed by model loading (delta before/after load).",
-)
 build_info_gauge = Gauge(
     "xinference:build_info",
     "Xinference build information (value=1).",
@@ -207,7 +203,6 @@ _SUPERVISOR_ONLY_METRICS = {
     "xinference:worker_gpu_memory_total_bytes",
     "xinference:model_gpu_binding",
     "xinference:model_gpu_memory_used_bytes",
-    "xinference:model_gpu_memory_loaded_bytes",
     "xinference:api_key_requests_total",
     "xinference:api_key_request_duration_seconds",
     "xinference:api_keys_active_total",

--- a/xinference/core/metrics.py
+++ b/xinference/core/metrics.py
@@ -144,6 +144,14 @@ model_gpu_binding_gauge = Gauge(
     "xinference:model_gpu_binding",
     "Per-replica GPU binding (one series per GPU per replica, value=1).",
 )
+model_gpu_memory_used_bytes = Gauge(
+    "xinference:model_gpu_memory_used_bytes",
+    "Per-model GPU memory used in bytes (real-time, per process).",
+)
+model_gpu_memory_loaded_bytes = Gauge(
+    "xinference:model_gpu_memory_loaded_bytes",
+    "GPU memory consumed by model loading (delta before/after load).",
+)
 build_info_gauge = Gauge(
     "xinference:build_info",
     "Xinference build information (value=1).",
@@ -198,6 +206,8 @@ _SUPERVISOR_ONLY_METRICS = {
     "xinference:worker_gpu_memory_used_bytes",
     "xinference:worker_gpu_memory_total_bytes",
     "xinference:model_gpu_binding",
+    "xinference:model_gpu_memory_used_bytes",
+    "xinference:model_gpu_memory_loaded_bytes",
     "xinference:api_key_requests_total",
     "xinference:api_key_request_duration_seconds",
     "xinference:api_keys_active_total",
@@ -229,6 +239,7 @@ _prev_worker_labels: Set[Tuple[str, ...]] = set()
 _prev_gpu_labels: Set[Tuple[str, ...]] = set()
 _prev_model_labels: Set[Tuple[str, ...]] = set()
 _prev_status_labels: Set[Tuple[str, ...]] = set()
+_prev_model_gpu_mem_labels: Set[Tuple[str, ...]] = set()
 _prev_gpu_binding_labels: Set[Tuple[str, ...]] = set()
 
 
@@ -295,7 +306,7 @@ def update_cluster_metrics(
 ) -> None:
     """Refresh all Supervisor-side Prometheus gauges from in-memory data."""
     global _prev_worker_labels, _prev_gpu_labels
-    global _prev_model_labels, _prev_status_labels, _prev_gpu_binding_labels
+    global _prev_model_labels, _prev_status_labels, _prev_gpu_binding_labels, _prev_model_gpu_mem_labels
 
     # --- Build info (set once, labels are static) ---
     cluster_name = cluster_data.get("cluster", "")
@@ -505,6 +516,55 @@ def update_cluster_metrics(
         }
         model_status_gauge.set(stale_labels, 0)
     _prev_status_labels = cur_status_labels
+
+    # --- Per-model GPU memory ---
+    cur_model_gpu_mem_labels: Set[Tuple[str, ...]] = set()
+    model_gpu_mem_data = cluster_data.get("model_gpu_memory", {})
+    from .utils import parse_replica_model_uid
+
+    for worker_addr, models_mem in model_gpu_mem_data.items():
+        for m_uid, gpu_mem in models_mem.items():
+            try:
+                base_uid, rep_idx = parse_replica_model_uid(m_uid)
+            except (TypeError, ValueError):
+                base_uid = m_uid
+                rep_idx = 0
+            m_spec = models_data.get(base_uid, {})
+            m_name = m_spec.get("model_name", "unknown")
+            m_type = m_spec.get("model_type", "unknown")
+            if m_name == "unknown":
+                continue
+            replica_index = rep_idx
+            for gpu_idx, mem_bytes in gpu_mem.items():
+                mem_labels = {
+                    "model_uid": base_uid,
+                    "model_name": m_name,
+                    "model_type": m_type,
+                    "gpu_index": str(gpu_idx),
+                    "worker_address": worker_addr,
+                    "replica_index": str(replica_index),
+                }
+                mem_key = (
+                    base_uid,
+                    m_name,
+                    m_type,
+                    str(gpu_idx),
+                    worker_addr,
+                    str(replica_index),
+                )
+                cur_model_gpu_mem_labels.add(mem_key)
+                model_gpu_memory_used_bytes.set(mem_labels, mem_bytes)
+    for stale in _prev_model_gpu_mem_labels - cur_model_gpu_mem_labels:
+        stale_labels = {
+            "model_uid": stale[0],
+            "model_name": stale[1],
+            "model_type": stale[2],
+            "gpu_index": stale[3],
+            "worker_address": stale[4],
+            "replica_index": stale[5],
+        }
+        model_gpu_memory_used_bytes.set(stale_labels, 0)
+    _prev_model_gpu_mem_labels = cur_model_gpu_mem_labels
 
 
 def launch_metrics_export_server(q, host=None, port=None):

--- a/xinference/core/model.py
+++ b/xinference/core/model.py
@@ -326,6 +326,11 @@ class ModelActor(xo.StatelessActor, CancelMixin):
             {"labels": self._metrics_labels, "value": limit_val},
         )
 
+    def get_pid(self) -> int:
+        import os
+
+        return os.getpid()
+
     def __repr__(self) -> str:
         return f"ModelActor({self._replica_model_uid})"
 

--- a/xinference/core/supervisor.py
+++ b/xinference/core/supervisor.py
@@ -2636,6 +2636,7 @@ class SupervisorActor(xo.StatelessActor):
             )
 
         self._worker_status.pop(worker_address, None)
+        self._worker_model_gpu_memory.pop(worker_address, None)
         try:
             from .otel import get_cluster_metrics_collector
 

--- a/xinference/core/supervisor.py
+++ b/xinference/core/supervisor.py
@@ -2682,7 +2682,7 @@ class SupervisorActor(xo.StatelessActor):
         if isinstance(status, dict):
             model_gpu_mem = status.pop("model_gpu_memory", None)
             if model_gpu_mem:
-                self._worker_model_gpu_memory[worker_address] = model_gpu_mem
+                self._worker_model_gpu_memory[worker_address] = model_gpu_mem  # type: ignore[assignment]
             elif worker_address in self._worker_model_gpu_memory:
                 del self._worker_model_gpu_memory[worker_address]
 

--- a/xinference/core/supervisor.py
+++ b/xinference/core/supervisor.py
@@ -136,6 +136,9 @@ class SupervisorActor(xo.StatelessActor):
         # launches, reverse-channel dead detection is exempted because
         # long-running model downloads can starve the actor event loop.
         self._workers_launching: Dict[str, int] = {}  # address -> active launch count
+        self._worker_model_gpu_memory: Dict[str, Dict[str, Dict[int, int]]] = (
+            {}
+        )  # worker_address -> {model_uid -> {gpu_idx -> bytes}}
 
     @classmethod
     def default_uid(cls) -> str:
@@ -923,6 +926,7 @@ class SupervisorActor(xo.StatelessActor):
             "workers": workers,
             "instance_infos": instance_infos,
             "model_replica_distribution": model_replica_distribution,
+            "model_gpu_memory": dict(self._worker_model_gpu_memory),
         }
 
     def _get_spec_dicts(
@@ -2672,6 +2676,14 @@ class SupervisorActor(xo.StatelessActor):
                     "Failed to feed worker status into OTEL collector for worker_address=%s",
                     worker_address,
                 )
+
+        # Extract and store per-model GPU memory data
+        if isinstance(status, dict):
+            model_gpu_mem = status.pop("model_gpu_memory", None)
+            if model_gpu_mem:
+                self._worker_model_gpu_memory[worker_address] = model_gpu_mem
+            elif worker_address in self._worker_model_gpu_memory:
+                del self._worker_model_gpu_memory[worker_address]
 
     async def receive_heartbeat(self, worker_address: str):
         """

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -217,9 +217,6 @@ class WorkerActor(xo.StatelessActor):
         self._model_uid_to_recover_count: Dict[str, Optional[int]] = {}
         self._model_uid_to_launch_args: Dict[str, Dict] = {}
         self._model_uid_to_pid: Dict[str, int] = {}
-        self._model_uid_to_gpu_pids: Dict[str, set] = {}
-        self._model_uid_to_gpu_snapshot_before: Dict[str, set] = {}
-        self._gpu_snapshot_lock = asyncio.Lock()
 
         if XINFERENCE_DISABLE_METRICS:
             logger.info(
@@ -2123,19 +2120,6 @@ class WorkerActor(xo.StatelessActor):
 
                 with progressor:
                     try:
-                        # PID snapshot before load (for GPU process tattoo)
-                        from ..device_utils import get_per_process_gpu_memory
-
-                        async with self._gpu_snapshot_lock:
-                            _before_gpu_pids = set(
-                                (
-                                    await asyncio.to_thread(get_per_process_gpu_memory)
-                                ).keys()
-                            )
-                            self._model_uid_to_gpu_snapshot_before[model_uid] = (
-                                _before_gpu_pids
-                            )
-
                         _load_start = time.time()
                         await model_ref.load()
                         _load_duration = time.time() - _load_start
@@ -2149,27 +2133,9 @@ class WorkerActor(xo.StatelessActor):
                             },
                             _load_duration,
                         )
-
-                        # PID snapshot after load (captures vLLM/SGLang GPU worker PIDs)
-                        async with self._gpu_snapshot_lock:
-                            _after_gpu_pids = set(
-                                (
-                                    await asyncio.to_thread(get_per_process_gpu_memory)
-                                ).keys()
-                            )
-                            _new_gpu_pids = _after_gpu_pids - _before_gpu_pids
-                            if _new_gpu_pids:
-                                self._model_uid_to_gpu_pids[model_uid] = _new_gpu_pids
-                                logger.info(
-                                    "GPU PID tattoo for %s: %s",
-                                    model_uid,
-                                    _new_gpu_pids,
-                                )
                     except xo.ServerClosed:
                         check_cancel()
                         raise
-                    finally:
-                        self._model_uid_to_gpu_snapshot_before.pop(model_uid, None)
             except Exception:
                 logger.error(f"Failed to load model {model_uid}", exc_info=True)
                 self.release_devices(model_uid=model_uid)
@@ -2364,6 +2330,7 @@ class WorkerActor(xo.StatelessActor):
             self._model_uid_to_addr.pop(model_uid, None)
             self._model_uid_to_recover_count.pop(model_uid, None)
             self._model_uid_to_launch_args.pop(model_uid, None)
+            self._model_uid_to_pid.pop(model_uid, None)
             # §4.3: Remove from persisted recovery file
             self._remove_persisted_launch_args(model_uid)
 
@@ -2423,24 +2390,27 @@ class WorkerActor(xo.StatelessActor):
             async with timeout(XINFERENCE_STATUS_GATHER_TIMEOUT):
                 status = await asyncio.to_thread(gather_node_info)
 
-                # Collect per-model GPU memory using PID tattoo
+                # Collect per-model GPU memory using psutil descendant PIDs
                 try:
+                    import psutil
+
                     from ..device_utils import get_per_process_gpu_memory
 
                     gpu_mem = await asyncio.to_thread(get_per_process_gpu_memory)
                     model_gpu_mem: Dict[str, Dict[int, int]] = {}
-                    for m_uid, pids in self._model_uid_to_gpu_pids.items():
+                    for m_uid, own_pid in self._model_uid_to_pid.items():
                         per_gpu: Dict[int, int] = {}
-                        for pid in pids:
+                        try:
+                            parent = psutil.Process(own_pid)
+                            all_pids = [own_pid] + [
+                                c.pid for c in parent.children(recursive=True)
+                            ]
+                        except (psutil.NoSuchProcess, psutil.AccessDenied):
+                            all_pids = [own_pid]
+                        for pid in all_pids:
                             if pid in gpu_mem:
                                 for gpu_idx, mem in gpu_mem[pid].items():
                                     per_gpu[gpu_idx] = per_gpu.get(gpu_idx, 0) + mem
-                        # Also check model's own PID
-                        own_pid = self._model_uid_to_pid.get(m_uid)
-                        if own_pid and own_pid in gpu_mem:
-                            for gpu_idx, mem in gpu_mem[own_pid].items():
-                                if gpu_idx not in per_gpu:
-                                    per_gpu[gpu_idx] = mem
                         if per_gpu:
                             model_gpu_mem[m_uid] = per_gpu
                     if model_gpu_mem:

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -216,6 +216,10 @@ class WorkerActor(xo.StatelessActor):
         self._model_uid_to_addr: Dict[str, str] = {}
         self._model_uid_to_recover_count: Dict[str, Optional[int]] = {}
         self._model_uid_to_launch_args: Dict[str, Dict] = {}
+        self._model_uid_to_pid: Dict[str, int] = {}
+        self._model_uid_to_gpu_pids: Dict[str, set] = {}
+        self._model_uid_to_gpu_snapshot_before: Dict[str, set] = {}
+        self._gpu_snapshot_lock = asyncio.Lock()
 
         if XINFERENCE_DISABLE_METRICS:
             logger.info(
@@ -2119,6 +2123,19 @@ class WorkerActor(xo.StatelessActor):
 
                 with progressor:
                     try:
+                        # PID snapshot before load (for GPU process tattoo)
+                        from ..device_utils import get_per_process_gpu_memory
+
+                        async with self._gpu_snapshot_lock:
+                            _before_gpu_pids = set(
+                                (
+                                    await asyncio.to_thread(get_per_process_gpu_memory)
+                                ).keys()
+                            )
+                            self._model_uid_to_gpu_snapshot_before[model_uid] = (
+                                _before_gpu_pids
+                            )
+
                         _load_start = time.time()
                         await model_ref.load()
                         _load_duration = time.time() - _load_start
@@ -2132,9 +2149,27 @@ class WorkerActor(xo.StatelessActor):
                             },
                             _load_duration,
                         )
+
+                        # PID snapshot after load (captures vLLM/SGLang GPU worker PIDs)
+                        async with self._gpu_snapshot_lock:
+                            _after_gpu_pids = set(
+                                (
+                                    await asyncio.to_thread(get_per_process_gpu_memory)
+                                ).keys()
+                            )
+                            _new_gpu_pids = _after_gpu_pids - _before_gpu_pids
+                            if _new_gpu_pids:
+                                self._model_uid_to_gpu_pids[model_uid] = _new_gpu_pids
+                                logger.info(
+                                    "GPU PID tattoo for %s: %s",
+                                    model_uid,
+                                    _new_gpu_pids,
+                                )
                     except xo.ServerClosed:
                         check_cancel()
                         raise
+                    finally:
+                        self._model_uid_to_gpu_snapshot_before.pop(model_uid, None)
             except Exception:
                 logger.error(f"Failed to load model {model_uid}", exc_info=True)
                 self.release_devices(model_uid=model_uid)
@@ -2145,6 +2180,10 @@ class WorkerActor(xo.StatelessActor):
                         continue
                 raise
             self._model_uid_to_model[model_uid] = model_ref
+            try:
+                self._model_uid_to_pid[model_uid] = await model_ref.get_pid()
+            except Exception:
+                pass
             model_spec = model.model_family.to_description()
             self._model_uid_to_model_spec[model_uid] = model_spec
             self._model_uid_to_model_status[model_uid] = ModelStatus()
@@ -2383,6 +2422,31 @@ class WorkerActor(xo.StatelessActor):
             # Use configurable timeout for status gathering
             async with timeout(XINFERENCE_STATUS_GATHER_TIMEOUT):
                 status = await asyncio.to_thread(gather_node_info)
+
+                # Collect per-model GPU memory using PID tattoo
+                try:
+                    from ..device_utils import get_per_process_gpu_memory
+
+                    gpu_mem = await asyncio.to_thread(get_per_process_gpu_memory)
+                    model_gpu_mem: Dict[str, Dict[int, int]] = {}
+                    for m_uid, pids in self._model_uid_to_gpu_pids.items():
+                        per_gpu: Dict[int, int] = {}
+                        for pid in pids:
+                            if pid in gpu_mem:
+                                for gpu_idx, mem in gpu_mem[pid].items():
+                                    per_gpu[gpu_idx] = per_gpu.get(gpu_idx, 0) + mem
+                        # Also check model's own PID
+                        own_pid = self._model_uid_to_pid.get(m_uid)
+                        if own_pid and own_pid in gpu_mem:
+                            for gpu_idx, mem in gpu_mem[own_pid].items():
+                                if gpu_idx not in per_gpu:
+                                    per_gpu[gpu_idx] = mem
+                        if per_gpu:
+                            model_gpu_mem[m_uid] = per_gpu
+                    if model_gpu_mem:
+                        status["model_gpu_memory"] = model_gpu_mem
+                except Exception:
+                    pass
         except asyncio.CancelledError:
             raise
         except Exception:

--- a/xinference/device_utils.py
+++ b/xinference/device_utils.py
@@ -613,3 +613,46 @@ def get_gpu_info() -> Dict:
     if spec is None:
         return {}
     return spec.get_gpu_info_fn()
+
+
+def get_per_process_gpu_memory() -> Dict[int, Dict[int, int]]:
+    """Query per-process GPU memory usage via pynvml.
+
+    Returns: {pid: {gpu_index: memory_bytes}}
+    """
+    result: Dict[int, Dict[int, int]] = {}
+    try:
+        from pynvml import (
+            NVMLError,
+            nvmlDeviceGetComputeRunningProcesses,
+            nvmlDeviceGetCount,
+            nvmlDeviceGetHandleByIndex,
+            nvmlInit,
+        )
+    except ImportError:
+        return result
+
+    try:
+        nvmlInit()
+    except Exception:
+        return result
+
+    try:
+        device_count = nvmlDeviceGetCount()
+        for i in range(device_count):
+            try:
+                handle = nvmlDeviceGetHandleByIndex(i)
+                processes = nvmlDeviceGetComputeRunningProcesses(handle)
+            except NVMLError:
+                continue
+            for proc in processes:
+                mem = getattr(proc, "usedGpuMemory", None)
+                if mem is None:
+                    continue
+                if proc.pid not in result:
+                    result[proc.pid] = {}
+                result[proc.pid][i] = mem
+    except NVMLError:
+        pass
+
+    return result

--- a/xinference/device_utils.py
+++ b/xinference/device_utils.py
@@ -628,6 +628,7 @@ def get_per_process_gpu_memory() -> Dict[int, Dict[int, int]]:
             nvmlDeviceGetCount,
             nvmlDeviceGetHandleByIndex,
             nvmlInit,
+            nvmlShutdown,
         )
     except ImportError:
         return result
@@ -654,5 +655,10 @@ def get_per_process_gpu_memory() -> Dict[int, Dict[int, int]]:
                 result[proc.pid][i] = mem
     except NVMLError:
         pass
+    finally:
+        try:
+            nvmlShutdown()
+        except Exception:
+            pass
 
     return result


### PR DESCRIPTION
## Summary
- Add real-time per-model GPU memory monitoring via Prometheus Gauge `xinference:model_gpu_memory_used_bytes`
- Uses pynvml to query per-process GPU memory with a PID tattoo mechanism to associate GPU worker processes (vLLM/SGLang) with their parent model
- Supports multi-GPU and multi-replica scenarios with labels: `model_uid`, `model_name`, `model_type`, `gpu_index`, `worker_address`, `replica_index`

## Changes
- `xinference/device_utils.py` — add `get_per_process_gpu_memory()` via pynvml
- `xinference/core/model.py` — add `get_pid()` method to ModelActor
- `xinference/core/worker.py` — GPU PID snapshot before/after model load + report per-model GPU memory in status
- `xinference/core/supervisor.py` — aggregate model_gpu_memory from workers
- `xinference/core/metrics.py` — new Gauge definitions + collection logic with stale label cleanup

## Test plan
- [ ] Load a model on GPU → verify `model_gpu_memory_used_bytes` appears in `/metrics` with correct labels
- [ ] Load multiple models → verify each model has distinct metrics
- [ ] Unload a model → verify its metric drops to 0 (stale cleanup)
- [ ] Test without GPU (CPU-only) → verify no errors, metric simply not populated
- [ ] Test with vLLM engine → verify GPU worker subprocess memory is attributed to correct model
