### PR TITLE
fix(worker): ensure subpool monitor starts after append_sub_pool

### DIFF
--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -905,6 +905,18 @@ class WorkerActor(xo.StatelessActor):
             for model_info in model_infos:
                 self._user_specified_gpu_to_model_uids[dev].remove(model_info)
 
+    async def _ensure_subpool_monitor(self):
+        # The worker main pool is created with n_process=0, so xoscar's
+        # start_monitor() (called once in start()) is a no-op because its guard
+        # `and self.sub_processes` is empty at that point; monitor_sub_pools
+        # therefore never runs and subprocess deaths (OOM / crash / kill) go
+        # undetected and unrecovered. After every append_sub_pool the new
+        # subpool is already in sub_processes, so calling start_monitor() again
+        # here actually starts the monitor loop. start_monitor has its own
+        # `_monitor_task is None` guard, so this is idempotent: at most one
+        # monitor task per worker process.
+        await self._main_pool.start_monitor()
+
     async def _create_subpool(
         self,
         model_uid: str,
@@ -937,6 +949,7 @@ class WorkerActor(xo.StatelessActor):
         subpool_address = await self._main_pool.append_sub_pool(
             env=env, start_python=start_python
         )
+        await self._ensure_subpool_monitor()
         return subpool_address, [str(dev) for dev in devices]
 
     def _check_model_is_valid(self, model_name: str, model_format: Optional[str]):
@@ -2201,6 +2214,7 @@ class WorkerActor(xo.StatelessActor):
                                     )
                                 )
                             pool_addresses = await asyncio.gather(*coros)
+                            await self._ensure_subpool_monitor()
                             all_subpool_addresses.extend(pool_addresses)
                             await model_ref.set_pool_addresses(pool_addresses)
 
@@ -2790,6 +2804,7 @@ class WorkerActor(xo.StatelessActor):
         from ..model.llm.vllm.xavier.collective_manager import Rank0ModelActor
 
         subpool_address = await self._main_pool.append_sub_pool()
+        await self._ensure_subpool_monitor()
 
         store_address = subpool_address.split(":")[0]
         # Note that `store_port` needs to be generated on the worker,

--- a/xinference/deploy/local.py
+++ b/xinference/deploy/local.py
@@ -98,9 +98,7 @@ def run(
     signal.signal(signal.SIGTERM, sigterm_handler)
 
     try:
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        task = loop.create_task(
+        asyncio.run(
             _start_local_cluster(
                 address=address,
                 metrics_exporter_host=metrics_exporter_host,
@@ -109,7 +107,6 @@ def run(
                 conn=conn,
             )
         )
-        loop.run_until_complete(task)
     except Exception:
         tb = traceback.format_exc()
         if conn:

--- a/xinference/deploy/local.py
+++ b/xinference/deploy/local.py
@@ -98,7 +98,8 @@ def run(
     signal.signal(signal.SIGTERM, sigterm_handler)
 
     try:
-        loop = asyncio.get_event_loop()
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
         task = loop.create_task(
             _start_local_cluster(
                 address=address,


### PR DESCRIPTION
## Summary
- The worker main pool is created with `n_process=0`, so xoscar's `start_monitor()` is a no-op at startup because `sub_processes` is empty at that point. After `append_sub_pool()` adds model subpools, `start_monitor()` is never called again, so `monitor_sub_pools` never runs and subprocess deaths (OOM / crash / kill) go undetected and unrecovered.
- Add `_ensure_subpool_monitor()` that calls `start_monitor()` after every `append_sub_pool` call site (3 total: `_create_subpool`, multi-worker `append_sub_pool`, and `launch_rank0_model`). `start_monitor` has its own `_monitor_task is None` idempotency guard, so at most one monitor task runs per worker process.
- Also fix deprecated `asyncio.get_event_loop()` in `deploy/local.py` (switched to `asyncio.new_event_loop()` + `asyncio.set_event_loop()`).

## Test plan
- [ ] Launch a model and verify `monitor_sub_pools` is running (check worker debug logs for subpool monitoring activity)
- [ ] Kill a model subprocess externally and verify `recover_sub_pool` is triggered within the xoscar monitor interval
- [ ] Verify local mode (`xinference-local`) starts without `DeprecationWarning` for `get_event_loop`
