### PR TITLE
feat: persist launch model configuration history server-side

### DIFF
--- a/doc/source/getting_started/environments.rst
+++ b/doc/source/getting_started/environments.rst
@@ -115,3 +115,12 @@ XINFERENCE_QWEN3_RERANK_TEMPLATE
 ~~~~~~~~~~~~~~~~~~~~~~~
 Enable template for Qwen3 rerank model family (0.6B, 4B, 8B,etc) globally.
 Default value is 1.
+
+XINFERENCE_LAUNCH_HISTORY_DB_PATH
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Path to the SQLite database that stores the model launch configuration history
+shown in the "Launch Model" drawer of the Web UI. This store is shared across
+all clients so the history is available from any browser or machine, and it is
+independent of the authentication database. When authentication is enabled, each
+record keeps the creator's username (``created_by``).
+Default value is ``<XINFERENCE_HOME>/launch_history.db``.

--- a/xinference/api/restful_api.py
+++ b/xinference/api/restful_api.py
@@ -58,6 +58,7 @@ from ..constants import (
     XINFERENCE_DEFAULT_ENDPOINT_PORT,
     XINFERENCE_DISABLE_METRICS,
     XINFERENCE_ENABLE_OTEL,
+    XINFERENCE_LAUNCH_HISTORY_DB_PATH,
     XINFERENCE_SSE_PING_ATTEMPTS_SECONDS,
 )
 from ..core.event import Event, EventCollectorActor, EventType
@@ -138,6 +139,12 @@ class RESTfulAPI(CancelMixin):
             self._auth_service = self._advanced_auth_service
         else:
             self._auth_service = AuthService(auth_config_file)
+
+        from ..core.launch_history_store import LaunchHistoryStore
+
+        self._launch_history_store = LaunchHistoryStore(
+            XINFERENCE_LAUNCH_HISTORY_DB_PATH
+        )
 
         self._router = APIRouter()
         self._app = FastAPI()

--- a/xinference/api/routers/__init__.py
+++ b/xinference/api/routers/__init__.py
@@ -8,7 +8,17 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from . import admin, audio, embeddings, images, llm, models, rerank, videos
+from . import (
+    admin,
+    audio,
+    embeddings,
+    images,
+    launch_history,
+    llm,
+    models,
+    rerank,
+    videos,
+)
 
 if TYPE_CHECKING:
     from ..restful_api import RESTfulAPI
@@ -24,3 +34,4 @@ def register_all_routes(api: RESTfulAPI) -> None:
     audio.register_routes(api)
     images.register_routes(api)
     videos.register_routes(api)
+    launch_history.register_routes(api)

--- a/xinference/api/routers/launch_history.py
+++ b/xinference/api/routers/launch_history.py
@@ -1,0 +1,129 @@
+# Copyright 2022-2026 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Launch history route registration and handlers."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Optional
+
+from fastapi import Depends, HTTPException, Query, Request, Security
+
+from ..dependencies import get_api
+from ..responses import JSONResponse
+
+if TYPE_CHECKING:
+    from ..restful_api import RESTfulAPI
+
+logger = logging.getLogger(__name__)
+
+
+async def list_launch_history(
+    model_name: Optional[str] = Query(None),
+    api: "RESTfulAPI" = Depends(get_api),
+) -> JSONResponse:
+    try:
+        data = api._launch_history_store.list(model_name=model_name)
+        return JSONResponse(content=data)
+    except Exception as e:
+        logger.error(e, exc_info=True)
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+async def create_launch_history(
+    request: Request,
+    api: "RESTfulAPI" = Depends(get_api),
+    user: Optional[dict] = None,
+) -> JSONResponse:
+    try:
+        body = await request.json()
+        model_name = body.get("model_name")
+        model_uid = body.get("model_uid", "")
+        data = body.get("data", {})
+        if not model_name:
+            raise HTTPException(status_code=400, detail="model_name is required")
+        username = user.get("username", "") if user else ""
+        api._launch_history_store.upsert(
+            model_name=model_name,
+            model_uid=model_uid,
+            data=data,
+            username=username,
+        )
+        return JSONResponse(content={"status": "ok"})
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(e, exc_info=True)
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+async def delete_launch_history(
+    model_name: str,
+    model_uid: str = "",
+    api: "RESTfulAPI" = Depends(get_api),
+) -> JSONResponse:
+    try:
+        deleted = api._launch_history_store.delete(model_name, model_uid)
+        if not deleted:
+            raise HTTPException(status_code=404, detail="Record not found")
+        return JSONResponse(content={"status": "ok"})
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(e, exc_info=True)
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+def register_routes(api: "RESTfulAPI") -> None:
+    router = api._router
+    auth = api._auth_service
+    is_auth = api.is_authenticated()
+
+    if is_auth:
+
+        async def create_handler(
+            request: Request,
+            user: dict = Security(auth, scopes=["models:write"]),
+            api_: "RESTfulAPI" = Depends(get_api),
+        ) -> JSONResponse:
+            return await create_launch_history(request, api_, user)
+
+    else:
+        create_handler = create_launch_history  # type: ignore[assignment]
+
+    router.add_api_route(
+        "/v1/launch_history",
+        list_launch_history,
+        methods=["GET"],
+        dependencies=([Security(auth, scopes=["models:list"])] if is_auth else None),
+    )
+    router.add_api_route(
+        "/v1/launch_history",
+        create_handler,
+        methods=["POST"],
+    )
+    router.add_api_route(
+        "/v1/launch_history/{model_name}/{model_uid}",
+        delete_launch_history,
+        methods=["DELETE"],
+        dependencies=([Security(auth, scopes=["models:write"])] if is_auth else None),
+    )
+    # Variant for the common case of an empty model_uid, which cannot be
+    # expressed as a non-empty path segment.
+    router.add_api_route(
+        "/v1/launch_history/{model_name}",
+        delete_launch_history,
+        methods=["DELETE"],
+        dependencies=([Security(auth, scopes=["models:write"])] if is_auth else None),
+    )

--- a/xinference/api/routers/launch_history.py
+++ b/xinference/api/routers/launch_history.py
@@ -32,9 +32,11 @@ logger = logging.getLogger(__name__)
 def list_launch_history(
     model_name: Optional[str] = Query(None),
     api: "RESTfulAPI" = Depends(get_api),
+    user: Optional[dict] = None,
 ) -> JSONResponse:
     try:
-        data = api._launch_history_store.list(model_name=model_name)
+        username = user.get("username", "") if user else ""
+        data = api._launch_history_store.list(model_name=model_name, username=username)
         return JSONResponse(content=data)
     except Exception as e:
         logger.error(e, exc_info=True)
@@ -72,9 +74,11 @@ def delete_launch_history(
     model_name: str,
     model_uid: str = "",
     api: "RESTfulAPI" = Depends(get_api),
+    user: Optional[dict] = None,
 ) -> JSONResponse:
     try:
-        deleted = api._launch_history_store.delete(model_name, model_uid)
+        username = user.get("username", "") if user else ""
+        deleted = api._launch_history_store.delete(model_name, model_uid, username)
         if not deleted:
             raise HTTPException(status_code=404, detail="Record not found")
         return JSONResponse(content={"status": "ok"})
@@ -91,6 +95,8 @@ def register_routes(api: "RESTfulAPI") -> None:
     is_auth = api.is_authenticated()
 
     create_handler: Callable[..., Awaitable[JSONResponse]]
+    list_handler: Callable[..., JSONResponse]
+    delete_handler: Callable[..., JSONResponse]
     if is_auth:
 
         async def create_handler_authed(
@@ -101,6 +107,25 @@ def register_routes(api: "RESTfulAPI") -> None:
             return await create_launch_history(request, api_, user)
 
         create_handler = create_handler_authed
+
+        def list_handler_authed(
+            model_name: Optional[str] = Query(None),
+            user: dict = Security(auth, scopes=["models:list"]),
+            api_: "RESTfulAPI" = Depends(get_api),
+        ) -> JSONResponse:
+            return list_launch_history(model_name, api_, user)
+
+        list_handler = list_handler_authed
+
+        def delete_handler_authed(
+            model_name: str,
+            model_uid: str = "",
+            user: dict = Security(auth, scopes=["models:write"]),
+            api_: "RESTfulAPI" = Depends(get_api),
+        ) -> JSONResponse:
+            return delete_launch_history(model_name, model_uid, api_, user)
+
+        delete_handler = delete_handler_authed
     else:
 
         async def create_handler_anon(
@@ -111,11 +136,27 @@ def register_routes(api: "RESTfulAPI") -> None:
 
         create_handler = create_handler_anon
 
+        def list_handler_anon(
+            model_name: Optional[str] = Query(None),
+            api_: "RESTfulAPI" = Depends(get_api),
+        ) -> JSONResponse:
+            return list_launch_history(model_name, api_, None)
+
+        list_handler = list_handler_anon
+
+        def delete_handler_anon(
+            model_name: str,
+            model_uid: str = "",
+            api_: "RESTfulAPI" = Depends(get_api),
+        ) -> JSONResponse:
+            return delete_launch_history(model_name, model_uid, api_, None)
+
+        delete_handler = delete_handler_anon
+
     router.add_api_route(
         "/v1/launch_history",
-        list_launch_history,
+        list_handler,
         methods=["GET"],
-        dependencies=([Security(auth, scopes=["models:list"])] if is_auth else None),
     )
     router.add_api_route(
         "/v1/launch_history",
@@ -124,15 +165,13 @@ def register_routes(api: "RESTfulAPI") -> None:
     )
     router.add_api_route(
         "/v1/launch_history/{model_name}/{model_uid}",
-        delete_launch_history,
+        delete_handler,
         methods=["DELETE"],
-        dependencies=([Security(auth, scopes=["models:write"])] if is_auth else None),
     )
     # Variant for the common case of an empty model_uid, which cannot be
     # expressed as a non-empty path segment.
     router.add_api_route(
         "/v1/launch_history/{model_name}",
-        delete_launch_history,
+        delete_handler,
         methods=["DELETE"],
-        dependencies=([Security(auth, scopes=["models:write"])] if is_auth else None),
     )

--- a/xinference/api/routers/launch_history.py
+++ b/xinference/api/routers/launch_history.py
@@ -16,7 +16,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Awaitable, Callable, Optional
 
 from fastapi import Depends, HTTPException, Query, Request, Security
 
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-async def list_launch_history(
+def list_launch_history(
     model_name: Optional[str] = Query(None),
     api: "RESTfulAPI" = Depends(get_api),
 ) -> JSONResponse:
@@ -68,7 +68,7 @@ async def create_launch_history(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-async def delete_launch_history(
+def delete_launch_history(
     model_name: str,
     model_uid: str = "",
     api: "RESTfulAPI" = Depends(get_api),
@@ -90,17 +90,26 @@ def register_routes(api: "RESTfulAPI") -> None:
     auth = api._auth_service
     is_auth = api.is_authenticated()
 
+    create_handler: Callable[..., Awaitable[JSONResponse]]
     if is_auth:
 
-        async def create_handler(
+        async def create_handler_authed(
             request: Request,
             user: dict = Security(auth, scopes=["models:write"]),
             api_: "RESTfulAPI" = Depends(get_api),
         ) -> JSONResponse:
             return await create_launch_history(request, api_, user)
 
+        create_handler = create_handler_authed
     else:
-        create_handler = create_launch_history  # type: ignore[assignment]
+
+        async def create_handler_anon(
+            request: Request,
+            api_: "RESTfulAPI" = Depends(get_api),
+        ) -> JSONResponse:
+            return await create_launch_history(request, api_, None)
+
+        create_handler = create_handler_anon
 
     router.add_api_route(
         "/v1/launch_history",

--- a/xinference/api/tests/test_launch_history.py
+++ b/xinference/api/tests/test_launch_history.py
@@ -49,16 +49,24 @@ def test_upsert_inserts_then_lists(store):
     assert row["updated_by"] == "alice"
 
 
-def test_upsert_updates_existing_keeps_created_by(store):
+def test_upsert_same_user_updates_in_place(store):
     store.upsert("llama", "", {"v": 1}, username="alice")
-    store.upsert("llama", "", {"v": 2}, username="bob")
+    store.upsert("llama", "", {"v": 2}, username="alice")
     rows = store.list()
     assert len(rows) == 1
     row = rows[0]
     assert row["data"] == {"v": 2}
-    # created_by must be preserved; only updated_by changes.
     assert row["created_by"] == "alice"
-    assert row["updated_by"] == "bob"
+    assert row["updated_by"] == "alice"
+
+
+def test_upsert_distinct_users_create_separate_rows(store):
+    # Each user owns a separate row per (model_name, model_uid).
+    store.upsert("llama", "", {"v": 1}, username="alice")
+    store.upsert("llama", "", {"v": 2}, username="bob")
+    rows = store.list()
+    assert len(rows) == 2
+    assert {r["created_by"] for r in rows} == {"alice", "bob"}
 
 
 def test_upsert_distinct_uids_are_separate_rows(store):
@@ -91,6 +99,50 @@ def test_delete_removes_row(store):
 
 def test_delete_missing_returns_false(store):
     assert store.delete("nope", "") is False
+
+
+def test_delete_scoped_to_owner(store):
+    store.upsert("llama", "", {"v": 1}, username="alice")
+    # A different user cannot delete someone else's row.
+    assert store.delete("llama", "", "bob") is False
+    assert len(store.list()) == 1
+    # The owner can delete their own row.
+    assert store.delete("llama", "", "alice") is True
+    assert store.list() == []
+
+
+def test_list_redacts_other_users_sensitive_fields(store):
+    store.upsert(
+        "llama",
+        "",
+        {
+            "model_engine": "vllm",
+            "envs": {"HF_TOKEN": "secret"},
+            "api_key": "sk-should-not-leak",
+        },
+        username="alice",
+    )
+    rows = store.list(model_name="llama", username="bob")
+    assert len(rows) == 1
+    # Only whitelisted fields survive for another user.
+    assert rows[0]["data"] == {"model_engine": "vllm"}
+    assert "envs" not in rows[0]["data"]
+    assert "api_key" not in rows[0]["data"]
+
+
+def test_list_returns_full_data_for_owner(store):
+    payload = {"model_engine": "vllm", "envs": {"HF_TOKEN": "secret"}}
+    store.upsert("llama", "", payload, username="alice")
+    rows = store.list(model_name="llama", username="alice")
+    assert rows[0]["data"] == payload
+
+
+def test_list_without_username_is_unredacted(store):
+    payload = {"model_engine": "vllm", "envs": {"HF_TOKEN": "secret"}}
+    store.upsert("llama", "", payload, username="alice")
+    # username=None means a trusted/unscoped call: no redaction.
+    rows = store.list(model_name="llama")
+    assert rows[0]["data"] == payload
 
 
 def test_empty_username_defaults_to_blank(store):
@@ -128,7 +180,9 @@ def test_list_handler_returns_store_data(mock_api):
     mock_api._launch_history_store.list.return_value = [{"model_name": "llama"}]
     response = launch_history.list_launch_history(model_name="llama", api=mock_api)
     assert _json_body(response) == [{"model_name": "llama"}]
-    mock_api._launch_history_store.list.assert_called_once_with(model_name="llama")
+    mock_api._launch_history_store.list.assert_called_once_with(
+        model_name="llama", username=""
+    )
 
 
 def test_list_handler_raises_500_on_error(mock_api):
@@ -225,3 +279,44 @@ async def test_auth_off_post_handler_forwards_none_user():
     assert _json_body(response) == {"status": "ok"}
     _, kwargs = api._launch_history_store.upsert.call_args
     assert kwargs["username"] == ""
+
+
+def test_auth_off_get_handler_exposes_no_user_param():
+    _, captured = _register_and_capture(is_auth=False)
+    get_handler = captured[("/v1/launch_history", ("GET",))]
+    assert "user" not in inspect.signature(get_handler).parameters
+
+
+def test_auth_off_get_handler_forwards_blank_username():
+    api, captured = _register_and_capture(is_auth=False)
+    api._launch_history_store.list.return_value = []
+    get_handler = captured[("/v1/launch_history", ("GET",))]
+    get_handler(model_name="llama", api_=api)
+    _, kwargs = api._launch_history_store.list.call_args
+    assert kwargs["username"] == ""
+
+
+def test_auth_on_get_handler_scopes_by_username():
+    api, captured = _register_and_capture(is_auth=True)
+    api._launch_history_store.list.return_value = []
+    get_handler = captured[("/v1/launch_history", ("GET",))]
+    get_handler(model_name="llama", user={"username": "alice"}, api_=api)
+    _, kwargs = api._launch_history_store.list.call_args
+    assert kwargs["username"] == "alice"
+
+
+def test_auth_off_delete_handler_exposes_no_user_param():
+    _, captured = _register_and_capture(is_auth=False)
+    delete_handler = captured[("/v1/launch_history/{model_name}", ("DELETE",))]
+    assert "user" not in inspect.signature(delete_handler).parameters
+
+
+def test_auth_on_delete_handler_scopes_by_username():
+    api, captured = _register_and_capture(is_auth=True)
+    api._launch_history_store.delete.return_value = True
+    delete_handler = captured[("/v1/launch_history/{model_name}", ("DELETE",))]
+    delete_handler(
+        model_name="llama", model_uid="", user={"username": "alice"}, api_=api
+    )
+    args, _ = api._launch_history_store.delete.call_args
+    assert args == ("llama", "", "alice")

--- a/xinference/api/tests/test_launch_history.py
+++ b/xinference/api/tests/test_launch_history.py
@@ -1,0 +1,194 @@
+# Copyright 2022-2026 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the launch history store and router handlers."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from xinference.api.routers import launch_history
+from xinference.core.launch_history_store import LaunchHistoryStore
+
+
+def _json_body(response):
+    return json.loads(response.body.decode())
+
+
+@pytest.fixture
+def store(tmp_path):
+    return LaunchHistoryStore(str(tmp_path / "launch_history.db"))
+
+
+# --- Store tests ---
+
+
+def test_upsert_inserts_then_lists(store):
+    store.upsert("llama", "", {"model_engine": "vllm"}, username="alice")
+    rows = store.list()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["model_name"] == "llama"
+    assert row["model_uid"] == ""
+    assert row["data"] == {"model_engine": "vllm"}
+    assert row["created_by"] == "alice"
+    assert row["updated_by"] == "alice"
+
+
+def test_upsert_updates_existing_keeps_created_by(store):
+    store.upsert("llama", "", {"v": 1}, username="alice")
+    store.upsert("llama", "", {"v": 2}, username="bob")
+    rows = store.list()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["data"] == {"v": 2}
+    # created_by must be preserved; only updated_by changes.
+    assert row["created_by"] == "alice"
+    assert row["updated_by"] == "bob"
+
+
+def test_upsert_distinct_uids_are_separate_rows(store):
+    store.upsert("llama", "uid-1", {"v": 1})
+    store.upsert("llama", "uid-2", {"v": 2})
+    assert len(store.list()) == 2
+
+
+def test_list_filters_by_model_name(store):
+    store.upsert("llama", "", {"v": 1})
+    store.upsert("qwen", "", {"v": 2})
+    rows = store.list(model_name="qwen")
+    assert len(rows) == 1
+    assert rows[0]["model_name"] == "qwen"
+
+
+def test_list_emits_utc_z_timestamps(store):
+    store.upsert("llama", "", {"v": 1})
+    row = store.list()[0]
+    for key in ("created_at", "updated_at"):
+        assert row[key].endswith("Z")
+        assert "T" in row[key]
+
+
+def test_delete_removes_row(store):
+    store.upsert("llama", "", {"v": 1})
+    assert store.delete("llama", "") is True
+    assert store.list() == []
+
+
+def test_delete_missing_returns_false(store):
+    assert store.delete("nope", "") is False
+
+
+def test_empty_username_defaults_to_blank(store):
+    store.upsert("llama", "", {"v": 1})
+    row = store.list()[0]
+    assert row["created_by"] == ""
+    assert row["updated_by"] == ""
+
+
+def test_store_persists_across_instances(tmp_path):
+    db = str(tmp_path / "lh.db")
+    LaunchHistoryStore(db).upsert("llama", "", {"v": 1}, username="alice")
+    rows = LaunchHistoryStore(db).list()
+    assert len(rows) == 1
+    assert rows[0]["created_by"] == "alice"
+
+
+# --- Router handler tests ---
+
+
+@pytest.fixture
+def mock_api():
+    api = MagicMock()
+    api._launch_history_store = MagicMock()
+    return api
+
+
+def _request_with_json(body):
+    request = MagicMock()
+    request.json = AsyncMock(return_value=body)
+    return request
+
+
+@pytest.mark.asyncio
+async def test_list_handler_returns_store_data(mock_api):
+    mock_api._launch_history_store.list.return_value = [{"model_name": "llama"}]
+    response = await launch_history.list_launch_history(
+        model_name="llama", api=mock_api
+    )
+    assert _json_body(response) == [{"model_name": "llama"}]
+    mock_api._launch_history_store.list.assert_called_once_with(model_name="llama")
+
+
+@pytest.mark.asyncio
+async def test_list_handler_raises_500_on_error(mock_api):
+    mock_api._launch_history_store.list.side_effect = RuntimeError("boom")
+    with pytest.raises(HTTPException) as exc:
+        await launch_history.list_launch_history(api=mock_api)
+    assert exc.value.status_code == 500
+
+
+@pytest.mark.asyncio
+async def test_create_handler_upserts_with_username(mock_api):
+    request = _request_with_json(
+        {"model_name": "llama", "model_uid": "", "data": {"model_engine": "vllm"}}
+    )
+    response = await launch_history.create_launch_history(
+        request=request, api=mock_api, user={"username": "alice"}
+    )
+    assert _json_body(response) == {"status": "ok"}
+    mock_api._launch_history_store.upsert.assert_called_once_with(
+        model_name="llama",
+        model_uid="",
+        data={"model_engine": "vllm"},
+        username="alice",
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_handler_blank_username_without_user(mock_api):
+    request = _request_with_json({"model_name": "llama", "data": {}})
+    await launch_history.create_launch_history(request=request, api=mock_api)
+    _, kwargs = mock_api._launch_history_store.upsert.call_args
+    assert kwargs["username"] == ""
+
+
+@pytest.mark.asyncio
+async def test_create_handler_requires_model_name(mock_api):
+    request = _request_with_json({"data": {"x": 1}})
+    with pytest.raises(HTTPException) as exc:
+        await launch_history.create_launch_history(request=request, api=mock_api)
+    assert exc.value.status_code == 400
+    mock_api._launch_history_store.upsert.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_delete_handler_ok(mock_api):
+    mock_api._launch_history_store.delete.return_value = True
+    response = await launch_history.delete_launch_history(
+        model_name="llama", model_uid="", api=mock_api
+    )
+    assert _json_body(response) == {"status": "ok"}
+
+
+@pytest.mark.asyncio
+async def test_delete_handler_404_when_missing(mock_api):
+    mock_api._launch_history_store.delete.return_value = False
+    with pytest.raises(HTTPException) as exc:
+        await launch_history.delete_launch_history(
+            model_name="nope", model_uid="", api=mock_api
+        )
+    assert exc.value.status_code == 404

--- a/xinference/api/tests/test_launch_history.py
+++ b/xinference/api/tests/test_launch_history.py
@@ -14,6 +14,7 @@
 
 """Unit tests for the launch history store and router handlers."""
 
+import inspect
 import json
 from unittest.mock import AsyncMock, MagicMock
 
@@ -123,21 +124,17 @@ def _request_with_json(body):
     return request
 
 
-@pytest.mark.asyncio
-async def test_list_handler_returns_store_data(mock_api):
+def test_list_handler_returns_store_data(mock_api):
     mock_api._launch_history_store.list.return_value = [{"model_name": "llama"}]
-    response = await launch_history.list_launch_history(
-        model_name="llama", api=mock_api
-    )
+    response = launch_history.list_launch_history(model_name="llama", api=mock_api)
     assert _json_body(response) == [{"model_name": "llama"}]
     mock_api._launch_history_store.list.assert_called_once_with(model_name="llama")
 
 
-@pytest.mark.asyncio
-async def test_list_handler_raises_500_on_error(mock_api):
+def test_list_handler_raises_500_on_error(mock_api):
     mock_api._launch_history_store.list.side_effect = RuntimeError("boom")
     with pytest.raises(HTTPException) as exc:
-        await launch_history.list_launch_history(api=mock_api)
+        launch_history.list_launch_history(api=mock_api)
     assert exc.value.status_code == 500
 
 
@@ -175,20 +172,56 @@ async def test_create_handler_requires_model_name(mock_api):
     mock_api._launch_history_store.upsert.assert_not_called()
 
 
-@pytest.mark.asyncio
-async def test_delete_handler_ok(mock_api):
+def test_delete_handler_ok(mock_api):
     mock_api._launch_history_store.delete.return_value = True
-    response = await launch_history.delete_launch_history(
+    response = launch_history.delete_launch_history(
         model_name="llama", model_uid="", api=mock_api
     )
     assert _json_body(response) == {"status": "ok"}
 
 
-@pytest.mark.asyncio
-async def test_delete_handler_404_when_missing(mock_api):
+def test_delete_handler_404_when_missing(mock_api):
     mock_api._launch_history_store.delete.return_value = False
     with pytest.raises(HTTPException) as exc:
-        await launch_history.delete_launch_history(
+        launch_history.delete_launch_history(
             model_name="nope", model_uid="", api=mock_api
         )
     assert exc.value.status_code == 404
+
+
+# --- register_routes tests ---
+
+
+def _register_and_capture(is_auth):
+    captured = {}
+
+    def add_api_route(path, endpoint, methods=None, **kwargs):
+        captured[(path, tuple(methods or []))] = endpoint
+
+    api = MagicMock()
+    api._router.add_api_route.side_effect = add_api_route
+    api._auth_service = MagicMock()
+    api.is_authenticated.return_value = is_auth
+    api._launch_history_store = MagicMock()
+    launch_history.register_routes(api)
+    return api, captured
+
+
+def test_auth_off_post_handler_exposes_no_user_param():
+    # Regression: when auth is disabled the POST handler must not expose a
+    # `user: Optional[dict]` parameter, otherwise FastAPI treats it as a request
+    # body field and rejects normal launches with HTTP 422.
+    _, captured = _register_and_capture(is_auth=False)
+    post_handler = captured[("/v1/launch_history", ("POST",))]
+    assert "user" not in inspect.signature(post_handler).parameters
+
+
+@pytest.mark.asyncio
+async def test_auth_off_post_handler_forwards_none_user():
+    api, captured = _register_and_capture(is_auth=False)
+    post_handler = captured[("/v1/launch_history", ("POST",))]
+    request = _request_with_json({"model_name": "llama", "data": {"x": 1}})
+    response = await post_handler(request=request, api_=api)
+    assert _json_body(response) == {"status": "ok"}
+    _, kwargs = api._launch_history_store.upsert.call_args
+    assert kwargs["username"] == ""

--- a/xinference/constants.py
+++ b/xinference/constants.py
@@ -103,6 +103,10 @@ XINFERENCE_AUTH_ENCRYPTION_KEY = os.environ.get("XINFERENCE_AUTH_ENCRYPTION_KEY"
 XINFERENCE_AUTH_DB_PATH = os.environ.get(
     "XINFERENCE_AUTH_DB_PATH", os.path.join(XINFERENCE_HOME, "auth", "auth.db")
 )
+XINFERENCE_LAUNCH_HISTORY_DB_PATH = os.environ.get(
+    "XINFERENCE_LAUNCH_HISTORY_DB_PATH",
+    os.path.join(XINFERENCE_HOME, "launch_history.db"),
+)
 
 # OIDC / SSO
 XINFERENCE_OIDC_ENABLED = os.environ.get("XINFERENCE_OIDC_ENABLED", "").lower() in (

--- a/xinference/core/launch_history_store.py
+++ b/xinference/core/launch_history_store.py
@@ -1,0 +1,132 @@
+# Copyright 2022-2026 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import json
+import logging
+import sqlite3
+import threading
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS launch_history (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    model_name TEXT NOT NULL,
+    model_uid TEXT NOT NULL DEFAULT '',
+    data TEXT NOT NULL,
+    created_by TEXT DEFAULT '',
+    updated_by TEXT DEFAULT '',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_launch_history_model
+    ON launch_history(model_name, model_uid);
+"""
+
+
+class LaunchHistoryStore:
+    """SQLite-backed store for model launch configuration history.
+
+    The store is independent of the auth database so it works in any deployment
+    mode. ``created_by`` / ``updated_by`` are populated from the authenticated
+    username when authentication is enabled, and left empty otherwise.
+    """
+
+    def __init__(self, db_path: str):
+        self._db_path = db_path
+        self._lock = threading.Lock()
+        self._init_db()
+
+    def _init_db(self):
+        Path(self._db_path).parent.mkdir(parents=True, exist_ok=True)
+        with self._get_conn() as conn:
+            conn.executescript(SCHEMA_SQL)
+
+    @contextmanager
+    def _get_conn(self):
+        conn = sqlite3.connect(self._db_path)
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.row_factory = sqlite3.Row
+        try:
+            yield conn
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+    def list(self, model_name: Optional[str] = None) -> List[Dict[str, Any]]:
+        with self._get_conn() as conn:
+            if model_name:
+                rows = conn.execute(
+                    "SELECT * FROM launch_history WHERE model_name = ? "
+                    "ORDER BY updated_at DESC",
+                    (model_name,),
+                ).fetchall()
+            else:
+                rows = conn.execute(
+                    "SELECT * FROM launch_history ORDER BY updated_at DESC"
+                ).fetchall()
+        result = []
+        for row in rows:
+            item = dict(row)
+            try:
+                item["data"] = json.loads(item["data"])
+            except (json.JSONDecodeError, TypeError):
+                pass
+            # SQLite CURRENT_TIMESTAMP yields naive UTC "YYYY-MM-DD HH:MM:SS";
+            # emit ISO-8601 with explicit Z so clients parse it as UTC.
+            for key in ("created_at", "updated_at"):
+                value = item.get(key)
+                if value:
+                    item[key] = str(value).replace(" ", "T") + "Z"
+            result.append(item)
+        return result
+
+    def upsert(
+        self,
+        model_name: str,
+        model_uid: str,
+        data: Dict[str, Any],
+        username: str = "",
+    ) -> None:
+        # ON CONFLICT intentionally does not update created_by so the original
+        # creator is preserved across later updates.
+        data_json = json.dumps(data, ensure_ascii=False)
+        with self._lock:
+            with self._get_conn() as conn:
+                conn.execute(
+                    """INSERT INTO launch_history
+                           (model_name, model_uid, data, created_by, updated_by)
+                       VALUES (?, ?, ?, ?, ?)
+                       ON CONFLICT(model_name, model_uid) DO UPDATE SET
+                           data = excluded.data,
+                           updated_by = excluded.updated_by,
+                           updated_at = CURRENT_TIMESTAMP""",
+                    (model_name, model_uid, data_json, username, username),
+                )
+
+    def delete(self, model_name: str, model_uid: str) -> bool:
+        with self._lock:
+            with self._get_conn() as conn:
+                cursor = conn.execute(
+                    "DELETE FROM launch_history "
+                    "WHERE model_name = ? AND model_uid = ?",
+                    (model_name, model_uid),
+                )
+                return cursor.rowcount > 0

--- a/xinference/core/launch_history_store.py
+++ b/xinference/core/launch_history_store.py
@@ -34,8 +34,40 @@ CREATE TABLE IF NOT EXISTS launch_history (
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS idx_launch_history_model
-    ON launch_history(model_name, model_uid);
+    ON launch_history(model_name, model_uid, created_by);
 """
+
+# Fields that are safe to expose to other users when sharing launch history.
+# Anything not listed here (env vars, arbitrary custom kwargs, filesystem
+# paths, infra hints) is stripped from another user's entries on read so that
+# secrets such as tokens injected via `envs` or custom parameters never leak
+# across users. The owner of an entry always receives the full payload.
+SHAREABLE_KEYS = frozenset(
+    {
+        "model_uid",
+        "model_name",
+        "model_type",
+        "model_engine",
+        "model_format",
+        "model_size_in_billions",
+        "quantization",
+        "n_worker",
+        "n_gpu",
+        "n_gpu_layers",
+        "replica",
+        "request_limits",
+        "gpu_idx",
+        "download_hub",
+        "reasoning_content",
+        "gguf_quantization",
+        "lightning_version",
+        "cpu_offload",
+        "enable_thinking",
+        "multimodal_projector",
+        "enable_virtual_env",
+        "virtual_env_packages",
+    }
+)
 
 
 class LaunchHistoryStore:
@@ -70,7 +102,11 @@ class LaunchHistoryStore:
         finally:
             conn.close()
 
-    def list(self, model_name: Optional[str] = None) -> List[Dict[str, Any]]:
+    def list(
+        self,
+        model_name: Optional[str] = None,
+        username: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
         with self._get_conn() as conn:
             if model_name:
                 rows = conn.execute(
@@ -89,6 +125,15 @@ class LaunchHistoryStore:
                 item["data"] = json.loads(item["data"])
             except (json.JSONDecodeError, TypeError):
                 pass
+            # Redact sensitive fields from entries owned by other users so that
+            # secrets (envs, custom kwargs, ...) never leak across users.
+            # ``username is None`` means an unscoped/trusted call (no redaction).
+            if username is not None and item.get("created_by") != username:
+                data = item.get("data")
+                if isinstance(data, dict):
+                    item["data"] = {
+                        k: v for k, v in data.items() if k in SHAREABLE_KEYS
+                    }
             # SQLite CURRENT_TIMESTAMP yields naive UTC "YYYY-MM-DD HH:MM:SS";
             # emit ISO-8601 with explicit Z so clients parse it as UTC.
             for key in ("created_at", "updated_at"):
@@ -105,8 +150,8 @@ class LaunchHistoryStore:
         data: Dict[str, Any],
         username: str = "",
     ) -> None:
-        # ON CONFLICT intentionally does not update created_by so the original
-        # creator is preserved across later updates.
+        # Each user owns a separate row per (model_name, model_uid); a later
+        # upsert by the same user updates only their own row.
         data_json = json.dumps(data, ensure_ascii=False)
         with self._lock:
             with self._get_conn() as conn:
@@ -114,19 +159,20 @@ class LaunchHistoryStore:
                     """INSERT INTO launch_history
                            (model_name, model_uid, data, created_by, updated_by)
                        VALUES (?, ?, ?, ?, ?)
-                       ON CONFLICT(model_name, model_uid) DO UPDATE SET
+                       ON CONFLICT(model_name, model_uid, created_by) DO UPDATE SET
                            data = excluded.data,
                            updated_by = excluded.updated_by,
                            updated_at = CURRENT_TIMESTAMP""",
                     (model_name, model_uid, data_json, username, username),
                 )
 
-    def delete(self, model_name: str, model_uid: str) -> bool:
+    def delete(self, model_name: str, model_uid: str, username: str = "") -> bool:
+        # A user may only delete their own row.
         with self._lock:
             with self._get_conn() as conn:
                 cursor = conn.execute(
                     "DELETE FROM launch_history "
-                    "WHERE model_name = ? AND model_uid = ?",
-                    (model_name, model_uid),
+                    "WHERE model_name = ? AND model_uid = ? AND created_by = ?",
+                    (model_name, model_uid, username),
                 )
                 return cursor.rowcount > 0

--- a/xinference/ui/web/ui/src/locales/en.json
+++ b/xinference/ui/web/ui/src/locales/en.json
@@ -97,6 +97,7 @@
     "loadCache": "Use",
     "deleteCache": "Delete Cache",
     "lastUpdated": "Last Updated",
+    "createdBy": "Created By",
     "defaultConfig": "Default Config",
     "confirmDeleteConfigCache": "Delete this cached configuration? This action is irreversible.",
     "invalidConfigCache": "The model engine required by this cached configuration is unavailable.",

--- a/xinference/ui/web/ui/src/locales/ja.json
+++ b/xinference/ui/web/ui/src/locales/ja.json
@@ -90,6 +90,7 @@
     "loadCache": "使用する",
     "deleteCache": "キャッシュを削除",
     "lastUpdated": "最終更新",
+    "createdBy": "作成者",
     "defaultConfig": "デフォルト設定",
     "confirmDeleteConfigCache": "この設定キャッシュを削除しますか？この操作は元に戻せません。",
     "invalidConfigCache": "この設定キャッシュに必要なモデルエンジンは現在利用できません。",

--- a/xinference/ui/web/ui/src/locales/ko.json
+++ b/xinference/ui/web/ui/src/locales/ko.json
@@ -90,6 +90,7 @@
     "loadCache": "사용하기",
     "deleteCache": "캐시 삭제",
     "lastUpdated": "마지막 업데이트",
+    "createdBy": "작성자",
     "defaultConfig": "기본 구성",
     "confirmDeleteConfigCache": "이 구성 캐시를 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.",
     "invalidConfigCache": "이 구성 캐시에 필요한 모델 엔진을 현재 사용할 수 없습니다.",

--- a/xinference/ui/web/ui/src/locales/zh.json
+++ b/xinference/ui/web/ui/src/locales/zh.json
@@ -97,6 +97,7 @@
     "loadCache": "使用",
     "deleteCache": "删除缓存",
     "lastUpdated": "最后更新",
+    "createdBy": "创建者",
     "defaultConfig": "默认配置",
     "confirmDeleteConfigCache": "确认删除这条配置缓存吗？此操作无法恢复。",
     "invalidConfigCache": "这条配置缓存对应的模型引擎当前不可用。",

--- a/xinference/ui/web/ui/src/scenes/launch_model/components/launchModelDrawer.js
+++ b/xinference/ui/web/ui/src/scenes/launch_model/components/launchModelDrawer.js
@@ -210,11 +210,18 @@ const LaunchModelDrawer = ({
 
     const modelUID = data.model_uid || item.model_uid || ''
 
+    const rawUpdatedAt = item.updated_at
+    const updatedAt =
+      typeof rawUpdatedAt === 'number'
+        ? rawUpdatedAt
+        : Date.parse(rawUpdatedAt)
+
     return {
       cache_key: buildHistoryKey(modelName, modelUID),
       model_name: modelName,
       model_uid: modelUID,
-      updated_at: Number(item.updated_at) || 0,
+      updated_at: Number.isFinite(updatedAt) ? updatedAt : 0,
+      created_by: item.created_by || data.created_by || '',
       data,
     }
   }
@@ -247,10 +254,66 @@ const LaunchModelDrawer = ({
           model_name: item.model_name,
           model_uid: item.model_uid,
           updated_at: item.updated_at,
+          created_by: item.created_by || '',
           data: item.data,
         }))
       )
     )
+  }
+
+  // Replace this model's cached entries with the authoritative server set
+  // while preserving other models' offline entries in localStorage.
+  const mirrorModelEntriesToLocal = (modelName, modelEntries) => {
+    const others = readHistoryEntries().filter(
+      (item) => item.model_name !== modelName
+    )
+    writeHistoryEntries([...others, ...modelEntries])
+  }
+
+  const loadHistoryFromServer = async () => {
+    try {
+      const res = await fetchWrapper.get(
+        `/v1/launch_history?model_name=${encodeURIComponent(
+          modelData.model_name
+        )}`
+      )
+      const entries = (Array.isArray(res) ? res : [])
+        .map(normalizeHistoryEntry)
+        .filter(Boolean)
+      mirrorModelEntriesToLocal(modelData.model_name, entries)
+      return sortHistoryEntries(entries)
+    } catch (error) {
+      console.error('Failed to load launch history from server:', error)
+      // Offline fallback: use whatever is cached locally.
+      return getHistoryEntriesForModel()
+    }
+  }
+
+  const syncHistoryToServer = async (data) => {
+    try {
+      await fetchWrapper.post('/v1/launch_history', {
+        model_name: data.model_name,
+        model_uid: data.model_uid || '',
+        data,
+      })
+      // Refresh from server so created_by populated by the backend shows up.
+      setHistoryEntries(await loadHistoryFromServer())
+    } catch (error) {
+      console.error('Failed to sync launch history to server:', error)
+    }
+  }
+
+  const deleteHistoryOnServer = async (modelName, modelUID) => {
+    try {
+      const path = modelUID
+        ? `/v1/launch_history/${encodeURIComponent(
+            modelName
+          )}/${encodeURIComponent(modelUID)}`
+        : `/v1/launch_history/${encodeURIComponent(modelName)}`
+      await fetchWrapper.delete(path)
+    } catch (error) {
+      console.error('Failed to delete launch history on server:', error)
+    }
   }
 
   const upsertHistoryEntry = (data) => {
@@ -316,6 +379,11 @@ const LaunchModelDrawer = ({
 
     const wasSelected = historyToDelete.cache_key === selectedHistoryKey
     const nextEntries = removeHistoryEntry(historyToDelete.cache_key)
+
+    deleteHistoryOnServer(
+      historyToDelete.model_name,
+      historyToDelete.model_uid
+    )
 
     setHistoryEntries(nextEntries)
     setHistoryToDelete(null)
@@ -611,6 +679,8 @@ const LaunchModelDrawer = ({
   }
 
   useEffect(() => {
+    // Show locally cached entries immediately for a fast open, then refresh
+    // from the server (source of truth) which also brings in created_by.
     const entries = getHistoryEntriesForModel()
     setHistoryEntries(entries)
 
@@ -623,6 +693,19 @@ const LaunchModelDrawer = ({
         applyHistory(latestEntry.data)
       }
     }
+
+    loadHistoryFromServer().then((serverEntries) => {
+      setHistoryEntries(serverEntries)
+      if (!latestEntry && serverEntries[0]) {
+        const latest = serverEntries[0]
+        setSelectedHistoryKey(latest.cache_key)
+        if (modelEngineType.includes(modelType)) {
+          setPendingHistory(latest.data)
+        } else {
+          applyHistory(latest.data)
+        }
+      }
+    })
   }, [])
 
   useEffect(() => {
@@ -1127,6 +1210,7 @@ const LaunchModelDrawer = ({
           setSelectedHistoryKey(
             buildHistoryKey(data.model_name, data.model_uid)
           )
+          syncHistoryToServer(data)
         })
         .catch((error) => {
           console.error('Error:', error)
@@ -1593,6 +1677,14 @@ const LaunchModelDrawer = ({
                           {t('launchModel.lastUpdated')}:{' '}
                           {formatHistoryTime(entry.updated_at)}
                         </Typography>
+                        {entry.created_by ? (
+                          <Typography
+                            variant="body2"
+                            color="text.secondary"
+                          >
+                            {t('launchModel.createdBy')}: {entry.created_by}
+                          </Typography>
+                        ) : null}
                       </Box>
                       <Box
                         sx={{

--- a/xinference/ui/web/ui/src/scenes/launch_model/components/launchModelDrawer.js
+++ b/xinference/ui/web/ui/src/scenes/launch_model/components/launchModelDrawer.js
@@ -194,8 +194,8 @@ const LaunchModelDrawer = ({
       arr.map(({ key, value }) => [key, transformValue(value)])
     )
 
-  const buildHistoryKey = (modelName, modelUID) =>
-    `${modelName}::${modelUID || defaultHistoryUID}`
+  const buildHistoryKey = (modelName, modelUID, createdBy = '') =>
+    `${modelName}::${modelUID || defaultHistoryUID}::${createdBy}`
 
   const normalizeHistoryEntry = (item) => {
     if (!item || typeof item !== 'object') return null
@@ -214,12 +214,14 @@ const LaunchModelDrawer = ({
     const updatedAt =
       typeof rawUpdatedAt === 'number' ? rawUpdatedAt : Date.parse(rawUpdatedAt)
 
+    const createdBy = item.created_by || data.created_by || ''
+
     return {
-      cache_key: buildHistoryKey(modelName, modelUID),
+      cache_key: buildHistoryKey(modelName, modelUID, createdBy),
       model_name: modelName,
       model_uid: modelUID,
       updated_at: Number.isFinite(updatedAt) ? updatedAt : 0,
-      created_by: item.created_by || data.created_by || '',
+      created_by: createdBy,
       data,
     }
   }

--- a/xinference/ui/web/ui/src/scenes/launch_model/components/launchModelDrawer.js
+++ b/xinference/ui/web/ui/src/scenes/launch_model/components/launchModelDrawer.js
@@ -212,9 +212,7 @@ const LaunchModelDrawer = ({
 
     const rawUpdatedAt = item.updated_at
     const updatedAt =
-      typeof rawUpdatedAt === 'number'
-        ? rawUpdatedAt
-        : Date.parse(rawUpdatedAt)
+      typeof rawUpdatedAt === 'number' ? rawUpdatedAt : Date.parse(rawUpdatedAt)
 
     return {
       cache_key: buildHistoryKey(modelName, modelUID),
@@ -380,10 +378,7 @@ const LaunchModelDrawer = ({
     const wasSelected = historyToDelete.cache_key === selectedHistoryKey
     const nextEntries = removeHistoryEntry(historyToDelete.cache_key)
 
-    deleteHistoryOnServer(
-      historyToDelete.model_name,
-      historyToDelete.model_uid
-    )
+    deleteHistoryOnServer(historyToDelete.model_name, historyToDelete.model_uid)
 
     setHistoryEntries(nextEntries)
     setHistoryToDelete(null)
@@ -1683,10 +1678,7 @@ const LaunchModelDrawer = ({
                           {formatHistoryTime(entry.updated_at)}
                         </Typography>
                         {entry.created_by ? (
-                          <Typography
-                            variant="body2"
-                            color="text.secondary"
-                          >
+                          <Typography variant="body2" color="text.secondary">
                             {t('launchModel.createdBy')}: {entry.created_by}
                           </Typography>
                         ) : null}

--- a/xinference/ui/web/ui/src/scenes/launch_model/components/launchModelDrawer.js
+++ b/xinference/ui/web/ui/src/scenes/launch_model/components/launchModelDrawer.js
@@ -696,13 +696,18 @@ const LaunchModelDrawer = ({
 
     loadHistoryFromServer().then((serverEntries) => {
       setHistoryEntries(serverEntries)
-      if (!latestEntry && serverEntries[0]) {
-        const latest = serverEntries[0]
-        setSelectedHistoryKey(latest.cache_key)
-        if (modelEngineType.includes(modelType)) {
-          setPendingHistory(latest.data)
-        } else {
-          applyHistory(latest.data)
+      const serverLatest = serverEntries[0]
+      if (serverLatest) {
+        const shouldApply =
+          !latestEntry ||
+          serverLatest.updated_at > (latestEntry.updated_at || 0)
+        if (shouldApply) {
+          setSelectedHistoryKey(serverLatest.cache_key)
+          if (modelEngineType.includes(modelType)) {
+            setPendingHistory(serverLatest.data)
+          } else {
+            applyHistory(serverLatest.data)
+          }
         }
       }
     })


### PR DESCRIPTION
## Summary

The "Launch Model" drawer's deployment configuration history (engine, format, quantization, replica count, etc.) is currently stored only in the browser's `localStorage` (`historyArr`). This means the history is lost when switching browsers, using incognito mode, or moving to another machine.

This PR persists that history server-side in a standalone SQLite store so it is shared across all clients, and records the creator's username (`created_by`) when authentication is enabled.

### Backend
- New `xinference/core/launch_history_store.py`: SQLite-backed store (WAL, thread lock, UPSERT keyed on `(model_name, model_uid)`). `created_by` is preserved across later updates; `updated_by`/`updated_at` change on update. Timestamps are emitted as ISO-8601 with explicit `Z` so clients parse them as UTC.
- New `xinference/api/routers/launch_history.py`: `GET`/`POST`/`DELETE /v1/launch_history`. When authentication is enabled, routes are guarded by `models:list` / `models:write` scopes and `created_by`/`updated_by` are filled from the authenticated user; when auth is off the fields are empty strings.
- New env var `XINFERENCE_LAUNCH_HISTORY_DB_PATH` (default `<XINFERENCE_HOME>/launch_history.db`), independent of the auth database, so it works in any deployment mode.
- Unit tests in `xinference/api/tests/test_launch_history.py` and docs in `environments.rst`.

### Frontend
- `launchModelDrawer.js` now treats the API as the source of truth while keeping `localStorage` as an offline fallback: locally cached entries render immediately on open for a fast paint, then the server set replaces them; successful launches sync to the server; deletions are removed on the server. Each history item displays the creator (`created_by`).
- Adds the `createdBy` label to `en` / `zh` / `ja` / `ko` locales.

### Notes / design decisions
- The history is **globally shared** (all authenticated users see all stored configurations). This is intentional for the team-shared use case and was confirmed with maintainers beforehand.
- The store is deliberately separate from the auth DB so it functions whether or not authentication is enabled.

## Test plan
- [ ] `pytest -vv xinference/api/tests/test_launch_history.py`
- [ ] Deploy a model in a normal browser, confirm the configuration is written server-side (row in `launch_history.db`).
- [ ] Open the same page in an incognito window (empty localStorage), confirm history loads from the API.
- [ ] With authentication enabled, deploy as user A and confirm `created_by` shows A for user B.
- [ ] With authentication disabled, confirm no creator row is rendered.
- [ ] Restart the service, confirm history persists.
- [ ] `cd xinference/ui/web/ui && npm ci && npx eslint . && npx prettier --check . && npm run build`
