### PR TITLE
fix(vllm): read json_schema from `schema_` so guided decoding applies

### DIFF
--- a/xinference/model/llm/vllm/core.py
+++ b/xinference/model/llm/vllm/core.py
@@ -961,7 +961,7 @@ class VLLMModel(LLM):
             elif response_format.get("type") == "json_schema":
                 json_schema = response_format.get("json_schema")
                 assert json_schema is not None
-                guided_json = json_schema.get("json_schema")
+                guided_json = json_schema.get("schema_") or json_schema.get("schema")
 
         sanitized.setdefault("lora_name", generate_config.get("lora_name", None))
         sanitized.setdefault("n", generate_config.get("n", 1))

--- a/xinference/model/llm/vllm/core.py
+++ b/xinference/model/llm/vllm/core.py
@@ -961,7 +961,13 @@ class VLLMModel(LLM):
             elif response_format.get("type") == "json_schema":
                 json_schema = response_format.get("json_schema")
                 assert json_schema is not None
-                guided_json = json_schema.get("schema_") or json_schema.get("schema")
+                # Real serialized key is the field name `schema_` (the model
+                # aliases the reserved `schema`); fall back to `schema` for raw
+                # passthrough. Check `is None` rather than truthiness so a valid
+                # empty schema ({}) is not dropped.
+                guided_json = json_schema.get("schema_")
+                if guided_json is None:
+                    guided_json = json_schema.get("schema")
 
         sanitized.setdefault("lora_name", generate_config.get("lora_name", None))
         sanitized.setdefault("n", generate_config.get("n", 1))

--- a/xinference/model/llm/vllm/core.py
+++ b/xinference/model/llm/vllm/core.py
@@ -1319,7 +1319,9 @@ class VLLMModel(LLM):
             # Extract guided decoding parameters
             guided_params: dict[str, Any] = {}
             guided_json = sanitized_generate_config.pop("guided_json", None)
-            if guided_json:
+            # Check `is not None` rather than truthiness so a valid empty
+            # schema ({}) is forwarded to vLLM instead of being dropped.
+            if guided_json is not None:
                 guided_params["json"] = guided_json
 
             guided_regex = sanitized_generate_config.pop("guided_regex", None)

--- a/xinference/model/llm/vllm/tests/test_core_chat_model.py
+++ b/xinference/model/llm/vllm/tests/test_core_chat_model.py
@@ -1586,7 +1586,11 @@ class TestVLLMSanitizeGenerateConfig:
 
     def test_json_schema_empty_schema_preserved(self):
         # An empty dict is a valid schema; `is None` (not truthiness) must keep
-        # it instead of falling through to the absent `schema` key.
+        # it instead of falling through to the absent `schema` key. The
+        # downstream guard in async_generate likewise uses `is not None`, so a
+        # preserved {} actually reaches vLLM guided decoding rather than being
+        # dropped. This asserts the intermediate value; the async_generate path
+        # depends on vLLM and is not unit-tested here.
         sanitized = self._sanitize(
             {
                 "type": "json_schema",

--- a/xinference/model/llm/vllm/tests/test_core_chat_model.py
+++ b/xinference/model/llm/vllm/tests/test_core_chat_model.py
@@ -1584,6 +1584,17 @@ class TestVLLMSanitizeGenerateConfig:
         assert sanitized["guided_json"] is None
         assert sanitized["guided_json_object"] is True
 
+    def test_json_schema_empty_schema_preserved(self):
+        # An empty dict is a valid schema; `is None` (not truthiness) must keep
+        # it instead of falling through to the absent `schema` key.
+        sanitized = self._sanitize(
+            {
+                "type": "json_schema",
+                "json_schema": {"name": "judge", "schema_": {}},
+            }
+        )
+        assert sanitized["guided_json"] == {}
+
     def test_no_response_format(self):
         from ..core import VLLMChatModel
 

--- a/xinference/model/llm/vllm/tests/test_core_chat_model.py
+++ b/xinference/model/llm/vllm/tests/test_core_chat_model.py
@@ -1534,3 +1534,58 @@ class TestVLLMChatModel:
             expected_result = filter_ids_and_created(expected_chunks[i])
             assert result == expected_result
             i = i + 1
+
+
+class TestVLLMSanitizeGenerateConfig:
+    """Guided-decoding extraction from response_format=json_schema.
+
+    The OpenAI-compatible request body serializes the JSONSchema model without
+    by_alias, so the real key reaching the engine is the field name ``schema_``
+    (``schema`` is a reserved Pydantic name, aliased in _compat.JSONSchema).
+    _sanitize_generate_config must read ``schema_`` (with a ``schema`` fallback
+    for raw passthrough), matching sglang/core.py and llm/utils.py.
+    """
+
+    _SCHEMA = {
+        "type": "object",
+        "properties": {"score": {"type": "integer"}},
+        "required": ["score"],
+    }
+
+    def _sanitize(self, response_format):
+        from ..core import VLLMChatModel
+
+        return VLLMChatModel._sanitize_generate_config(
+            {"response_format": response_format}
+        )
+
+    def test_json_schema_serialized_key(self):
+        # Real serialized shape (field name, not alias).
+        sanitized = self._sanitize(
+            {
+                "type": "json_schema",
+                "json_schema": {"name": "judge", "schema_": self._SCHEMA},
+            }
+        )
+        assert sanitized["guided_json"] == self._SCHEMA
+
+    def test_json_schema_alias_fallback(self):
+        # Raw passthrough shape using the alias.
+        sanitized = self._sanitize(
+            {
+                "type": "json_schema",
+                "json_schema": {"name": "judge", "schema": self._SCHEMA},
+            }
+        )
+        assert sanitized["guided_json"] == self._SCHEMA
+
+    def test_json_object_unaffected(self):
+        sanitized = self._sanitize({"type": "json_object"})
+        assert sanitized["guided_json"] is None
+        assert sanitized["guided_json_object"] is True
+
+    def test_no_response_format(self):
+        from ..core import VLLMChatModel
+
+        sanitized = VLLMChatModel._sanitize_generate_config({})
+        assert sanitized["guided_json"] is None


### PR DESCRIPTION
## Summary

`response_format={"type": "json_schema", ...}` was silently ignored on the vLLM backend — the model returned free-form text instead of schema-constrained JSON.

Root cause is a wrong key lookup in `VLLMModel._sanitize_generate_config` (`xinference/model/llm/vllm/core.py`):

```python
elif response_format.get("type") == "json_schema":
    json_schema = response_format.get("json_schema")
    assert json_schema is not None
    guided_json = json_schema.get("json_schema")   # key does not exist -> None
```

The OpenAI-compatible request body serializes `_compat.JSONSchema` **without** `by_alias` (`restful_api.py` uses `body.dict(exclude_unset=True, ...)`). Since `schema` is a reserved Pydantic name, the model field is `schema_ = Field(alias="schema")`, and without `by_alias` the serialized key is the **field name** `schema_`. So the inner dict only ever has `name` / `schema_` / `strict` — never `json_schema`. `guided_json` therefore stayed `None`, `guided_params` got no `json`, and vLLM skipped guided decoding.

### Fix

Read `schema_` with a `schema` fallback (for raw `extra_body` passthrough):

```python
guided_json = json_schema.get("schema_") or json_schema.get("schema")
```

This matches the already-correct handling elsewhere in the codebase:
- `xinference/model/llm/sglang/core.py` (reads `schema_`, falls back to `schema`)
- `xinference/model/llm/utils.py` (`schema_block.get("schema_") or schema_block.get("schema")`)

vLLM's `core.py` was the lone outlier. Both the chat path and the plain `/v1/completions` path funnel through `_sanitize_generate_config`, so this single change covers both.

### Why fix here, not at serialization

Switching `restful_api.py` to `by_alias=True` would rename the key globally (`schema_` -> `schema`) and break every consumer that currently reads `schema_` (e.g. the chat-config path and the engines listed above). The localized fix is minimal and aligns vLLM with the existing convention.

No public API, request/response schema, or CLI changes. Backward compatible: requests without `response_format`, or with `json_object`, are unaffected.

## Test plan

- [x] Added `TestVLLMSanitizeGenerateConfig` covering: serialized `schema_` key, `schema` alias fallback, `json_object` regression, and no-`response_format` regression.
- [ ] `pytest -vv xinference/model/llm/vllm/tests/test_core_chat_model.py -k SanitizeGenerateConfig` in an env with vLLM installed (these tests are ignored in the non-GPU CI job; I could not run them in my environment).
- [ ] End-to-end: send a `json_schema` `response_format` to `/v1/chat/completions` on a vLLM-served model and confirm the output is schema-valid JSON.
- [ ] `pre-commit run --all-files`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)