### PR TITLE
doc: remove WeChat QR links from docs site

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -114,12 +114,6 @@ if version_match != 'zh-cn':
     html_theme_options["header_links_before_dropdown"] = 3
 else:
     html_theme_options['icon_links'].extend([{
-        "name": "WeChat",
-        "url": "https://xinference.cn/images/WeCom.jpg",
-        "icon": "fa-brands fa-weixin",
-        "type": "fontawesome",
-    },
-    {
         "name": "Zhihu",
         "url": "https://zhihu.com/org/xorbits",
         "icon": "fa-brands fa-zhihu",

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -253,11 +253,6 @@ Getting Involved
       .. grid:: 1
          :gutter: 3
 
-         .. grid-item-card:: 
-            :link: https://xinference.cn/images/WeCom.jpg
-            
-            :fab:`weixin` Find community on WeChat
-
          .. grid-item-card::
             :link: https://discord.gg/Xw9tszSkr5
 

--- a/doc/source/locale/zh_CN/LC_MESSAGES/index.po
+++ b/doc/source/locale/zh_CN/LC_MESSAGES/index.po
@@ -171,10 +171,6 @@ msgstr ":fab:`zhihu` 阅读知乎博客"
 msgid "Get Support"
 msgstr "寻求帮助"
 
-#: ../../source/index.rst:259
-msgid ":fab:`weixin` Find community on WeChat"
-msgstr ":fab:`weixin` 微信社区"
-
 #: ../../source/index.rst:264
 msgid ":fab:`discord` Find community on Discord"
 msgstr ":fab:`discord` Discord 社区"
@@ -193,4 +189,3 @@ msgstr ":fab:`github` 在 Github 上提 PR"
 
 #~ msgid "Vision"
 #~ msgstr "视觉"
-

--- a/doc/source/locale/zh_CN/LC_MESSAGES/models/xinference_model_hub.po
+++ b/doc/source/locale/zh_CN/LC_MESSAGES/models/xinference_model_hub.po
@@ -138,13 +138,8 @@ msgid ""
 msgstr "本节面向拥有模型注册或维护权限的用户，介绍模型注册、维护及审核流程。"
 
 #: ../../source/models/xinference_model_hub.rst:56
-msgid ""
-"**Audience:** Users with model registration or maintenance permissions. "
-"If you wish to become a model maintainer, you can `contact us "
-"<https://xinference.cn/images/WeCom.jpg>`_."
-msgstr ""
-"**适用对象：** 拥有模型注册或维护权限的用户。若希望成为模型维护者，可 "
-"`联系我们 <https://xinference.cn/images/WeCom.jpg>`_。"
+msgid "**Audience:** Users with model registration or maintenance permissions."
+msgstr "**适用对象：** 拥有模型注册或维护权限的用户。"
 
 #: ../../source/models/xinference_model_hub.rst:62
 msgid ""

--- a/doc/source/locale/zh_CN/LC_MESSAGES/models/xinference_models_hub.po
+++ b/doc/source/locale/zh_CN/LC_MESSAGES/models/xinference_models_hub.po
@@ -128,11 +128,8 @@ msgid ""
 msgstr "本节介绍具备模型注册或维护权限的用户可使用的功能，包括模型注册、更新与评审流程。"
 
 #: ../../source/models/xinference_models_hub.rst:50
-msgid ""
-"**Audience:** Users with model registration or maintenance permissions. "
-"To become a model maintainer, you may `contact us "
-"<https://xinference.cn/images/WeCom.jpg>`_."
-msgstr "**适用对象：** 具有模型注册或维护权限的用户。如需成为模型维护者，可 `联系我们 <https://xinference.cn/images/WeCom.jpg>`_。"
+msgid "**Audience:** Users with model registration or maintenance permissions."
+msgstr "**适用对象：** 具有模型注册或维护权限的用户。"
 
 #: ../../source/models/xinference_models_hub.rst:54
 msgid "Core Features (Login Required)"

--- a/doc/source/models/xinference_models_hub.rst
+++ b/doc/source/models/xinference_models_hub.rst
@@ -48,7 +48,6 @@ Guide for Model Maintainers
 This section describes the features available to users with model registration or maintenance permissions, including model registration, updates, and review workflows.
 
 **Audience:** Users with model registration or maintenance permissions.
-To become a model maintainer, you may `contact us <https://xinference.cn/images/WeCom.jpg>`_.
 
 Core Features (Login Required)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Summary:
- Remove the WeChat QR card from the docs home page support section.
- Remove the Chinese docs navbar WeChat icon that linked directly to the QR image.
- Remove the model-maintainer QR contact link and sync zh_CN translation entries.

Validation:
- python -m py_compile doc/source/conf.py
- msgfmt -c for the touched zh_CN .po files
- rg confirms WeCom.jpg is absent from doc/source, docs, .readthedocs.yaml, and the generated /tmp HTML output

Note: a full Sphinx -W build still exits nonzero on existing unrelated docs warnings/errors, including models/custom.rst:308 and models/virtualenv.rst title-level issues.