### PR TITLE
feat(ui): allow editing API key name and description in edit dialog

### DIFF
--- a/xinference/ui/web/ui/src/locales/en.json
+++ b/xinference/ui/web/ui/src/locales/en.json
@@ -454,6 +454,7 @@
     "copied": "Copied to clipboard",
     "editPermTooltip": "Edit permissions",
     "editPermTitle": "Edit Model Permissions —",
+    "editKeyTitle": "Edit API Key —",
     "mixedMode": "By type + By instance (mixed)",
     "modelInstances": "Model instances",
     "permissionsSaved": "Permissions saved",

--- a/xinference/ui/web/ui/src/locales/ja.json
+++ b/xinference/ui/web/ui/src/locales/ja.json
@@ -447,6 +447,7 @@
     "copied": "クリップボードにコピーしました",
     "editPermTooltip": "権限編集",
     "editPermTitle": "モデル権限編集 —",
+    "editKeyTitle": "API Key 編集 —",
     "mixedMode": "タイプ別 + インスタンス別（混合）",
     "bans": "禁止数",
     "description": "説明",

--- a/xinference/ui/web/ui/src/locales/ko.json
+++ b/xinference/ui/web/ui/src/locales/ko.json
@@ -447,6 +447,7 @@
     "copied": "클립보드에 복사됨",
     "editPermTooltip": "권한 편집",
     "editPermTitle": "모델 권한 편집 —",
+    "editKeyTitle": "API Key 편집 —",
     "mixedMode": "유형별 + 인스턴스별 (혼합)",
     "bans": "차단 수",
     "description": "설명",

--- a/xinference/ui/web/ui/src/locales/zh.json
+++ b/xinference/ui/web/ui/src/locales/zh.json
@@ -454,6 +454,7 @@
     "copied": "已复制到剪贴板",
     "editPermTooltip": "编辑权限",
     "editPermTitle": "编辑模型权限 —",
+    "editKeyTitle": "编辑 API Key —",
     "mixedMode": "按类型 + 按实例（混合）",
     "modelInstances": "模型实例",
     "permissionsSaved": "权限已保存",

--- a/xinference/ui/web/ui/src/scenes/apikey_management/index.js
+++ b/xinference/ui/web/ui/src/scenes/apikey_management/index.js
@@ -284,8 +284,8 @@ function ApiKeyManagement() {
         })
       }
       await fetchWrapper.put(`/v1/admin/keys/${editingKey.id}`, {
-        name: editName || undefined,
-        description: editDescription || undefined,
+        name: editName === '' ? null : editName,
+        description: editDescription === '' ? null : editDescription,
         model_permissions,
       })
       setEditOpen(false)

--- a/xinference/ui/web/ui/src/scenes/apikey_management/index.js
+++ b/xinference/ui/web/ui/src/scenes/apikey_management/index.js
@@ -60,6 +60,8 @@ function ApiKeyManagement() {
   const [editOpen, setEditOpen] = useState(false)
   const [editingKey, setEditingKey] = useState(null)
   const [editPermType, setEditPermType] = useState('all')
+  const [editName, setEditName] = useState('')
+  const [editDescription, setEditDescription] = useState('')
   const [editModelTypes, setEditModelTypes] = useState([])
   const [editModelIds, setEditModelIds] = useState([])
   const [bansDialogOpen, setBansDialogOpen] = useState(false)
@@ -238,6 +240,8 @@ function ApiKeyManagement() {
       setEditModelTypes(types)
       setEditModelIds(ids)
     }
+    setEditName(key.name || '')
+    setEditDescription(key.description || '')
     setEditingKey(key)
     setEditOpen(true)
   }
@@ -279,7 +283,9 @@ function ApiKeyManagement() {
           })
         })
       }
-      await fetchWrapper.put(`/v1/admin/keys/${editingKey.id}/permissions`, {
+      await fetchWrapper.put(`/v1/admin/keys/${editingKey.id}`, {
+        name: editName || undefined,
+        description: editDescription || undefined,
         model_permissions,
       })
       setEditOpen(false)
@@ -693,10 +699,27 @@ function ApiKeyManagement() {
         fullWidth
       >
         <DialogTitle>
-          {t('apikeyManagement.editPermTitle')}{' '}
+          {t('apikeyManagement.editKeyTitle')}{' '}
           {editingKey && (editingKey.name || editingKey.key_prefix)}
         </DialogTitle>
         <DialogContent>
+          <TextField
+            margin="dense"
+            label={t('apikeyManagement.nameLabel')}
+            fullWidth
+            value={editName}
+            onChange={(e) => setEditName(e.target.value)}
+          />
+          <TextField
+            margin="dense"
+            label={t('apikeyManagement.descriptionLabel')}
+            fullWidth
+            multiline
+            minRows={2}
+            maxRows={4}
+            value={editDescription}
+            onChange={(e) => setEditDescription(e.target.value)}
+          />
           <TextField
             margin="dense"
             label={t('apikeyManagement.permissionType')}


### PR DESCRIPTION
## Summary

- Extend the existing "Edit Model Permissions" dialog to also allow editing the API key **name** and **description** fields
- Change the save endpoint from `PUT /v1/admin/keys/{id}/permissions` to the general `PUT /v1/admin/keys/{id}` which already supports all fields
- Update dialog title to "Edit API Key" and add i18n keys for en/zh/ja/ko

## Motivation

Currently, once an API key is assigned, there is no UI to modify its name or description (申请理由). The backend already supports updating these fields via the general update endpoint, but the frontend lacked the entry point.

## Test plan

- [ ] Open the API Key management page
- [ ] Click edit on an existing key → dialog shows name and description fields pre-filled
- [ ] Modify name/description and save → verify changes persist
- [ ] Verify model permissions editing still works as before
- [ ] Test with en/zh/ja/ko locales for correct translations
