### PR TITLE
bug: Adapt vLLM LoRA request path parameter

### DIFF
--- a/xinference/model/llm/vllm/core.py
+++ b/xinference/model/llm/vllm/core.py
@@ -476,6 +476,15 @@ class VLLMModel(LLM):
 
         if self.lora_modules is None:
             self.lora_requests = []
+        elif VLLM_VERSION and VLLM_VERSION >= version.parse("0.14.0"):
+            self.lora_requests = [
+                LoRARequest(
+                    lora_name=lora.lora_name,
+                    lora_int_id=i,
+                    lora_path=lora.local_path,
+                )
+                for i, lora in enumerate(self.lora_modules, start=1)
+            ]
         else:
             self.lora_requests = [
                 LoRARequest(


### PR DESCRIPTION
## Summary

- Adapt vLLM LoRA request construction for vLLM 0.14.0 and newer by passing `lora_path`.
- Keep `lora_local_path` for older vLLM versions to preserve compatibility.

## Release note

- Fix LoRA module loading with newer vLLM versions that expect `LoRARequest(lora_path=...)`.

## Validation

- `python -m py_compile xinference/model/llm/vllm/core.py`
- `git diff --check -- xinference/model/llm/vllm/core.py`

Fixes #4764
