### PR TITLE
fix(worker): pop launch_ts in recover_model to avoid strict-constructor crashes

### DIFF
--- a/xinference/core/tests/test_worker.py
+++ b/xinference/core/tests/test_worker.py
@@ -1432,3 +1432,59 @@ async def test_mark_replica_dead_last_replica_terminates_rank0():
     assert "model-x-0" not in supervisor._replica_model_uid_to_worker
     # Failure gauge marker stays lit (mark_replica_dead must not clear it).
     assert ("model-x", 0) in supervisor._unexpected_down_replicas
+
+
+@pytest.mark.asyncio
+async def test_recover_model_pops_launch_ts_from_kwargs():
+    """launch_ts is an internal timestamp stamped onto the launch snapshot at
+    launch_builtin_model entry. recover_model splats the snapshot back via
+    launch_builtin_model(**launch_args), which would inject launch_ts into the
+    model's self._kwargs. Models that forward the full self._kwargs into a
+    strict constructor (e.g. jina-reranker-v3 -> AutoModelForCausalLM.from_pretrained)
+    then crash with TypeError. recover_model must pop launch_ts before the splat,
+    mirroring the existing cleanup in recover_models_on_startup."""
+
+    # Use a minimal mock object to avoid WorkerActor initialization complexity
+    class _MockWorker:
+        async def launch_builtin_model(self, **kwargs):
+            self._captured_kwargs = kwargs
+            return "mock-subpool-address"
+
+        async def get_supervisor_ref(self, add_worker=False):
+            return None
+
+    worker = _MockWorker()
+
+    # Simulate a cached launch snapshot with launch_ts (the internal timestamp)
+    launch_args = {
+        "model_uid": "test-model-0",
+        "model_name": "test-model",
+        "launch_ts": 1780900592,  # Internal timestamp, not a model param
+        "some_param": "value",
+    }
+    original_launch_args = dict(launch_args)
+
+    # Mock parse_replica_model_uid to avoid dependency
+    def mock_parse(uid):
+        return ("test-model", 0)
+
+    import xinference.core.worker as worker_module
+
+    original_parse = worker_module.parse_replica_model_uid
+    worker_module.parse_replica_model_uid = mock_parse
+
+    try:
+        # Call recover_model directly (it's a standalone async method)
+        await WorkerActor.recover_model(worker, launch_args)
+
+        # Assert: launch_builtin_model was called without launch_ts
+        assert hasattr(worker, "_captured_kwargs")
+        assert "launch_ts" not in worker._captured_kwargs
+        assert worker._captured_kwargs["model_uid"] == "test-model-0"
+        assert worker._captured_kwargs["some_param"] == "value"
+
+        # Assert: original launch_args still has launch_ts (copy isolation)
+        assert launch_args == original_launch_args
+        assert launch_args["launch_ts"] == 1780900592
+    finally:
+        worker_module.parse_replica_model_uid = original_parse

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -2871,6 +2871,20 @@ class WorkerActor(xo.StatelessActor):
 
     @no_type_check
     async def recover_model(self, launch_args: Dict[str, Any]):
+        # `launch_ts` is an internal timestamp stamped onto the launch snapshot at
+        # the entry of `launch_builtin_model` (see the `launch_args["launch_ts"]`
+        # assignment); it is not a model construction parameter. recover_model
+        # splats the whole snapshot back via `launch_builtin_model(**launch_args)`,
+        # so `launch_ts` would land in that call's `**kwargs` and sink into the
+        # model's `self._kwargs`. Models that forward the full `self._kwargs` into a
+        # strict constructor (e.g. jina-reranker-v3 ->
+        # `AutoModelForCausalLM.from_pretrained(**model_kwargs)`) then crash with
+        # `TypeError: ... unexpected keyword argument 'launch_ts'`. The cross-session
+        # recovery path (`recover_models_on_startup`) already pops it before
+        # relaunch; do the same here. Copy first so the cached snapshot in
+        # `self._model_uid_to_launch_args` keeps its `launch_ts` (used as created_ts).
+        launch_args = dict(launch_args)
+        launch_args.pop("launch_ts", None)
         rep_model_uid = launch_args.get("model_uid")
         origin_uid, _ = parse_replica_model_uid(rep_model_uid)
         xavier_config: Optional[Dict[str, Any]] = launch_args.get("xavier_config", None)


### PR DESCRIPTION
## Summary
- **Bug**: OOM auto-recovery (`recover_sub_pool` → `recover_model`) crashes strict-constructor models (e.g., jina-reranker-v3) with `TypeError: unexpected keyword argument 'launch_ts'`. The bug is that `recover_model` splats the cached launch snapshot (which includes `launch_ts`, an internal timestamp) back into `launch_builtin_model(**launch_args)`, injecting `launch_ts` into the model's `self._kwargs`. Models that forward the full `self._kwargs` into a strict constructor (like `AutoModelForCausalLM.from_pretrained(**model_kwargs)`) then crash.
- **Fix**: Pop `launch_ts` from `launch_args` in `recover_model` before the splat, mirroring the existing cleanup in `recover_models_on_startup` (line 788). Copy the dict first to avoid mutating the cached snapshot in `self._model_uid_to_launch_args` (which legitimately uses `launch_ts` as `created_ts`).
- **Impact**: Fixes OOM auto-recovery for all strict-constructor models (jina-reranker-v3, qwen3 rerank, Qwen3-VL-Embedding, etc.). Without this fix, the replica stays permanently down after OOM even though `recover_sub_pool` detects the crash and triggers recovery.

## Root cause analysis (from production logs)

```
16:47:40.000 Process xinference-worker-4090-1:42155 is down.                    # 10: monitor detects crash
16:47:40.012 Recreating model actor 24a22820-9128-...-0 ...                    # recover_sub_pool triggers
16:47:52.717 Starting ModelActor at ...:34755 (new pid 966847)                 # new subpool created
16:47:53.234 Loading qwen3 rerank with kwargs {'device_map': 'auto', 'launch_ts': 1780900592}  # ⚠️ launch_ts leaks
16:47:53.246 Failed to load model ... TypeError: ... unexpected keyword argument 'launch_ts'    # ❌ crash
16:47:53.330 Launch finished: model_name=jina-reranker-v3 ... (active: 0/5)    # replica stays down
```

**Why embedding v3/v4 survived**: They use `.get()` to selectively extract kwargs (not a full splat), so `launch_ts` was never passed to the constructor. Only models that forward the entire `self._kwargs` via `**` are affected.

## Test plan
- [x] Unit test added: `test_recover_model_pops_launch_ts_from_kwargs` in `xinference/core/tests/test_worker.py` — verifies `launch_ts` is removed from kwargs passed to `launch_builtin_model`, and that the original cached snapshot still contains `launch_ts` (copy isolation).
- [ ] Real-world test: Deploy jina-reranker-v3 on 4090×2 worker with `XINFERENCE_MODEL_ACTOR_AUTO_RECOVER_LIMIT=2`, trigger OOM, verify auto-recovery completes within 30s (should see `ModelActor loaded` instead of `TypeError`).
- [ ] Regression: Ensure embedding v3/v4 OOM recovery still works (should be unaffected since they don't splat `self._kwargs`).

## Related PRs
- **#5004** (merged): Ensured `monitor_sub_pools` runs so `recover_sub_pool` detects crashes.
- **#5005** (merged): Used `os._exit(1)` so OOM crashes are detectable.
- **#5006** (merged): Evicts dead replicas from round-robin scheduler when auto-recovery is exhausted.
- **This PR**: Fixes the latent bug exposed by #5004/#5005/#5006 — the recovery chain now works end-to-end, but the recovered model failed to load due to `launch_ts` leakage.

## Blast radius
- **Scope**: `recover_model` only. Does not affect `recover_models_on_startup` (already had the cleanup), `launch_builtin_model` (no changes), or model-side code.
- **Backwards compatibility**: The cached snapshot in `self._model_uid_to_launch_args` is unchanged (copy isolation), so any code that reads `launch_ts` from the cache (e.g., `created_ts` computation) is unaffected.
- **Risk**: Minimal — the fix is a direct port of existing logic from `recover_models_on_startup` to `recover_model`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
