### PR TITLE
doc: hide Zhihu link from English docs

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -14,6 +14,8 @@ import os
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
+from docutils import nodes
+
 
 # -- Project information -----------------------------------------------------
 
@@ -73,6 +75,8 @@ version_match = os.environ.get("READTHEDOCS_LANGUAGE")
 json_url = "https://inference.readthedocs.io/en/latest/_static/switcher.json"
 if not version_match:
     version_match = 'en'
+if version_match == 'zh-cn':
+    tags.add("zh_cn")
 
 html_theme_options = {
     "show_toc_level": 2,
@@ -130,3 +134,23 @@ else:
     ]
 
 html_favicon = "_static/favicon.svg"
+
+
+def _remove_non_zh_cn_nodes(app, doctree, docname):
+    current_language = getattr(app.config, "language", None)
+    is_zh_cn = version_match == "zh-cn" or current_language in {"zh_CN", "zh-cn"}
+    if is_zh_cn:
+        return
+
+    for node in list(
+        doctree.findall(
+            lambda n: isinstance(n, nodes.Element)
+            and "zh-cn-only" in n.get("classes", [])
+        )
+    ):
+        if node.parent is not None and node in node.parent:
+            node.parent.remove(node)
+
+
+def setup(app):
+    app.connect("doctree-resolved", _remove_non_zh_cn_nodes)

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -238,8 +238,9 @@ Getting Involved
 
             :fab:`twitter` Follow us on Twitter
 
-         .. grid-item-card::  
+         .. grid-item-card::
             :link: https://zhihu.com/org/xorbits
+            :class-item: zh-cn-only
 
             :fab:`zhihu` Read our blogs
 


### PR DESCRIPTION
## Summary
- hide the Zhihu blog card from the English docs index page
- keep the Zhihu card visible in zh-cn docs builds
- preserve the existing zh-cn navbar Zhihu icon behavior

## Validation
- git diff --check
- python -m py_compile doc/source/conf.py
- python -m sphinx -b html -q doc/source /tmp/xinference-doc-en-zhihu-check2
- READTHEDOCS_LANGUAGE=zh-cn python -m sphinx -b html -q -D language=zh_CN doc/source /tmp/xinference-doc-zh-zhihu-check
- verified English index.html has no zhihu.com/org/xorbits or "Read our blogs"
- verified zh-cn index.html keeps zhihu.com/org/xorbits and "阅读知乎博客"