### PR TITLE
bug: fix llama.cpp streaming tool call edge cases

### DIFF
--- a/xinference/model/llm/llama_cpp/core.py
+++ b/xinference/model/llm/llama_cpp/core.py
@@ -16,6 +16,8 @@ import logging
 import os
 import pprint
 import queue
+import time
+import uuid
 from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
 from packaging import version
@@ -69,6 +71,37 @@ class _Error:
         self.msg = msg
 
 
+def _error_message(msg: Any) -> str:
+    if isinstance(msg, dict):
+        for key in ("message", "msg", "error"):
+            value = msg.get(key)
+            if value:
+                return str(value)
+    return str(msg)
+
+
+def _is_tool_call_arguments_parse_error(msg: Any) -> bool:
+    return "Failed to parse tool call arguments as JSON" in _error_message(msg)
+
+
+def _make_stream_stop_chunk(
+    chunk: CompletionChunk, fallback_model: str
+) -> ChatCompletionChunk:
+    return {
+        "id": str(chunk.get("id") or f"chatcmpl-{uuid.uuid4()}"),
+        "model": str(chunk.get("model") or fallback_model),
+        "created": int(chunk.get("created") or time.time()),
+        "object": "chat.completion.chunk",
+        "choices": [
+            {
+                "index": 0,
+                "delta": {},
+                "finish_reason": "stop",
+            }
+        ],
+    }
+
+
 class XllamaCppModel(LLM, ChatModelMixin):
     allow_batch = True
 
@@ -111,7 +144,7 @@ class XllamaCppModel(LLM, ChatModelMixin):
     @classmethod
     def check_lib(cls) -> Union[bool, Tuple[bool, str]]:
         dep_check = check_dependency_available("xllamacpp", "xllamacpp")
-        if dep_check != True:
+        if dep_check is not True:
             return dep_check
         return True
 
@@ -390,9 +423,25 @@ class XllamaCppModel(LLM, ChatModelMixin):
         if stream:
 
             def _to_iterator():
+                last_chunk = None
                 while (r := q.get()) is not _Done:
                     if type(r) is _Error:
+                        if (
+                            tools
+                            and last_chunk is not None
+                            and _is_tool_call_arguments_parse_error(r.msg)
+                        ):
+                            logger.warning(
+                                "xllamacpp failed to parse streamed tool call "
+                                "arguments; ending stream with a synthetic stop "
+                                "chunk so callers can validate or retry the "
+                                "partial tool arguments. error=%s",
+                                _error_message(r.msg),
+                            )
+                            yield _make_stream_stop_chunk(last_chunk, self.model_uid)
+                            break
                         raise Exception(f"Got error in chat stream: {r.msg}")
+                    last_chunk = r
                     yield r
 
             return self._to_chat_completion_chunks(

--- a/xinference/model/llm/llama_cpp/core.py
+++ b/xinference/model/llm/llama_cpp/core.py
@@ -18,12 +18,18 @@ import pprint
 import queue
 import time
 import uuid
-from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
+from typing import Any, Dict, Iterator, List, Optional, Tuple, Union, cast
 
 from packaging import version
 
 from ....constants import XINFERENCE_MAX_TOKENS
-from ....types import ChatCompletion, ChatCompletionChunk, Completion, CompletionChunk
+from ....types import (
+    ChatCompletion,
+    ChatCompletionChunk,
+    Completion,
+    CompletionChoice,
+    CompletionChunk,
+)
 from ...utils import check_dependency_available
 from ..core import LLM, chat_context_var
 from ..llm_family import LLMFamilyV2, LLMSpecV1
@@ -362,8 +368,8 @@ class XllamaCppModel(LLM, ChatModelMixin):
             return r
 
     def _normalize_disabled_thinking_reasoning_content(
-        self, response: Completion, tools: List[dict]
-    ) -> Completion:
+        self, response: ChatCompletion, tools: List[dict]
+    ) -> ChatCompletion:
         if self.reasoning_parser and self.reasoning_parser.check_content_parser():
             return response
         if response.get("object") != "chat.completion":
@@ -372,50 +378,49 @@ class XllamaCppModel(LLM, ChatModelMixin):
         if not choices:
             return response
         choice = choices[0]
-        message = choice.get("message") or {}
+        message = cast(Dict[str, Any], choice.get("message") or {})
         reasoning_content = message.get("reasoning_content")
         if not reasoning_content:
             return response
         if message.get("content") or message.get("tool_calls"):
-            response = response.copy()
-            choices = [dict(item) for item in choices]
-            response["choices"] = choices
-            choice = choices[0]
+            response_dict = cast(Dict[str, Any], response.copy())
+            choices_dicts = [cast(Dict[str, Any], dict(item)) for item in choices]
+            response_dict["choices"] = choices_dicts
+            choice_dict = choices_dicts[0]
             message = dict(message)
-            choice["message"] = message
+            choice_dict["message"] = message
             message.pop("reasoning_content", None)
-            return response
+            return cast(ChatCompletion, response_dict)
 
         logger.warning(
             "xllamacpp returned visible output in reasoning_content while thinking "
             "is disabled; normalizing it as message content."
         )
         if not tools or not self.tool_parser:
-            response = response.copy()
-            choices = [dict(item) for item in choices]
-            response["choices"] = choices
-            choice = choices[0]
+            response_dict = cast(Dict[str, Any], response.copy())
+            choices_dicts = [cast(Dict[str, Any], dict(item)) for item in choices]
+            response_dict["choices"] = choices_dicts
+            choice_dict = choices_dicts[0]
             message = dict(message)
-            choice["message"] = message
+            choice_dict["message"] = message
             message["content"] = reasoning_content
             message.pop("reasoning_content", None)
-            return response
+            return cast(ChatCompletion, response_dict)
 
-        completion = {
-            "id": response.get("id") or f"cmpl-{uuid.uuid4()}",
-            "object": "text_completion",
-            "created": response.get("created") or int(time.time()),
-            "model": response.get("model") or self.model_uid,
-            "choices": [
-                {
-                    "index": choice.get("index", 0),
-                    "text": reasoning_content,
-                    "logprobs": None,
-                    "finish_reason": choice.get("finish_reason"),
-                }
-            ],
-            "usage": response.get("usage"),
-        }
+        completion_choice = CompletionChoice(
+            index=choice.get("index", 0),
+            text=reasoning_content,
+            logprobs=None,
+            finish_reason=choice.get("finish_reason"),
+        )
+        completion = Completion(
+            id=response.get("id") or f"cmpl-{uuid.uuid4()}",
+            object="text_completion",
+            created=response.get("created") or int(time.time()),
+            model=response.get("model") or self.model_uid,
+            choices=[completion_choice],
+            usage=response["usage"],
+        )
         return self._post_process_completion(None, self.model_uid, completion)
 
     def chat(

--- a/xinference/model/llm/llama_cpp/core.py
+++ b/xinference/model/llm/llama_cpp/core.py
@@ -361,6 +361,45 @@ class XllamaCppModel(LLM, ChatModelMixin):
                 raise Exception("Got error in generate: %s", r.msg)
             return r
 
+    def _recover_tool_calls_from_reasoning_content(
+        self, response: Completion, tools: List[dict]
+    ) -> Completion:
+        if not tools or not self.tool_parser:
+            return response
+        if response.get("object") != "chat.completion":
+            return response
+        choices = response.get("choices")
+        if not choices:
+            return response
+        choice = choices[0]
+        message = choice.get("message") or {}
+        if message.get("content") or message.get("tool_calls"):
+            return response
+        reasoning_content = message.get("reasoning_content")
+        if not reasoning_content:
+            return response
+
+        logger.warning(
+            "xllamacpp returned tool-call content in reasoning_content with empty "
+            "message content; reparsing it as visible output."
+        )
+        completion = {
+            "id": response.get("id") or f"cmpl-{uuid.uuid4()}",
+            "object": "text_completion",
+            "created": response.get("created") or int(time.time()),
+            "model": response.get("model") or self.model_uid,
+            "choices": [
+                {
+                    "index": choice.get("index", 0),
+                    "text": reasoning_content,
+                    "logprobs": None,
+                    "finish_reason": choice.get("finish_reason"),
+                }
+            ],
+            "usage": response.get("usage"),
+        }
+        return self._post_process_completion(None, self.model_uid, completion)
+
     def chat(
         self,
         messages: List[dict],
@@ -451,4 +490,5 @@ class XllamaCppModel(LLM, ChatModelMixin):
             r = q.get()
             if type(r) is _Error:
                 raise Exception(f"Got error in chat: {r.msg}")
+            r = self._recover_tool_calls_from_reasoning_content(r, tools)
             return self._to_chat_completion(r, self.reasoning_parser)

--- a/xinference/model/llm/llama_cpp/core.py
+++ b/xinference/model/llm/llama_cpp/core.py
@@ -361,10 +361,10 @@ class XllamaCppModel(LLM, ChatModelMixin):
                 raise Exception("Got error in generate: %s", r.msg)
             return r
 
-    def _recover_tool_calls_from_reasoning_content(
+    def _normalize_disabled_thinking_reasoning_content(
         self, response: Completion, tools: List[dict]
     ) -> Completion:
-        if not tools or not self.tool_parser:
+        if self.reasoning_parser and self.reasoning_parser.check_content_parser():
             return response
         if response.get("object") != "chat.completion":
             return response
@@ -373,16 +373,34 @@ class XllamaCppModel(LLM, ChatModelMixin):
             return response
         choice = choices[0]
         message = choice.get("message") or {}
-        if message.get("content") or message.get("tool_calls"):
-            return response
         reasoning_content = message.get("reasoning_content")
         if not reasoning_content:
             return response
+        if message.get("content") or message.get("tool_calls"):
+            response = response.copy()
+            choices = [dict(item) for item in choices]
+            response["choices"] = choices
+            choice = choices[0]
+            message = dict(message)
+            choice["message"] = message
+            message.pop("reasoning_content", None)
+            return response
 
         logger.warning(
-            "xllamacpp returned tool-call content in reasoning_content with empty "
-            "message content; reparsing it as visible output."
+            "xllamacpp returned visible output in reasoning_content while thinking "
+            "is disabled; normalizing it as message content."
         )
+        if not tools or not self.tool_parser:
+            response = response.copy()
+            choices = [dict(item) for item in choices]
+            response["choices"] = choices
+            choice = choices[0]
+            message = dict(message)
+            choice["message"] = message
+            message["content"] = reasoning_content
+            message.pop("reasoning_content", None)
+            return response
+
         completion = {
             "id": response.get("id") or f"cmpl-{uuid.uuid4()}",
             "object": "text_completion",
@@ -490,5 +508,5 @@ class XllamaCppModel(LLM, ChatModelMixin):
             r = q.get()
             if type(r) is _Error:
                 raise Exception(f"Got error in chat: {r.msg}")
-            r = self._recover_tool_calls_from_reasoning_content(r, tools)
+            r = self._normalize_disabled_thinking_reasoning_content(r, tools)
             return self._to_chat_completion(r, self.reasoning_parser)

--- a/xinference/model/llm/llama_cpp/tests/test_structured.py
+++ b/xinference/model/llm/llama_cpp/tests/test_structured.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel
 
 from xinference.client import Client
 
+from ...tool_parsers.qwen_tool_parser import QwenToolParser
 from ..core import XllamaCppModel, _apply_response_format
 
 
@@ -35,6 +36,7 @@ def _new_fake_llamacpp_model(responses):
     model = XllamaCppModel.__new__(XllamaCppModel)
     model.model_uid = "test-model"
     model.reasoning_parser = None
+    model.tool_parser = None
     model._executor = _InlineExecutor()
     model._llm = _FakeLlamaCppServer(responses)
     return model
@@ -121,6 +123,70 @@ def test_llamacpp_stream_non_tool_parse_error_still_raises():
 
     with pytest.raises(Exception, match="Got error in chat stream"):
         list(model.chat([{"role": "user", "content": "hi"}], {"stream": True}))
+
+
+def test_llamacpp_chat_reparses_tool_call_from_reasoning_content():
+    model = _new_fake_llamacpp_model(
+        [
+            {
+                "choices": [
+                    {
+                        "finish_reason": "stop",
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "",
+                            "reasoning_content": (
+                                "I should call the tool.\n\n"
+                                "<tool_call>\n"
+                                "<function=execute_python_code>\n"
+                                "<parameter=code>\n"
+                                "import random\n"
+                                "random.randint(1, 100)\n"
+                                "</parameter>\n"
+                                "</function>\n"
+                                "</tool_call>"
+                            ),
+                        },
+                    }
+                ],
+                "created": 123,
+                "id": "chatcmpl-test",
+                "model": "test-model",
+                "object": "chat.completion",
+                "usage": {
+                    "prompt_tokens": 10,
+                    "completion_tokens": 20,
+                    "total_tokens": 30,
+                },
+            }
+        ]
+    )
+    model.tool_parser = QwenToolParser()
+
+    response = model.chat(
+        [{"role": "user", "content": "run python"}],
+        {
+            "stream": False,
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "execute_python_code",
+                        "parameters": {"type": "object"},
+                    },
+                }
+            ],
+        },
+    )
+
+    message = response["choices"][0]["message"]
+    assert response["choices"][0]["finish_reason"] == "tool_calls"
+    assert message["content"] == "I should call the tool.\n\n"
+    assert message["tool_calls"][0]["function"]["name"] == "execute_python_code"
+    assert json.loads(message["tool_calls"][0]["function"]["arguments"]) == {
+        "code": "import random\nrandom.randint(1, 100)"
+    }
 
 
 class CarType(str, Enum):

--- a/xinference/model/llm/llama_cpp/tests/test_structured.py
+++ b/xinference/model/llm/llama_cpp/tests/test_structured.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel
 
 from xinference.client import Client
 
+from ...reasoning_parser import ReasoningParser
 from ...tool_parsers.qwen_tool_parser import QwenToolParser
 from ..core import XllamaCppModel, _apply_response_format
 
@@ -162,6 +163,12 @@ def test_llamacpp_chat_reparses_tool_call_from_reasoning_content():
             }
         ]
     )
+    model.reasoning_parser = ReasoningParser(
+        reasoning_content=True,
+        reasoning_start_tag="<think>",
+        reasoning_end_tag="</think>",
+        enable_thinking=False,
+    )
     model.tool_parser = QwenToolParser()
 
     response = model.chat(
@@ -187,6 +194,51 @@ def test_llamacpp_chat_reparses_tool_call_from_reasoning_content():
     assert json.loads(message["tool_calls"][0]["function"]["arguments"]) == {
         "code": "import random\nrandom.randint(1, 100)"
     }
+    assert "reasoning_content" not in message
+
+
+def test_llamacpp_chat_moves_reasoning_content_to_content_when_thinking_disabled():
+    model = _new_fake_llamacpp_model(
+        [
+            {
+                "choices": [
+                    {
+                        "finish_reason": "stop",
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "",
+                            "reasoning_content": "visible answer",
+                        },
+                    }
+                ],
+                "created": 123,
+                "id": "chatcmpl-test",
+                "model": "test-model",
+                "object": "chat.completion",
+                "usage": {
+                    "prompt_tokens": 10,
+                    "completion_tokens": 20,
+                    "total_tokens": 30,
+                },
+            }
+        ]
+    )
+    model.reasoning_parser = ReasoningParser(
+        reasoning_content=True,
+        reasoning_start_tag="<think>",
+        reasoning_end_tag="</think>",
+        enable_thinking=False,
+    )
+
+    response = model.chat(
+        [{"role": "user", "content": "hi"}],
+        {"stream": False},
+    )
+
+    message = response["choices"][0]["message"]
+    assert message["content"] == "visible answer"
+    assert "reasoning_content" not in message
 
 
 class CarType(str, Enum):

--- a/xinference/model/llm/llama_cpp/tests/test_structured.py
+++ b/xinference/model/llm/llama_cpp/tests/test_structured.py
@@ -12,7 +12,115 @@ from pydantic import BaseModel
 
 from xinference.client import Client
 
-from ..core import _apply_response_format
+from ..core import XllamaCppModel, _apply_response_format
+
+
+class _InlineExecutor:
+    def submit(self, fn):
+        fn()
+
+
+class _FakeLlamaCppServer:
+    def __init__(self, responses):
+        self.responses = responses
+        self.requests = []
+
+    def handle_chat_completions(self, data, callback):
+        self.requests.append(data)
+        for response in self.responses:
+            callback(response)
+
+
+def _new_fake_llamacpp_model(responses):
+    model = XllamaCppModel.__new__(XllamaCppModel)
+    model.model_uid = "test-model"
+    model.reasoning_parser = None
+    model._executor = _InlineExecutor()
+    model._llm = _FakeLlamaCppServer(responses)
+    return model
+
+
+def test_llamacpp_stream_tool_parse_error_finishes_partial_stream():
+    first_chunk = {
+        "choices": [
+            {
+                "finish_reason": None,
+                "index": 0,
+                "delta": {
+                    "tool_calls": [
+                        {
+                            "index": 0,
+                            "id": "call-1",
+                            "type": "function",
+                            "function": {
+                                "name": "select_execution_pattern",
+                                "arguments": '{"answer":"unterminated',
+                            },
+                        }
+                    ]
+                },
+            }
+        ],
+        "created": 123,
+        "id": "chatcmpl-test",
+        "model": "test-model",
+        "object": "chat.completion.chunk",
+    }
+    model = _new_fake_llamacpp_model(
+        [
+            first_chunk,
+            {
+                "code": 500,
+                "message": (
+                    "Failed to parse tool call arguments as JSON: "
+                    "[json.exception.parse_error.101] missing closing quote"
+                ),
+            },
+        ]
+    )
+
+    chunks = list(
+        model.chat(
+            [{"role": "user", "content": "hi"}],
+            {
+                "stream": True,
+                "tools": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "select_execution_pattern",
+                            "parameters": {"type": "object"},
+                        },
+                    }
+                ],
+            },
+        )
+    )
+
+    assert chunks[0] == first_chunk
+    assert chunks[-1]["id"] == first_chunk["id"]
+    assert chunks[-1]["model"] == first_chunk["model"]
+    assert chunks[-1]["created"] == first_chunk["created"]
+    assert chunks[-1]["choices"] == [
+        {"index": 0, "delta": {"content": ""}, "finish_reason": "stop"}
+    ]
+
+
+def test_llamacpp_stream_non_tool_parse_error_still_raises():
+    model = _new_fake_llamacpp_model(
+        [
+            {
+                "code": 500,
+                "message": (
+                    "Failed to parse tool call arguments as JSON: "
+                    "[json.exception.parse_error.101] missing closing quote"
+                ),
+            }
+        ]
+    )
+
+    with pytest.raises(Exception, match="Got error in chat stream"):
+        list(model.chat([{"role": "user", "content": "hi"}], {"stream": True}))
 
 
 class CarType(str, Enum):

--- a/xinference/model/llm/tests/test_utils.py
+++ b/xinference/model/llm/tests/test_utils.py
@@ -15,10 +15,22 @@
 import asyncio
 from types import SimpleNamespace
 
+import pytest
+
+from ..core import chat_context_var
 from ..reasoning_parser import ReasoningParser
 from ..tool_parsers.llama3_tool_parser import Llama3ToolParser
 from ..tool_parsers.qwen_tool_parser import QwenToolParser
 from ..utils import ChatModelMixin
+
+
+@pytest.fixture(autouse=True)
+def reset_chat_context_var():
+    token = chat_context_var.set({})
+    try:
+        yield
+    finally:
+        chat_context_var.reset(token)
 
 
 def test_is_valid_model_name():

--- a/xinference/model/llm/tests/test_utils.py
+++ b/xinference/model/llm/tests/test_utils.py
@@ -187,7 +187,7 @@ def test_deepseekv4_get_full_context_attaches_tools(tmp_path):
     encoding_dir = tmp_path / "encoding"
     encoding_dir.mkdir()
     (encoding_dir / "encoding_dsv4.py").write_text(
-        "def encode_messages(messages, thinking_mode):\n" "    return messages\n",
+        "def encode_messages(messages, thinking_mode):\n    return messages\n",
         encoding="utf-8",
     )
     mixin = ChatModelMixin()
@@ -216,6 +216,38 @@ def test_deepseekv4_get_full_context_attaches_tools(tmp_path):
 
     assert messages[0] == {"role": "system", "content": "", "tools": tools}
     assert messages[1] == {"role": "user", "content": "How is the weather?"}
+
+
+def test_chat_template_kwargs_inherit_model_thinking_default():
+    reasoning_parser = ReasoningParser(
+        reasoning_content=False,
+        reasoning_start_tag="<think>",
+        reasoning_end_tag="</think>",
+        enable_thinking=False,
+    )
+
+    kwargs = ChatModelMixin._get_chat_template_kwargs_from_generate_config(
+        {"chat_template_kwargs": {"add_vision_id": True}},
+        reasoning_parser,
+    )
+
+    assert kwargs == {"add_vision_id": True, "enable_thinking": False}
+
+
+def test_chat_template_kwargs_keep_request_thinking_override():
+    reasoning_parser = ReasoningParser(
+        reasoning_content=False,
+        reasoning_start_tag="<think>",
+        reasoning_end_tag="</think>",
+        enable_thinking=False,
+    )
+
+    kwargs = ChatModelMixin._get_chat_template_kwargs_from_generate_config(
+        {"chat_template_kwargs": {"thinking": True}},
+        reasoning_parser,
+    )
+
+    assert kwargs == {"thinking": True, "enable_thinking": True}
 
 
 def test_post_process_completion_chunk_without_thinking():

--- a/xinference/model/llm/tests/test_utils.py
+++ b/xinference/model/llm/tests/test_utils.py
@@ -250,6 +250,22 @@ def test_chat_template_kwargs_keep_request_thinking_override():
     assert kwargs == {"thinking": True, "enable_thinking": True}
 
 
+def test_chat_template_kwargs_string_normalizes_thinking():
+    reasoning_parser = ReasoningParser(
+        reasoning_content=False,
+        reasoning_start_tag="<think>",
+        reasoning_end_tag="</think>",
+        enable_thinking=False,
+    )
+
+    kwargs = ChatModelMixin._get_chat_template_kwargs_from_generate_config(
+        {"chat_template_kwargs": '{"thinking": true}'},
+        reasoning_parser,
+    )
+
+    assert kwargs == {"thinking": True, "enable_thinking": True}
+
+
 def test_post_process_completion_chunk_without_thinking():
     mixin = ChatModelMixin()
     mixin.tool_parser = QwenToolParser()

--- a/xinference/model/llm/tests/test_utils.py
+++ b/xinference/model/llm/tests/test_utils.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
 from types import SimpleNamespace
 
 from ..reasoning_parser import ReasoningParser
@@ -46,6 +47,96 @@ def filter_ids_and_created(data):
             if k not in ["id", "created"]
         }
     return data
+
+
+def test_to_chat_completion_chunks_usage_only_chunk_without_metadata():
+    chunks = [
+        {
+            "id": "cmpl-test",
+            "object": "text_completion",
+            "created": 123,
+            "model": "test-model",
+            "choices": [
+                {
+                    "index": 0,
+                    "text": "hello",
+                    "logprobs": None,
+                    "finish_reason": None,
+                }
+            ],
+        },
+        {
+            "usage": {
+                "prompt_tokens": 3,
+                "completion_tokens": 2,
+                "total_tokens": 5,
+            }
+        },
+    ]
+
+    results = list(ChatModelMixin._to_chat_completion_chunks(iter(chunks)))
+
+    assert results[-1] == {
+        "id": "chatcmpl-test",
+        "model": "test-model",
+        "created": 123,
+        "object": "chat.completion.chunk",
+        "choices": [],
+        "usage": {
+            "prompt_tokens": 3,
+            "completion_tokens": 2,
+            "total_tokens": 5,
+        },
+    }
+
+
+def test_async_to_chat_completion_chunks_preserves_usage_only_chunk():
+    async def _chunks():
+        yield {
+            "id": "cmpl-test",
+            "object": "text_completion",
+            "created": 123,
+            "model": "test-model",
+            "choices": [
+                {
+                    "index": 0,
+                    "text": "",
+                    "logprobs": None,
+                    "finish_reason": "stop",
+                }
+            ],
+        }
+        yield {
+            "choices": [],
+            "usage": {
+                "prompt_tokens": 3,
+                "completion_tokens": 2,
+                "total_tokens": 5,
+            },
+        }
+
+    async def _collect():
+        return [
+            chunk
+            async for chunk in ChatModelMixin._async_to_chat_completion_chunks(
+                _chunks()
+            )
+        ]
+
+    results = asyncio.run(_collect())
+
+    assert results[-1] == {
+        "id": "chatcmpl-test",
+        "model": "test-model",
+        "created": 123,
+        "object": "chat.completion.chunk",
+        "choices": [],
+        "usage": {
+            "prompt_tokens": 3,
+            "completion_tokens": 2,
+            "total_tokens": 5,
+        },
+    }
 
 
 def test_transform_messages_preserves_tool_call_fields():

--- a/xinference/model/llm/utils.py
+++ b/xinference/model/llm/utils.py
@@ -163,7 +163,10 @@ class ChatModelMixin:
         tokenize=False,
         **kwargs,
     ):
-        if "vision" not in self.model_family.model_ability and "audio" not in self.model_family.model_ability:  # type: ignore
+        if (
+            "vision" not in self.model_family.model_ability
+            and "audio" not in self.model_family.model_ability
+        ):  # type: ignore
             messages = self.convert_messages_with_content_list_to_str_conversion(
                 messages
             )
@@ -227,6 +230,14 @@ class ChatModelMixin:
                         f"`chat_template_kwargs` should be json parsable, got: {kwargs}"
                     )
             elif isinstance(kwargs, dict):
+                kwargs = dict(kwargs)
+                if reasoning_parser and "enable_thinking" not in kwargs:
+                    thinking = kwargs.get("thinking")
+                    kwargs["enable_thinking"] = (
+                        thinking
+                        if isinstance(thinking, bool)
+                        else reasoning_parser.enable_thinking
+                    )
                 return kwargs
             else:
                 raise TypeError(
@@ -1149,11 +1160,13 @@ def parse_messages(messages: List[Dict]) -> Tuple:
 @functools.lru_cache
 def _load_deepseekv4_encoding_module(model_path: str):
     module_path = os.path.join(
-        model_path, "encoding", "encoding_dsv4.py"  # type: ignore
+        model_path,
+        "encoding",
+        "encoding_dsv4.py",  # type: ignore
     )
     if not os.path.exists(module_path):
         raise FileNotFoundError(
-            f"Missing {module_path}." "Please verify the model repository files."
+            f"Missing {module_path}.Please verify the model repository files."
         )
     spec = importlib.util.spec_from_file_location("encoding_dsv4", module_path)
     if spec is None or spec.loader is None:

--- a/xinference/model/llm/utils.py
+++ b/xinference/model/llm/utils.py
@@ -408,7 +408,7 @@ class ChatModelMixin:
             )
         assert choices is not None
         usage = (
-            chunk["usage"]
+            chunk.get("usage")
             if choices and choices[0]["finish_reason"] is not None or not choices
             else None
         )
@@ -461,19 +461,58 @@ class ChatModelMixin:
         return chunks
 
     @classmethod
+    def _get_chat_completion_chunk_id(
+        cls,
+        chunk: CompletionChunk,
+        fallback_chunk: Optional[CompletionChunk] = None,
+    ) -> str:
+        source_chunk = chunk if chunk.get("id") else fallback_chunk or {}
+        chunk_id = source_chunk.get("id")
+        if not chunk_id:
+            return f"chatcmpl-{uuid.uuid4()}"
+        chunk_id = str(chunk_id)
+        if source_chunk.get("object") == "chat.completion.chunk":
+            return chunk_id
+        return "chat" + chunk_id
+
+    @classmethod
     def _get_final_chat_completion_chunk(
-        cls, chunk: CompletionChunk
+        cls,
+        chunk: CompletionChunk,
+        fallback_chunk: Optional[CompletionChunk] = None,
     ) -> ChatCompletionChunk:
-        chat_chunk = {
-            "id": "chat" + chunk["id"],
-            "model": chunk["model"],
-            "created": chunk["created"],
+        chat_chunk: Dict[str, Any] = {
+            "id": cls._get_chat_completion_chunk_id(chunk, fallback_chunk),
+            "model": chunk.get("model") or (fallback_chunk or {}).get("model") or "",
+            "created": chunk.get("created")
+            or (fallback_chunk or {}).get("created")
+            or int(time.time()),
             "object": "chat.completion.chunk",
             "choices": [
                 ChatCompletionChunkChoice(
                     index=0, delta=ChatCompletionChunkDelta(), finish_reason="stop"
                 )
             ],
+        }
+        usage = chunk.get("usage")
+        if usage is not None:
+            chat_chunk["usage"] = usage
+        return cast(ChatCompletionChunk, chat_chunk)
+
+    @classmethod
+    def _get_usage_chat_completion_chunk(
+        cls,
+        chunk: CompletionChunk,
+        fallback_chunk: Optional[CompletionChunk] = None,
+    ) -> ChatCompletionChunk:
+        chat_chunk: Dict[str, Any] = {
+            "id": cls._get_chat_completion_chunk_id(chunk, fallback_chunk),
+            "model": chunk.get("model") or (fallback_chunk or {}).get("model") or "",
+            "created": chunk.get("created")
+            or (fallback_chunk or {}).get("created")
+            or int(time.time()),
+            "object": "chat.completion.chunk",
+            "choices": [],
         }
         usage = chunk.get("usage")
         if usage is not None:
@@ -488,6 +527,7 @@ class ChatModelMixin:
     ) -> Iterator[ChatCompletionChunk]:
         previous_texts = [""]
         is_first_chunk = True
+        fallback_chunk: Optional[CompletionChunk] = None
         if reasoning_parse:
             chunks = reasoning_parse.prepare_reasoning_content_sync(chunks)
         for _, chunk in enumerate(chunks):
@@ -508,14 +548,18 @@ class ChatModelMixin:
                         )
                     ]
                     choices = chunk["choices"]
+                elif chunk.get("usage") is not None:
+                    yield cls._get_usage_chat_completion_chunk(chunk, fallback_chunk)
+                    continue
                 else:
-                    yield cls._get_final_chat_completion_chunk(chunk)
+                    yield cls._get_final_chat_completion_chunk(chunk, fallback_chunk)
                     continue
 
             r = cls._to_chat_completion_chunk(
                 chunk, reasoning_parse, previous_texts, ensure_role=is_first_chunk
             )
             is_first_chunk = False
+            fallback_chunk = chunk
             yield r
 
     @classmethod
@@ -561,6 +605,7 @@ class ChatModelMixin:
         previous_texts = [""]
         full_text = ""
         is_first_chunk = True
+        fallback_chunk: Optional[CompletionChunk] = None
         # Process chunks
         if reasoning_parser:
             set_context()
@@ -570,7 +615,14 @@ class ChatModelMixin:
             choices = chunk.get("choices")
             if not choices:
                 # usage
-                chat_chunk = cls._get_final_chat_completion_chunk(chunk)
+                if chunk.get("usage") is not None:
+                    chat_chunk = cls._get_usage_chat_completion_chunk(
+                        chunk, fallback_chunk
+                    )
+                else:
+                    chat_chunk = cls._get_final_chat_completion_chunk(
+                        chunk, fallback_chunk
+                    )
             else:
                 if choices[0].get("text"):
                     full_text += choices[0]["text"]  # type: ignore
@@ -581,6 +633,7 @@ class ChatModelMixin:
                     previous_texts,
                     ensure_role=is_first_chunk,
                 )
+                fallback_chunk = chunk
             is_first_chunk = False
             yield chat_chunk
         logger.debug("Chat finished, output: %s", full_text)

--- a/xinference/model/llm/utils.py
+++ b/xinference/model/llm/utils.py
@@ -224,12 +224,12 @@ class ChatModelMixin:
             kwargs = generate_config["chat_template_kwargs"]
             if isinstance(kwargs, str):
                 try:
-                    return json.loads(kwargs)
+                    kwargs = json.loads(kwargs)
                 except json.JSONDecodeError:
                     raise TypeError(
                         f"`chat_template_kwargs` should be json parsable, got: {kwargs}"
                     )
-            elif isinstance(kwargs, dict):
+            if isinstance(kwargs, dict):
                 kwargs = dict(kwargs)
                 if reasoning_parser and "enable_thinking" not in kwargs:
                     thinking = kwargs.get("thinking")

--- a/xinference/model/llm/utils.py
+++ b/xinference/model/llm/utils.py
@@ -477,7 +477,9 @@ class ChatModelMixin:
         chunk: CompletionChunk,
         fallback_chunk: Optional[CompletionChunk] = None,
     ) -> str:
-        source_chunk = chunk if chunk.get("id") else fallback_chunk or {}
+        source_chunk: Dict[str, Any] = cast(
+            Dict[str, Any], chunk if chunk.get("id") else fallback_chunk or {}
+        )
         chunk_id = source_chunk.get("id")
         if not chunk_id:
             return f"chatcmpl-{uuid.uuid4()}"
@@ -492,11 +494,12 @@ class ChatModelMixin:
         chunk: CompletionChunk,
         fallback_chunk: Optional[CompletionChunk] = None,
     ) -> ChatCompletionChunk:
+        fallback: Dict[str, Any] = cast(Dict[str, Any], fallback_chunk or {})
         chat_chunk: Dict[str, Any] = {
             "id": cls._get_chat_completion_chunk_id(chunk, fallback_chunk),
-            "model": chunk.get("model") or (fallback_chunk or {}).get("model") or "",
+            "model": chunk.get("model") or fallback.get("model") or "",
             "created": chunk.get("created")
-            or (fallback_chunk or {}).get("created")
+            or fallback.get("created")
             or int(time.time()),
             "object": "chat.completion.chunk",
             "choices": [
@@ -516,11 +519,12 @@ class ChatModelMixin:
         chunk: CompletionChunk,
         fallback_chunk: Optional[CompletionChunk] = None,
     ) -> ChatCompletionChunk:
+        fallback: Dict[str, Any] = cast(Dict[str, Any], fallback_chunk or {})
         chat_chunk: Dict[str, Any] = {
             "id": cls._get_chat_completion_chunk_id(chunk, fallback_chunk),
-            "model": chunk.get("model") or (fallback_chunk or {}).get("model") or "",
+            "model": chunk.get("model") or fallback.get("model") or "",
             "created": chunk.get("created")
-            or (fallback_chunk or {}).get("created")
+            or fallback.get("created")
             or int(time.time()),
             "object": "chat.completion.chunk",
             "choices": [],


### PR DESCRIPTION
## Summary
- preserve model-level thinking defaults when request chat_template_kwargs are present
- normalize disabled-thinking xllamacpp reasoning_content back into content/tool calls
- keep llama.cpp streamed tool-call parse failures from aborting already-started streams
- handle usage-only/no-choice stream chunks without metadata
- isolate LLM utility tests from leaked chat template context

## Tests
- python -m pytest -q xinference/model/llm/tests/test_utils.py::test_chat_template_kwargs_inherit_model_thinking_default xinference/model/llm/tests/test_utils.py::test_chat_template_kwargs_keep_request_thinking_override xinference/model/llm/tests/test_utils.py::test_chat_template_kwargs_string_normalizes_thinking
- python -m pytest -q xinference/model/llm/llama_cpp/tests/test_structured.py::test_llamacpp_chat_reparses_tool_call_from_reasoning_content xinference/model/llm/llama_cpp/tests/test_structured.py::test_llamacpp_chat_moves_reasoning_content_to_content_when_thinking_disabled xinference/model/llm/llama_cpp/tests/test_structured.py::test_llamacpp_stream_tool_parse_error_finishes_partial_stream xinference/model/llm/llama_cpp/tests/test_structured.py::test_llamacpp_stream_non_tool_parse_error_still_raises
- python -m pytest -q xinference/model/llm/tests/test_utils.py::test_chat_template_kwargs_inherit_model_thinking_default xinference/model/llm/tests/test_utils.py::test_chat_template_kwargs_keep_request_thinking_override xinference/model/llm/tests/test_utils.py::test_chat_template_kwargs_string_normalizes_thinking xinference/model/llm/llama_cpp/tests/test_structured.py::test_llamacpp_chat_reparses_tool_call_from_reasoning_content xinference/model/llm/llama_cpp/tests/test_structured.py::test_llamacpp_chat_moves_reasoning_content_to_content_when_thinking_disabled xinference/model/llm/llama_cpp/tests/test_structured.py::test_llamacpp_stream_tool_parse_error_finishes_partial_stream xinference/model/llm/llama_cpp/tests/test_structured.py::test_llamacpp_stream_non_tool_parse_error_still_raises
- python - <<PY ... pytest.main(["-q", "xinference/model/llm/tests/test_utils.py::test_post_process_completion_with_parser"]) with chat_context_var pre-set to {"enable_thinking": False}
- python -m pytest -q xinference/model/llm/tests/test_utils.py
- pre-commit run --files xinference/model/llm/utils.py xinference/model/llm/tests/test_utils.py
- pre-commit run --files xinference/model/llm/llama_cpp/core.py xinference/model/llm/llama_cpp/tests/test_structured.py
- pre-commit run --files xinference/model/llm/tests/test_utils.py
- pre-commit run mypy --all-files
- pre-commit run --all-files