### PR TITLE
feat(ui): add change password for local users in user management

### DIFF
--- a/xinference/api/oauth2/advanced/routes.py
+++ b/xinference/api/oauth2/advanced/routes.py
@@ -248,6 +248,10 @@ async def change_password(user_id: int, request: Request) -> JSONResponse:
     user = auth.db.get_user_by_id(user_id)
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
+    if user["source"] != "local":
+        raise HTTPException(
+            status_code=400, detail="Only local users can change password"
+        )
     body = await request.json()
     new_password = body.get("new_password")
     if not new_password:

--- a/xinference/ui/web/ui/src/locales/en.json
+++ b/xinference/ui/web/ui/src/locales/en.json
@@ -397,7 +397,14 @@
     "selectAll": "Select All",
     "editPermissions": "Edit Permissions",
     "editPermissionsTitle": "Edit Permissions",
-    "save": "Save"
+    "save": "Save",
+    "changePassword": "Change Password",
+    "changePasswordTitle": "Change Password",
+    "newPassword": "New Password",
+    "confirmPassword": "Confirm Password",
+    "passwordMismatch": "Passwords do not match",
+    "passwordTooShort": "Password must be at least 8 characters",
+    "changePasswordSuccess": "Password changed successfully"
   },
   "permissions": {
     "admin": "Administrator",

--- a/xinference/ui/web/ui/src/locales/ja.json
+++ b/xinference/ui/web/ui/src/locales/ja.json
@@ -390,7 +390,14 @@
     "selectAll": "全選択",
     "editPermissions": "権限編集",
     "editPermissionsTitle": "権限編集",
-    "save": "保存"
+    "save": "保存",
+    "changePassword": "パスワード変更",
+    "changePasswordTitle": "パスワード変更",
+    "newPassword": "新しいパスワード",
+    "confirmPassword": "パスワード確認",
+    "passwordMismatch": "パスワードが一致しません",
+    "passwordTooShort": "パスワードは8文字以上である必要があります",
+    "changePasswordSuccess": "パスワードが正常に変更されました"
   },
   "permissions": {
     "admin": "管理者",

--- a/xinference/ui/web/ui/src/locales/ko.json
+++ b/xinference/ui/web/ui/src/locales/ko.json
@@ -390,7 +390,14 @@
     "selectAll": "전체 선택",
     "editPermissions": "권한 편집",
     "editPermissionsTitle": "권한 편집",
-    "save": "저장"
+    "save": "저장",
+    "changePassword": "비밀번호 변경",
+    "changePasswordTitle": "비밀번호 변경",
+    "newPassword": "새 비밀번호",
+    "confirmPassword": "비밀번호 확인",
+    "passwordMismatch": "비밀번호가 일치하지 않습니다",
+    "passwordTooShort": "비밀번호는 최소 8자 이상이어야 합니다",
+    "changePasswordSuccess": "비밀번호가 성공적으로 변경되었습니다"
   },
   "permissions": {
     "admin": "관리자",

--- a/xinference/ui/web/ui/src/locales/zh.json
+++ b/xinference/ui/web/ui/src/locales/zh.json
@@ -397,7 +397,14 @@
     "selectAll": "全选",
     "editPermissions": "编辑权限",
     "editPermissionsTitle": "编辑权限",
-    "save": "保存"
+    "save": "保存",
+    "changePassword": "修改密码",
+    "changePasswordTitle": "修改密码",
+    "newPassword": "新密码",
+    "confirmPassword": "确认密码",
+    "passwordMismatch": "两次输入的密码不一致",
+    "passwordTooShort": "密码至少需要8个字符",
+    "changePasswordSuccess": "密码修改成功"
   },
   "permissions": {
     "admin": "管理员",

--- a/xinference/ui/web/ui/src/scenes/user_management/index.js
+++ b/xinference/ui/web/ui/src/scenes/user_management/index.js
@@ -2,6 +2,7 @@ import BlockIcon from '@mui/icons-material/Block'
 import CheckCircleIcon from '@mui/icons-material/CheckCircle'
 import DeleteIcon from '@mui/icons-material/Delete'
 import EditIcon from '@mui/icons-material/Edit'
+import VpnKeyIcon from '@mui/icons-material/VpnKey'
 import {
   Alert,
   Box,
@@ -51,6 +52,11 @@ function UserManagement() {
   const [editPermOpen, setEditPermOpen] = useState(false)
   const [editingUser, setEditingUser] = useState(null)
   const [editPerms, setEditPerms] = useState([])
+  const [pwdDialogOpen, setPwdDialogOpen] = useState(false)
+  const [pwdTargetUser, setPwdTargetUser] = useState(null)
+  const [newPwd, setNewPwd] = useState('')
+  const [confirmPwd, setConfirmPwd] = useState('')
+  const [pwdError, setPwdError] = useState('')
 
   const loadUsers = async () => {
     try {
@@ -156,6 +162,38 @@ function UserManagement() {
     }
   }
 
+  const handleChangePassword = (user) => {
+    setPwdTargetUser(user)
+    setNewPwd('')
+    setConfirmPwd('')
+    setPwdError('')
+    setPwdDialogOpen(true)
+  }
+
+  const handleSubmitPassword = async () => {
+    if (!pwdTargetUser) return
+    if (newPwd !== confirmPwd) {
+      setPwdError(t('userManagement.passwordMismatch'))
+      return
+    }
+    if (newPwd.length < 8) {
+      setPwdError(t('userManagement.passwordTooShort'))
+      return
+    }
+    try {
+      await fetchWrapper.put(`/v1/admin/users/${pwdTargetUser.id}/password`, {
+        new_password: newPwd,
+      })
+      setPwdDialogOpen(false)
+      setPwdTargetUser(null)
+      setNewPwd('')
+      setConfirmPwd('')
+      setSnackError(t('userManagement.changePasswordSuccess'))
+    } catch (e) {
+      setPwdError(e.message || String(e))
+    }
+  }
+
   const columns = [
     { field: 'id', headerName: t('userManagement.id'), width: 60 },
     { field: 'username', headerName: t('userManagement.username'), width: 150 },
@@ -212,6 +250,16 @@ function UserManagement() {
               <EditIcon />
             </IconButton>
           </Tooltip>
+          {params.row.source === 'local' && (
+            <Tooltip title={t('userManagement.changePassword')}>
+              <IconButton
+                size="small"
+                onClick={() => handleChangePassword(params.row)}
+              >
+                <VpnKeyIcon />
+              </IconButton>
+            </Tooltip>
+          )}
           <Tooltip
             title={
               params.row.enabled
@@ -418,6 +466,50 @@ function UserManagement() {
           </Button>
           <Button variant="contained" onClick={handleSavePermissions}>
             {t('userManagement.save') || 'Save'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Change Password Dialog */}
+      <Dialog
+        open={pwdDialogOpen}
+        onClose={() => setPwdDialogOpen(false)}
+        maxWidth="xs"
+        fullWidth
+      >
+        <DialogTitle>
+          {t('userManagement.changePasswordTitle')}{' '}
+          {pwdTargetUser && `- ${pwdTargetUser.username}`}
+        </DialogTitle>
+        <DialogContent>
+          {pwdError && (
+            <Alert severity="error" sx={{ mb: 2 }}>
+              {pwdError}
+            </Alert>
+          )}
+          <TextField
+            margin="dense"
+            label={t('userManagement.newPassword')}
+            type="password"
+            fullWidth
+            value={newPwd}
+            onChange={(e) => setNewPwd(e.target.value)}
+          />
+          <TextField
+            margin="dense"
+            label={t('userManagement.confirmPassword')}
+            type="password"
+            fullWidth
+            value={confirmPwd}
+            onChange={(e) => setConfirmPwd(e.target.value)}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setPwdDialogOpen(false)}>
+            {t('userManagement.cancel')}
+          </Button>
+          <Button variant="contained" onClick={handleSubmitPassword}>
+            {t('userManagement.save')}
           </Button>
         </DialogActions>
       </Dialog>

--- a/xinference/ui/web/ui/src/scenes/user_management/index.js
+++ b/xinference/ui/web/ui/src/scenes/user_management/index.js
@@ -49,6 +49,7 @@ function UserManagement() {
   const [newPassword, setNewPassword] = useState('')
   const [selectedPerms, setSelectedPerms] = useState([])
   const [snackError, setSnackError] = useState('')
+  const [snackSeverity, setSnackSeverity] = useState('error')
   const [editPermOpen, setEditPermOpen] = useState(false)
   const [editingUser, setEditingUser] = useState(null)
   const [editPerms, setEditPerms] = useState([])
@@ -84,6 +85,7 @@ function UserManagement() {
       setSelectedPerms([])
       loadUsers()
     } catch (e) {
+      setSnackSeverity('error')
       setSnackError(e.message || String(e))
     }
   }
@@ -95,6 +97,7 @@ function UserManagement() {
       })
       loadUsers()
     } catch (e) {
+      setSnackSeverity('error')
       setSnackError(e.message || String(e))
     }
   }
@@ -110,6 +113,7 @@ function UserManagement() {
       await fetchWrapper.delete(`/v1/admin/users/${user.id}`)
       loadUsers()
     } catch (e) {
+      setSnackSeverity('error')
       setSnackError(e.message || String(e))
     }
   }
@@ -158,6 +162,7 @@ function UserManagement() {
       setEditingUser(null)
       loadUsers()
     } catch (e) {
+      setSnackSeverity('error')
       setSnackError(e.message || String(e))
     }
   }
@@ -188,6 +193,7 @@ function UserManagement() {
       setPwdTargetUser(null)
       setNewPwd('')
       setConfirmPwd('')
+      setSnackSeverity('success')
       setSnackError(t('userManagement.changePasswordSuccess'))
     } catch (e) {
       setPwdError(e.message || String(e))
@@ -521,7 +527,7 @@ function UserManagement() {
         anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
       >
         <Alert
-          severity="error"
+          severity={snackSeverity}
           onClose={() => setSnackError('')}
           variant="filled"
         >


### PR DESCRIPTION
## Summary
- Add a password change button (VpnKey icon) in the user management action column, conditionally rendered only for `source === 'local'` users
- New dialog with password/confirm-password fields, client-side validation (match check, min 8 chars), calling the existing `PUT /v1/admin/users/{id}/password` endpoint
- Add backend `source == 'local'` guard in `change_password` route to prevent API-level password changes for OIDC users (security hardening)
- Add i18n keys for zh/en/ja/ko (7 new keys under `userManagement`)

## Test plan
- [ ] Start UI (`cd xinference/ui/web/ui && npm start`), navigate to User Management
- [ ] Verify VpnKey icon appears in action column for `local` users only
- [ ] Click the icon, enter a new password (twice), save — verify success snackbar
- [ ] Log in with the changed password to confirm it took effect
- [ ] Verify OIDC users do NOT show the change password button
- [ ] Directly call `PUT /v1/admin/users/{oidc_user_id}/password` and verify 400 response
- [ ] Switch UI language to en/ja/ko and verify labels are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)