### PR TITLE
BUG: fix jina-embeddings-v2-base-zh deployment dependencies

### DIFF
--- a/xinference/model/embedding/model_spec.json
+++ b/xinference/model/embedding/model_spec.json
@@ -755,12 +755,12 @@
     "featured": false,
     "virtualenv": {
       "packages": [
-        "sentence_transformers",
-        "einops",
-        "accelerate>=0.28.0",
+        "sentence_transformers ; #engine# == \"sentence_transformers\"",
+        "einops ; #engine# == \"sentence_transformers\"",
+        "accelerate>=0.28.0 ; #engine# == \"sentence_transformers\"",
         "#system_torchvision# ; #engine# == \"sentence_transformers\"",
         "#system_torch# ; #engine# == \"sentence_transformers\"",
-        "transformers==4.52.0"
+        "transformers==4.52.0 ; #engine# == \"sentence_transformers\""
       ]
     }
   },

--- a/xinference/model/embedding/model_spec.json
+++ b/xinference/model/embedding/model_spec.json
@@ -755,8 +755,12 @@
     "featured": false,
     "virtualenv": {
       "packages": [
-        "#sentence_transformers_dependencies# ; #engine# == \"sentence_transformers\"",
-        "#system_torchvision# ; #engine# == \"sentence_transformers\""
+        "sentence_transformers",
+        "einops",
+        "accelerate>=0.28.0",
+        "#system_torchvision# ; #engine# == \"sentence_transformers\"",
+        "#system_torch# ; #engine# == \"sentence_transformers\"",
+        "transformers==4.52.0"
       ]
     }
   },


### PR DESCRIPTION
## Summary

- Fix the virtualenv dependency set for `jina-embeddings-v2-base-zh` so it can be deployed.
- Pin `transformers==4.52.0` and add `einops` + `accelerate>=0.28.0`, matching the working dependency set already used by `jina-embeddings-v3` and `jina-embeddings-v2-base-zh`'s sibling models.

## Why

`jina-embeddings-v2-base-zh` loads via `trust_remote_code` and requires `einops`. The previous generic `#sentence_transformers_dependencies#` entry pulls a newer `transformers` release that breaks model loading at deployment time. Aligning the dependencies with the proven `jina-embeddings-v3` set resolves the deployment failure.

## Test plan

- [ ] Launch `jina-embeddings-v2-base-zh` with the `sentence_transformers` engine in a fresh virtualenv and confirm it loads and serves embeddings.