### PR TITLE
fix(monitor): correct alert rule labels/expressions and add 4 new rules

### DIFF
--- a/monitor/alert/README.md
+++ b/monitor/alert/README.md
@@ -25,7 +25,7 @@ All files share the same alert expressions and thresholds — only `summary` and
 
 - **Severity**: warning
 - **Condition**: Model request error rate > 5% for 3 minutes
-- **Expression**: `rate(xinference:model_request_errors_total[5m]) / rate(xinference:model_request_total[5m]) > 0.05`
+- **Expression**: `sum without (stream) (rate(xinference:model_request_errors_total[5m])) / sum without (stream) (rate(xinference:model_request_total[5m])) > 0.05`
 
 ### TTFTHigh
 

--- a/monitor/alert/README.md
+++ b/monitor/alert/README.md
@@ -44,18 +44,43 @@ All files share the same alert expressions and thresholds — only `summary` and
 - **Severity**: critical
 - **Condition**: Disk available space < 10% for 5 minutes
 - **Expression**: `(node_filesystem_avail_bytes / node_filesystem_size_bytes) < 0.1`
+- **Note**: This rule depends on [node_exporter](https://github.com/prometheus/node_exporter) being deployed on all cluster nodes.
 
 ### RequestQueueBacklog
 
 - **Severity**: warning
-- **Condition**: Pending requests > 10 for 3 minutes
-- **Expression**: `xinference:model_pending_requests > 10`
+- **Condition**: Model concurrency ratio (active / limit) > 90% for 3 minutes
+- **Expression**: `xinference:model_serve_count / xinference:model_request_limit > 0.9`
 
 ### ModelLoadSlow
 
 - **Severity**: warning
 - **Condition**: Model load time > 5 minutes
 - **Expression**: `xinference:model_last_load_duration_seconds > 300`
+
+### ReplicaUnexpectedTerminated
+
+- **Severity**: critical
+- **Condition**: A replica is marked as unexpectedly terminated (worker failure) for 1 minute
+- **Expression**: `xinference:model_unexpected_termination == 1`
+
+### WorkerMemoryHigh
+
+- **Severity**: warning
+- **Condition**: Worker memory usage > 90% for 5 minutes
+- **Expression**: `xinference:worker_memory_used_bytes / xinference:worker_memory_total_bytes > 0.9`
+
+### RequestLatencyHigh
+
+- **Severity**: warning
+- **Condition**: P95 request latency > 60 seconds for 3 minutes
+- **Expression**: `histogram_quantile(0.95, rate(xinference:model_request_duration_seconds_bucket[5m])) > 60`
+
+### BannedIPsSpike
+
+- **Severity**: warning
+- **Condition**: Banned IP count > 10 for 2 minutes
+- **Expression**: `xinference:banned_ips_total > 10`
 
 ## Usage
 

--- a/monitor/alert/README.md
+++ b/monitor/alert/README.md
@@ -50,7 +50,7 @@ All files share the same alert expressions and thresholds — only `summary` and
 
 - **Severity**: warning
 - **Condition**: Model concurrency ratio (active / limit) > 90% for 3 minutes
-- **Expression**: `xinference:model_serve_count / xinference:model_request_limit > 0.9`
+- **Expression**: `xinference:model_serve_count / (xinference:model_request_limit > 0) > 0.9`
 
 ### ModelLoadSlow
 

--- a/monitor/alert/README_zh-CN.md
+++ b/monitor/alert/README_zh-CN.md
@@ -44,18 +44,43 @@
 - **级别**: critical（严重）
 - **条件**: 磁盘可用空间 < 10%，持续 5 分钟
 - **表达式**: `(node_filesystem_avail_bytes / node_filesystem_size_bytes) < 0.1`
+- **备注**: 此规则依赖在所有集群节点上部署 [node_exporter](https://github.com/prometheus/node_exporter)。
 
-### RequestQueueBacklog — 请求队列积压
+### RequestQueueBacklog — 请求并发接近上限
 
 - **级别**: warning（警告）
-- **条件**: 排队请求数 > 10，持续 3 分钟
-- **表达式**: `xinference:model_pending_requests > 10`
+- **条件**: 模型并发比率（活跃数 / 上限）> 90%，持续 3 分钟
+- **表达式**: `xinference:model_serve_count / xinference:model_request_limit > 0.9`
 
 ### ModelLoadSlow — 模型加载缓慢
 
 - **级别**: warning（警告）
 - **条件**: 模型加载耗时 > 5 分钟
 - **表达式**: `xinference:model_last_load_duration_seconds > 300`
+
+### ReplicaUnexpectedTerminated — 副本异常终止
+
+- **级别**: critical（严重）
+- **条件**: 副本因 Worker 故障被标记为异常下线，持续 1 分钟
+- **表达式**: `xinference:model_unexpected_termination == 1`
+
+### WorkerMemoryHigh — Worker 内存使用率过高
+
+- **级别**: warning（警告）
+- **条件**: Worker 内存使用率 > 90%，持续 5 分钟
+- **表达式**: `xinference:worker_memory_used_bytes / xinference:worker_memory_total_bytes > 0.9`
+
+### RequestLatencyHigh — 请求延迟过高
+
+- **级别**: warning（警告）
+- **条件**: P95 请求延迟 > 60 秒，持续 3 分钟
+- **表达式**: `histogram_quantile(0.95, rate(xinference:model_request_duration_seconds_bucket[5m])) > 60`
+
+### BannedIPsSpike — 封禁 IP 数量异常
+
+- **级别**: warning（警告）
+- **条件**: 封禁 IP 数 > 10，持续 2 分钟
+- **表达式**: `xinference:banned_ips_total > 10`
 
 ## 使用方法
 

--- a/monitor/alert/README_zh-CN.md
+++ b/monitor/alert/README_zh-CN.md
@@ -25,7 +25,7 @@
 
 - **级别**: warning（警告）
 - **条件**: 模型请求错误率 > 5%，持续 3 分钟
-- **表达式**: `rate(xinference:model_request_errors_total[5m]) / rate(xinference:model_request_total[5m]) > 0.05`
+- **表达式**: `sum without (stream) (rate(xinference:model_request_errors_total[5m])) / sum without (stream) (rate(xinference:model_request_total[5m])) > 0.05`
 
 ### TTFTHigh — 首 Token 延迟过高
 

--- a/monitor/alert/README_zh-CN.md
+++ b/monitor/alert/README_zh-CN.md
@@ -50,7 +50,7 @@
 
 - **级别**: warning（警告）
 - **条件**: 模型并发比率（活跃数 / 上限）> 90%，持续 3 分钟
-- **表达式**: `xinference:model_serve_count / xinference:model_request_limit > 0.9`
+- **表达式**: `xinference:model_serve_count / (xinference:model_request_limit > 0) > 0.9`
 
 ### ModelLoadSlow — 模型加载缓慢
 

--- a/monitor/alert/rules-ja.yml
+++ b/monitor/alert/rules-ja.yml
@@ -47,7 +47,7 @@ groups:
           description: "ノード {{ $labels.instance }} マウントポイント {{ $labels.mountpoint }} 残り容量 {{ $value | humanizePercentage }}。"
 
       - alert: RequestQueueBacklog
-        expr: xinference:model_serve_count / xinference:model_request_limit > 0.9
+        expr: xinference:model_serve_count / (xinference:model_request_limit > 0) > 0.9
         for: 3m
         labels:
           severity: warning

--- a/monitor/alert/rules-ja.yml
+++ b/monitor/alert/rules-ja.yml
@@ -11,7 +11,7 @@ groups:
           description: "Worker {{ $labels.worker_address }} GPU {{ $labels.gpu_index }} メモリ使用率 {{ $value | humanizePercentage }}、5 分間継続。"
 
       - alert: ModelRequestErrorRateHigh
-        expr: rate(xinference:model_request_errors_total[5m]) / rate(xinference:model_request_total[5m]) > 0.05
+        expr: sum without (stream) (rate(xinference:model_request_errors_total[5m])) / sum without (stream) (rate(xinference:model_request_total[5m])) > 0.05
         for: 3m
         labels:
           severity: warning

--- a/monitor/alert/rules-ja.yml
+++ b/monitor/alert/rules-ja.yml
@@ -17,7 +17,7 @@ groups:
           severity: warning
         annotations:
           summary: "モデルリクエストエラー率が 5% を超過"
-          description: "モデル {{ $labels.model }} エラー率 {{ $value | humanizePercentage }}、3 分間継続。"
+          description: "モデル {{ $labels.model_name }} エラー率 {{ $value | humanizePercentage }}、3 分間継続。"
 
       - alert: TTFTHigh
         expr: rate(xinference:time_to_first_token_seconds_sum[5m]) / rate(xinference:time_to_first_token_seconds_count[5m]) > 10
@@ -26,7 +26,7 @@ groups:
           severity: warning
         annotations:
           summary: "初回トークン遅延が 10 秒を超過"
-          description: "モデル {{ $labels.model }} TTFT {{ $value }}ms、3 分間継続。"
+          description: "モデル {{ $labels.model_name }} TTFT {{ $value }}s、3 分間継続。"
 
       - alert: WorkerOffline
         expr: xinference:workers_total < 1
@@ -47,13 +47,13 @@ groups:
           description: "ノード {{ $labels.instance }} マウントポイント {{ $labels.mountpoint }} 残り容量 {{ $value | humanizePercentage }}。"
 
       - alert: RequestQueueBacklog
-        expr: xinference:model_pending_requests > 10
+        expr: xinference:model_serve_count / xinference:model_request_limit > 0.9
         for: 3m
         labels:
           severity: warning
         annotations:
-          summary: "モデルリクエストキューが滞留"
-          description: "モデル {{ $labels.model }} 待機リクエスト数 {{ $value }}、3 分間継続。"
+          summary: "モデルリクエスト同時実行数が上限に接近"
+          description: "モデル {{ $labels.model_name }} 同時実行比率 {{ $value | humanizePercentage }}、3 分間継続。"
 
       - alert: ModelLoadSlow
         expr: xinference:model_last_load_duration_seconds > 300
@@ -62,4 +62,40 @@ groups:
           severity: warning
         annotations:
           summary: "モデルロード時間が 5 分を超過"
-          description: "モデル {{ $labels.model_name }} 直近の平均ロード時間 {{ $value | humanizeDuration }}。"
+          description: "モデル {{ $labels.model_name }} 直近のロード時間 {{ $value | humanizeDuration }}。"
+
+      - alert: ReplicaUnexpectedTerminated
+        expr: xinference:model_unexpected_termination == 1
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "モデルレプリカが予期せず終了"
+          description: "モデル {{ $labels.model_name }} レプリカ {{ $labels.replica_index }} が Worker 障害によりダウンしています。"
+
+      - alert: WorkerMemoryHigh
+        expr: xinference:worker_memory_used_bytes / xinference:worker_memory_total_bytes > 0.9
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Worker メモリ使用率が 90% を超過"
+          description: "Worker {{ $labels.worker_address }} メモリ使用率 {{ $value | humanizePercentage }}、5 分間継続。"
+
+      - alert: RequestLatencyHigh
+        expr: histogram_quantile(0.95, rate(xinference:model_request_duration_seconds_bucket[5m])) > 60
+        for: 3m
+        labels:
+          severity: warning
+        annotations:
+          summary: "P95 リクエスト遅延が 60 秒を超過"
+          description: "モデル {{ $labels.model_name }} P95 遅延 {{ $value }}s、3 分間継続。"
+
+      - alert: BannedIPsSpike
+        expr: xinference:banned_ips_total > 10
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: "BAN された IP 数が異常に多い"
+          description: "現在 {{ $value }} 件の IP が BAN されています。ブルートフォース攻撃や不正利用の可能性があります。"

--- a/monitor/alert/rules-ko.yml
+++ b/monitor/alert/rules-ko.yml
@@ -11,7 +11,7 @@ groups:
           description: "Worker {{ $labels.worker_address }} GPU {{ $labels.gpu_index }} 메모리 사용률 {{ $value | humanizePercentage }}, 5분간 지속."
 
       - alert: ModelRequestErrorRateHigh
-        expr: rate(xinference:model_request_errors_total[5m]) / rate(xinference:model_request_total[5m]) > 0.05
+        expr: sum without (stream) (rate(xinference:model_request_errors_total[5m])) / sum without (stream) (rate(xinference:model_request_total[5m])) > 0.05
         for: 3m
         labels:
           severity: warning

--- a/monitor/alert/rules-ko.yml
+++ b/monitor/alert/rules-ko.yml
@@ -47,7 +47,7 @@ groups:
           description: "노드 {{ $labels.instance }} 마운트 포인트 {{ $labels.mountpoint }} 잔여 공간 {{ $value | humanizePercentage }}."
 
       - alert: RequestQueueBacklog
-        expr: xinference:model_serve_count / xinference:model_request_limit > 0.9
+        expr: xinference:model_serve_count / (xinference:model_request_limit > 0) > 0.9
         for: 3m
         labels:
           severity: warning

--- a/monitor/alert/rules-ko.yml
+++ b/monitor/alert/rules-ko.yml
@@ -17,7 +17,7 @@ groups:
           severity: warning
         annotations:
           summary: "모델 요청 오류율 5% 초과"
-          description: "모델 {{ $labels.model }} 오류율 {{ $value | humanizePercentage }}, 3분간 지속."
+          description: "모델 {{ $labels.model_name }} 오류율 {{ $value | humanizePercentage }}, 3분간 지속."
 
       - alert: TTFTHigh
         expr: rate(xinference:time_to_first_token_seconds_sum[5m]) / rate(xinference:time_to_first_token_seconds_count[5m]) > 10
@@ -26,7 +26,7 @@ groups:
           severity: warning
         annotations:
           summary: "첫 토큰 지연 시간 10초 초과"
-          description: "모델 {{ $labels.model }} TTFT {{ $value }}ms, 3분간 지속."
+          description: "모델 {{ $labels.model_name }} TTFT {{ $value }}s, 3분간 지속."
 
       - alert: WorkerOffline
         expr: xinference:workers_total < 1
@@ -47,13 +47,13 @@ groups:
           description: "노드 {{ $labels.instance }} 마운트 포인트 {{ $labels.mountpoint }} 잔여 공간 {{ $value | humanizePercentage }}."
 
       - alert: RequestQueueBacklog
-        expr: xinference:model_pending_requests > 10
+        expr: xinference:model_serve_count / xinference:model_request_limit > 0.9
         for: 3m
         labels:
           severity: warning
         annotations:
-          summary: "모델 요청 대기열 적체"
-          description: "모델 {{ $labels.model }} 대기 요청 수 {{ $value }}, 3분간 지속."
+          summary: "모델 요청 동시 실행 수 한계 접근"
+          description: "모델 {{ $labels.model_name }} 동시 실행 비율 {{ $value | humanizePercentage }}, 3분간 지속."
 
       - alert: ModelLoadSlow
         expr: xinference:model_last_load_duration_seconds > 300
@@ -62,4 +62,40 @@ groups:
           severity: warning
         annotations:
           summary: "모델 로딩 시간 5분 초과"
-          description: "모델 {{ $labels.model_name }} 최근 평균 로딩 시간 {{ $value | humanizeDuration }}."
+          description: "모델 {{ $labels.model_name }} 최근 로딩 소요 시간 {{ $value | humanizeDuration }}."
+
+      - alert: ReplicaUnexpectedTerminated
+        expr: xinference:model_unexpected_termination == 1
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "모델 레플리카 예기치 않은 종료"
+          description: "모델 {{ $labels.model_name }} 레플리카 {{ $labels.replica_index }} 가 Worker 장애로 인해 다운되었습니다."
+
+      - alert: WorkerMemoryHigh
+        expr: xinference:worker_memory_used_bytes / xinference:worker_memory_total_bytes > 0.9
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Worker 메모리 사용률 90% 초과"
+          description: "Worker {{ $labels.worker_address }} 메모리 사용률 {{ $value | humanizePercentage }}, 5분간 지속."
+
+      - alert: RequestLatencyHigh
+        expr: histogram_quantile(0.95, rate(xinference:model_request_duration_seconds_bucket[5m])) > 60
+        for: 3m
+        labels:
+          severity: warning
+        annotations:
+          summary: "P95 요청 지연 시간 60초 초과"
+          description: "모델 {{ $labels.model_name }} P95 지연 시간 {{ $value }}s, 3분간 지속."
+
+      - alert: BannedIPsSpike
+        expr: xinference:banned_ips_total > 10
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: "차단 IP 수 이상 증가"
+          description: "현재 {{ $value }}개의 IP가 차단되었습니다. 무차별 공격 또는 오용 가능성이 있습니다."

--- a/monitor/alert/rules-zh-CN.yml
+++ b/monitor/alert/rules-zh-CN.yml
@@ -11,7 +11,7 @@ groups:
           description: "Worker {{ $labels.worker_address }} GPU {{ $labels.gpu_index }} 显存使用率 {{ $value | humanizePercentage }}，持续 5 分钟。"
 
       - alert: ModelRequestErrorRateHigh
-        expr: rate(xinference:model_request_errors_total[5m]) / rate(xinference:model_request_total[5m]) > 0.05
+        expr: sum without (stream) (rate(xinference:model_request_errors_total[5m])) / sum without (stream) (rate(xinference:model_request_total[5m])) > 0.05
         for: 3m
         labels:
           severity: warning

--- a/monitor/alert/rules-zh-CN.yml
+++ b/monitor/alert/rules-zh-CN.yml
@@ -17,7 +17,7 @@ groups:
           severity: warning
         annotations:
           summary: "模型请求错误率超过 5%"
-          description: "模型 {{ $labels.model }} 错误率 {{ $value | humanizePercentage }}，持续 3 分钟。"
+          description: "模型 {{ $labels.model_name }} 错误率 {{ $value | humanizePercentage }}，持续 3 分钟。"
 
       - alert: TTFTHigh
         expr: rate(xinference:time_to_first_token_seconds_sum[5m]) / rate(xinference:time_to_first_token_seconds_count[5m]) > 10
@@ -26,7 +26,7 @@ groups:
           severity: warning
         annotations:
           summary: "首 Token 延迟超过 10 秒"
-          description: "模型 {{ $labels.model }} TTFT {{ $value }}ms，持续 3 分钟。"
+          description: "模型 {{ $labels.model_name }} TTFT {{ $value }}s，持续 3 分钟。"
 
       - alert: WorkerOffline
         expr: xinference:workers_total < 1
@@ -47,13 +47,13 @@ groups:
           description: "节点 {{ $labels.instance }} 挂载点 {{ $labels.mountpoint }} 剩余空间 {{ $value | humanizePercentage }}。"
 
       - alert: RequestQueueBacklog
-        expr: xinference:model_pending_requests > 10
+        expr: xinference:model_serve_count / xinference:model_request_limit > 0.9
         for: 3m
         labels:
           severity: warning
         annotations:
-          summary: "模型请求队列积压"
-          description: "模型 {{ $labels.model }} 排队请求数 {{ $value }}，持续 3 分钟。"
+          summary: "模型请求并发接近上限"
+          description: "模型 {{ $labels.model_name }} 并发比率 {{ $value | humanizePercentage }}，持续 3 分钟。"
 
       - alert: ModelLoadSlow
         expr: xinference:model_last_load_duration_seconds > 300
@@ -62,4 +62,40 @@ groups:
           severity: warning
         annotations:
           summary: "模型加载耗时超过 5 分钟"
-          description: "模型 {{ $labels.model_name }} 最近加载平均耗时 {{ $value | humanizeDuration }}。"
+          description: "模型 {{ $labels.model_name }} 最近加载耗时 {{ $value | humanizeDuration }}。"
+
+      - alert: ReplicaUnexpectedTerminated
+        expr: xinference:model_unexpected_termination == 1
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "模型副本异常终止"
+          description: "模型 {{ $labels.model_name }} 副本 {{ $labels.replica_index }} 因 Worker 故障而下线。"
+
+      - alert: WorkerMemoryHigh
+        expr: xinference:worker_memory_used_bytes / xinference:worker_memory_total_bytes > 0.9
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Worker 内存使用率超过 90%"
+          description: "Worker {{ $labels.worker_address }} 内存使用率 {{ $value | humanizePercentage }}，持续 5 分钟。"
+
+      - alert: RequestLatencyHigh
+        expr: histogram_quantile(0.95, rate(xinference:model_request_duration_seconds_bucket[5m])) > 60
+        for: 3m
+        labels:
+          severity: warning
+        annotations:
+          summary: "P95 请求延迟超过 60 秒"
+          description: "模型 {{ $labels.model_name }} P95 延迟 {{ $value }}s，持续 3 分钟。"
+
+      - alert: BannedIPsSpike
+        expr: xinference:banned_ips_total > 10
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: "封禁 IP 数量异常偏高"
+          description: "当前封禁 IP 数 {{ $value }}，可能存在暴力攻击或滥用行为。"

--- a/monitor/alert/rules-zh-CN.yml
+++ b/monitor/alert/rules-zh-CN.yml
@@ -47,7 +47,7 @@ groups:
           description: "节点 {{ $labels.instance }} 挂载点 {{ $labels.mountpoint }} 剩余空间 {{ $value | humanizePercentage }}。"
 
       - alert: RequestQueueBacklog
-        expr: xinference:model_serve_count / xinference:model_request_limit > 0.9
+        expr: xinference:model_serve_count / (xinference:model_request_limit > 0) > 0.9
         for: 3m
         labels:
           severity: warning

--- a/monitor/alert/rules.yml
+++ b/monitor/alert/rules.yml
@@ -47,7 +47,7 @@ groups:
           description: "Node {{ $labels.instance }} mountpoint {{ $labels.mountpoint }} remaining space {{ $value | humanizePercentage }}."
 
       - alert: RequestQueueBacklog
-        expr: xinference:model_serve_count / xinference:model_request_limit > 0.9
+        expr: xinference:model_serve_count / (xinference:model_request_limit > 0) > 0.9
         for: 3m
         labels:
           severity: warning

--- a/monitor/alert/rules.yml
+++ b/monitor/alert/rules.yml
@@ -11,7 +11,7 @@ groups:
           description: "Worker {{ $labels.worker_address }} GPU {{ $labels.gpu_index }} memory usage {{ $value | humanizePercentage }}, lasting 5 minutes."
 
       - alert: ModelRequestErrorRateHigh
-        expr: rate(xinference:model_request_errors_total[5m]) / rate(xinference:model_request_total[5m]) > 0.05
+        expr: sum without (stream) (rate(xinference:model_request_errors_total[5m])) / sum without (stream) (rate(xinference:model_request_total[5m])) > 0.05
         for: 3m
         labels:
           severity: warning

--- a/monitor/alert/rules.yml
+++ b/monitor/alert/rules.yml
@@ -17,7 +17,7 @@ groups:
           severity: warning
         annotations:
           summary: "Model request error rate exceeds 5%"
-          description: "Model {{ $labels.model }} error rate {{ $value | humanizePercentage }}, lasting 3 minutes."
+          description: "Model {{ $labels.model_name }} error rate {{ $value | humanizePercentage }}, lasting 3 minutes."
 
       - alert: TTFTHigh
         expr: rate(xinference:time_to_first_token_seconds_sum[5m]) / rate(xinference:time_to_first_token_seconds_count[5m]) > 10
@@ -26,7 +26,7 @@ groups:
           severity: warning
         annotations:
           summary: "Time to first token exceeds 10 seconds"
-          description: "Model {{ $labels.model }} TTFT {{ $value }}ms, lasting 3 minutes."
+          description: "Model {{ $labels.model_name }} TTFT {{ $value }}s, lasting 3 minutes."
 
       - alert: WorkerOffline
         expr: xinference:workers_total < 1
@@ -47,13 +47,13 @@ groups:
           description: "Node {{ $labels.instance }} mountpoint {{ $labels.mountpoint }} remaining space {{ $value | humanizePercentage }}."
 
       - alert: RequestQueueBacklog
-        expr: xinference:model_pending_requests > 10
+        expr: xinference:model_serve_count / xinference:model_request_limit > 0.9
         for: 3m
         labels:
           severity: warning
         annotations:
-          summary: "Model request queue backlog"
-          description: "Model {{ $labels.model }} pending requests {{ $value }}, lasting 3 minutes."
+          summary: "Model request concurrency approaching limit"
+          description: "Model {{ $labels.model_name }} concurrency ratio {{ $value | humanizePercentage }}, lasting 3 minutes."
 
       - alert: ModelLoadSlow
         expr: xinference:model_last_load_duration_seconds > 300
@@ -62,4 +62,40 @@ groups:
           severity: warning
         annotations:
           summary: "Model load time exceeds 5 minutes"
-          description: "Model {{ $labels.model_name }} recent average load time {{ $value | humanizeDuration }}."
+          description: "Model {{ $labels.model_name }} recent load duration {{ $value | humanizeDuration }}."
+
+      - alert: ReplicaUnexpectedTerminated
+        expr: xinference:model_unexpected_termination == 1
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Model replica terminated unexpectedly"
+          description: "Model {{ $labels.model_name }} replica {{ $labels.replica_index }} is down due to worker failure."
+
+      - alert: WorkerMemoryHigh
+        expr: xinference:worker_memory_used_bytes / xinference:worker_memory_total_bytes > 0.9
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Worker memory usage exceeds 90%"
+          description: "Worker {{ $labels.worker_address }} memory usage {{ $value | humanizePercentage }}, lasting 5 minutes."
+
+      - alert: RequestLatencyHigh
+        expr: histogram_quantile(0.95, rate(xinference:model_request_duration_seconds_bucket[5m])) > 60
+        for: 3m
+        labels:
+          severity: warning
+        annotations:
+          summary: "P95 request latency exceeds 60 seconds"
+          description: "Model {{ $labels.model_name }} P95 latency {{ $value }}s, lasting 3 minutes."
+
+      - alert: BannedIPsSpike
+        expr: xinference:banned_ips_total > 10
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Banned IP count abnormally high"
+          description: "Currently {{ $value }} IPs banned, possible brute-force or abuse."


### PR DESCRIPTION
## Summary
- Fix `$labels.model` → `$labels.model_name` in HighModelErrorRate and TTFTHigh annotations across all 4 locale rule files (`metrics.py` uses `model_name` as the label key)
- Fix TTFT description unit from `ms` to `s` (metric is `time_to_first_token_seconds`)
- Replace RequestQueueBacklog expression: `model_pending_requests` does not exist in `metrics.py`; changed to `model_serve_count / model_request_limit > 0.9` (both gauges exist)
- Fix ModelLoadSlow description: remove "average" (metric is `model_last_load_duration_seconds`, not an average)
- Add 4 new alert rules, all referencing metrics that exist in `xinference/core/metrics.py`:
  - **ReplicaUnexpectedTerminated** (critical): `model_unexpected_termination == 1`
  - **WorkerMemoryHigh** (warning): `worker_memory_used_bytes / worker_memory_total_bytes > 0.9`
  - **RequestLatencyHigh** (warning): `histogram_quantile(0.95, rate(model_request_duration_seconds_bucket[5m])) > 60`
  - **BannedIPsSpike** (warning): `banned_ips_total > 10`
- Update README.md and README_zh-CN.md with node_exporter dependency note and docs for all new rules

## Test plan
- [ ] Verify `promtool check rules monitor/alert/rules.yml` passes
- [ ] Deploy rules to a Prometheus instance with Xinference metrics and confirm:
  - [ ] HighModelErrorRate/TTFTHigh fire with correct `model_name` label in alert description
  - [ ] RequestQueueBacklog fires when concurrency ratio exceeds 90%
  - [ ] New rules (ReplicaUnexpectedTerminated, WorkerMemoryHigh, RequestLatencyHigh, BannedIPsSpike) evaluate without "no metric" errors
- [ ] Check ja/ko/zh-CN locale rule files have identical structure and expressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)