### PR TITLE
fix(logs): fix empty node filter dropdown and redesign toolbar layout

### DIFF
--- a/xinference/api/routers/admin.py
+++ b/xinference/api/routers/admin.py
@@ -422,6 +422,57 @@ async def search_logs(
     return JSONResponse(content={"hits": hits, "total": total})
 
 
+async def list_log_nodes() -> JSONResponse:
+    es_url = os.environ.get("XINFERENCE_ES_URL", "")
+    if not es_url:
+        raise HTTPException(status_code=503, detail="Elasticsearch is not configured")
+
+    es_index = os.environ.get("XINFERENCE_ES_INDEX", "xinference-logs-*")
+    es_auth = os.environ.get("XINFERENCE_ES_AUTH", "")
+
+    headers = {"Content-Type": "application/json"}
+    auth = None
+    if es_auth:
+        if es_auth.startswith("ApiKey "):
+            headers["Authorization"] = es_auth
+        else:
+            parts = es_auth.split(":", 1)
+            if len(parts) == 2:
+                auth = aiohttp.BasicAuth(parts[0], parts[1])
+
+    url = f"{es_url.rstrip('/')}/{es_index}/_search"
+
+    async def _aggregate(field: str) -> Optional[list[dict[str, Any]]]:
+        body = {"size": 0, "aggs": {"nodes": {"terms": {"field": field, "size": 200}}}}
+        timeout = aiohttp.ClientTimeout(total=10)
+        async with aiohttp.ClientSession(timeout=timeout, auth=auth) as session:
+            async with session.post(url, json=body, headers=headers) as resp:
+                if resp.status != 200:
+                    return None
+                data = await resp.json()
+        return data.get("aggregations", {}).get("nodes", {}).get("buckets", [])
+
+    try:
+        # "node" is usually a keyword field; fall back to "node.keyword" if the
+        # mapping is text (terms aggregation requires a keyword/fielddata field).
+        buckets = await _aggregate("node")
+        if buckets is None:
+            buckets = await _aggregate("node.keyword")
+    except (aiohttp.ClientError, asyncio.TimeoutError) as e:
+        logger.error("ES connection error or timeout: %s", e)
+        raise HTTPException(
+            status_code=502,
+            detail="Failed to connect to Elasticsearch or query timed out",
+        )
+
+    if buckets is None:
+        logger.error("ES node aggregation failed for both 'node' and 'node.keyword'")
+        raise HTTPException(status_code=502, detail="Elasticsearch query failed")
+
+    nodes = [b["key"] for b in buckets if b.get("key")]
+    return JSONResponse(content={"nodes": nodes})
+
+
 async def search_logs_context(
     timestamp: str = "",
     size: int = 5,
@@ -902,6 +953,13 @@ def register_routes(api: "RESTfulAPI") -> None:
     router.add_api_route(
         "/v1/cluster/logs/context",
         search_logs_context,
+        methods=["GET"],
+        dependencies=([Security(auth, scopes=["admin"])] if is_auth else None),
+    )
+
+    router.add_api_route(
+        "/v1/cluster/logs/nodes",
+        list_log_nodes,
         methods=["GET"],
         dependencies=([Security(auth, scopes=["admin"])] if is_auth else None),
     )

--- a/xinference/api/routers/admin.py
+++ b/xinference/api/routers/admin.py
@@ -299,6 +299,7 @@ async def search_logs(
     time_to: str = "now",
     size: int = 200,
     page_from: int = 0,
+    node_field: str = "node",
 ) -> JSONResponse:
     es_url = os.environ.get("XINFERENCE_ES_URL", "")
     if not es_url:
@@ -309,6 +310,8 @@ async def search_logs(
 
     size = max(1, min(size, 500))
     page_from = max(0, min(page_from, 10000 - size))
+    if node_field not in ("node", "node.keyword"):
+        node_field = "node"
 
     must = []
     filter_clauses: list[dict[str, Any]] = [
@@ -329,7 +332,7 @@ async def search_logs(
     for field, value in [
         ("level", level),
         ("module", module),
-        ("node", node),
+        (node_field, node),
         ("log_type", log_type),
     ]:
         if value:
@@ -349,6 +352,8 @@ async def search_logs(
         op = token[0]
         field_name = token[1:sep]
         field_value = token[sep + 1 :]
+        if field_name == "node":
+            field_name = node_field
         if not _FIELD_NAME_RE.match(field_name) or not field_value:
             continue
         if op == "+":
@@ -456,8 +461,10 @@ async def list_log_nodes() -> JSONResponse:
         # "node" is usually a keyword field; fall back to "node.keyword" if the
         # mapping is text (terms aggregation requires a keyword/fielddata field).
         buckets = await _aggregate("node")
+        node_field = "node"
         if buckets is None:
             buckets = await _aggregate("node.keyword")
+            node_field = "node.keyword"
     except (aiohttp.ClientError, asyncio.TimeoutError) as e:
         logger.error("ES connection error or timeout: %s", e)
         raise HTTPException(
@@ -470,13 +477,14 @@ async def list_log_nodes() -> JSONResponse:
         raise HTTPException(status_code=502, detail="Elasticsearch query failed")
 
     nodes = [b["key"] for b in buckets if b.get("key")]
-    return JSONResponse(content={"nodes": nodes})
+    return JSONResponse(content={"nodes": nodes, "node_field": node_field})
 
 
 async def search_logs_context(
     timestamp: str = "",
     size: int = 5,
     node: str = "",
+    node_field: str = "node",
 ) -> JSONResponse:
     if not timestamp:
         raise HTTPException(status_code=400, detail="timestamp is required")
@@ -489,10 +497,12 @@ async def search_logs_context(
     es_auth = os.environ.get("XINFERENCE_ES_AUTH", "")
 
     size = max(1, min(size, 50))
+    if node_field not in ("node", "node.keyword"):
+        node_field = "node"
 
     node_filter: list[dict[str, Any]] = []
     if node:
-        node_filter = [{"term": {"node": node}}]
+        node_filter = [{"term": {node_field: node}}]
 
     older_body: dict[str, Any] = {
         "query": {

--- a/xinference/ui/web/ui/src/locales/en.json
+++ b/xinference/ui/web/ui/src/locales/en.json
@@ -336,6 +336,8 @@
     "notConfigured": "Log query not configured. Please set XINFERENCE_ES_URL environment variable.",
     "searchPlaceholder": "Search logs...",
     "allNodes": "All Nodes",
+    "logLevel": "Log Level",
+    "nodeType": "Node Type",
     "time": "Time",
     "level": "Level",
     "node": "Node",
@@ -397,7 +399,14 @@
     "selectAll": "Select All",
     "editPermissions": "Edit Permissions",
     "editPermissionsTitle": "Edit Permissions",
-    "save": "Save"
+    "save": "Save",
+    "changePassword": "Change Password",
+    "changePasswordTitle": "Change Password",
+    "newPassword": "New Password",
+    "confirmPassword": "Confirm Password",
+    "passwordMismatch": "Passwords do not match",
+    "passwordTooShort": "Password must be at least 8 characters",
+    "changePasswordSuccess": "Password changed successfully"
   },
   "permissions": {
     "admin": "Administrator",

--- a/xinference/ui/web/ui/src/locales/en.json
+++ b/xinference/ui/web/ui/src/locales/en.json
@@ -399,14 +399,7 @@
     "selectAll": "Select All",
     "editPermissions": "Edit Permissions",
     "editPermissionsTitle": "Edit Permissions",
-    "save": "Save",
-    "changePassword": "Change Password",
-    "changePasswordTitle": "Change Password",
-    "newPassword": "New Password",
-    "confirmPassword": "Confirm Password",
-    "passwordMismatch": "Passwords do not match",
-    "passwordTooShort": "Password must be at least 8 characters",
-    "changePasswordSuccess": "Password changed successfully"
+    "save": "Save"
   },
   "permissions": {
     "admin": "Administrator",

--- a/xinference/ui/web/ui/src/locales/ja.json
+++ b/xinference/ui/web/ui/src/locales/ja.json
@@ -329,6 +329,8 @@
     "notConfigured": "ログクエリが設定されていません。XINFERENCE_ES_URL 環境変数を設定してください。",
     "searchPlaceholder": "ログを検索...",
     "allNodes": "全ノード",
+    "logLevel": "ログレベル",
+    "nodeType": "ノードタイプ",
     "time": "時刻",
     "level": "レベル",
     "node": "ノード",
@@ -390,7 +392,14 @@
     "selectAll": "全選択",
     "editPermissions": "権限編集",
     "editPermissionsTitle": "権限編集",
-    "save": "保存"
+    "save": "保存",
+    "changePassword": "パスワード変更",
+    "changePasswordTitle": "パスワード変更",
+    "newPassword": "新しいパスワード",
+    "confirmPassword": "パスワード確認",
+    "passwordMismatch": "パスワードが一致しません",
+    "passwordTooShort": "パスワードは8文字以上である必要があります",
+    "changePasswordSuccess": "パスワードが正常に変更されました"
   },
   "permissions": {
     "admin": "管理者",

--- a/xinference/ui/web/ui/src/locales/ja.json
+++ b/xinference/ui/web/ui/src/locales/ja.json
@@ -392,14 +392,7 @@
     "selectAll": "全選択",
     "editPermissions": "権限編集",
     "editPermissionsTitle": "権限編集",
-    "save": "保存",
-    "changePassword": "パスワード変更",
-    "changePasswordTitle": "パスワード変更",
-    "newPassword": "新しいパスワード",
-    "confirmPassword": "パスワード確認",
-    "passwordMismatch": "パスワードが一致しません",
-    "passwordTooShort": "パスワードは8文字以上である必要があります",
-    "changePasswordSuccess": "パスワードが正常に変更されました"
+    "save": "保存"
   },
   "permissions": {
     "admin": "管理者",

--- a/xinference/ui/web/ui/src/locales/ko.json
+++ b/xinference/ui/web/ui/src/locales/ko.json
@@ -329,6 +329,8 @@
     "notConfigured": "로그 조회가 구성되지 않았습니다. XINFERENCE_ES_URL 환경 변수를 설정하세요.",
     "searchPlaceholder": "로그 검색...",
     "allNodes": "전체 노드",
+    "logLevel": "로그 레벨",
+    "nodeType": "노드 유형",
     "time": "시간",
     "level": "레벨",
     "node": "노드",
@@ -390,7 +392,14 @@
     "selectAll": "전체 선택",
     "editPermissions": "권한 편집",
     "editPermissionsTitle": "권한 편집",
-    "save": "저장"
+    "save": "저장",
+    "changePassword": "비밀번호 변경",
+    "changePasswordTitle": "비밀번호 변경",
+    "newPassword": "새 비밀번호",
+    "confirmPassword": "비밀번호 확인",
+    "passwordMismatch": "비밀번호가 일치하지 않습니다",
+    "passwordTooShort": "비밀번호는 최소 8자 이상이어야 합니다",
+    "changePasswordSuccess": "비밀번호가 성공적으로 변경되었습니다"
   },
   "permissions": {
     "admin": "관리자",

--- a/xinference/ui/web/ui/src/locales/ko.json
+++ b/xinference/ui/web/ui/src/locales/ko.json
@@ -392,14 +392,7 @@
     "selectAll": "전체 선택",
     "editPermissions": "권한 편집",
     "editPermissionsTitle": "권한 편집",
-    "save": "저장",
-    "changePassword": "비밀번호 변경",
-    "changePasswordTitle": "비밀번호 변경",
-    "newPassword": "새 비밀번호",
-    "confirmPassword": "비밀번호 확인",
-    "passwordMismatch": "비밀번호가 일치하지 않습니다",
-    "passwordTooShort": "비밀번호는 최소 8자 이상이어야 합니다",
-    "changePasswordSuccess": "비밀번호가 성공적으로 변경되었습니다"
+    "save": "저장"
   },
   "permissions": {
     "admin": "관리자",

--- a/xinference/ui/web/ui/src/locales/zh.json
+++ b/xinference/ui/web/ui/src/locales/zh.json
@@ -336,6 +336,8 @@
     "notConfigured": "日志查询未配置，请设置 XINFERENCE_ES_URL 环境变量。",
     "searchPlaceholder": "搜索日志...",
     "allNodes": "全部节点",
+    "logLevel": "日志级别",
+    "nodeType": "节点类型",
     "time": "时间",
     "level": "级别",
     "node": "节点",
@@ -397,7 +399,14 @@
     "selectAll": "全选",
     "editPermissions": "编辑权限",
     "editPermissionsTitle": "编辑权限",
-    "save": "保存"
+    "save": "保存",
+    "changePassword": "修改密码",
+    "changePasswordTitle": "修改密码",
+    "newPassword": "新密码",
+    "confirmPassword": "确认密码",
+    "passwordMismatch": "两次输入的密码不一致",
+    "passwordTooShort": "密码至少需要8个字符",
+    "changePasswordSuccess": "密码修改成功"
   },
   "permissions": {
     "admin": "管理员",

--- a/xinference/ui/web/ui/src/locales/zh.json
+++ b/xinference/ui/web/ui/src/locales/zh.json
@@ -399,14 +399,7 @@
     "selectAll": "全选",
     "editPermissions": "编辑权限",
     "editPermissionsTitle": "编辑权限",
-    "save": "保存",
-    "changePassword": "修改密码",
-    "changePasswordTitle": "修改密码",
-    "newPassword": "新密码",
-    "confirmPassword": "确认密码",
-    "passwordMismatch": "两次输入的密码不一致",
-    "passwordTooShort": "密码至少需要8个字符",
-    "changePasswordSuccess": "密码修改成功"
+    "save": "保存"
   },
   "permissions": {
     "admin": "管理员",

--- a/xinference/ui/web/ui/src/scenes/logs/index.js
+++ b/xinference/ui/web/ui/src/scenes/logs/index.js
@@ -178,6 +178,7 @@ function DetailRow({
   selectedLogType,
   endPoint,
   onViewContext,
+  nodeField,
 }) {
   const [tab, setTab] = useState(0)
   const [copied, setCopied] = useState(false)
@@ -401,13 +402,14 @@ function DetailRow({
           onClose={() => setContextOpen(false)}
           anchorRow={row}
           endPoint={endPoint}
+          nodeField={nodeField}
         />
       )}
     </Box>
   )
 }
 
-function ContextDialog({ open, onClose, anchorRow, endPoint }) {
+function ContextDialog({ open, onClose, anchorRow, endPoint, nodeField }) {
   const { t } = useTranslation()
   const [currentAnchor, setCurrentAnchor] = useState(anchorRow)
   const [olderSize, setOlderSize] = useState(5)
@@ -439,6 +441,7 @@ function ContextDialog({ open, onClose, anchorRow, endPoint }) {
     params.set('timestamp', timestamp)
     params.set('size', String(Math.max(olderSize, newerSize)))
     if (currentAnchor.node) params.set('node', currentAnchor.node)
+    if (nodeField && nodeField !== 'node') params.set('node_field', nodeField)
 
     const token = sessionStorage.getItem('token')
     const headers = { 'Content-Type': 'application/json' }
@@ -656,6 +659,7 @@ function ContextDialog({ open, onClose, anchorRow, endPoint }) {
                 selectedLogType=""
                 endPoint={endPoint}
                 onViewContext={handleSwitchAnchor}
+                nodeField={nodeField}
               />
             </Collapse>
           </TableCell>
@@ -803,6 +807,7 @@ const Logs = () => {
   const [selectedLogType, setSelectedLogType] = useState('')
   const [selectedNode, setSelectedNode] = useState('')
   const [nodes, setNodes] = useState([])
+  const [nodeField, setNodeField] = useState('node')
   const [pageFrom, setPageFrom] = useState(0)
   const [expandedRow, setExpandedRow] = useState(null)
   const [fieldFilters, setFieldFilters] = useState([])
@@ -841,6 +846,7 @@ const Logs = () => {
       .then((res) => res.json())
       .then((data) => {
         setNodes(Array.isArray(data.nodes) ? data.nodes : [])
+        setNodeField(data.node_field || 'node')
       })
       .catch(() => setNodes([]))
   }, [endPoint, esEnabled])
@@ -853,6 +859,7 @@ const Logs = () => {
     if (selectedLevels.length) params.set('level', selectedLevels.join(','))
     if (selectedLogType) params.set('log_type', selectedLogType)
     if (selectedNode) params.set('node', selectedNode)
+    if (nodeField !== 'node') params.set('node_field', nodeField)
     params.set('time_from', timeRange.from)
     params.set('time_to', timeRange.to)
     params.set('size', String(PAGE_SIZE))
@@ -887,6 +894,7 @@ const Logs = () => {
     selectedLevels,
     selectedLogType,
     selectedNode,
+    nodeField,
     timeRange,
     pageFrom,
     fieldFilters,
@@ -1448,6 +1456,7 @@ const Logs = () => {
                             selectedLevels={selectedLevels}
                             selectedLogType={selectedLogType}
                             endPoint={endPoint}
+                            nodeField={nodeField}
                           />
                         </Collapse>
                       </TableCell>

--- a/xinference/ui/web/ui/src/scenes/logs/index.js
+++ b/xinference/ui/web/ui/src/scenes/logs/index.js
@@ -837,16 +837,10 @@ const Logs = () => {
     const token = sessionStorage.getItem('token')
     const headers = { 'Content-Type': 'application/json' }
     if (token) headers['Authorization'] = `Bearer ${token}`
-    fetch(endPoint + '/v1/cluster/info', { headers })
+    fetch(endPoint + '/v1/cluster/logs/nodes', { headers })
       .then((res) => res.json())
       .then((data) => {
-        const nodeSet = new Set()
-        if (Array.isArray(data)) {
-          data.forEach((item) => {
-            if (item.node) nodeSet.add(item.node)
-          })
-        }
-        setNodes([...nodeSet])
+        setNodes(Array.isArray(data.nodes) ? data.nodes : [])
       })
       .catch(() => setNodes([]))
   }, [endPoint, esEnabled])
@@ -1044,219 +1038,263 @@ const Logs = () => {
         sx={{
           minHeight: 48,
           px: 2,
+          py: 1,
           gap: 1,
           borderBottom: 1,
           borderColor: 'divider',
-          flexWrap: 'wrap',
+          flexDirection: 'column',
+          alignItems: 'stretch',
         }}
       >
-        {/* Search */}
-        <TextField
-          size="small"
-          placeholder={t('logs.searchPlaceholder')}
-          value={searchText}
-          onChange={handleSearchChange}
-          onKeyDown={handleSearchKeyDown}
+        {/* Row 1: Node Select + Search + Time/Refresh */}
+        <Box
           sx={{
-            'width': 240,
-            '& .MuiInputBase-input': { fontSize: FONT_SIZE },
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1,
+            width: '100%',
           }}
-          InputProps={{
-            startAdornment: (
-              <InputAdornment position="start">
-                <SearchIcon fontSize="small" />
-              </InputAdornment>
-            ),
-          }}
-        />
-
-        {/* Level Chips */}
-        <Box sx={{ display: 'flex', gap: 0.5 }}>
-          {LEVELS.map((level) => (
-            <Chip
-              key={level}
-              label={level}
-              size="small"
-              variant={selectedLevels.includes(level) ? 'filled' : 'outlined'}
-              color={
-                level === 'ERROR'
-                  ? 'error'
-                  : level === 'WARNING'
-                  ? 'warning'
-                  : 'default'
-              }
-              onClick={() => toggleLevel(level)}
-              sx={{ fontSize: FONT_SIZE }}
-            />
-          ))}
-        </Box>
-
-        {/* Log Type Chips */}
-        <Box sx={{ display: 'flex', gap: 0.5 }}>
-          {LOG_TYPES.map((lt) => (
-            <Chip
-              key={lt}
-              label={lt}
-              size="small"
-              variant={selectedLogType === lt ? 'filled' : 'outlined'}
-              onClick={() => {
-                setSelectedLogType((prev) => (prev === lt ? '' : lt))
-                setPageFrom(0)
-              }}
-              sx={{ fontSize: FONT_SIZE }}
-            />
-          ))}
-        </Box>
-
-        {/* Node Select */}
-        {nodes.length > 0 && (
-          <FormControl size="small" sx={{ minWidth: 140 }}>
-            <Select
-              value={selectedNode}
-              onChange={(e) => {
-                setSelectedNode(e.target.value)
-                setPageFrom(0)
-              }}
-              displayEmpty
-              sx={{ fontSize: FONT_SIZE }}
-            >
-              <MenuItem value="" sx={{ fontSize: FONT_SIZE }}>
-                {t('logs.allNodes')}
-              </MenuItem>
-              {nodes.map((n) => (
-                <MenuItem key={n} value={n} sx={{ fontSize: FONT_SIZE }}>
-                  {n}
+        >
+          {/* Node Select */}
+          {nodes.length > 0 && (
+            <FormControl size="small" sx={{ minWidth: 200 }}>
+              <Select
+                value={selectedNode}
+                onChange={(e) => {
+                  setSelectedNode(e.target.value)
+                  setPageFrom(0)
+                }}
+                displayEmpty
+                sx={{ fontSize: FONT_SIZE }}
+              >
+                <MenuItem value="" sx={{ fontSize: FONT_SIZE }}>
+                  {t('logs.allNodes')}
                 </MenuItem>
-              ))}
-            </Select>
-          </FormControl>
-        )}
-
-        <Box sx={{ flex: 1 }} />
-
-        {/* Time Range */}
-        <Button
-          size="small"
-          color="inherit"
-          startIcon={<AccessTime fontSize="small" />}
-          onClick={(e) => setTimeAnchor(e.currentTarget)}
-          sx={{ textTransform: 'none', fontSize: FONT_SIZE }}
-        >
-          {timeRangeLabel ? t(timeRangeLabel) : customDisplay}
-        </Button>
-        <Popover
-          anchorEl={timeAnchor}
-          open={Boolean(timeAnchor)}
-          onClose={() => setTimeAnchor(null)}
-          anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
-          transformOrigin={{ vertical: 'top', horizontal: 'right' }}
-        >
-          <Box sx={{ display: 'flex', width: 480, maxHeight: 400 }}>
-            <Box
-              sx={{
-                width: 240,
-                p: 2,
-                display: 'flex',
-                flexDirection: 'column',
-                gap: 1.5,
-              }}
-            >
-              <Typography
-                variant="subtitle2"
-                color="text.secondary"
-                sx={{ fontSize: FONT_SIZE }}
-              >
-                {t('monitoring.absoluteRange')}
-              </Typography>
-              <LocalizationProvider
-                dateAdapter={AdapterDayjs}
-                adapterLocale={dayjsLocale}
-                localeText={
-                  PICKER_LOCALE_TEXT[(i18n.language || 'en').split('-')[0]] ||
-                  PICKER_LOCALE_TEXT.en
-                }
-              >
-                <DateTimePicker
-                  label={t('monitoring.from')}
-                  value={customFrom}
-                  onChange={(v) => setCustomFrom(v)}
-                  ampm={false}
-                  slotProps={DATE_TIME_SLOT_PROPS}
-                />
-                <DateTimePicker
-                  label={t('monitoring.to')}
-                  value={customTo}
-                  onChange={(v) => setCustomTo(v)}
-                  ampm={false}
-                  slotProps={DATE_TIME_SLOT_PROPS}
-                />
-              </LocalizationProvider>
-              <Button
-                variant="contained"
-                size="small"
-                onClick={handleApplyAbsolute}
-                disabled={!customFrom || !customTo}
-                fullWidth
-                sx={{ fontSize: FONT_SIZE }}
-              >
-                {t('monitoring.applyTimeRange')}
-              </Button>
-            </Box>
-            <Divider orientation="vertical" flexItem />
-            <Box sx={{ width: 240, overflow: 'auto' }}>
-              <MenuList dense disablePadding>
-                {TIME_RANGES.map((item) => (
-                  <MenuItem
-                    key={item.labelKey}
-                    selected={item.labelKey === timeRangeLabel}
-                    onClick={() => handleQuickRange(item)}
-                    sx={{ fontSize: FONT_SIZE }}
-                  >
-                    {t(item.labelKey)}
+                {nodes.map((n) => (
+                  <MenuItem key={n} value={n} sx={{ fontSize: FONT_SIZE }}>
+                    {n}
                   </MenuItem>
                 ))}
-              </MenuList>
+              </Select>
+            </FormControl>
+          )}
+
+          {/* Search */}
+          <TextField
+            size="small"
+            placeholder={t('logs.searchPlaceholder')}
+            value={searchText}
+            onChange={handleSearchChange}
+            onKeyDown={handleSearchKeyDown}
+            sx={{
+              'width': 280,
+              '& .MuiInputBase-input': { fontSize: FONT_SIZE },
+            }}
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position="start">
+                  <SearchIcon fontSize="small" />
+                </InputAdornment>
+              ),
+            }}
+          />
+
+          <Box sx={{ flex: 1 }} />
+
+          {/* Time Range */}
+          <Button
+            size="small"
+            color="inherit"
+            startIcon={<AccessTime fontSize="small" />}
+            onClick={(e) => setTimeAnchor(e.currentTarget)}
+            sx={{ textTransform: 'none', fontSize: FONT_SIZE }}
+          >
+            {timeRangeLabel ? t(timeRangeLabel) : customDisplay}
+          </Button>
+          <Popover
+            anchorEl={timeAnchor}
+            open={Boolean(timeAnchor)}
+            onClose={() => setTimeAnchor(null)}
+            anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+            transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+          >
+            <Box sx={{ display: 'flex', width: 480, maxHeight: 400 }}>
+              <Box
+                sx={{
+                  width: 240,
+                  p: 2,
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: 1.5,
+                }}
+              >
+                <Typography
+                  variant="subtitle2"
+                  color="text.secondary"
+                  sx={{ fontSize: FONT_SIZE }}
+                >
+                  {t('monitoring.absoluteRange')}
+                </Typography>
+                <LocalizationProvider
+                  dateAdapter={AdapterDayjs}
+                  adapterLocale={dayjsLocale}
+                  localeText={
+                    PICKER_LOCALE_TEXT[(i18n.language || 'en').split('-')[0]] ||
+                    PICKER_LOCALE_TEXT.en
+                  }
+                >
+                  <DateTimePicker
+                    label={t('monitoring.from')}
+                    value={customFrom}
+                    onChange={(v) => setCustomFrom(v)}
+                    ampm={false}
+                    slotProps={DATE_TIME_SLOT_PROPS}
+                  />
+                  <DateTimePicker
+                    label={t('monitoring.to')}
+                    value={customTo}
+                    onChange={(v) => setCustomTo(v)}
+                    ampm={false}
+                    slotProps={DATE_TIME_SLOT_PROPS}
+                  />
+                </LocalizationProvider>
+                <Button
+                  variant="contained"
+                  size="small"
+                  onClick={handleApplyAbsolute}
+                  disabled={!customFrom || !customTo}
+                  fullWidth
+                  sx={{ fontSize: FONT_SIZE }}
+                >
+                  {t('monitoring.applyTimeRange')}
+                </Button>
+              </Box>
+              <Divider orientation="vertical" flexItem />
+              <Box sx={{ width: 240, overflow: 'auto' }}>
+                <MenuList dense disablePadding>
+                  {TIME_RANGES.map((item) => (
+                    <MenuItem
+                      key={item.labelKey}
+                      selected={item.labelKey === timeRangeLabel}
+                      onClick={() => handleQuickRange(item)}
+                      sx={{ fontSize: FONT_SIZE }}
+                    >
+                      {t(item.labelKey)}
+                    </MenuItem>
+                  ))}
+                </MenuList>
+              </Box>
             </Box>
+          </Popover>
+
+          {/* Refresh */}
+          <Tooltip title={t('logs.refresh')}>
+            <IconButton size="small" color="inherit" onClick={fetchLogs}>
+              <RefreshIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+
+          {/* Auto Refresh Interval */}
+          <Button
+            size="small"
+            color="inherit"
+            startIcon={<RefreshIcon fontSize="small" />}
+            onClick={(e) => setRefreshAnchor(e.currentTarget)}
+            sx={{ textTransform: 'none', fontSize: FONT_SIZE }}
+          >
+            {t(refreshLabel)}
+          </Button>
+          <Menu
+            anchorEl={refreshAnchor}
+            open={Boolean(refreshAnchor)}
+            onClose={() => setRefreshAnchor(null)}
+          >
+            {REFRESH_OPTIONS.map((item) => (
+              <MenuItem
+                key={item.labelKey}
+                selected={item.labelKey === refreshLabel}
+                onClick={() => {
+                  setRefreshInterval(item.value)
+                  setRefreshLabel(item.labelKey)
+                  setRefreshAnchor(null)
+                }}
+                sx={{ fontSize: FONT_SIZE }}
+              >
+                {t(item.labelKey)}
+              </MenuItem>
+            ))}
+          </Menu>
+        </Box>
+
+        {/* Row 2: Log Level */}
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1,
+            width: '100%',
+          }}
+        >
+          <Typography
+            variant="body2"
+            color="text.secondary"
+            sx={{ fontSize: FONT_SIZE, minWidth: 64 }}
+          >
+            {t('logs.logLevel')}
+          </Typography>
+          <Box sx={{ display: 'flex', gap: 0.5 }}>
+            {LEVELS.map((level) => (
+              <Chip
+                key={level}
+                label={level}
+                size="small"
+                variant={selectedLevels.includes(level) ? 'filled' : 'outlined'}
+                color={
+                  level === 'ERROR'
+                    ? 'error'
+                    : level === 'WARNING'
+                    ? 'warning'
+                    : 'default'
+                }
+                onClick={() => toggleLevel(level)}
+                sx={{ fontSize: FONT_SIZE }}
+              />
+            ))}
           </Box>
-        </Popover>
+        </Box>
 
-        {/* Refresh */}
-        <Tooltip title={t('logs.refresh')}>
-          <IconButton size="small" color="inherit" onClick={fetchLogs}>
-            <RefreshIcon fontSize="small" />
-          </IconButton>
-        </Tooltip>
-
-        {/* Auto Refresh Interval */}
-        <Button
-          size="small"
-          color="inherit"
-          startIcon={<RefreshIcon fontSize="small" />}
-          onClick={(e) => setRefreshAnchor(e.currentTarget)}
-          sx={{ textTransform: 'none', fontSize: FONT_SIZE }}
+        {/* Row 3: Node Type */}
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1,
+            width: '100%',
+          }}
         >
-          {t(refreshLabel)}
-        </Button>
-        <Menu
-          anchorEl={refreshAnchor}
-          open={Boolean(refreshAnchor)}
-          onClose={() => setRefreshAnchor(null)}
-        >
-          {REFRESH_OPTIONS.map((item) => (
-            <MenuItem
-              key={item.labelKey}
-              selected={item.labelKey === refreshLabel}
-              onClick={() => {
-                setRefreshInterval(item.value)
-                setRefreshLabel(item.labelKey)
-                setRefreshAnchor(null)
-              }}
-              sx={{ fontSize: FONT_SIZE }}
-            >
-              {t(item.labelKey)}
-            </MenuItem>
-          ))}
-        </Menu>
+          <Typography
+            variant="body2"
+            color="text.secondary"
+            sx={{ fontSize: FONT_SIZE, minWidth: 64 }}
+          >
+            {t('logs.nodeType')}
+          </Typography>
+          <Box sx={{ display: 'flex', gap: 0.5 }}>
+            {LOG_TYPES.map((lt) => (
+              <Chip
+                key={lt}
+                label={lt}
+                size="small"
+                variant={selectedLogType === lt ? 'filled' : 'outlined'}
+                onClick={() => {
+                  setSelectedLogType((prev) => (prev === lt ? '' : lt))
+                  setPageFrom(0)
+                }}
+                sx={{ fontSize: FONT_SIZE }}
+              />
+            ))}
+          </Box>
+        </Box>
       </Toolbar>
 
       {/* Active Field Filters */}


### PR DESCRIPTION
## Summary
- Add `GET /v1/cluster/logs/nodes` endpoint using ES `terms` aggregation to return the actual node list from log data (the previous `/v1/cluster/info` endpoint had no `node` field, causing the dropdown to always be hidden)
- Update frontend to fetch nodes from the new endpoint instead of `/v1/cluster/info`
- Redesign toolbar from single-row `flexWrap` into a 3-row layout: node select + search + time controls on row 1, log level chips with label on row 2, node type chips with label on row 3
- Add 2 i18n keys (`logLevel`, `nodeType`) for zh/en/ja/ko

## Test plan
- [ ] Configure `XINFERENCE_ES_URL`, start UI, navigate to Log Center
- [ ] Verify node dropdown appears and lists actual node values from logs
- [ ] Select a node and verify the log table filters correctly
- [ ] Verify toolbar layout matches 3-row structure (search row, level chips row, type chips row)
- [ ] Verify time range picker / refresh / auto-refresh still work as before
- [ ] Test without `XINFERENCE_ES_URL` — dropdown should not appear (graceful degradation)
- [ ] Switch UI language to en/ja/ko and verify chip labels are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)