### PR TITLE
feat(logging): add three-level download progress logging

### DIFF
--- a/doc/source/getting_started/logging.rst
+++ b/doc/source/getting_started/logging.rst
@@ -20,6 +20,29 @@ Xinference supports log rotation of log files.
 By default, logs rotate when they reach 100MB (maxBytes), and up to 30 backup files (backupCount) are kept.
 Note that the log level configured above takes effect in both the command line logs and the log files.
 
+Environment Variables
+#####################
+Xinference provides several environment variables to control logging behavior:
+
+- ``XINFERENCE_LOG_CONSOLE``: Enable or disable console output (default: ``true``).
+  When set to ``false``, logs are written only to files, and tqdm progress bars are captured and sampled.
+- ``XINFERENCE_LOG_FORMAT``: Log format, either ``text`` (default) or ``json``.
+- ``XINFERENCE_LOG_DOWNLOAD_PROGRESS``: Control how download progress bars are logged when ``XINFERENCE_LOG_CONSOLE=false``.
+  Valid values are ``sampled`` (default, logs at 25/50/75/100% per file), ``full`` (logs every frame), or ``off`` (no progress logs).
+
+Example usage:
+
+.. code-block:: bash
+
+  # Disable console output, log download progress at sampling points
+  XINFERENCE_LOG_CONSOLE=false XINFERENCE_LOG_DOWNLOAD_PROGRESS=sampled xinference-local
+
+  # Disable console output, log every download progress frame
+  XINFERENCE_LOG_CONSOLE=false XINFERENCE_LOG_DOWNLOAD_PROGRESS=full xinference-local
+
+  # Disable console output, no download progress logs
+  XINFERENCE_LOG_CONSOLE=false XINFERENCE_LOG_DOWNLOAD_PROGRESS=off xinference-local
+
 Log Directory Structure
 ***********************
 All the logs are stored in the ``<XINFERENCE_HOME>/logs`` directory, where ``<XINFERENCE_HOME>`` can be configured as mentioned in :ref:`using_xinference`.

--- a/xinference/constants.py
+++ b/xinference/constants.py
@@ -141,6 +141,25 @@ XINFERENCE_LOG_FORMAT = os.environ.get("XINFERENCE_LOG_FORMAT", "text").lower()
 XINFERENCE_LOG_CONSOLE = (
     os.environ.get("XINFERENCE_LOG_CONSOLE", "true").lower() == "true"
 )
+
+# Download progress logging level (only effective when XINFERENCE_LOG_CONSOLE=false)
+# - "sampled": log 25/50/75/100% per shard + terminal state on exit (default)
+# - "full": log every tqdm frame
+# - "off": no progress frames, only start/error lines
+_XINFERENCE_LOG_DOWNLOAD_PROGRESS_RAW = os.environ.get(
+    "XINFERENCE_LOG_DOWNLOAD_PROGRESS", "sampled"
+).lower()
+if _XINFERENCE_LOG_DOWNLOAD_PROGRESS_RAW not in ("sampled", "full", "off"):
+    import sys
+
+    print(
+        f"WARNING: XINFERENCE_LOG_DOWNLOAD_PROGRESS={_XINFERENCE_LOG_DOWNLOAD_PROGRESS_RAW!r} "
+        f"is invalid, falling back to 'sampled'",
+        file=sys.stderr,
+    )
+    XINFERENCE_LOG_DOWNLOAD_PROGRESS = "sampled"
+else:
+    XINFERENCE_LOG_DOWNLOAD_PROGRESS = _XINFERENCE_LOG_DOWNLOAD_PROGRESS_RAW
 XINFERENCE_LOG_RETENTION_DAYS = int(
     os.environ.get("XINFERENCE_LOG_RETENTION_DAYS", "30")
 )

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -56,6 +56,7 @@ from ..constants import (
     XINFERENCE_HEALTH_CHECK_INTERVAL,
     XINFERENCE_HOME,
     XINFERENCE_LOG_CONSOLE,
+    XINFERENCE_LOG_DOWNLOAD_PROGRESS,
     XINFERENCE_MODEL_DOWNLOAD_WORKERS,
     XINFERENCE_STATUS_GATHER_TIMEOUT,
     XINFERENCE_STATUS_REPORT_MULTIPLIER,
@@ -2032,7 +2033,9 @@ class WorkerActor(xo.StatelessActor):
                                 from ..deploy.utils import redirect_streams_to_logger
 
                                 def _create_with_redirect():
-                                    with redirect_streams_to_logger():
+                                    with redirect_streams_to_logger(
+                                        XINFERENCE_LOG_DOWNLOAD_PROGRESS
+                                    ):
                                         return create_model_instance(
                                             model_uid,
                                             model_type,

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -55,6 +55,7 @@ from ..constants import (
     XINFERENCE_ENABLE_VIRTUAL_ENV,
     XINFERENCE_HEALTH_CHECK_INTERVAL,
     XINFERENCE_HOME,
+    XINFERENCE_LOG_CONSOLE,
     XINFERENCE_MODEL_DOWNLOAD_WORKERS,
     XINFERENCE_STATUS_GATHER_TIMEOUT,
     XINFERENCE_STATUS_REPORT_MULTIPLIER,
@@ -2026,20 +2027,42 @@ class WorkerActor(xo.StatelessActor):
                             XINFERENCE_MODEL_DOWNLOAD_WORKERS
                         )
                         try:
-                            model = await asyncio.to_thread(
-                                create_model_instance,
-                                model_uid,
-                                model_type,
-                                model_name,
-                                model_engine,
-                                model_format,
-                                model_size_in_billions,
-                                quantization,
-                                peft_model_config,
-                                download_hub,
-                                model_path,
-                                **model_kwargs,
-                            )
+                            # Wrap download phase with stream redirect when console logging is disabled
+                            if not XINFERENCE_LOG_CONSOLE:
+                                from ..deploy.utils import redirect_streams_to_logger
+
+                                def _create_with_redirect():
+                                    with redirect_streams_to_logger():
+                                        return create_model_instance(
+                                            model_uid,
+                                            model_type,
+                                            model_name,
+                                            model_engine,
+                                            model_format,
+                                            model_size_in_billions,
+                                            quantization,
+                                            peft_model_config,
+                                            download_hub,
+                                            model_path,
+                                            **model_kwargs,
+                                        )
+
+                                model = await asyncio.to_thread(_create_with_redirect)
+                            else:
+                                model = await asyncio.to_thread(
+                                    create_model_instance,
+                                    model_uid,
+                                    model_type,
+                                    model_name,
+                                    model_engine,
+                                    model_format,
+                                    model_size_in_billions,
+                                    quantization,
+                                    peft_model_config,
+                                    download_hub,
+                                    model_path,
+                                    **model_kwargs,
+                                )
                         finally:
                             if _orig_hf_workers is not None:
                                 os.environ["HF_HUB_DOWNLOAD_WORKERS"] = _orig_hf_workers

--- a/xinference/deploy/utils.py
+++ b/xinference/deploy/utils.py
@@ -155,7 +155,10 @@ class StreamToLogger:
 
         # Track last seen frame for terminal state emission
         with self._lock:
-            self._last_seen[key] = (pct, line)
+            if pct >= 100:
+                self._last_seen.pop(key, None)
+            else:
+                self._last_seen[key] = (pct, line)
 
         # Mode-based filtering
         if self._progress_mode == "off":

--- a/xinference/deploy/utils.py
+++ b/xinference/deploy/utils.py
@@ -26,7 +26,11 @@ from typing import TYPE_CHECKING, Any, Optional
 
 import xoscar as xo
 
-from ..constants import XINFERENCE_DEFAULT_LOG_FILE_NAME, XINFERENCE_LOG_DIR
+from ..constants import (
+    XINFERENCE_DEFAULT_LOG_FILE_NAME,
+    XINFERENCE_LOG_DIR,
+    XINFERENCE_LOG_DOWNLOAD_PROGRESS,
+)
 
 if TYPE_CHECKING:
     from xoscar.backends.pool import MainActorPoolType
@@ -79,20 +83,31 @@ _ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;?]*[A-Za-z]")
 
 
 class StreamToLogger:
-    """Redirect stdout/stderr to a logger with progress bar sampling."""
+    """Redirect stdout/stderr to a logger with progress bar sampling.
+
+    Args:
+        progress_mode: Controls how progress bars are logged.
+            - "sampled": log 25/50/75/100% per bar + terminal state on finalize
+            - "full": log every tqdm frame
+            - "off": no progress frames, only start/error lines
+    """
 
     def __init__(
         self,
         logger_instance: logging.Logger,
         original_stream,
         stream_name: str = "stdout",
+        progress_mode: str = "sampled",
     ):
         self._logger = logger_instance
         self._original = original_stream
         self._stream_name = stream_name
+        self._progress_mode = progress_mode
         self._buffer = ""
         self._progress_thresholds = {25, 50, 75, 100}
         self._last_reported_pct: dict = {}
+        # Track last seen frame per bar key for terminal state emission
+        self._last_seen: dict = {}
         # Downloads run multi-threaded (HF_HUB_DOWNLOAD_WORKERS); concurrent
         # writes to the shared buffer would interleave without this lock.
         # Reentrant: while the lock is held we call logger.info(), and a logging
@@ -137,6 +152,19 @@ class StreamToLogger:
         # short-description formats (e.g. "Downloading: 26%|"), making each
         # frame a distinct key and defeating threshold sampling.
         key = line[: match.start()].strip()
+
+        # Track last seen frame for terminal state emission
+        with self._lock:
+            self._last_seen[key] = (pct, line)
+
+        # Mode-based filtering
+        if self._progress_mode == "off":
+            return
+        elif self._progress_mode == "full":
+            self._logger.info(line)
+            return
+
+        # sampled mode: threshold-based sampling
         last = self._last_reported_pct.get(key, 0)
         for threshold in sorted(self._progress_thresholds):
             if last < threshold <= pct:
@@ -162,6 +190,26 @@ class StreamToLogger:
             except (OSError, ValueError):
                 pass
 
+    def _finalize(self) -> None:
+        """Emit terminal state for in-flight progress bars.
+
+        Called once when the redirect context exits (ref_count -> 0).
+        For sampled mode, this ensures interrupted downloads show their
+        last known percentage instead of the last sampled threshold.
+        """
+        if self._progress_mode != "sampled":
+            return
+        try:
+            with self._lock:
+                for key, (pct, line) in self._last_seen.items():
+                    last_reported = self._last_reported_pct.get(key, 0)
+                    if pct != last_reported:
+                        self._logger.info(line)
+                self._last_seen.clear()
+        except Exception:
+            # Never let finalize errors mask the real download exception
+            pass
+
     def fileno(self) -> int:
         return self._original.fileno()
 
@@ -182,8 +230,8 @@ def install_stream_redirect() -> None:
 
     stdout_logger = logging.getLogger("xinference.stdout")
     stderr_logger = logging.getLogger("xinference.stderr")
-    sys.stdout = StreamToLogger(stdout_logger, original_stdout, "stdout")  # type: ignore[assignment]
-    sys.stderr = StreamToLogger(stderr_logger, original_stderr, "stderr")  # type: ignore[assignment]
+    sys.stdout = StreamToLogger(stdout_logger, original_stdout, "stdout", XINFERENCE_LOG_DOWNLOAD_PROGRESS)  # type: ignore[assignment]
+    sys.stderr = StreamToLogger(stderr_logger, original_stderr, "stderr", XINFERENCE_LOG_DOWNLOAD_PROGRESS)  # type: ignore[assignment]
 
     for handler in logging.root.handlers:
         if isinstance(handler, logging.StreamHandler) and not isinstance(
@@ -211,8 +259,8 @@ class redirect_streams_to_logger:
 
                 stdout_logger = logging.getLogger("xinference.stdout")
                 stderr_logger = logging.getLogger("xinference.stderr")
-                sys.stdout = StreamToLogger(stdout_logger, redirect_streams_to_logger._original_stdout, "stdout")  # type: ignore[assignment]
-                sys.stderr = StreamToLogger(stderr_logger, redirect_streams_to_logger._original_stderr, "stderr")  # type: ignore[assignment]
+                sys.stdout = StreamToLogger(stdout_logger, redirect_streams_to_logger._original_stdout, "stdout", XINFERENCE_LOG_DOWNLOAD_PROGRESS)  # type: ignore[assignment]
+                sys.stderr = StreamToLogger(stderr_logger, redirect_streams_to_logger._original_stderr, "stderr", XINFERENCE_LOG_DOWNLOAD_PROGRESS)  # type: ignore[assignment]
 
                 redirect_streams_to_logger._handler_streams = []
                 for handler in logging.root.handlers:
@@ -234,8 +282,10 @@ class redirect_streams_to_logger:
             if redirect_streams_to_logger._ref_count == 0:
                 if isinstance(sys.stdout, StreamToLogger):
                     sys.stdout.flush()
+                    sys.stdout._finalize()
                 if isinstance(sys.stderr, StreamToLogger):
                     sys.stderr.flush()
+                    sys.stderr._finalize()
 
                 sys.stdout = redirect_streams_to_logger._original_stdout
                 sys.stderr = redirect_streams_to_logger._original_stderr

--- a/xinference/deploy/utils.py
+++ b/xinference/deploy/utils.py
@@ -244,13 +244,23 @@ def install_stream_redirect() -> None:
 
 
 class redirect_streams_to_logger:
-    """Context manager to temporarily redirect stdout/stderr to logger during model loading."""
+    """Context manager to temporarily redirect stdout/stderr to logger during model loading.
+
+    Args:
+        progress_mode: Controls how progress bars are logged. Defaults to "sampled".
+            - "sampled": log 25/50/75/100% per bar + terminal state on finalize
+            - "full": log every tqdm frame
+            - "off": no progress frames, only start/error lines
+    """
 
     _lock = threading.Lock()
     _ref_count = 0
     _original_stdout = None
     _original_stderr = None
     _handler_streams: list = []
+
+    def __init__(self, progress_mode: str = "sampled"):
+        self._progress_mode = progress_mode
 
     def __enter__(self):
         import sys
@@ -262,8 +272,8 @@ class redirect_streams_to_logger:
 
                 stdout_logger = logging.getLogger("xinference.stdout")
                 stderr_logger = logging.getLogger("xinference.stderr")
-                sys.stdout = StreamToLogger(stdout_logger, redirect_streams_to_logger._original_stdout, "stdout", XINFERENCE_LOG_DOWNLOAD_PROGRESS)  # type: ignore[assignment]
-                sys.stderr = StreamToLogger(stderr_logger, redirect_streams_to_logger._original_stderr, "stderr", XINFERENCE_LOG_DOWNLOAD_PROGRESS)  # type: ignore[assignment]
+                sys.stdout = StreamToLogger(stdout_logger, redirect_streams_to_logger._original_stdout, "stdout", self._progress_mode)  # type: ignore[assignment]
+                sys.stderr = StreamToLogger(stderr_logger, redirect_streams_to_logger._original_stderr, "stderr", self._progress_mode)  # type: ignore[assignment]
 
                 redirect_streams_to_logger._handler_streams = []
                 for handler in logging.root.handlers:


### PR DESCRIPTION
## Summary

When `XINFERENCE_LOG_CONSOLE=false`, add `XINFERENCE_LOG_DOWNLOAD_PROGRESS` env var to control how tqdm progress bars from model downloads are logged:

- **`sampled`** (default): log at 25/50/75/100% per shard, plus terminal state for interrupted downloads on context exit
- **`full`**: log every tqdm frame  
- **`off`**: no progress frames, only start/error lines

This builds on PR #4983 which fixed ANSI stripping and flush routing for the existing `StreamToLogger` infrastructure.

## Changes

- `xinference/constants.py`: Add `XINFERENCE_LOG_DOWNLOAD_PROGRESS` with validation and fallback
- `xinference/deploy/utils.py`: `StreamToLogger` gains `progress_mode` parameter, `_last_seen` tracking, and `_finalize()` method to emit terminal state for in-flight bars
- `xinference/core/worker.py`: Wrap `create_model_instance` call with `redirect_streams_to_logger` when console logging is disabled
- `doc/source/getting_started/logging.rst`: Document new environment variables

## Behavior Matrix

| CONSOLE | DOWNLOAD_PROGRESS | console | xinference.log |
|---|---|---|---|
| `true` (default) | any (ignored) | full real-time animation (unchanged) | not written |
| `false` | `off` | none | start/error only |
| `false` | `sampled` | none | sampled + terminal state + start/error |
| `false` | `full` | none | every frame + start/error |

## Example Output (sampled mode, interrupted download)

```
... Downloading Model from https://www.modelscope.cn to directory: /root/.cache/modelscope/...
... Downloading [model-00001-of-00026.safetensors]:  25%|...
... Downloading [model-00001-of-00026.safetensors]:  50%|...
... Downloading [model-00001-of-00026.safetensors]:  75%|...
... Downloading [model-00001-of-00026.safetensors]: 100%|...
... (4 lines per shard) ...
... Downloading [model-00022-of-00026.safetensors]:  50%|...
# ↓ _finalize() emits last seen frame for in-flight shards on context exit
... Downloading [model-00022-of-00026.safetensors]:  62%|██████▏   | 1.96G/3.14G [17:57<09:44, 2.16MB/s]
... ERROR xinference ... Failed to load model qwen3.6-0
Traceback (most recent call last): ...
```

## Test Plan

- [ ] `XINFERENCE_LOG_CONSOLE=false` + `sampled`: verify sampled output (25/50/75/100) per shard, no full frame storm
- [ ] Interrupted download: verify terminal state emission shows actual last percentage
- [ ] `XINFERENCE_LOG_CONSOLE=false` + `off`: verify no progress frames
- [ ] `XINFERENCE_LOG_CONSOLE=false` + `full`: verify every frame logged (ANSI stripped)
- [ ] `XINFERENCE_LOG_CONSOLE=true`: verify unchanged behavior (real-time console animation)
- [ ] Multi-threaded downloads (`HF_HUB_DOWNLOAD_WORKERS>1`): verify no log interleaving
- [ ] Unknown value (e.g., `foo`): verify fallback to `sampled` with warning
- [ ] Non-LLM model types (image/audio/video/embedding/rerank): verify no subprocess silent death
- [ ] `pre-commit run --all-files` passes

## Related

- Builds on PR #4983 (ANSI stripping + flush routing fix)
- Implements the three-level download progress feature from the design document
