### PR TITLE
fix(supervisor): evict dead replica from round-robin when auto-recover exhausted

### DIFF
--- a/xinference/client/tests/test_async_client.py
+++ b/xinference/client/tests/test_async_client.py
@@ -14,7 +14,6 @@
 
 import asyncio
 import os
-import time
 
 import psutil
 import pytest
@@ -587,7 +586,7 @@ async def test_auto_recover(set_auto_recover_limit, setup_cluster):
             assert "text" in completion["choices"][0]
             break
         except Exception:
-            time.sleep(1)
+            await asyncio.sleep(1)
     else:
         assert False
     await model.close()
@@ -684,7 +683,7 @@ async def test_model_oom_recover_exhausted_evicts_replica(
         if len(await client.list_models()) == 0:
             evicted = True
             break
-        time.sleep(1)
+        await asyncio.sleep(1)
     assert (
         evicted
     ), "dead replica was not evicted from supervisor after recover exhausted"

--- a/xinference/client/tests/test_async_client.py
+++ b/xinference/client/tests/test_async_client.py
@@ -656,6 +656,42 @@ async def test_model_oom_triggers_restart(set_test_oom_error, setup_cluster):
 
 
 @pytest.mark.asyncio
+async def test_model_oom_recover_exhausted_evicts_replica(
+    set_auto_recover_limit, set_test_oom_error, setup_cluster
+):
+    # Once worker exhausts AUTO_RECOVER_LIMIT (=1), it stops recreating and
+    # calls back supervisor.mark_replica_dead, which evicts the dead replica.
+    # For a single-replica model the model is taken fully offline, so
+    # list_models() drains to empty.
+    endpoint, _ = setup_cluster
+    client = AsyncRESTfulClient(endpoint)
+
+    model_uid = await client.launch_model(
+        model_name="qwen1.5-chat",
+        model_engine="llama.cpp",
+        model_size_in_billions="0_5",
+        quantization="q4_0",
+    )
+    assert len(await client.list_models()) == 1
+
+    evicted = False
+    for _ in range(60):
+        try:
+            model = await client.get_model(model_uid=model_uid)
+            await model.generate("Once upon a time, there was a very old computer")
+        except Exception:
+            pass
+        if len(await client.list_models()) == 0:
+            evicted = True
+            break
+        time.sleep(1)
+    assert (
+        evicted
+    ), "dead replica was not evicted from supervisor after recover exhausted"
+    await client.close()
+
+
+@pytest.mark.asyncio
 async def test_async_restful_chat_enable_thinking_injected():
     handle = AsyncRESTfulChatModelHandle.__new__(AsyncRESTfulChatModelHandle)
     handle._model_uid = "test-model"

--- a/xinference/client/tests/test_client.py
+++ b/xinference/client/tests/test_client.py
@@ -583,6 +583,41 @@ def test_model_oom_triggers_restart(set_test_oom_error, setup_cluster):
         assert False, "OOM subprocess did not exit (sys.exit swallowed by xoscar)"
 
 
+def test_model_oom_recover_exhausted_evicts_replica(
+    set_auto_recover_limit, set_test_oom_error, setup_cluster
+):
+    # Once worker exhausts AUTO_RECOVER_LIMIT (=1), it stops recreating and
+    # calls back supervisor.mark_replica_dead, which evicts the dead replica
+    # from the round-robin scheduler. For a single-replica model that means
+    # the model is taken fully offline, so list_models() drains to empty.
+    endpoint, _ = setup_cluster
+    client = RESTfulClient(endpoint)
+
+    model_uid = client.launch_model(
+        model_name="qwen2.5-instruct",
+        model_engine="llama.cpp",
+        model_size_in_billions="0_5",
+        model_format="ggufv2",
+        quantization="q4_0",
+    )
+    assert len(client.list_models()) == 1
+
+    evicted = False
+    for _ in range(60):
+        try:
+            model = client.get_model(model_uid=model_uid)
+            model.generate("Once upon a time, there was a very old computer")
+        except Exception:
+            pass
+        if len(client.list_models()) == 0:
+            evicted = True
+            break
+        time.sleep(1)
+    assert (
+        evicted
+    ), "dead replica was not evicted from supervisor after recover exhausted"
+
+
 def test_restful_chat_enable_thinking_injected():
     handle = RESTfulChatModelHandle("test-model", "http://localhost", {})
     dummy_session = _DummySession()

--- a/xinference/core/supervisor.py
+++ b/xinference/core/supervisor.py
@@ -2531,13 +2531,48 @@ class SupervisorActor(xo.StatelessActor):
         self._model_uid_to_replica_info.pop(model_uid, None)
         self._clear_unexpected_down_replicas(model_uid)
 
+        await self._cleanup_distributed_actors(
+            model_uid, terminate_rank0_on_worker=True
+        )
+
+        return 0
+
+    async def _cleanup_distributed_actors(
+        self, model_uid: str, terminate_rank0_on_worker: bool = True
+    ) -> None:
+        """Tear down supervisor-side actors/mappings created for distributed
+        (Xavier) models when the last replica of ``model_uid`` goes away: the
+        rank0 model, the collective manager, and the block tracker.
+
+        Shared by terminate_model_replica (graceful teardown) and
+        mark_replica_dead (auto-recover exhaustion). Without this, exhausting
+        AUTO_RECOVER_LIMIT on a distributed model would leak the rank0 actor and
+        the collective/block-tracker mappings, and a later launch reusing the
+        same uid could hit stale actors.
+
+        terminate_rank0_on_worker: when True, RPC the worker to terminate the
+        rank0 model. mark_replica_dead passes False -- the worker already
+        terminated the model locally before giving up recreating, so it only
+        needs the supervisor-side mapping dropped.
+
+        Deliberately does NOT touch _unexpected_down_replicas: callers decide
+        whether the down marker stays lit (terminate clears it, mark_replica_dead
+        keeps it for the failure gauge).
+        """
         rank0_uid = model_uid + "-rank0"
-        if rank0_uid in self._replica_model_uid_to_worker:
-            rank0_worker_refs = self._replica_model_uid_to_worker.pop(rank0_uid)
+        rank0_worker_refs = self._replica_model_uid_to_worker.pop(rank0_uid, None)
+        if rank0_worker_refs is not None and terminate_rank0_on_worker:
             if not isinstance(rank0_worker_refs, (list, tuple)):
                 rank0_worker_refs = [rank0_worker_refs]
             for worker_ref in rank0_worker_refs:
-                await worker_ref.terminate_model(model_uid=rank0_uid)
+                try:
+                    await worker_ref.terminate_model(model_uid=rank0_uid)
+                except Exception as e:
+                    logger.debug(
+                        "Terminate rank0 model failed, model uid: %s, error: %s",
+                        rank0_uid,
+                        e,
+                    )
 
         collective_manager_ref = self._collective_manager_mapping.pop(model_uid, None)
         if collective_manager_ref is not None:
@@ -2561,15 +2596,14 @@ class SupervisorActor(xo.StatelessActor):
                     e,
                 )
 
-        return 0
-
     async def mark_replica_dead(self, replica_model_uid: str) -> None:
         """Called back by worker after its local recover_sub_pool exhausts
         AUTO_RECOVER_LIMIT (worker.py "Stop recreating model actor.").
 
         Responsibilities: evict the dead replica from the round-robin scheduler
         and light up model_unexpected_termination; when the single/last replica
-        dies, advance base_uid to TERMINATED.
+        dies, advance base_uid to TERMINATED and tear down the distributed
+        (Xavier) actors/mappings via _cleanup_distributed_actors.
 
         Deliberately does NOT call back worker.terminate_model -- the worker
         already terminated the model locally before giving up recreating
@@ -2629,6 +2663,15 @@ class SupervisorActor(xo.StatelessActor):
 
         # Single replica / last replica died -> take the model fully offline.
         self._model_uid_to_replica_info.pop(base_uid, None)
+
+        # Tear down distributed (Xavier) actors/mappings. terminate_rank0_on_worker
+        # =False: the worker already terminated the model locally before giving up
+        # recreating, so we only drop the supervisor-side state. Keeps the
+        # _unexpected_down_replicas marker lit for the failure gauge.
+        await self._cleanup_distributed_actors(
+            base_uid, terminate_rank0_on_worker=False
+        )
+
         try:
             await self._status_guard_ref.update_instance_info(
                 base_uid, {"status": LaunchStatus.TERMINATED.name}

--- a/xinference/core/supervisor.py
+++ b/xinference/core/supervisor.py
@@ -2551,9 +2551,15 @@ class SupervisorActor(xo.StatelessActor):
         same uid could hit stale actors.
 
         terminate_rank0_on_worker: when True, RPC the worker to terminate the
-        rank0 model. mark_replica_dead passes False -- the worker already
-        terminated the model locally before giving up recreating, so it only
-        needs the supervisor-side mapping dropped.
+        rank0 model. Both terminate_model_replica (graceful) and
+        mark_replica_dead (auto-recover exhaustion) pass True: rank0 is a
+        SEPARATE subpool (launch_rank0_model appends its own sub pool with its
+        own address) that a regular replica's OOM does NOT terminate -- the
+        worker's recover_sub_pool only acts on the subpool whose address died,
+        so an exhausted regular replica leaves rank0 alive. Dropping only the
+        supervisor mapping would leak the rank0 actor/subpool. The RPC is
+        bounded by xo.wait_for(5s) so a stalled worker cannot hold up the
+        death-recovery tail path; failure/timeout is non-fatal.
 
         Deliberately does NOT touch _unexpected_down_replicas: callers decide
         whether the down marker stays lit (terminate clears it, mark_replica_dead
@@ -2566,7 +2572,10 @@ class SupervisorActor(xo.StatelessActor):
                 rank0_worker_refs = [rank0_worker_refs]
             for worker_ref in rank0_worker_refs:
                 try:
-                    await worker_ref.terminate_model(model_uid=rank0_uid)
+                    await xo.wait_for(
+                        worker_ref.terminate_model(model_uid=rank0_uid),
+                        timeout=5,
+                    )
                 except Exception as e:
                     logger.debug(
                         "Terminate rank0 model failed, model uid: %s, error: %s",
@@ -2605,12 +2614,15 @@ class SupervisorActor(xo.StatelessActor):
         dies, advance base_uid to TERMINATED and tear down the distributed
         (Xavier) actors/mappings via _cleanup_distributed_actors.
 
-        Deliberately does NOT call back worker.terminate_model -- the worker
-        already terminated the model locally before giving up recreating
-        (recover_sub_pool calls terminate_model(is_model_die=True)).
-        Equivalent to terminate_model_replica's "eviction half" (minus the
-        worker RPC) plus _record_unexpected_down_replicas' "observability half".
-        Idempotent: no-op if the replica is already evicted.
+        Does NOT call back worker.terminate_model for the dead replica itself --
+        the worker already terminated it locally before giving up recreating
+        (recover_sub_pool calls terminate_model(is_model_die=True)). It DOES, on
+        last-replica death, terminate the separate rank0 actor via
+        _cleanup_distributed_actors, because a regular replica's OOM does not
+        reach rank0's distinct subpool (see that helper).
+        Equivalent to terminate_model_replica's "eviction half" (minus the dead
+        replica's worker RPC) plus _record_unexpected_down_replicas'
+        "observability half". Idempotent: no-op if the replica is already evicted.
         """
         parsed = self._get_model_uid_and_replica_index(replica_model_uid)
         if parsed is None:
@@ -2664,13 +2676,14 @@ class SupervisorActor(xo.StatelessActor):
         # Single replica / last replica died -> take the model fully offline.
         self._model_uid_to_replica_info.pop(base_uid, None)
 
-        # Tear down distributed (Xavier) actors/mappings. terminate_rank0_on_worker
-        # =False: the worker already terminated the model locally before giving up
-        # recreating, so we only drop the supervisor-side state. Keeps the
-        # _unexpected_down_replicas marker lit for the failure gauge.
-        await self._cleanup_distributed_actors(
-            base_uid, terminate_rank0_on_worker=False
-        )
+        # Tear down distributed (Xavier) actors/mappings. rank0 is a separate
+        # subpool that the regular replica's OOM did NOT terminate (the worker
+        # only recovered the dead replica's own subpool), so we must RPC the
+        # worker to terminate it -- dropping just the supervisor mapping would
+        # leak the rank0 actor/subpool. The RPC is bounded (xo.wait_for 5s) and
+        # best-effort. Keeps the _unexpected_down_replicas marker lit for the
+        # failure gauge.
+        await self._cleanup_distributed_actors(base_uid, terminate_rank0_on_worker=True)
 
         try:
             await self._status_guard_ref.update_instance_info(

--- a/xinference/core/supervisor.py
+++ b/xinference/core/supervisor.py
@@ -2563,6 +2563,79 @@ class SupervisorActor(xo.StatelessActor):
 
         return 0
 
+    async def mark_replica_dead(self, replica_model_uid: str) -> None:
+        """Called back by worker after its local recover_sub_pool exhausts
+        AUTO_RECOVER_LIMIT (worker.py "Stop recreating model actor.").
+
+        Responsibilities: evict the dead replica from the round-robin scheduler
+        and light up model_unexpected_termination; when the single/last replica
+        dies, advance base_uid to TERMINATED.
+
+        Deliberately does NOT call back worker.terminate_model -- the worker
+        already terminated the model locally before giving up recreating
+        (recover_sub_pool calls terminate_model(is_model_die=True)).
+        Equivalent to terminate_model_replica's "eviction half" (minus the
+        worker RPC) plus _record_unexpected_down_replicas' "observability half".
+        Idempotent: no-op if the replica is already evicted.
+        """
+        parsed = self._get_model_uid_and_replica_index(replica_model_uid)
+        if parsed is None:
+            return
+        base_uid, replica_idx = parsed
+
+        replica_info = self._model_uid_to_replica_info.get(base_uid)
+        if replica_info is None:
+            return  # model already gone, idempotent no-op
+        if replica_idx not in replica_info.active_replica_ids:
+            return  # replica already evicted, idempotent no-op
+
+        # Observability half: read model_name BEFORE any TERMINATED transition.
+        # get_instance_info filters out TERMINATED entries; right now base_uid is
+        # the ERROR the worker set (not filtered), so model_name is readable.
+        try:
+            info_list = await self._status_guard_ref.get_instance_info(
+                model_uid=base_uid
+            )
+            m_name = info_list[0].model_name if info_list else "unknown"
+        except Exception:
+            m_name = "unknown"
+        self._unexpected_down_replicas[(base_uid, replica_idx)] = m_name
+        logger.warning(
+            "Replica down: worker exhausted auto-recover limit. "
+            "model_uid: %s, model_name: %s, replica_index: %s",
+            base_uid,
+            m_name,
+            replica_idx,
+        )
+
+        # Eviction half: mirror terminate_model_replica, minus
+        # worker_ref.terminate_model.
+        self._replica_model_uid_to_worker.pop(replica_model_uid, None)
+        self._replica_model_uid_to_worker_shards.pop(replica_model_uid, None)
+        replica_info.replica_to_worker_refs.pop(replica_idx, None)
+        replica_info.active_replica_ids.remove(replica_idx)
+        self._refresh_replica_scheduler(replica_info)
+
+        remaining = await self._status_guard_ref.remove_replica_status(
+            base_uid, replica_idx
+        )
+        if remaining > 0:
+            # Degraded: healthy replicas remain -> keep READY.
+            await self._status_guard_ref.update_instance_info(
+                base_uid,
+                {"replica": remaining, "status": LaunchStatus.READY.name},
+            )
+            return
+
+        # Single replica / last replica died -> take the model fully offline.
+        self._model_uid_to_replica_info.pop(base_uid, None)
+        try:
+            await self._status_guard_ref.update_instance_info(
+                base_uid, {"status": LaunchStatus.TERMINATED.name}
+            )
+        except Exception:
+            logger.warning("Failed to mark %s TERMINATED in status guard", base_uid)
+
     @log_async(logger=logger)
     async def get_model(self, model_uid: str) -> xo.ActorRefType["ModelActor"]:
         replica_info = self._model_uid_to_replica_info.get(model_uid, None)

--- a/xinference/core/tests/test_worker.py
+++ b/xinference/core/tests/test_worker.py
@@ -1335,3 +1335,100 @@ async def test_launch_semaphore_concurrency():
     await asyncio.gather(*[simulate_launch() for _ in range(6)])
 
     assert peak_concurrent == max_concurrent
+
+
+class _RecordingWorkerRef(DummyActorRef):
+    """Worker ref that records terminate_model calls for rank0 eviction tests."""
+
+    def __init__(self, address: str):
+        super().__init__(address)
+        self.terminated: List[str] = []
+
+    async def terminate_model(self, model_uid: str):
+        self.terminated.append(model_uid)
+
+
+@pytest.mark.asyncio
+async def test_cleanup_distributed_actors_terminates_rank0():
+    """rank0 lives in its own subpool that a regular replica's OOM never
+    terminates, so _cleanup_distributed_actors(terminate_rank0_on_worker=True)
+    must RPC the worker to terminate it -- not merely drop the supervisor
+    mapping (which would leak the rank0 actor/subpool)."""
+    supervisor = SupervisorActor()
+    rank0_ref = _RecordingWorkerRef("worker-1")
+    supervisor._replica_model_uid_to_worker = {"model-x-rank0": rank0_ref}
+    supervisor._collective_manager_mapping = {}
+    supervisor._block_tracker_mapping = {}
+
+    await supervisor._cleanup_distributed_actors(
+        "model-x", terminate_rank0_on_worker=True
+    )
+
+    assert rank0_ref.terminated == ["model-x-rank0"]
+    assert "model-x-rank0" not in supervisor._replica_model_uid_to_worker
+
+
+@pytest.mark.asyncio
+async def test_cleanup_distributed_actors_skips_rank0_rpc_when_false():
+    """With terminate_rank0_on_worker=False the supervisor mapping is dropped
+    but no terminate RPC is issued (the graceful caller already knows rank0 is
+    gone)."""
+    supervisor = SupervisorActor()
+    rank0_ref = _RecordingWorkerRef("worker-1")
+    supervisor._replica_model_uid_to_worker = {"model-x-rank0": rank0_ref}
+    supervisor._collective_manager_mapping = {}
+    supervisor._block_tracker_mapping = {}
+
+    await supervisor._cleanup_distributed_actors(
+        "model-x", terminate_rank0_on_worker=False
+    )
+
+    assert rank0_ref.terminated == []
+    assert "model-x-rank0" not in supervisor._replica_model_uid_to_worker
+
+
+@pytest.mark.asyncio
+async def test_mark_replica_dead_last_replica_terminates_rank0():
+    """End to end: when the single (last) replica of a Xavier model exhausts
+    auto-recover, mark_replica_dead's last-replica branch must terminate the
+    separate rank0 actor, drop its mapping, and keep the failure marker lit."""
+
+    class _Info:
+        model_name = "m"
+
+    class _StatusGuard:
+        async def get_instance_info(self, model_name=None, model_uid=None):
+            return [_Info()]
+
+        async def remove_replica_status(self, model_uid: str, replica_id: int):
+            return 0  # last replica gone
+
+        async def update_instance_info(self, model_uid: str, updates: dict):
+            pass
+
+    supervisor = SupervisorActor()
+    supervisor._status_guard_ref = _StatusGuard()
+    supervisor._collective_manager_mapping = {}
+    supervisor._block_tracker_mapping = {}
+
+    replica_ref = _RecordingWorkerRef("worker-1")
+    rank0_ref = _RecordingWorkerRef("worker-1")
+    replica_info = ReplicaInfo(replica=1, scheduler=itertools.cycle(range(1)))
+    replica_info.active_replica_ids.append(0)
+    replica_info.replica_to_worker_refs[0].append(replica_ref)
+    supervisor._model_uid_to_replica_info = {"model-x": replica_info}
+    supervisor._replica_model_uid_to_worker = {
+        "model-x-0": replica_ref,
+        "model-x-rank0": rank0_ref,
+    }
+
+    await supervisor.mark_replica_dead("model-x-0")
+
+    # rank0 terminated on the worker and supervisor mapping dropped.
+    assert rank0_ref.terminated == ["model-x-rank0"]
+    assert "model-x-rank0" not in supervisor._replica_model_uid_to_worker
+    # Dead replica evicted and model taken offline.
+    assert "model-x" not in supervisor._model_uid_to_replica_info
+    assert "model-x-0" not in supervisor._replica_model_uid_to_worker
+    # Failure gauge marker stays lit (mark_replica_dead must not clear it).
+    assert ("model-x", 0) in supervisor._unexpected_down_replicas

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -315,6 +315,30 @@ class WorkerActor(xo.StatelessActor):
                             await self.recover_model(launch_args)
                         else:
                             logger.warning("Stop recreating model actor.")
+                            # Worker has given up recreating; notify supervisor
+                            # to evict the dead replica from round-robin and
+                            # light up the failure gauge. add_worker=False:
+                            # only fetch the ref, do not trigger
+                            # re-registration. Wrap in xo.wait_for(5s): this
+                            # runs inside the recover_sub_pool tail path, so a
+                            # stalled supervisor must not hold up the worker's
+                            # local shutdown. A failure/timeout is non-fatal --
+                            # the next death detection / redeploy will
+                            # reconcile.
+                            try:
+                                supervisor_ref = await self.get_supervisor_ref(
+                                    add_worker=False
+                                )
+                                await xo.wait_for(
+                                    supervisor_ref.mark_replica_dead(model_uid),
+                                    timeout=5,
+                                )
+                            except Exception:
+                                logger.warning(
+                                    "Failed to notify supervisor of dead replica %s",
+                                    model_uid,
+                                    exc_info=True,
+                                )
                     else:
                         logger.warning("Recreating model actor %s ...", model_uid)
                         await self.recover_model(launch_args)

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -315,22 +315,30 @@ class WorkerActor(xo.StatelessActor):
                             await self.recover_model(launch_args)
                         else:
                             logger.warning("Stop recreating model actor.")
+
                             # Worker has given up recreating; notify supervisor
                             # to evict the dead replica from round-robin and
                             # light up the failure gauge. add_worker=False:
                             # only fetch the ref, do not trigger
-                            # re-registration. Wrap in xo.wait_for(5s): this
-                            # runs inside the recover_sub_pool tail path, so a
-                            # stalled supervisor must not hold up the worker's
-                            # local shutdown. A failure/timeout is non-fatal --
-                            # the next death detection / redeploy will
-                            # reconcile.
-                            try:
+                            # re-registration. The whole notification --
+                            # get_supervisor_ref + mark_replica_dead -- is
+                            # wrapped in a single xo.wait_for(5s): this runs
+                            # inside the recover_sub_pool tail path, and
+                            # get_supervisor_ref itself issues blocking
+                            # xo.actor_ref calls when the cached ref is missing,
+                            # so the bound must cover both to keep a stalled
+                            # supervisor from holding up the worker's local
+                            # shutdown. A failure/timeout is non-fatal -- the
+                            # next death detection / redeploy will reconcile.
+                            async def _notify_replica_dead():
                                 supervisor_ref = await self.get_supervisor_ref(
                                     add_worker=False
                                 )
+                                await supervisor_ref.mark_replica_dead(model_uid)
+
+                            try:
                                 await xo.wait_for(
-                                    supervisor_ref.mark_replica_dead(model_uid),
+                                    _notify_replica_dead(),
                                     timeout=5,
                                 )
                             except Exception:


### PR DESCRIPTION
## Summary
- When worker exhausts `AUTO_RECOVER_LIMIT` and stops recreating a model actor, the dead replica remains in supervisor's round-robin scheduler and `model_unexpected_termination` gauge is never lit. Requests routed to the dead replica fail silently, and ops has no observability signal that N-1 out of N replicas are healthy.
- Add `supervisor.mark_replica_dead()` that evicts the dead replica from the round-robin scheduler, lights up `model_unexpected_termination`, and advances `base_uid` to `TERMINATED` when the single/last replica dies. The method is idempotent and deliberately does not call back `worker.terminate_model` (the worker already terminated the model locally before giving up recreating).
- Worker calls back `supervisor.mark_replica_dead()` after "Stop recreating model actor." with a 5s `xo.wait_for` timeout guard so a stalled supervisor does not hold up the worker's local shutdown. Failure/timeout is non-fatal — the next death detection or redeploy will reconcile.
- Add regression tests in both sync and async client test suites (`test_model_oom_recover_exhausted_evicts_replica`).

**Depends on #5005** (fix/model: use os._exit for OOM to trigger pool recovery) which provides the `os._exit(1)` fix that makes OOM-triggered recovery cycles actually work. This PR includes #5005's commits as its base; the PR3-specific changes are in the supervisor.py `mark_replica_dead` method, the worker callback, and the eviction test.

## Test plan
- [ ] Run `test_model_oom_recover_exhausted_evicts_replica` in both `test_client.py` and `test_async_client.py` — verifies dead replica is evicted after recover limit exhausted
- [ ] Run existing `test_model_oom_triggers_restart` (from #5005) — verifies OOM still triggers subprocess exit
- [ ] Run existing `test_auto_recover` — verifies normal auto-recovery still works
- [ ] Manual test: deploy a model with `XINFERENCE_MODEL_ACTOR_AUTO_RECOVER_LIMIT=1`, trigger repeated OOM, verify `model_unexpected_termination` gauge lights up and `list_models()` drains to empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)