### PR TITLE
fix(supervisor): self-heal worker registry after supervisor restart

### DIFF
--- a/xinference/core/supervisor.py
+++ b/xinference/core/supervisor.py
@@ -100,7 +100,7 @@ class WorkerNotRegisteredError(Exception):
     branch, which re-runs ``add_worker`` and self-heals the registry (and thus
     ``workers_total``). Subclasses ``Exception`` (not ``RuntimeError``) on
     purpose: the worker report loop treats some ``RuntimeError``s as fatal and
-    breaks, which must never happen here. See optimize/20260603/2026060306.md.
+    breaks, which must never happen here.
     """
 
 
@@ -2670,7 +2670,7 @@ class SupervisorActor(xo.StatelessActor):
             # report_status reconnect branch re-runs add_worker and self-heals
             # the registry, restoring workers_total and replaying running
             # replicas. Do NOT fabricate a _worker_status entry here, otherwise
-            # the registry would stay stale forever. See 2026060306.md.
+            # the registry would stay stale forever.
             raise WorkerNotRegisteredError(worker_address)
 
         if worker_address not in self._worker_status:
@@ -2721,7 +2721,7 @@ class SupervisorActor(xo.StatelessActor):
             # report_status -> report_worker_status (which raises and triggers
             # the worker's reconnect/add_worker path). We must NOT raise here:
             # heartbeat() has no reconnect branch and the worker report loop may
-            # treat a raised RuntimeError as fatal and break. See 2026060306.md.
+            # treat a raised RuntimeError as fatal and break.
             logger.debug(
                 "Worker %s heartbeat ignored: not registered, waiting for "
                 "report_status to re-register",

--- a/xinference/core/supervisor.py
+++ b/xinference/core/supervisor.py
@@ -92,6 +92,18 @@ def callback_for_async_launch(model_uid: str):
     logger.debug(f"Model uid: {model_uid} async launch completes.")
 
 
+class WorkerNotRegisteredError(Exception):
+    """Raised when a worker reports status but is absent from the supervisor
+    registry (``_worker_address_to_worker``). Most commonly happens after a
+    supervisor restart clears the in-memory registry while workers keep their
+    cached refs. Raising forces the worker into ``report_status``'s reconnect
+    branch, which re-runs ``add_worker`` and self-heals the registry (and thus
+    ``workers_total``). Subclasses ``Exception`` (not ``RuntimeError``) on
+    purpose: the worker report loop treats some ``RuntimeError``s as fatal and
+    breaks, which must never happen here. See optimize/20260603/2026060306.md.
+    """
+
+
 @dataclass
 class WorkerStatus:
     update_time: float
@@ -2652,6 +2664,15 @@ class SupervisorActor(xo.StatelessActor):
     async def report_worker_status(
         self, worker_address: str, status: Dict[str, Union[ResourceStatus, GPUStatus]]
     ):
+        if worker_address not in self._worker_address_to_worker:
+            # Worker is reporting but is absent from the registry (typically
+            # after a supervisor restart cleared it). Reject so the worker's
+            # report_status reconnect branch re-runs add_worker and self-heals
+            # the registry, restoring workers_total and replaying running
+            # replicas. Do NOT fabricate a _worker_status entry here, otherwise
+            # the registry would stay stale forever. See 2026060306.md.
+            raise WorkerNotRegisteredError(worker_address)
+
         if worker_address not in self._worker_status:
             logger.debug("Worker %s resources: %s", worker_address, status)
             self._worker_status[worker_address] = WorkerStatus(
@@ -2692,6 +2713,22 @@ class SupervisorActor(xo.StatelessActor):
         Only updates the timestamp without collecting resource info.
         Used for liveness detection separate from full status reporting.
         """
+        if worker_address not in self._worker_address_to_worker:
+            # Worker not in the registry (typically after a supervisor restart).
+            # Stay a no-op: do NOT fabricate a _worker_status entry, otherwise
+            # dead-node detection would see a fake-alive worker and the registry
+            # would never self-heal. Registry recovery is driven solely by
+            # report_status -> report_worker_status (which raises and triggers
+            # the worker's reconnect/add_worker path). We must NOT raise here:
+            # heartbeat() has no reconnect branch and the worker report loop may
+            # treat a raised RuntimeError as fatal and break. See 2026060306.md.
+            logger.debug(
+                "Worker %s heartbeat ignored: not registered, waiting for "
+                "report_status to re-register",
+                worker_address,
+            )
+            return
+
         if worker_address not in self._worker_status:
             # New worker, create initial status with empty state
             logger.debug("Worker %s heartbeat: new worker", worker_address)

--- a/xinference/core/tests/test_heartbeat.py
+++ b/xinference/core/tests/test_heartbeat.py
@@ -50,14 +50,21 @@ def _build_worker_status(*, gpu_utils=None):
 class DummySupervisorWithHeartbeat:
     receive_heartbeat = SupervisorActor.receive_heartbeat
 
-    def __init__(self, worker_status):
+    def __init__(self, worker_status, registered_workers=None):
         self._worker_status = worker_status
+        # receive_heartbeat is now gated on the registry: it only refreshes
+        # liveness for workers already in _worker_address_to_worker. Default to
+        # treating every worker that already has a status entry as registered so
+        # existing-worker tests keep their original meaning.
+        if registered_workers is None:
+            registered_workers = set(worker_status)
+        self._worker_address_to_worker = {addr: object() for addr in registered_workers}
 
 
 @pytest.mark.asyncio
-async def test_supervisor_receive_heartbeat_new_worker():
-    """Test that heartbeat creates initial status for new workers."""
-    supervisor = DummySupervisorWithHeartbeat({})
+async def test_supervisor_receive_heartbeat_registered_new_worker():
+    """A registered worker with no status yet gets an initial empty status."""
+    supervisor = DummySupervisorWithHeartbeat({}, registered_workers={"new-worker-1"})
 
     await supervisor.receive_heartbeat("new-worker-1")
 
@@ -67,6 +74,18 @@ async def test_supervisor_receive_heartbeat_new_worker():
     assert (
         status.failure_remaining_count == 5
     )  # XINFERENCE_HEALTH_CHECK_FAILURE_THRESHOLD
+
+
+@pytest.mark.asyncio
+async def test_supervisor_receive_heartbeat_unregistered_worker_is_noop():
+    """A heartbeat from a worker absent from the registry (e.g. after a
+    supervisor restart) must NOT fabricate a status entry, so the registry can
+    self-heal via report_status instead of looking fake-alive."""
+    supervisor = DummySupervisorWithHeartbeat({}, registered_workers=set())
+
+    await supervisor.receive_heartbeat("ghost-worker")
+
+    assert "ghost-worker" not in supervisor._worker_status
 
 
 @pytest.mark.asyncio
@@ -95,7 +114,7 @@ async def test_supervisor_receive_heartbeat_existing_worker():
 @pytest.mark.asyncio
 async def test_supervisor_receive_heartbeat_multiple_calls():
     """Test that multiple heartbeat calls only update timestamp."""
-    supervisor = DummySupervisorWithHeartbeat({})
+    supervisor = DummySupervisorWithHeartbeat({}, registered_workers={"worker-1"})
 
     await supervisor.receive_heartbeat("worker-1")
     first_time = supervisor._worker_status["worker-1"].update_time

--- a/xinference/core/tests/test_worker.py
+++ b/xinference/core/tests/test_worker.py
@@ -608,7 +608,7 @@ async def test_supervisor_report_worker_status_rejects_unregistered_worker():
     """report_worker_status must reject a worker absent from the registry
     (e.g. after a supervisor restart) instead of fabricating a _worker_status
     entry, so the worker is pushed into its reconnect/add_worker path and the
-    registry (and workers_total) self-heals. See 2026060306.md."""
+    registry (and workers_total) self-heals."""
     from ..supervisor import WorkerNotRegisteredError
 
     supervisor = SupervisorActor()

--- a/xinference/core/tests/test_worker.py
+++ b/xinference/core/tests/test_worker.py
@@ -604,6 +604,37 @@ async def test_supervisor_add_worker_idempotent_rebuilds_replica_state(monkeypat
 
 
 @pytest.mark.asyncio
+async def test_supervisor_report_worker_status_rejects_unregistered_worker():
+    """report_worker_status must reject a worker absent from the registry
+    (e.g. after a supervisor restart) instead of fabricating a _worker_status
+    entry, so the worker is pushed into its reconnect/add_worker path and the
+    registry (and workers_total) self-heals. See 2026060306.md."""
+    from ..supervisor import WorkerNotRegisteredError
+
+    supervisor = SupervisorActor()
+    assert "ghost-worker" not in supervisor._worker_address_to_worker
+
+    with pytest.raises(WorkerNotRegisteredError):
+        await supervisor.report_worker_status("ghost-worker", {"cpu": "ok"})
+
+    # No stale status entry should have been created.
+    assert "ghost-worker" not in supervisor._worker_status
+
+
+@pytest.mark.asyncio
+async def test_supervisor_report_worker_status_accepts_registered_worker():
+    """A worker present in the registry reports normally and its status is
+    recorded."""
+    supervisor = SupervisorActor()
+    supervisor._worker_address_to_worker["worker-1"] = object()
+
+    await supervisor.report_worker_status("worker-1", {"cpu": "ok"})
+
+    assert "worker-1" in supervisor._worker_status
+    assert supervisor._worker_status["worker-1"].status == {"cpu": "ok"}
+
+
+@pytest.mark.asyncio
 async def test_supervisor_add_worker_preserves_sharded_replicas_on_replay(monkeypatch):
     supervisor = SupervisorActor()
     supervisor._status_guard_ref = DummyStatusGuardRef()


### PR DESCRIPTION
## Summary

After a supervisor restart, the in-memory worker registry (`_worker_address_to_worker`) is wiped but workers continue sending heartbeats and status reports using cached supervisor refs. The existing `report_worker_status` silently fabricated `_worker_status` entries for unregistered workers, causing:

- `xinference:workers_total` to stay stuck below the real worker count (e.g. 5 workers but only 2 reported)
- The scheduler (which only iterates `_worker_address_to_worker` in `_choose_worker`) to permanently skip those workers for new model launches
- A "green dashboard, broken cluster" scenario: worker-level metrics show all workers alive, but `workers_total` is wrong and new models never get scheduled on the missing workers

## Root cause

`_worker_address_to_worker` (the registry) and `_worker_status` (the heartbeat table) are two separate dicts written at different times:

- **Registry** is only written by `add_worker`, which is called on worker first-connect and on reconnect. Once cached, `get_supervisor_ref` short-circuits and never re-runs `add_worker`.
- **Heartbeat table** is unconditionally fabricated by `report_worker_status` and `receive_heartbeat` for any reporting worker, regardless of whether it is in the registry.

After a supervisor restart, the heartbeat table self-heals (workers keep reporting), but the registry does not self-heal unless every worker happens to go through the `add_worker` path — which is rare.

## Fix

`report_worker_status` now raises `WorkerNotRegisteredError` when a worker reports but is absent from the registry. This triggers the worker's **existing** `report_status` except-branch (already present in `worker.py`), which calls `_clear_supervisor_refs()` and re-runs `add_worker` with `replica_states`, rebuilding the registry and restoring `workers_total`.

`receive_heartbeat` is changed to a no-op for unregistered workers (instead of fabricating a status entry) so dead-node detection is not fooled by ghost heartbeats that would keep the registry permanently stale. Heartbeat cannot trigger re-registration because the worker heartbeat path has no reconnect branch; only `report_status` does.

A new `WorkerNotRegisteredError` exception (subclass of `Exception`, not `RuntimeError`) is introduced: the worker report loop treats some `RuntimeError`s as fatal and would break the recovery loop if we raised `RuntimeError` here.

## Test plan

- [x] Unit tests added in `test_worker.py`:
  - `test_supervisor_report_worker_status_rejects_unregistered_worker`
  - `test_supervisor_report_worker_status_accepts_registered_worker`
- [x] Unit tests added/updated in `test_heartbeat.py`:
  - `test_supervisor_receive_heartbeat_unregistered_worker_is_noop` (new)
  - `test_supervisor_receive_heartbeat_registered_new_worker` (renamed from `test_supervisor_receive_heartbeat_new_worker` to reflect the new registry gate)
  - `test_supervisor_receive_heartbeat_multiple_calls` (updated to register the worker first)
- [x] Existing tests (`test_worker_report_status_reconnects_and_replays_running_models`, `test_worker_report_status_refreshes_supervisor_internal_address_on_reconnect`) already cover the worker-side reconnect/replay path that this fix relies on.
- [x] Verified functional behavior in production cluster (5-worker cluster, supervisor restart scenario)

## Related

- Follow-up: a companion PR will add Prometheus stale-series cleanup and an `unexpected_termination` gauge; that PR is stacked on this one and will be opened shortly.