### PR TITLE
fix(logging): strip all CSI escapes and route flush() through sampling

### DIFF
--- a/xinference/deploy/test/test_utils.py
+++ b/xinference/deploy/test/test_utils.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from unittest.mock import MagicMock
+
 import pytest
 
-from ..utils import handle_click_args_type
+from ..utils import StreamToLogger, handle_click_args_type
 
 
 class TestHandleClickArgsType:
@@ -222,3 +224,57 @@ class TestHandleClickArgsType:
         assert result[2] is None
         assert result[3] is True
         assert result[4] == {"key": "value"}
+
+
+class TestStreamToLoggerProgressSampling:
+    """Tests for StreamToLogger progress-bar threshold sampling.
+
+    The sampling key must be derived from the stable description *before*
+    the percentage so every frame of the same bar shares one key. Using a
+    fixed prefix slice (e.g. line[:30]) folds the changing percent text into
+    the key for short-description bars, making each frame a distinct key and
+    defeating threshold sampling (a per-frame log storm).
+    """
+
+    def _make_stream(self):
+        logger_instance = MagicMock()
+        stream = StreamToLogger(logger_instance, MagicMock(), "stderr")
+        return stream, logger_instance
+
+    def _logged_lines(self, logger_instance):
+        return [call.args[0] for call in logger_instance.info.call_args_list]
+
+    def test_short_description_bar_sampled_once_per_threshold(self):
+        """A short-description bar must log once per crossed threshold."""
+        stream, logger_instance = self._make_stream()
+        # Short description: the percentage is within the first 30 chars, so a
+        # fixed line[:30] slice would change every frame and defeat sampling.
+        for pct in [26, 30, 40, 50, 60, 76, 99, 100]:
+            stream._handle_progress(f"Downloading: {pct}%|##### | {pct}/100")
+
+        logged = self._logged_lines(logger_instance)
+        # Thresholds are {25, 50, 75, 100}; crossing frames are 26, 50, 76, 100.
+        assert logged == [
+            "Downloading: 26%|##### | 26/100",
+            "Downloading: 50%|##### | 50/100",
+            "Downloading: 76%|##### | 76/100",
+            "Downloading: 100%|##### | 100/100",
+        ]
+
+    def test_distinct_bars_tracked_independently(self):
+        """Two bars with different descriptions must not share sampling state."""
+        stream, logger_instance = self._make_stream()
+        stream._handle_progress("model-a.bin: 30%|## | 30/100")
+        stream._handle_progress("model-b.bin: 30%|## | 30/100")
+        stream._handle_progress("model-a.bin: 60%|#### | 60/100")
+        stream._handle_progress("model-b.bin: 60%|#### | 60/100")
+
+        logged = self._logged_lines(logger_instance)
+        # Each bar crosses the 25 threshold (at 30%) and the 50 threshold
+        # (at 60%) once, independently.
+        assert logged == [
+            "model-a.bin: 30%|## | 30/100",
+            "model-b.bin: 30%|## | 30/100",
+            "model-a.bin: 60%|#### | 60/100",
+            "model-b.bin: 60%|#### | 60/100",
+        ]

--- a/xinference/deploy/utils.py
+++ b/xinference/deploy/utils.py
@@ -131,7 +131,12 @@ class StreamToLogger:
         if not match:
             return
         pct = int(match.group(1))
-        key = line[:30]
+        # Derive the sampling key from the stable description *before* the
+        # percentage, so every frame of the same bar shares one key. Using
+        # line[:30] folds the changing percent/bar text into the key for
+        # short-description formats (e.g. "Downloading: 26%|"), making each
+        # frame a distinct key and defeating threshold sampling.
+        key = line[: match.start()].strip()
         last = self._last_reported_pct.get(key, 0)
         for threshold in sorted(self._progress_thresholds):
             if last < threshold <= pct:

--- a/xinference/deploy/utils.py
+++ b/xinference/deploy/utils.py
@@ -95,7 +95,10 @@ class StreamToLogger:
         self._last_reported_pct: dict = {}
         # Downloads run multi-threaded (HF_HUB_DOWNLOAD_WORKERS); concurrent
         # writes to the shared buffer would interleave without this lock.
-        self._lock = threading.Lock()
+        # Reentrant: while the lock is held we call logger.info(), and a logging
+        # handler error path (Handler.handleError -> sys.stderr) can re-enter
+        # write() on the same thread; RLock avoids a self-deadlock there.
+        self._lock = threading.RLock()
 
     def write(self, message: str) -> int:
         if not message:

--- a/xinference/deploy/utils.py
+++ b/xinference/deploy/utils.py
@@ -72,7 +72,10 @@ class LoggerNameFilter(logging.Filter):
 
 
 _PROGRESS_RE = re.compile(r"(\d+)%\|")
-_ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*m")
+# Strip all CSI sequences (cursor moves, hide-cursor, SGR colors), not just the
+# `m`-terminated color codes, so tqdm artifacts like `\x1b[A` / `\x1b[?25l` do
+# not leak into the log as junk lines (e.g. lone `[A`).
+_ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;?]*[A-Za-z]")
 
 
 class StreamToLogger:
@@ -90,21 +93,25 @@ class StreamToLogger:
         self._buffer = ""
         self._progress_thresholds = {25, 50, 75, 100}
         self._last_reported_pct: dict = {}
+        # Downloads run multi-threaded (HF_HUB_DOWNLOAD_WORKERS); concurrent
+        # writes to the shared buffer would interleave without this lock.
+        self._lock = threading.Lock()
 
     def write(self, message: str) -> int:
         if not message:
             return 0
-        self._buffer += message
-        while True:
-            pos_n = self._buffer.find("\n")
-            pos_r = self._buffer.find("\r")
-            if pos_n == -1 and pos_r == -1:
-                break
-            if pos_n != -1 and (pos_r == -1 or pos_n < pos_r):
-                line, self._buffer = self._buffer.split("\n", 1)
-            else:
-                line, self._buffer = self._buffer.split("\r", 1)
-            self._process_line(line)
+        with self._lock:
+            self._buffer += message
+            while True:
+                pos_n = self._buffer.find("\n")
+                pos_r = self._buffer.find("\r")
+                if pos_n == -1 and pos_r == -1:
+                    break
+                if pos_n != -1 and (pos_r == -1 or pos_n < pos_r):
+                    line, self._buffer = self._buffer.split("\n", 1)
+                else:
+                    line, self._buffer = self._buffer.split("\r", 1)
+                self._process_line(line)
         return len(message)
 
     def _process_line(self, raw: str) -> None:
@@ -132,11 +139,15 @@ class StreamToLogger:
             self._last_reported_pct.pop(key, None)
 
     def flush(self) -> None:
-        if self._buffer:
-            line = _ANSI_ESCAPE_RE.sub("", self._buffer).strip("\r\n").strip()
-            self._buffer = ""
-            if line and len(line) > 2:
-                self._logger.info(line)
+        # Route residual buffer through the sampling path instead of dumping it
+        # raw. tqdm calls flush() after every frame with a `\r`-terminated bar
+        # still in the buffer; a raw dump here bypasses _handle_progress and
+        # defeats sampling, producing a full per-frame storm in the log.
+        with self._lock:
+            if self._buffer:
+                residual = self._buffer
+                self._buffer = ""
+                self._process_line(residual)
         if self._original:
             try:
                 self._original.flush()


### PR DESCRIPTION
## Summary

The stdout/stderr redirect added in #4947 (`StreamToLogger` in `xinference/deploy/utils.py`) is meant to sample tqdm progress bars into `xinference.log`, but two defects let raw tqdm output leak through:

- **Junk `[A` lines.** `_ANSI_ESCAPE_RE` only stripped `m`-terminated SGR color codes (`\x1b\[[0-9;]*m`), so CSI cursor-control sequences such as `\x1b[A` (cursor up) and `\x1b[?25l` (hide cursor) survived stripping and landed in the log as junk lines (a lone `[A`). Widened to strip all CSI sequences: `\x1b\[[0-9;?]*[A-Za-z]`.
- **Sampling defeated by `flush()`.** `flush()` dumped the residual buffer raw, bypassing `_handle_progress`. tqdm writes a `\r`-terminated bar (no trailing terminator for `write()`'s split to consume) and calls `flush()` after every frame, so every frame went out un-sampled — a full per-frame storm instead of the intended 25/50/75/100 sampling. The residual is now routed through `_process_line` so sampling applies.

Also guards buffer mutation with a `threading.Lock`: downloads run multi-threaded (`HF_HUB_DOWNLOAD_WORKERS`) and concurrent writes to the shared buffer would interleave.

No public API, CLI, or schema changes. Behavior change is confined to what gets written to `xinference.log` when `XINFERENCE_LOG_CONSOLE=false`.

## Test plan

- [ ] With `XINFERENCE_LOG_CONSOLE=false`, load a model that emits tqdm bars; confirm `xinference.log` shows sampled progress (25/50/75/100) and **no** lone `[A` / cursor-control junk lines.
- [ ] Confirm no full per-frame storm in the log.
- [ ] Multi-threaded download (`HF_HUB_DOWNLOAD_WORKERS>1`): confirm log lines are not interleaved/truncated.
- [ ] `pre-commit run --all-files` (black/flake8/isort/mypy/codespell).
