### PR TITLE
fix(metrics): drop stale series and add unexpected termination gauge

### DIFF
--- a/xinference/core/metrics.py
+++ b/xinference/core/metrics.py
@@ -148,6 +148,10 @@ model_gpu_memory_used_bytes = Gauge(
     "xinference:model_gpu_memory_used_bytes",
     "Per-model GPU memory used in bytes (real-time, per process).",
 )
+model_unexpected_termination = Gauge(
+    "xinference:model_unexpected_termination",
+    "Replica currently down due to worker failure (value=1). Cleared on redeploy.",
+)
 build_info_gauge = Gauge(
     "xinference:build_info",
     "Xinference build information (value=1).",
@@ -203,6 +207,7 @@ _SUPERVISOR_ONLY_METRICS = {
     "xinference:worker_gpu_memory_total_bytes",
     "xinference:model_gpu_binding",
     "xinference:model_gpu_memory_used_bytes",
+    "xinference:model_unexpected_termination",
     "xinference:api_key_requests_total",
     "xinference:api_key_request_duration_seconds",
     "xinference:api_keys_active_total",
@@ -236,6 +241,20 @@ _prev_model_labels: Set[Tuple[str, ...]] = set()
 _prev_status_labels: Set[Tuple[str, ...]] = set()
 _prev_model_gpu_mem_labels: Set[Tuple[str, ...]] = set()
 _prev_gpu_binding_labels: Set[Tuple[str, ...]] = set()
+_prev_unexpected_labels: Set[Tuple[str, ...]] = set()
+
+
+def _drop_series(collector, labels: Dict[str, str]) -> None:
+    """Delete a single time series from a collector's underlying MetricDict.
+
+    aioprometheus has no public ``remove()``; the only correct way to drop one
+    series (instead of zeroing it) is to pop it from ``collector.values``.
+    HELP/TYPE rows are collector-level metadata and are unaffected.
+    """
+    try:
+        collector.values.pop(labels, None)
+    except Exception:
+        pass
 
 
 def record_metrics(name, op, kwargs):
@@ -302,6 +321,7 @@ def update_cluster_metrics(
     """Refresh all Supervisor-side Prometheus gauges from in-memory data."""
     global _prev_worker_labels, _prev_gpu_labels
     global _prev_model_labels, _prev_status_labels, _prev_gpu_binding_labels, _prev_model_gpu_mem_labels
+    global _prev_unexpected_labels
 
     # --- Build info (set once, labels are static) ---
     cluster_name = cluster_data.get("cluster", "")
@@ -366,16 +386,16 @@ def update_cluster_metrics(
     # Clear stale worker labels
     for stale in _prev_worker_labels - cur_worker_labels:
         s = {"worker_address": stale[0]}
-        worker_cpu_utilization.set(s, 0)
-        worker_memory_used_bytes.set(s, 0)
-        worker_memory_total_bytes.set(s, 0)
+        _drop_series(worker_cpu_utilization, s)
+        _drop_series(worker_memory_used_bytes, s)
+        _drop_series(worker_memory_total_bytes, s)
     _prev_worker_labels = cur_worker_labels
 
     for stale in _prev_gpu_labels - cur_gpu_labels:
         s = {"worker_address": stale[0], "gpu_index": stale[1], "gpu_name": stale[2]}
-        worker_gpu_utilization_percent.set(s, 0)
-        worker_gpu_memory_used_bytes.set(s, 0)
-        worker_gpu_memory_total_bytes.set(s, 0)
+        _drop_series(worker_gpu_utilization_percent, s)
+        _drop_series(worker_gpu_memory_used_bytes, s)
+        _drop_series(worker_gpu_memory_total_bytes, s)
     _prev_gpu_labels = cur_gpu_labels
 
     # --- Models loaded by type ---
@@ -443,7 +463,7 @@ def update_cluster_metrics(
             "replica_on_worker": stale[4],
             "replica_total": stale[5],
         }
-        model_info_gauge.set(stale_labels, 0)
+        _drop_series(model_info_gauge, stale_labels)
     _prev_model_labels = cur_model_labels
 
     # --- Model GPU binding (per-replica, per-GPU) ---
@@ -485,7 +505,7 @@ def update_cluster_metrics(
             "gpu_index": stale[4],
             "replica_index": stale[5],
         }
-        model_gpu_binding_gauge.set(stale_labels, 0)
+        _drop_series(model_gpu_binding_gauge, stale_labels)
     _prev_gpu_binding_labels = cur_gpu_binding_labels
 
     # --- Models loaded total (by type) ---
@@ -509,7 +529,7 @@ def update_cluster_metrics(
             "model_name": stale[1],
             "status": stale[2],
         }
-        model_status_gauge.set(stale_labels, 0)
+        _drop_series(model_status_gauge, stale_labels)
     _prev_status_labels = cur_status_labels
 
     # --- Per-model GPU memory ---
@@ -558,8 +578,36 @@ def update_cluster_metrics(
             "worker_address": stale[4],
             "replica_index": stale[5],
         }
-        model_gpu_memory_used_bytes.set(stale_labels, 0)
+        _drop_series(model_gpu_memory_used_bytes, stale_labels)
     _prev_model_gpu_mem_labels = cur_model_gpu_mem_labels
+
+    # --- Replica-level unexpected termination (worker failure) ---
+    # Pull model: supervisor maintains a plain dict and serializes it here; this
+    # API process owns the gauge instance that /metrics actually exposes.
+    cur_unexpected_labels: Set[Tuple[str, ...]] = set()
+    for item in cluster_data.get("unexpected_down_replicas", []):
+        uid = item.get("model_uid", "unknown")
+        m_name = item.get("model_name", "unknown")
+        rep_idx = str(item.get("replica_index", "0"))
+        u_labels = {
+            "model_uid": uid,
+            "model_name": m_name,
+            "replica_index": rep_idx,
+        }
+        cur_unexpected_labels.add((uid, m_name, rep_idx))
+        model_unexpected_termination.set(u_labels, 1)
+    # Redeploy clears the supervisor-side dict, so the uid no longer appears
+    # this frame -> stale-pop removes the series (disappears from /metrics).
+    for stale in _prev_unexpected_labels - cur_unexpected_labels:
+        _drop_series(
+            model_unexpected_termination,
+            {
+                "model_uid": stale[0],
+                "model_name": stale[1],
+                "replica_index": stale[2],
+            },
+        )
+    _prev_unexpected_labels = cur_unexpected_labels
 
 
 def update_security_gauges(auth_service) -> None:

--- a/xinference/core/supervisor.py
+++ b/xinference/core/supervisor.py
@@ -338,17 +338,29 @@ class SupervisorActor(xo.StatelessActor):
             if parsed is None:
                 continue
             base_uid, replica_idx = parsed
-            try:
-                info_list = await self._status_guard_ref.get_instance_info(
-                    model_uid=base_uid
-                )
-                m_name = info_list[0].model_name if info_list else "unknown"
-            except Exception:
-                m_name = "unknown"
+            m_name = "unknown"
+            if self._status_guard_ref is not None:
+                try:
+                    info_list = await self._status_guard_ref.get_instance_info(
+                        model_uid=base_uid
+                    )
+                    m_name = info_list[0].model_name if info_list else "unknown"
+                except Exception:
+                    pass
             collected.append((base_uid, replica_idx, m_name))
-        # Mutate the shared dict without awaiting in between.
+        # Mutate the shared dict without awaiting in between. Re-check that
+        # each replica is still mapped to this dead worker before writing:
+        # during the awaits above, a concurrent redeploy could have called
+        # _clear_unexpected_down_replicas and removed stale entries — blindly
+        # writing collected items back would resurrect them.
         for base_uid, replica_idx, m_name in collected:
-            self._unexpected_down_replicas[(base_uid, replica_idx)] = m_name
+            rep_uid = build_replica_model_uid(base_uid, replica_idx)
+            worker_refs = self._replica_model_uid_to_worker.get(rep_uid)
+            if worker_refs is not None:
+                if not isinstance(worker_refs, (list, tuple)):
+                    worker_refs = [worker_refs]
+                if any(wr.address == worker_address for wr in worker_refs):
+                    self._unexpected_down_replicas[(base_uid, replica_idx)] = m_name
         if collected:
             logger.warning(
                 "Replicas down due to worker failure. worker: %s, replicas: %s",

--- a/xinference/core/supervisor.py
+++ b/xinference/core/supervisor.py
@@ -101,7 +101,7 @@ class WorkerNotRegisteredError(Exception):
     branch, which re-runs ``add_worker`` and self-heals the registry (and thus
     ``workers_total``). Subclasses ``Exception`` (not ``RuntimeError``) on
     purpose: the worker report loop treats some ``RuntimeError``s as fatal and
-    breaks, which must never happen here. See optimize/20260603/2026060306.md.
+    breaks, which must never happen here.
     """
 
 
@@ -2449,6 +2449,7 @@ class SupervisorActor(xo.StatelessActor):
         if errors and not suppress_exception:
             raise errors[0]
         self._model_uid_to_replica_info.pop(model_uid, None)
+        self._clear_unexpected_down_replicas(model_uid)
 
         # clear for xavier
         rank0_uid = model_uid + "-rank0"
@@ -2524,9 +2525,11 @@ class SupervisorActor(xo.StatelessActor):
                 model_uid,
                 {"replica": remaining_replica_count, "status": LaunchStatus.READY.name},
             )
+            self._unexpected_down_replicas.pop((model_uid, replica_id), None)
             return remaining_replica_count
 
         self._model_uid_to_replica_info.pop(model_uid, None)
+        self._clear_unexpected_down_replicas(model_uid)
 
         rank0_uid = model_uid + "-rank0"
         if rank0_uid in self._replica_model_uid_to_worker:
@@ -2860,7 +2863,7 @@ class SupervisorActor(xo.StatelessActor):
             # report_status reconnect branch re-runs add_worker and self-heals
             # the registry, restoring workers_total and replaying running
             # replicas. Do NOT fabricate a _worker_status entry here, otherwise
-            # the registry would stay stale forever. See 2026060306.md.
+            # the registry would stay stale forever.
             raise WorkerNotRegisteredError(worker_address)
 
         if worker_address not in self._worker_status:
@@ -2911,7 +2914,7 @@ class SupervisorActor(xo.StatelessActor):
             # report_status -> report_worker_status (which raises and triggers
             # the worker's reconnect/add_worker path). We must NOT raise here:
             # heartbeat() has no reconnect branch and the worker report loop may
-            # treat a raised RuntimeError as fatal and break. See 2026060306.md.
+            # treat a raised RuntimeError as fatal and break.
             logger.debug(
                 "Worker %s heartbeat ignored: not registered, waiting for "
                 "report_status to re-register",

--- a/xinference/core/supervisor.py
+++ b/xinference/core/supervisor.py
@@ -92,6 +92,18 @@ def callback_for_async_launch(model_uid: str):
     logger.debug(f"Model uid: {model_uid} async launch completes.")
 
 
+class WorkerNotRegisteredError(Exception):
+    """Raised when a worker reports status but is absent from the supervisor
+    registry (``_worker_address_to_worker``). Most commonly happens after a
+    supervisor restart clears the in-memory registry while workers keep their
+    cached refs. Raising forces the worker into ``report_status``'s reconnect
+    branch, which re-runs ``add_worker`` and self-heals the registry (and thus
+    ``workers_total``). Subclasses ``Exception`` (not ``RuntimeError``) on
+    purpose: the worker report loop treats some ``RuntimeError``s as fatal and
+    breaks, which must never happen here. See optimize/20260603/2026060306.md.
+    """
+
+
 @dataclass
 class WorkerStatus:
     update_time: float
@@ -2652,6 +2664,15 @@ class SupervisorActor(xo.StatelessActor):
     async def report_worker_status(
         self, worker_address: str, status: Dict[str, Union[ResourceStatus, GPUStatus]]
     ):
+        if worker_address not in self._worker_address_to_worker:
+            # Worker is reporting but is absent from the registry (typically
+            # after a supervisor restart cleared it). Reject so the worker's
+            # report_status reconnect branch re-runs add_worker and self-heals
+            # the registry, restoring workers_total and replaying running
+            # replicas. Do NOT fabricate a _worker_status entry here, otherwise
+            # the registry would stay stale forever. See 2026060306.md.
+            raise WorkerNotRegisteredError(worker_address)
+
         if worker_address not in self._worker_status:
             logger.debug("Worker %s resources: %s", worker_address, status)
             self._worker_status[worker_address] = WorkerStatus(
@@ -2692,6 +2713,22 @@ class SupervisorActor(xo.StatelessActor):
         Only updates the timestamp without collecting resource info.
         Used for liveness detection separate from full status reporting.
         """
+        if worker_address not in self._worker_address_to_worker:
+            # Worker not in the registry (typically after a supervisor restart).
+            # Stay a no-op: do NOT fabricate a _worker_status entry, otherwise
+            # dead-node detection would see a fake-alive worker and the registry
+            # would never self-heal. Registry recovery is driven solely by
+            # report_status -> report_worker_status (which raises and triggers
+            # the worker's reconnect/add_worker path). We must NOT raise here:
+            # heartbeat() has no reconnect branch and the worker report loop may
+            # treat a raised RuntimeError as fatal and break. See 2026060306.md.
+            logger.debug(
+                "Worker %s heartbeat ignored: not registered, waiting for "
+                "report_status to re-register",
+                worker_address,
+            )
+            return
+
         if worker_address not in self._worker_status:
             # New worker, create initial status with empty state
             logger.debug("Worker %s heartbeat: new worker", worker_address)

--- a/xinference/core/supervisor.py
+++ b/xinference/core/supervisor.py
@@ -30,6 +30,7 @@ from typing import (
     List,
     Literal,
     Optional,
+    Set,
     Tuple,
     Type,
     Union,
@@ -151,6 +152,12 @@ class SupervisorActor(xo.StatelessActor):
         self._worker_model_gpu_memory: Dict[str, Dict[str, Dict[int, int]]] = (
             {}
         )  # worker_address -> {model_uid -> {gpu_idx -> bytes}}
+        # Replicas currently down due to worker failure. Key is
+        # (base_model_uid, replica_index), value is model_name. Populated on the
+        # death-detection paths, cleared on redeploy. Serialized in
+        # get_cluster_metrics_data() and translated into the
+        # xinference:model_unexpected_termination gauge in the API process.
+        self._unexpected_down_replicas: Dict[Tuple[str, int], str] = {}
 
     @classmethod
     def default_uid(cls) -> str:
@@ -295,6 +302,113 @@ class SupervisorActor(xo.StatelessActor):
                 continue
 
             self._model_uid_to_replica_info.pop(model_uid, None)
+
+    async def _record_unexpected_down_replicas(
+        self,
+        worker_address: str,
+        skip_replica_uids: Optional[Set[str]] = None,
+    ) -> List[str]:
+        """Record replicas on a now-dead worker into the unexpected-termination
+        tracking dict.
+
+        model_name is read from the status guard *before* any TERMINATED
+        transition, because get_instance_info filters out TERMINATED entries
+        (status_guard.py). Returns the affected replica_model_uids for logging.
+
+        skip_replica_uids lets the re-registration path (add_worker) pass the
+        replicas the worker still reports this round, so only the replicas that
+        silently disappeared (set difference) are treated as down. The death
+        paths pass nothing and treat every replica on the worker as down.
+        """
+        skip = skip_replica_uids or set()
+        affected_replica_uids: List[str] = []
+        collected: List[Tuple[str, int, str]] = []
+        for replica_model_uid in list(self._replica_model_uid_to_worker):
+            if replica_model_uid in skip:
+                continue
+            worker_refs = self._replica_model_uid_to_worker.get(replica_model_uid)
+            if worker_refs is None:
+                continue
+            if not isinstance(worker_refs, (list, tuple)):
+                worker_refs = [worker_refs]
+            if not any(wr.address == worker_address for wr in worker_refs):
+                continue
+            affected_replica_uids.append(replica_model_uid)
+            parsed = self._get_model_uid_and_replica_index(replica_model_uid)
+            if parsed is None:
+                continue
+            base_uid, replica_idx = parsed
+            try:
+                info_list = await self._status_guard_ref.get_instance_info(
+                    model_uid=base_uid
+                )
+                m_name = info_list[0].model_name if info_list else "unknown"
+            except Exception:
+                m_name = "unknown"
+            collected.append((base_uid, replica_idx, m_name))
+        # Mutate the shared dict without awaiting in between.
+        for base_uid, replica_idx, m_name in collected:
+            self._unexpected_down_replicas[(base_uid, replica_idx)] = m_name
+        if collected:
+            logger.warning(
+                "Replicas down due to worker failure. worker: %s, replicas: %s",
+                worker_address,
+                [
+                    {
+                        "model_uid": base_uid,
+                        "model_name": m_name,
+                        "replica_index": replica_idx,
+                    }
+                    for base_uid, replica_idx, m_name in collected
+                ],
+            )
+        return affected_replica_uids
+
+    async def _handle_dead_worker(self, worker_address: str) -> List[str]:
+        """Shared cleanup for a worker that has gone away — heartbeat-dead,
+        reverse-channel-dead, or graceful remove_worker.
+
+        1. Record each downed replica into _unexpected_down_replicas (per-replica;
+           degraded models keep their healthy replicas).
+        2. Remove only this worker's replicas via
+           _remove_worker_from_replica_mappings, which preserves healthy replicas
+           of multi-replica models on other workers and drops a model only when
+           *all* its replicas are gone.
+        3. Advance fully-gone models to TERMINATED so model_status disappears;
+           degraded models stay READY.
+        """
+        affected_replica_uids = await self._record_unexpected_down_replicas(
+            worker_address
+        )
+        base_uids_affected = set()
+        for replica_model_uid in affected_replica_uids:
+            parsed = self._get_model_uid_and_replica_index(replica_model_uid)
+            if parsed is not None:
+                base_uids_affected.add(parsed[0])
+
+        self._remove_worker_from_replica_mappings(worker_address)
+
+        for base_uid in base_uids_affected:
+            if base_uid not in self._model_uid_to_replica_info:
+                try:
+                    await self._status_guard_ref.update_instance_info(
+                        base_uid, {"status": LaunchStatus.TERMINATED.name}
+                    )
+                except Exception:
+                    logger.warning(
+                        "Failed to mark %s TERMINATED in status guard", base_uid
+                    )
+        return affected_replica_uids
+
+    def _clear_unexpected_down_replicas(self, model_uid: str) -> None:
+        """Drop all replica entries of a model_uid from the unexpected-termination
+        tracking dict (called on redeploy). The API process clears the matching
+        gauge series on its next refresh via stale-pop."""
+        self._unexpected_down_replicas = {
+            key: name
+            for key, name in self._unexpected_down_replicas.items()
+            if key[0] != model_uid
+        }
 
     def _rebuild_worker_replica_state(
         self,
@@ -939,6 +1053,16 @@ class SupervisorActor(xo.StatelessActor):
             "instance_infos": instance_infos,
             "model_replica_distribution": model_replica_distribution,
             "model_gpu_memory": dict(self._worker_model_gpu_memory),
+            "unexpected_down_replicas": [
+                {
+                    "model_uid": base_uid,
+                    "replica_index": replica_idx,
+                    "model_name": model_name,
+                }
+                for (base_uid, replica_idx), model_name in (
+                    self._unexpected_down_replicas.items()
+                )
+            ],
         }
 
     def _get_spec_dicts(
@@ -1890,6 +2014,8 @@ class SupervisorActor(xo.StatelessActor):
             raise ValueError(f"Model is already in the model list, uid: {model_uid}")
         # Set replica info first for exception handler to terminate model.
         self._model_uid_to_replica_info[model_uid] = self._build_replica_info(replica)
+        # Redeploy clears any stale unexpected-termination markers for this uid.
+        self._clear_unexpected_down_replicas(model_uid)
         instance_info = InstanceInfo(
             model_name=model_name,
             model_uid=model_uid,
@@ -2056,6 +2182,8 @@ class SupervisorActor(xo.StatelessActor):
 
         # Set replica info first for exception handler to terminate model.
         self._model_uid_to_replica_info[model_uid] = self._build_replica_info(replica)
+        # Redeploy clears any stale unexpected-termination markers for this uid.
+        self._clear_unexpected_down_replicas(model_uid)
         instance_info = InstanceInfo(
             model_name=model_name,
             model_uid=model_uid,
@@ -2172,12 +2300,8 @@ class SupervisorActor(xo.StatelessActor):
                             address,
                             dead_models,
                         )
-                        for replica_model_uid in dead_models:
-                            model_uid, _ = parse_replica_model_uid(replica_model_uid)
-                            self._model_uid_to_replica_info.pop(model_uid, None)
-                            self._replica_model_uid_to_worker.pop(
-                                replica_model_uid, None
-                            )
+                        # Defer model/replica cleanup to after this iteration so
+                        # we never await while iterating _worker_status.
                         dead_nodes.append(address)
                     elif (
                         status.failure_remaining_count
@@ -2190,8 +2314,13 @@ class SupervisorActor(xo.StatelessActor):
                         )
 
                 for address in dead_nodes:
+                    # Per-replica unexpected-termination recording + replica-level
+                    # mapping cleanup (preserves healthy replicas of multi-replica
+                    # models on surviving workers) + TERMINATED for fully-gone models.
+                    await self._handle_dead_worker(address)
                     self._worker_status.pop(address, None)
                     self._worker_address_to_worker.pop(address, None)
+                    self._worker_model_gpu_memory.pop(address, None)
 
                 # ---- Reverse-channel probe ----
                 # Heartbeat only covers worker->supervisor; this probes
@@ -2230,30 +2359,42 @@ class SupervisorActor(xo.StatelessActor):
                             status = self._worker_status.get(address)
                             if status is not None:
                                 status.failure_remaining_count = 0
-                            dead_models = []
-                            for model_uid in self._replica_model_uid_to_worker:
-                                worker_refs = self._replica_model_uid_to_worker[
-                                    model_uid
-                                ]
-                                if not isinstance(worker_refs, (list, tuple)):
-                                    worker_refs = [worker_refs]
-                                for wr in worker_refs:
-                                    if wr.address == address:
-                                        dead_models.append(model_uid)
+                            dead_models = [
+                                replica_model_uid
+                                for replica_model_uid in (
+                                    self._replica_model_uid_to_worker
+                                )
+                                for wr in (
+                                    self._replica_model_uid_to_worker[replica_model_uid]
+                                    if isinstance(
+                                        self._replica_model_uid_to_worker[
+                                            replica_model_uid
+                                        ],
+                                        (list, tuple),
+                                    )
+                                    else [
+                                        self._replica_model_uid_to_worker[
+                                            replica_model_uid
+                                        ]
+                                    ]
+                                )
+                                if wr.address == address
+                            ]
                             logger.error(
                                 "Worker reverse-channel dead. address: %s, "
                                 "influenced models: %s",
                                 address,
                                 dead_models,
                             )
-                            for replica_model_uid in dead_models:
-                                model_uid, _ = parse_replica_model_uid(
-                                    replica_model_uid
-                                )
-                                self._model_uid_to_replica_info.pop(model_uid, None)
-                                self._replica_model_uid_to_worker.pop(
-                                    replica_model_uid, None
-                                )
+                            # Per-replica unexpected-termination recording +
+                            # replica-level mapping cleanup + TERMINATED for
+                            # fully-gone models. Iterating a copied list above,
+                            # so full worker removal here is safe and keeps
+                            # _worker_status consistent with workers_total.
+                            await self._handle_dead_worker(address)
+                            self._worker_status.pop(address, None)
+                            self._worker_address_to_worker.pop(address, None)
+                            self._worker_model_gpu_memory.pop(address, None)
                             dead_nodes.append(address)
                             self._reverse_ping_failures.pop(address, None)
                         else:
@@ -2619,25 +2760,62 @@ class SupervisorActor(xo.StatelessActor):
             address=worker_address, uid=WorkerActor.default_uid()
         )
         self._worker_address_to_worker[worker_address] = worker_ref
-        self._rebuild_worker_replica_state(
-            worker_ref,
-            self._normalize_replica_states(
-                replica_states=replica_states,
-                replica_model_uids=replica_model_uids,
-            ),
+
+        normalized = self._normalize_replica_states(
+            replica_states=replica_states,
+            replica_model_uids=replica_model_uids,
         )
-        await self._rebuild_worker_status_guard_state(
-            worker_address,
-            self._normalize_replica_states(
-                replica_states=replica_states,
-                replica_model_uids=replica_model_uids,
-            ),
+
+        # Re-registration reconciliation: a worker restarting and reusing the
+        # same address never trips dead-node detection (its fresh heartbeat
+        # refreshes _worker_status before the failure threshold is hit), so the
+        # death paths' StatusGuard/gauge cleanup never runs. Before rebuilding,
+        # diff the replicas the supervisor still maps to this address against the
+        # ones the worker reports this round; the set difference is what silently
+        # went away and must be handled like an unexpected termination. Passing
+        # the reported uids as skip means a worker that *did* recover its models
+        # is not mis-flagged.
+        reported_uids: Set[str] = set()
+        for state in normalized:
+            replica_model_uid = state.get("replica_model_uid")
+            if isinstance(replica_model_uid, str):
+                reported_uids.add(replica_model_uid)
+        affected_replica_uids = await self._record_unexpected_down_replicas(
+            worker_address, skip_replica_uids=reported_uids
         )
+
+        self._rebuild_worker_replica_state(worker_ref, normalized)
+
+        # After the rebuild reflects what the worker reports now, advance any
+        # fully-gone model to TERMINATED so model_status stops showing it as
+        # READY. Degraded models (some replicas recovered/on other workers) stay
+        # in _model_uid_to_replica_info and are left untouched. Same logic as
+        # _handle_dead_worker.
+        base_uids_affected = set()
+        for replica_model_uid in affected_replica_uids:
+            parsed = self._get_model_uid_and_replica_index(replica_model_uid)
+            if parsed is not None:
+                base_uids_affected.add(parsed[0])
+        for base_uid in base_uids_affected:
+            if base_uid not in self._model_uid_to_replica_info:
+                try:
+                    await self._status_guard_ref.update_instance_info(
+                        base_uid, {"status": LaunchStatus.TERMINATED.name}
+                    )
+                except Exception:
+                    logger.warning(
+                        "Failed to mark %s TERMINATED in status guard", base_uid
+                    )
+
+        await self._rebuild_worker_status_guard_state(worker_address, normalized)
         logger.debug("Worker %s has been added successfully", worker_address)
 
     @log_async(logger=logger)
     async def remove_worker(self, worker_address: str):
-        self._remove_worker_from_replica_mappings(worker_address)
+        # Records downed replicas + replica-level mapping cleanup + TERMINATED
+        # for fully-gone models (graceful worker shutdown is the third path
+        # where models won't auto-recover and need redeploy).
+        await self._handle_dead_worker(worker_address)
 
         if worker_address in self._worker_address_to_worker:
             del self._worker_address_to_worker[worker_address]

--- a/xinference/core/tests/test_heartbeat.py
+++ b/xinference/core/tests/test_heartbeat.py
@@ -50,14 +50,21 @@ def _build_worker_status(*, gpu_utils=None):
 class DummySupervisorWithHeartbeat:
     receive_heartbeat = SupervisorActor.receive_heartbeat
 
-    def __init__(self, worker_status):
+    def __init__(self, worker_status, registered_workers=None):
         self._worker_status = worker_status
+        # receive_heartbeat is now gated on the registry: it only refreshes
+        # liveness for workers already in _worker_address_to_worker. Default to
+        # treating every worker that already has a status entry as registered so
+        # existing-worker tests keep their original meaning.
+        if registered_workers is None:
+            registered_workers = set(worker_status)
+        self._worker_address_to_worker = {addr: object() for addr in registered_workers}
 
 
 @pytest.mark.asyncio
-async def test_supervisor_receive_heartbeat_new_worker():
-    """Test that heartbeat creates initial status for new workers."""
-    supervisor = DummySupervisorWithHeartbeat({})
+async def test_supervisor_receive_heartbeat_registered_new_worker():
+    """A registered worker with no status yet gets an initial empty status."""
+    supervisor = DummySupervisorWithHeartbeat({}, registered_workers={"new-worker-1"})
 
     await supervisor.receive_heartbeat("new-worker-1")
 
@@ -67,6 +74,18 @@ async def test_supervisor_receive_heartbeat_new_worker():
     assert (
         status.failure_remaining_count == 5
     )  # XINFERENCE_HEALTH_CHECK_FAILURE_THRESHOLD
+
+
+@pytest.mark.asyncio
+async def test_supervisor_receive_heartbeat_unregistered_worker_is_noop():
+    """A heartbeat from a worker absent from the registry (e.g. after a
+    supervisor restart) must NOT fabricate a status entry, so the registry can
+    self-heal via report_status instead of looking fake-alive."""
+    supervisor = DummySupervisorWithHeartbeat({}, registered_workers=set())
+
+    await supervisor.receive_heartbeat("ghost-worker")
+
+    assert "ghost-worker" not in supervisor._worker_status
 
 
 @pytest.mark.asyncio
@@ -95,7 +114,7 @@ async def test_supervisor_receive_heartbeat_existing_worker():
 @pytest.mark.asyncio
 async def test_supervisor_receive_heartbeat_multiple_calls():
     """Test that multiple heartbeat calls only update timestamp."""
-    supervisor = DummySupervisorWithHeartbeat({})
+    supervisor = DummySupervisorWithHeartbeat({}, registered_workers={"worker-1"})
 
     await supervisor.receive_heartbeat("worker-1")
     first_time = supervisor._worker_status["worker-1"].update_time

--- a/xinference/core/tests/test_launch_strategy.py
+++ b/xinference/core/tests/test_launch_strategy.py
@@ -249,12 +249,14 @@ async def test_distributed_launch_avoids_same_worker_for_shards():
         _build_replica_info = staticmethod(SupervisorActor._build_replica_info)
         _choose_worker = SupervisorActor._choose_worker
         _launch_builtin_sharded_model = SupervisorActor._launch_builtin_sharded_model
+        _clear_unexpected_down_replicas = SupervisorActor._clear_unexpected_down_replicas
 
         def __init__(self, workers):
             self._worker_address_to_worker = workers
             self._model_uid_to_replica_info = {}
             self._replica_model_uid_to_worker = {}
             self._status_guard_ref = DummyStatusGuard()
+            self._unexpected_down_replicas = {}
 
         def _gen_model_uid(self, model_name: str) -> str:
             return f"{model_name}-uid"

--- a/xinference/core/tests/test_launch_strategy.py
+++ b/xinference/core/tests/test_launch_strategy.py
@@ -309,6 +309,9 @@ async def test_terminate_model_replica_updates_active_replica_set():
         _refresh_replica_scheduler = staticmethod(
             SupervisorActor._refresh_replica_scheduler
         )
+        _clear_unexpected_down_replicas = (
+            SupervisorActor._clear_unexpected_down_replicas
+        )
 
         def __init__(self):
             self._model_uid_to_replica_info = {
@@ -327,6 +330,7 @@ async def test_terminate_model_replica_updates_active_replica_set():
             self._status_guard_ref.replica_counts["demo-model"] = 3
             self._collective_manager_mapping = {}
             self._block_tracker_mapping = {}
+            self._unexpected_down_replicas = {}
 
     supervisor = DummySupervisor()
     remaining = await supervisor.terminate_model_replica("demo-model", 1)

--- a/xinference/core/tests/test_launch_strategy.py
+++ b/xinference/core/tests/test_launch_strategy.py
@@ -249,7 +249,9 @@ async def test_distributed_launch_avoids_same_worker_for_shards():
         _build_replica_info = staticmethod(SupervisorActor._build_replica_info)
         _choose_worker = SupervisorActor._choose_worker
         _launch_builtin_sharded_model = SupervisorActor._launch_builtin_sharded_model
-        _clear_unexpected_down_replicas = SupervisorActor._clear_unexpected_down_replicas
+        _clear_unexpected_down_replicas = (
+            SupervisorActor._clear_unexpected_down_replicas
+        )
 
         def __init__(self, workers):
             self._worker_address_to_worker = workers

--- a/xinference/core/tests/test_worker.py
+++ b/xinference/core/tests/test_worker.py
@@ -608,7 +608,7 @@ async def test_supervisor_report_worker_status_rejects_unregistered_worker():
     """report_worker_status must reject a worker absent from the registry
     (e.g. after a supervisor restart) instead of fabricating a _worker_status
     entry, so the worker is pushed into its reconnect/add_worker path and the
-    registry (and workers_total) self-heals. See 2026060306.md."""
+    registry (and workers_total) self-heals."""
     from ..supervisor import WorkerNotRegisteredError
 
     supervisor = SupervisorActor()

--- a/xinference/core/tests/test_worker.py
+++ b/xinference/core/tests/test_worker.py
@@ -604,6 +604,37 @@ async def test_supervisor_add_worker_idempotent_rebuilds_replica_state(monkeypat
 
 
 @pytest.mark.asyncio
+async def test_supervisor_report_worker_status_rejects_unregistered_worker():
+    """report_worker_status must reject a worker absent from the registry
+    (e.g. after a supervisor restart) instead of fabricating a _worker_status
+    entry, so the worker is pushed into its reconnect/add_worker path and the
+    registry (and workers_total) self-heals. See 2026060306.md."""
+    from ..supervisor import WorkerNotRegisteredError
+
+    supervisor = SupervisorActor()
+    assert "ghost-worker" not in supervisor._worker_address_to_worker
+
+    with pytest.raises(WorkerNotRegisteredError):
+        await supervisor.report_worker_status("ghost-worker", {"cpu": "ok"})
+
+    # No stale status entry should have been created.
+    assert "ghost-worker" not in supervisor._worker_status
+
+
+@pytest.mark.asyncio
+async def test_supervisor_report_worker_status_accepts_registered_worker():
+    """A worker present in the registry reports normally and its status is
+    recorded."""
+    supervisor = SupervisorActor()
+    supervisor._worker_address_to_worker["worker-1"] = object()
+
+    await supervisor.report_worker_status("worker-1", {"cpu": "ok"})
+
+    assert "worker-1" in supervisor._worker_status
+    assert supervisor._worker_status["worker-1"].status == {"cpu": "ok"}
+
+
+@pytest.mark.asyncio
 async def test_supervisor_add_worker_preserves_sharded_replicas_on_replay(monkeypatch):
     supervisor = SupervisorActor()
     supervisor._status_guard_ref = DummyStatusGuardRef()


### PR DESCRIPTION
> **Depends on #4998** — please review and merge #4998 first.
> This branch is stacked on top of #4998's branch. Once #4998 merges into
> `main`, I will rebase this branch onto `main` and the diff will shrink to
> only this PR's changes (2 files, +273/-47).

## Summary

Three related issues with supervisor-side Prometheus metrics when workers die, restart, or are removed:

1. **Stale series accumulate as value=0 zombies** (P1): `update_cluster_metrics` called `gauge.set(stale_labels, 0)` for removed models/workers instead of deleting the series. Since aioprometheus has no `remove()` API, these zombie series accumulated indefinitely, driving cardinality up. Fixed via `MetricDict.values.pop()` through a new `_drop_series()` helper.

2. **`model_status` shows "fake online"** (P0): When a worker crashes, the three death-detection paths (`_check_dead_nodes` heartbeat / reverse-channel, `remove_worker`) only cleaned supervisor's internal dicts but never advanced `StatusGuard` to `TERMINATED`. Since `model_status` is sourced from `get_instance_info()` which only filters `TERMINATED`, dead models lingered as `READY=1` in `/metrics` while already disappearing from the UI.

3. **No signal for "replica down due to worker failure"**: A gap between `model_status` (model-level lifecycle) and `workers_total` (infrastructure). When a worker died, there was no Prometheus series to alert on that said "this specific replica needs redeploy".

## Changes in this PR (2 files, +273/-47)

- `_drop_series()` helper for the only correct way to delete a series in aioprometheus (`collector.values.pop()`); applied to all supervisor-side stale-tracking loops (worker, GPU, model_info, model_gpu_binding, model_status, model_gpu_memory)
- New `xinference:model_unexpected_termination` gauge (replica-level: `model_uid`, `model_name`, `replica_index`), following the existing pull architecture — supervisor maintains `_unexpected_down_replicas` dict, serialized in `get_cluster_metrics_data()`, translated to gauge in `update_cluster_metrics()` with stale-pop cleanup
- `_handle_dead_worker()` consolidates the three death-detection paths: records affected replicas, calls `_remove_worker_from_replica_mappings` (preserving healthy replicas of multi-replica models on surviving workers), advances fully-gone models to `TERMINATED`
- `add_worker` reconciliation via `skip_replica_uids` parameter to `_record_unexpected_down_replicas`: diffs supervisor's previously-mapped replicas against the ones the worker reports this round, so the common "worker restarts with same address" case (which bypasses dead-node detection because the fresh heartbeat resets `failure_remaining_count` before the threshold is hit) is handled correctly
- `_clear_unexpected_down_replicas` in both launch entries so redeploy clears the gauge
- `WARNING` log line in `_record_unexpected_down_replicas` with `model_name` and `replica_index` for searchability
- `_check_dead_nodes` now pops `_worker_model_gpu_memory` for dead workers (aligning with `remove_worker`)

## Commits

- First commit (`fix(supervisor): self-heal worker registry after supervisor restart`) belongs to #4998. Please ignore it in this PR's diff.
- Second commit (`fix(metrics): drop stale series and add unexpected termination gauge`) is this PR's actual scope.

## Design decisions

- **Gauge, not Counter**: the signal must disappear when the same uid is redeployed. Counter cannot express this without manual `pop` which triggers counter-reset semantics in Prometheus and corrupts `rate()`/`increase()`.
- **"Disappear" not "ERROR"**: `model_status` transitions to `TERMINATED` (filtered out) rather than `ERROR`, because ERROR already has its own semantic (launch/runtime failure) and is not filtered by `_drop_terminated_info`, which would create permanent zombies.
- **Pull architecture**: supervisor runs in a separate subprocess (`n_process=0`, `deploy/supervisor.py`) and never exposes `/metrics`. Direct `gauge.set()` in supervisor writes to a private instance that is not the one served by the API process. All new state follows the existing pattern: plain dict in supervisor → `get_cluster_metrics_data()` serialization → API-process gauge translation.
- **Set-difference reconciliation in `add_worker`**: avoids false positives when a worker successfully recovers its models on restart (non-empty `replica_states`). Only replicas that the supervisor still maps to this address but the worker did not report are treated as unexpected terminations.

## Test plan

- [x] Functional verification in production cluster (worker restart, worker crash, redeploy scenarios all validated)
- [ ] Unit tests for `_handle_dead_worker`, `_record_unexpected_down_replicas` (with and without `skip_replica_uids`), `_drop_series`, `_clear_unexpected_down_replicas`, metrics translation, and `add_worker` reconciliation — planned for follow-up commit

## Related

- Depends on: #4998 (registry self-heal after supervisor restart, independent fix)