### PR TITLE
fix(monitor): capture vLLM/SGLang GPU workers via deferred PID tattoo

### DIFF
--- a/xinference/core/tests/test_worker.py
+++ b/xinference/core/tests/test_worker.py
@@ -121,6 +121,15 @@ class MockWorkerActor(WorkerActor):
         self._model_uid_to_launch_args.pop(model_uid, None)
         del self._model_uid_to_addr[model_uid]
 
+    # --- test helpers for report_status GPU attribution ---
+    def set_supervisor_ref_for_test(self, ref):
+        self._supervisor_ref = ref
+
+    def set_gpu_attribution_tables_for_test(self, pid, subpool, total_devices):
+        self._model_uid_to_pid = dict(pid)
+        self._model_uid_to_subpool_pids = {k: set(v) for k, v in subpool.items()}
+        self._total_gpu_devices = list(total_devices)
+
 
 @pytest_asyncio.fixture
 async def setup_pool():
@@ -1064,3 +1073,141 @@ async def test_launch_model_with_gpu_idx(setup_pool):
     for info in [llm_info, user_specified_info]:
         for dev, details in info.items():
             assert len(details) == 0
+
+
+class _FakeChild:
+    def __init__(self, pid: int):
+        self.pid = pid
+
+
+class _FakeProcess:
+    """Stand-in for psutil.Process exposing a preset recursive children map."""
+
+    _children_map: dict = {}
+
+    def __init__(self, pid: int):
+        self._pid = pid
+
+    def children(self, recursive: bool = False):
+        return [_FakeChild(p) for p in self._children_map.get(self._pid, [])]
+
+
+async def _make_gpu_worker(pool, cuda_devices=(0, 1)):
+    worker: xo.ActorRefType["MockWorkerActor"] = await xo.create_actor(  # type: ignore
+        MockWorkerActor,
+        address=pool.external_address,
+        uid=WorkerActor.default_uid(),
+        supervisor_address="test",
+        main_pool=pool,
+        cuda_devices=list(cuda_devices),
+    )
+    sup = DummySupervisorRef()
+    await worker.set_supervisor_ref_for_test(sup)
+    return worker, sup
+
+
+def _patch_gpu_sources(monkeypatch, gpu_mem, children_map=None, calls=None):
+    import psutil
+
+    def _fake_get_per_process_gpu_memory():
+        if calls is not None:
+            calls.append("called")
+        return gpu_mem
+
+    monkeypatch.setattr("xinference.core.worker.gather_node_info", lambda: {})
+    monkeypatch.setattr(
+        "xinference.device_utils.get_per_process_gpu_memory",
+        _fake_get_per_process_gpu_memory,
+    )
+    _FakeProcess._children_map = children_map or {}
+    monkeypatch.setattr(psutil, "Process", _FakeProcess)
+
+
+@pytest.mark.asyncio
+async def test_report_status_attributes_gpu_by_subpool_pids(setup_pool, monkeypatch):
+    # Scenario 4: multi-card multi-replica LLM. Each replica's GPU holders are
+    # its registered secondary sub-pool PIDs; same card shared, no cross/double.
+    worker, sup = await _make_gpu_worker(setup_pool)
+    await worker.set_gpu_attribution_tables_for_test(
+        pid={}, subpool={"A": {100, 101}, "B": {200, 201}}, total_devices=[0, 1]
+    )
+    _patch_gpu_sources(
+        monkeypatch,
+        gpu_mem={
+            100: {0: 1000},
+            101: {1: 1000},
+            200: {0: 500},
+            201: {1: 500},
+        },
+    )
+
+    await worker.report_status()
+
+    status = sup.report_worker_status_calls[-1][1]
+    assert status["model_gpu_memory"]["A"] == {0: 1000, 1: 1000}
+    assert status["model_gpu_memory"]["B"] == {0: 500, 1: 500}
+
+
+@pytest.mark.asyncio
+async def test_report_status_attributes_gpu_via_recursive_children(
+    setup_pool, monkeypatch
+):
+    # Scenario 1/2: single-card vLLM. GPU is held by the forked EngineCore, a
+    # recursive child of the primary sub-pool PID -- not registered directly.
+    worker, sup = await _make_gpu_worker(setup_pool, cuda_devices=[0])
+    await worker.set_gpu_attribution_tables_for_test(
+        pid={}, subpool={"A": {100}}, total_devices=[0]
+    )
+    _patch_gpu_sources(
+        monkeypatch,
+        gpu_mem={555: {0: 2000}},  # only the EngineCore holds GPU memory
+        children_map={100: [555]},
+    )
+
+    await worker.report_status()
+
+    status = sup.report_worker_status_calls[-1][1]
+    assert status["model_gpu_memory"]["A"] == {0: 2000}
+
+
+@pytest.mark.asyncio
+async def test_report_status_replicas_do_not_cross_or_double_count(
+    setup_pool, monkeypatch
+):
+    # Same-card concurrent replicas: disjoint PID sets attribute independently;
+    # a PID is counted once within a replica even if it appears via own_pid too.
+    worker, sup = await _make_gpu_worker(setup_pool, cuda_devices=[0])
+    await worker.set_gpu_attribution_tables_for_test(
+        pid={"A": 100},  # own_pid overlaps subpool set -> must not double count
+        subpool={"A": {100}, "B": {200}},
+        total_devices=[0],
+    )
+    _patch_gpu_sources(
+        monkeypatch,
+        gpu_mem={100: {0: 700}, 200: {0: 300}},
+    )
+
+    await worker.report_status()
+
+    status = sup.report_worker_status_calls[-1][1]
+    assert status["model_gpu_memory"]["A"] == {0: 700}
+    assert status["model_gpu_memory"]["B"] == {0: 300}
+
+
+@pytest.mark.asyncio
+async def test_report_status_skips_gpu_collection_when_cpu_only(
+    setup_pool, monkeypatch
+):
+    # No GPU devices -> the guard skips NVML entirely; no model_gpu_memory key.
+    worker, sup = await _make_gpu_worker(setup_pool, cuda_devices=[])
+    await worker.set_gpu_attribution_tables_for_test(
+        pid={"A": 100}, subpool={"A": {100}}, total_devices=[]
+    )
+    calls: list = []
+    _patch_gpu_sources(monkeypatch, gpu_mem={100: {0: 1000}}, calls=calls)
+
+    await worker.report_status()
+
+    status = sup.report_worker_status_calls[-1][1]
+    assert "model_gpu_memory" not in status
+    assert calls == []  # NVML never queried on CPU-only worker

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -217,9 +217,11 @@ class WorkerActor(xo.StatelessActor):
         self._model_uid_to_recover_count: Dict[str, Optional[int]] = {}
         self._model_uid_to_launch_args: Dict[str, Dict] = {}
         self._model_uid_to_pid: Dict[str, int] = {}
-        self._model_uid_to_gpu_pids: Dict[str, set] = {}
-        self._model_uid_to_gpu_snapshot_before: Dict[str, set] = {}
-        self._gpu_snapshot_lock = asyncio.Lock()
+        # Per-replica sub-pool process PIDs (primary ModelActor pool + per-device
+        # vLLM/SGLang rank pools). Used by report_status to attribute NVML GPU
+        # memory back to the owning replica deterministically, without reading
+        # any process environ.
+        self._model_uid_to_subpool_pids: Dict[str, Set[int]] = {}
 
         if XINFERENCE_DISABLE_METRICS:
             logger.info(
@@ -2123,23 +2125,6 @@ class WorkerActor(xo.StatelessActor):
 
                 with progressor:
                     try:
-                        # PID snapshot before load (GPU process tattoo, for
-                        # engines that spawn GPU workers outside the ModelActor
-                        # process tree, e.g. vLLM tensor parallelism).
-                        try:
-                            from ..device_utils import get_per_process_gpu_memory
-
-                            async with self._gpu_snapshot_lock:
-                                self._model_uid_to_gpu_snapshot_before[model_uid] = set(
-                                    (
-                                        await asyncio.to_thread(
-                                            get_per_process_gpu_memory
-                                        )
-                                    ).keys()
-                                )
-                        except Exception:
-                            pass
-
                         _load_start = time.time()
                         await model_ref.load()
                         _load_duration = time.time() - _load_start
@@ -2158,7 +2143,6 @@ class WorkerActor(xo.StatelessActor):
                         raise
             except Exception:
                 logger.error(f"Failed to load model {model_uid}", exc_info=True)
-                self._model_uid_to_gpu_snapshot_before.pop(model_uid, None)
                 self.release_devices(model_uid=model_uid)
                 for addr in all_subpool_addresses:
                     try:
@@ -2171,6 +2155,19 @@ class WorkerActor(xo.StatelessActor):
                 self._model_uid_to_pid[model_uid] = await model_ref.get_pid()
             except Exception:
                 pass
+            # Deterministic provenance: register all sub-pool process PIDs for
+            # this replica (primary ModelActor pool + per-device vLLM/SGLang rank
+            # pools). report_status maps NVML PIDs back to the owning replica via
+            # this table, without reading any process environ.
+            subpool_pids: Set[int] = set()
+            for _addr in all_subpool_addresses:
+                try:
+                    _proc = self._main_pool.sub_processes.get(_addr)
+                    if _proc is not None and _proc.pid is not None:
+                        subpool_pids.add(_proc.pid)
+                except Exception:
+                    continue
+            self._model_uid_to_subpool_pids[model_uid] = subpool_pids
             model_spec = model.model_family.to_description()
             self._model_uid_to_model_spec[model_uid] = model_spec
             self._model_uid_to_model_status[model_uid] = ModelStatus()
@@ -2224,26 +2221,6 @@ class WorkerActor(xo.StatelessActor):
     async def wait_for_load(self, model_uid: str):
         model_ref = self._model_uid_to_model[model_uid]
         await model_ref.wait_for_load()
-
-        # Deferred GPU PID tattoo: by now vLLM/SGLang GPU worker processes,
-        # which spawn after model_ref.load() returns, are fully up.
-        before_pids = self._model_uid_to_gpu_snapshot_before.pop(model_uid, None)
-        if before_pids is not None:
-            try:
-                from ..device_utils import get_per_process_gpu_memory
-
-                async with self._gpu_snapshot_lock:
-                    after_pids = set(
-                        (await asyncio.to_thread(get_per_process_gpu_memory)).keys()
-                    )
-                new_pids = after_pids - before_pids
-                if new_pids:
-                    self._model_uid_to_gpu_pids[model_uid] = new_pids
-                    logger.info("GPU PID tattoo for %s: %s", model_uid, new_pids)
-            except Exception:
-                logger.warning(
-                    "Failed deferred GPU PID tattoo for %s", model_uid, exc_info=True
-                )
 
     @log_sync(logger=logger, level=logging.INFO)
     async def cancel_launch_model(self, model_uid: str):
@@ -2372,8 +2349,7 @@ class WorkerActor(xo.StatelessActor):
             self._model_uid_to_recover_count.pop(model_uid, None)
             self._model_uid_to_launch_args.pop(model_uid, None)
             self._model_uid_to_pid.pop(model_uid, None)
-            self._model_uid_to_gpu_pids.pop(model_uid, None)
-            self._model_uid_to_gpu_snapshot_before.pop(model_uid, None)
+            self._model_uid_to_subpool_pids.pop(model_uid, None)
             # §4.3: Remove from persisted recovery file
             self._remove_persisted_launch_args(model_uid)
 
@@ -2433,36 +2409,53 @@ class WorkerActor(xo.StatelessActor):
             async with timeout(XINFERENCE_STATUS_GATHER_TIMEOUT):
                 status = await asyncio.to_thread(gather_node_info)
 
-                # Collect per-model GPU memory using psutil descendant PIDs
-                try:
-                    import psutil
+                # Collect per-model GPU memory. Each replica's GPU holders are
+                # its registered sub-pool PIDs (primary ModelActor pool +
+                # per-device vLLM/SGLang rank pools) plus their recursive
+                # children (e.g. vLLM V1 forked EngineCore). Attribution is
+                # deterministic and reads no process environ.
+                if self._total_gpu_devices:
+                    try:
+                        import psutil
 
-                    from ..device_utils import get_per_process_gpu_memory
+                        from ..device_utils import get_per_process_gpu_memory
 
-                    gpu_mem = await asyncio.to_thread(get_per_process_gpu_memory)
-                    model_gpu_mem: Dict[str, Dict[int, int]] = {}
-                    for m_uid, own_pid in self._model_uid_to_pid.items():
-                        per_gpu: Dict[int, int] = {}
-                        try:
-                            parent = psutil.Process(own_pid)
-                            all_pids = [own_pid] + [
-                                c.pid for c in parent.children(recursive=True)
-                            ]
-                        except (psutil.NoSuchProcess, psutil.AccessDenied):
-                            all_pids = [own_pid]
-                        # Include tattooed GPU PIDs (covers vLLM/SGLang workers
-                        # spawned outside the ModelActor process tree).
-                        all_pids.extend(self._model_uid_to_gpu_pids.get(m_uid, ()))
-                        for pid in set(all_pids):
-                            if pid in gpu_mem:
-                                for gpu_idx, mem in gpu_mem[pid].items():
-                                    per_gpu[gpu_idx] = per_gpu.get(gpu_idx, 0) + mem
-                        if per_gpu:
-                            model_gpu_mem[m_uid] = per_gpu
-                    if model_gpu_mem:
-                        status["model_gpu_memory"] = model_gpu_mem
-                except Exception:
-                    pass
+                        gpu_mem = await asyncio.to_thread(get_per_process_gpu_memory)
+                        model_gpu_mem: Dict[str, Dict[int, int]] = {}
+
+                        for m_uid in set(self._model_uid_to_pid) | set(
+                            self._model_uid_to_subpool_pids
+                        ):
+                            pids: Set[int] = set(
+                                self._model_uid_to_subpool_pids.get(m_uid, set())
+                            )
+                            own_pid = self._model_uid_to_pid.get(m_uid)
+                            if own_pid is not None:
+                                pids.add(own_pid)
+                            # Recursive children cover GPU holders forked outside
+                            # the registered sub-pools (e.g. vLLM V1 EngineCore).
+                            for base in list(pids):
+                                try:
+                                    pids.update(
+                                        c.pid
+                                        for c in psutil.Process(base).children(
+                                            recursive=True
+                                        )
+                                    )
+                                except (psutil.NoSuchProcess, psutil.AccessDenied):
+                                    pass
+                            per_gpu: Dict[int, int] = {}
+                            for pid in pids:
+                                if pid in gpu_mem:
+                                    for gpu_idx, mem in gpu_mem[pid].items():
+                                        per_gpu[gpu_idx] = per_gpu.get(gpu_idx, 0) + mem
+                            if per_gpu:
+                                model_gpu_mem[m_uid] = per_gpu
+
+                        if model_gpu_mem:
+                            status["model_gpu_memory"] = model_gpu_mem
+                    except Exception:
+                        pass
         except asyncio.CancelledError:
             raise
         except Exception:

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -217,6 +217,9 @@ class WorkerActor(xo.StatelessActor):
         self._model_uid_to_recover_count: Dict[str, Optional[int]] = {}
         self._model_uid_to_launch_args: Dict[str, Dict] = {}
         self._model_uid_to_pid: Dict[str, int] = {}
+        self._model_uid_to_gpu_pids: Dict[str, set] = {}
+        self._model_uid_to_gpu_snapshot_before: Dict[str, set] = {}
+        self._gpu_snapshot_lock = asyncio.Lock()
 
         if XINFERENCE_DISABLE_METRICS:
             logger.info(
@@ -2120,6 +2123,23 @@ class WorkerActor(xo.StatelessActor):
 
                 with progressor:
                     try:
+                        # PID snapshot before load (GPU process tattoo, for
+                        # engines that spawn GPU workers outside the ModelActor
+                        # process tree, e.g. vLLM tensor parallelism).
+                        try:
+                            from ..device_utils import get_per_process_gpu_memory
+
+                            async with self._gpu_snapshot_lock:
+                                self._model_uid_to_gpu_snapshot_before[model_uid] = set(
+                                    (
+                                        await asyncio.to_thread(
+                                            get_per_process_gpu_memory
+                                        )
+                                    ).keys()
+                                )
+                        except Exception:
+                            pass
+
                         _load_start = time.time()
                         await model_ref.load()
                         _load_duration = time.time() - _load_start
@@ -2138,6 +2158,7 @@ class WorkerActor(xo.StatelessActor):
                         raise
             except Exception:
                 logger.error(f"Failed to load model {model_uid}", exc_info=True)
+                self._model_uid_to_gpu_snapshot_before.pop(model_uid, None)
                 self.release_devices(model_uid=model_uid)
                 for addr in all_subpool_addresses:
                     try:
@@ -2203,6 +2224,26 @@ class WorkerActor(xo.StatelessActor):
     async def wait_for_load(self, model_uid: str):
         model_ref = self._model_uid_to_model[model_uid]
         await model_ref.wait_for_load()
+
+        # Deferred GPU PID tattoo: by now vLLM/SGLang GPU worker processes,
+        # which spawn after model_ref.load() returns, are fully up.
+        before_pids = self._model_uid_to_gpu_snapshot_before.pop(model_uid, None)
+        if before_pids is not None:
+            try:
+                from ..device_utils import get_per_process_gpu_memory
+
+                async with self._gpu_snapshot_lock:
+                    after_pids = set(
+                        (await asyncio.to_thread(get_per_process_gpu_memory)).keys()
+                    )
+                new_pids = after_pids - before_pids
+                if new_pids:
+                    self._model_uid_to_gpu_pids[model_uid] = new_pids
+                    logger.info("GPU PID tattoo for %s: %s", model_uid, new_pids)
+            except Exception:
+                logger.warning(
+                    "Failed deferred GPU PID tattoo for %s", model_uid, exc_info=True
+                )
 
     @log_sync(logger=logger, level=logging.INFO)
     async def cancel_launch_model(self, model_uid: str):
@@ -2331,6 +2372,8 @@ class WorkerActor(xo.StatelessActor):
             self._model_uid_to_recover_count.pop(model_uid, None)
             self._model_uid_to_launch_args.pop(model_uid, None)
             self._model_uid_to_pid.pop(model_uid, None)
+            self._model_uid_to_gpu_pids.pop(model_uid, None)
+            self._model_uid_to_gpu_snapshot_before.pop(model_uid, None)
             # §4.3: Remove from persisted recovery file
             self._remove_persisted_launch_args(model_uid)
 
@@ -2407,7 +2450,10 @@ class WorkerActor(xo.StatelessActor):
                             ]
                         except (psutil.NoSuchProcess, psutil.AccessDenied):
                             all_pids = [own_pid]
-                        for pid in all_pids:
+                        # Include tattooed GPU PIDs (covers vLLM/SGLang workers
+                        # spawned outside the ModelActor process tree).
+                        all_pids.extend(self._model_uid_to_gpu_pids.get(m_uid, ()))
+                        for pid in set(all_pids):
                             if pid in gpu_mem:
                                 for gpu_idx, mem in gpu_mem[pid].items():
                                     per_gpu[gpu_idx] = per_gpu.get(gpu_idx, 0) + mem


### PR DESCRIPTION
## Summary

Per-model GPU memory metrics added in #4965 attribute usage by walking the `ModelActor`'s psutil process tree. This works for embedding/rerank models (loaded in-process via Transformers) but **misses vLLM/SGLang tensor-parallel engines**: their GPU worker / `EngineCore` processes are spawned

- **outside** the `ModelActor` process tree (independent multiprocessing / Ray spawn), and
- **after** `model_ref.load()` returns.

As a result `psutil.Process(...).children(recursive=True)` never finds them, and LLM models report no `xinference:model_gpu_memory_used_bytes`.

## Approach

Deferred GPU-PID "tattoo":

1. Before `model_ref.load()`, snapshot the set of GPU PIDs (`get_per_process_gpu_memory().keys()`).
2. In `wait_for_load()` — invoked per replica after the engine is fully up — take a fresh snapshot and diff it against the pre-load set. The new PIDs are the model's GPU workers.
3. Tattoo those PIDs to the model and merge them into the `report_status` collection loop alongside the existing process-tree PIDs.

Snapshot calls are serialized with an `asyncio.Lock`; all per-model state is cleaned up on load failure and on `terminate_model`. The change is purely additive (+47/-1, single file) and builds only on primitives already introduced by #4965.

## Known limitation

Concurrent launches may cross-attribute newly spawned PIDs (the `B - A` diff can include another model's workers if it spawns within the same window). This affects **monitoring attribution only**, not functionality; the lock narrows but does not fully eliminate the window.

## Test plan

- [ ] Deploy a vLLM LLM (e.g. qwen3, TP=2); worker log shows `GPU PID tattoo for ...`.
- [ ] `/metrics` reports `xinference:model_gpu_memory_used_bytes` for the LLM (~per-GPU VRAM).
- [ ] embedding/rerank model metrics unchanged.
- [ ] Concurrent launch of two models attributes PIDs to the correct model.
- [ ] Load failure / terminate leaves no leaked snapshot or tattoo state.

Related: #4965