### PR TITLE
feat: add jina-embeddings-v5 series support

### DIFF
--- a/xinference/model/embedding/model_spec.json
+++ b/xinference/model/embedding/model_spec.json
@@ -1550,6 +1550,176 @@
   },
   {
     "version": 2,
+    "model_name": "jina-embeddings-v5-text-nano",
+    "dimensions": 768,
+    "max_tokens": 8192,
+    "language": [
+      "multilingual"
+    ],
+    "model_specs": [
+      {
+        "model_format": "pytorch",
+        "model_src": {
+          "huggingface": {
+            "model_id": "jinaai/jina-embeddings-v5-text-nano",
+            "quantizations": [
+              "none"
+            ]
+          },
+          "modelscope": {
+            "model_id": "jinaai/jina-embeddings-v5-text-nano",
+            "quantizations": [
+              "none"
+            ]
+          }
+        }
+      }
+    ],
+    "virtualenv": {
+      "packages": [
+        "sentence_transformers",
+        "einops",
+        "peft>=0.15.2",
+        "accelerate>=0.28.0",
+        "#system_torchvision# ; #engine# == \"sentence_transformers\"",
+        "#system_torch# ; #engine# == \"sentence_transformers\"",
+        "transformers>=4.57.0"
+      ]
+    },
+    "updated_at": 1781165260,
+    "featured": true
+  },
+  {
+    "version": 2,
+    "model_name": "jina-embeddings-v5-text-small",
+    "dimensions": 1024,
+    "max_tokens": 32768,
+    "language": [
+      "multilingual"
+    ],
+    "model_specs": [
+      {
+        "model_format": "pytorch",
+        "model_src": {
+          "huggingface": {
+            "model_id": "jinaai/jina-embeddings-v5-text-small",
+            "quantizations": [
+              "none"
+            ]
+          },
+          "modelscope": {
+            "model_id": "jinaai/jina-embeddings-v5-text-small",
+            "quantizations": [
+              "none"
+            ]
+          }
+        }
+      }
+    ],
+    "virtualenv": {
+      "packages": [
+        "sentence_transformers",
+        "einops",
+        "peft>=0.15.2",
+        "accelerate>=0.28.0",
+        "#system_torchvision# ; #engine# == \"sentence_transformers\"",
+        "#system_torch# ; #engine# == \"sentence_transformers\"",
+        "transformers>=4.57.0"
+      ]
+    },
+    "updated_at": 1781165260,
+    "featured": true
+  },
+  {
+    "version": 2,
+    "model_name": "jina-embeddings-v5-omni-nano",
+    "dimensions": 768,
+    "max_tokens": 8192,
+    "language": [
+      "multilingual"
+    ],
+    "model_specs": [
+      {
+        "model_format": "pytorch",
+        "model_src": {
+          "huggingface": {
+            "model_id": "jinaai/jina-embeddings-v5-omni-nano",
+            "quantizations": [
+              "none"
+            ]
+          },
+          "modelscope": {
+            "model_id": "jinaai/jina-embeddings-v5-omni-nano",
+            "quantizations": [
+              "none"
+            ]
+          }
+        }
+      }
+    ],
+    "virtualenv": {
+      "packages": [
+        "sentence_transformers",
+        "einops",
+        "peft>=0.15.2",
+        "accelerate>=0.28.0",
+        "pillow",
+        "librosa",
+        "soundfile",
+        "#system_torchvision# ; #engine# == \"sentence_transformers\"",
+        "#system_torch# ; #engine# == \"sentence_transformers\"",
+        "transformers>=5.0.0"
+      ]
+    },
+    "updated_at": 1781165260,
+    "featured": false
+  },
+  {
+    "version": 2,
+    "model_name": "jina-embeddings-v5-omni-small",
+    "dimensions": 1024,
+    "max_tokens": 32768,
+    "language": [
+      "multilingual"
+    ],
+    "model_specs": [
+      {
+        "model_format": "pytorch",
+        "model_src": {
+          "huggingface": {
+            "model_id": "jinaai/jina-embeddings-v5-omni-small",
+            "quantizations": [
+              "none"
+            ]
+          },
+          "modelscope": {
+            "model_id": "jinaai/jina-embeddings-v5-omni-small",
+            "quantizations": [
+              "none"
+            ]
+          }
+        }
+      }
+    ],
+    "virtualenv": {
+      "packages": [
+        "sentence_transformers",
+        "einops",
+        "peft>=0.15.2",
+        "accelerate>=0.28.0",
+        "pillow",
+        "librosa",
+        "soundfile",
+        "#system_torchvision# ; #engine# == \"sentence_transformers\"",
+        "#system_torch# ; #engine# == \"sentence_transformers\"",
+        "transformers>=5.1.0"
+      ]
+    },
+    "updated_at": 1781165260,
+    "featured": false
+  },
+  {
+    "version": 2,
     "model_name": "gme-Qwen2-VL-2B-Instruct",
     "dimensions": 1536,
     "max_tokens": 32768,

--- a/xinference/model/embedding/sentence_transformers/core.py
+++ b/xinference/model/embedding/sentence_transformers/core.py
@@ -52,6 +52,23 @@ JINA_V4_VALID_TASKS = {
     "document",
 }
 
+# jina-embeddings-v5 (text-* and omni-*): custom encode() consumes ``task`` directly.
+# Valid tasks come from the v5 model cards on HuggingFace.
+JINA_V5_VALID_TASKS = {
+    "retrieval",
+    "text-matching",
+    "classification",
+    "clustering",
+}
+# v5 retrieval additionally uses ``prompt_name`` to distinguish query vs document.
+JINA_V5_PROMPT_NAME_ALIASES = {
+    "query": "query",
+    "document": "document",
+    "passage": "document",
+    "retrieval.query": "query",
+    "retrieval.passage": "document",
+}
+
 
 def _resolve_jina_task(
     model_name: str, task: Optional[str]
@@ -62,11 +79,18 @@ def _resolve_jina_task(
         (prompt_name, task_passthrough)
         - v3: (prompt_name, None) — uses prompt_name to look up prompt template
         - v4: (None, task) — passes task directly to model.forward()
+        - v5: (prompt_name_or_None, task) — passes task directly to model.encode();
+              v5 models reject a missing task, so default to ``retrieval`` when the
+              caller does not pass one (OpenAI-compatible clients usually omit it)
         - other models: (None, None)
     """
-    if task is None:
-        return None, None
     model_lower = model_name.lower()
+    if task is None:
+        # v5 mandates a task on every call. Fall back to ``retrieval`` so OpenAI-
+        # style clients that have no notion of a task parameter still work.
+        if "jina-embeddings-v5" in model_lower:
+            return None, "retrieval"
+        return None, None
     if "jina-embeddings-v3" in model_lower:
         prompt_name = JINA_V3_TASK_TO_PROMPT_NAME.get(task)
         if prompt_name is None:
@@ -78,6 +102,20 @@ def _resolve_jina_task(
     elif "jina-embeddings-v4" in model_lower:
         if task not in JINA_V4_VALID_TASKS:
             valid = sorted(JINA_V4_VALID_TASKS)
+            raise ValueError(
+                f"Invalid task: {task}. Must be one of {valid} for model {model_name}."
+            )
+        return None, task
+    elif "jina-embeddings-v5" in model_lower:
+        # ``task`` may carry either a v5 task name or a retrieval-side alias
+        # (e.g. ``query`` / ``document``). Aliases imply ``task=retrieval``.
+        prompt_name = JINA_V5_PROMPT_NAME_ALIASES.get(task)
+        if prompt_name is not None:
+            return prompt_name, "retrieval"
+        if task not in JINA_V5_VALID_TASKS:
+            valid = sorted(
+                JINA_V5_VALID_TASKS | set(JINA_V5_PROMPT_NAME_ALIASES.keys())
+            )
             raise ValueError(
                 f"Invalid task: {task}. Must be one of {valid} for model {model_name}."
             )
@@ -218,12 +256,23 @@ class SentenceTransformerEmbeddingModel(EmbeddingModel, BatchMixin):
             )
         else:
             model_kwargs = {"torch_dtype": torch_dtype} if torch_dtype else None
+            # jina-embeddings-v5-omni: the model card recommends loading via
+            # ``model_kwargs={"default_task": "retrieval"}`` so that the task
+            # adapter is selected up-front and ``encode()`` works for image /
+            # video / audio inputs (which cannot carry a ``task`` keyword).
+            st_kwargs: Dict[str, Any] = {}
+            if "jina-embeddings-v5-omni" in self.model_family.model_name.lower():
+                st_kwargs["model_kwargs"] = {"default_task": "retrieval"}
+                if model_kwargs:
+                    st_kwargs["model_kwargs"].update(model_kwargs)
+            else:
+                st_kwargs["model_kwargs"] = model_kwargs
             self._model = SentenceTransformer(
                 self._model_path,
                 device=self._device,
-                model_kwargs=model_kwargs,
                 trust_remote_code=True,
                 truncate_dim=dimensions,
+                **st_kwargs,
             )
 
         if hasattr(self._model, "tokenizer"):
@@ -505,6 +554,108 @@ class SentenceTransformerEmbeddingModel(EmbeddingModel, BatchMixin):
                 objs,
                 **encode_kwargs,
             )
+        elif "jina-embeddings-v5-omni" in self.model_family.model_name.lower():
+            # jina-embeddings-v5-omni accepts text, image, video and audio.
+            # Per the model card, the SentenceTransformer wrapper auto-detects
+            # the modality of each sentence: URLs / file paths / PIL.Image /
+            # bytes / np.ndarray / torch.Tensor are routed to the matching
+            # tower. We additionally accept dict inputs of the form
+            # ``{"text": ...}`` / ``{"image": url_or_b64}`` /
+            # ``{"video": url_or_path}`` / ``{"audio": url_or_path}`` so the
+            # OpenAI-compatible HTTP API can express multimodal payloads.
+            #
+            # NOTE: we cannot reuse the local ``encode`` helper because it
+            # calls ``model.tokenize`` -> ``model.forward`` and assumes text
+            # input. Multimodal routing only happens inside
+            # ``SentenceTransformer.encode``.
+            import base64
+            import re
+            from io import BytesIO
+
+            from PIL import Image
+
+            def _b64_to_image(b64: str) -> Image.Image:
+                payload = b64.split(",", 1)[1] if "," in b64 else b64
+                return Image.open(BytesIO(base64.b64decode(payload)))
+
+            def _coerce_omni_item(item: Any) -> Any:
+                if isinstance(item, dict):
+                    if item.get("text") is not None:
+                        return item["text"]
+                    img = item.get("image")
+                    if img is not None:
+                        if isinstance(img, str) and re.match(
+                            r"^data:image/.+;base64,", img
+                        ):
+                            return _b64_to_image(img)
+                        return img
+                    video = item.get("video")
+                    if video is not None:
+                        return video
+                    audio = item.get("audio")
+                    if audio is not None:
+                        return audio
+                    raise ValueError(
+                        "jina-embeddings-v5-omni input dict must contain one "
+                        "of: text, image, video, audio."
+                    )
+                return item
+
+            # Treat str and dict as single-item inputs; only true sequences
+            # should be iterated. ``isinstance(sentences, dict)`` is critical:
+            # without it, iterating a dict yields its keys (e.g. "image"),
+            # which silently embeds the key name instead of the payload.
+            if isinstance(sentences, (str, dict)):
+                objs = [_coerce_omni_item(cast(Any, sentences))]
+                input_was_single = True
+            else:
+                objs = [_coerce_omni_item(it) for it in cast(List[Any], sentences)]
+                input_was_single = False
+
+            omni_kwargs = dict(kwargs)
+            omni_kwargs.pop("convert_to_numpy", None)
+            # OpenAI's embedding API uses ``dimensions`` to request Matryoshka
+            # truncation; v5-omni's encode() expects ``truncate_dim``.
+            if "dimensions" in omni_kwargs and "truncate_dim" not in omni_kwargs:
+                omni_kwargs["truncate_dim"] = omni_kwargs.pop("dimensions")
+            else:
+                omni_kwargs.pop("dimensions", None)
+            if jina_prompt_name is not None:
+                omni_kwargs["prompt_name"] = jina_prompt_name
+
+            assert self._model is not None
+            with torch.no_grad():
+                omni_out = self._model.encode(
+                    objs,
+                    convert_to_numpy=True,
+                    **omni_kwargs,
+                )
+
+            # ``encode`` on a single-item list returns either a 2-D ndarray of
+            # shape (1, dim) or a 1-D ndarray of shape (dim,). The downstream
+            # code below iterates ``all_embeddings`` and calls ``.tolist()`` on
+            # each item, expecting a flat 1-D vector per input. Normalise both
+            # shapes accordingly so the response stays ``[float, ...]`` rather
+            # than the accidentally-nested ``[[float, ...]]``.
+            if input_was_single:
+                if hasattr(omni_out, "ndim") and getattr(omni_out, "ndim", 0) > 1:
+                    all_embeddings = [omni_out[0]]
+                else:
+                    all_embeddings = [omni_out]
+            elif hasattr(omni_out, "ndim") and getattr(omni_out, "ndim", 0) == 1:
+                all_embeddings = [omni_out]
+            else:
+                all_embeddings = list(omni_out)
+            # The shared tail below re-wraps ``all_embeddings`` when
+            # ``sentences`` is a ``str``. We have already normalised the omni
+            # output into ``[ndarray]``; promote ``sentences`` to a list so the
+            # tail does not double-wrap it into ``[[ndarray]]`` and break the
+            # subsequent ``data.tolist()`` call.
+            if isinstance(sentences, (str, dict)):
+                sentences = [sentences]
+            # token accounting for multimodal inputs is not meaningful; report
+            # the input item count so usage stays non-zero.
+            all_token_nums = len(objs)
         else:
             encode_kwargs = _build_encode_kwargs(kwargs, jina_prompt_name)
             all_embeddings, all_token_nums = encode(

--- a/xinference/model/embedding/sentence_transformers/tests/test_jina_task_mapping.py
+++ b/xinference/model/embedding/sentence_transformers/tests/test_jina_task_mapping.py
@@ -13,16 +13,24 @@
 # limitations under the License.
 
 """
-Tests for Jina embeddings v3/v4 task parameter mapping.
+Tests for Jina embeddings v3/v4/v5 task parameter mapping.
 
 Verifies that the Jina-style ``task`` parameter is correctly resolved:
 - v3: maps to SentenceTransformer ``prompt_name`` (dot-notation keys)
 - v4: passes task through to ``model.forward()``
+- v5: passes task through to ``model.encode()`` and additionally maps
+      query/document aliases to v5 ``prompt_name``
 """
 
 import pytest
 
-from ..core import JINA_V3_TASK_TO_PROMPT_NAME, JINA_V4_VALID_TASKS, _resolve_jina_task
+from ..core import (
+    JINA_V3_TASK_TO_PROMPT_NAME,
+    JINA_V4_VALID_TASKS,
+    JINA_V5_PROMPT_NAME_ALIASES,
+    JINA_V5_VALID_TASKS,
+    _resolve_jina_task,
+)
 
 # ---------------------------------------------------------------------------
 # _resolve_jina_task unit tests
@@ -173,3 +181,93 @@ class TestJinaMappingTables:
     def test_v3_dotted_tasks_map_to_themselves(self):
         for task in ("retrieval.passage", "retrieval.query"):
             assert JINA_V3_TASK_TO_PROMPT_NAME[task] == task
+
+    def test_v5_valid_tasks(self):
+        assert JINA_V5_VALID_TASKS == {
+            "retrieval",
+            "text-matching",
+            "classification",
+            "clustering",
+        }
+
+    def test_v5_alias_keys(self):
+        assert set(JINA_V5_PROMPT_NAME_ALIASES.keys()) == {
+            "query",
+            "document",
+            "passage",
+            "retrieval.query",
+            "retrieval.passage",
+        }
+
+
+class TestResolveJinaTaskV5:
+    """Tests for v5: returns (prompt_name_or_None, task)."""
+
+    @pytest.mark.parametrize(
+        "model_name",
+        [
+            "jina-embeddings-v5-text-nano",
+            "jina-embeddings-v5-text-small",
+            "jina-embeddings-v5-omni-nano",
+            "jina-embeddings-v5-omni-small",
+        ],
+    )
+    def test_retrieval_passthrough(self, model_name):
+        prompt_name, task = _resolve_jina_task(model_name, "retrieval")
+        assert prompt_name is None
+        assert task == "retrieval"
+
+    @pytest.mark.parametrize(
+        "task_name",
+        ["text-matching", "classification", "clustering"],
+    )
+    def test_non_retrieval_tasks_passthrough(self, task_name):
+        prompt_name, task = _resolve_jina_task(
+            "jina-embeddings-v5-text-small", task_name
+        )
+        assert prompt_name is None
+        assert task == task_name
+
+    def test_query_alias_maps_to_retrieval(self):
+        prompt_name, task = _resolve_jina_task("jina-embeddings-v5-text-small", "query")
+        assert prompt_name == "query"
+        assert task == "retrieval"
+
+    def test_document_alias_maps_to_retrieval(self):
+        prompt_name, task = _resolve_jina_task(
+            "jina-embeddings-v5-text-small", "document"
+        )
+        assert prompt_name == "document"
+        assert task == "retrieval"
+
+    def test_passage_alias_maps_to_document(self):
+        prompt_name, task = _resolve_jina_task(
+            "jina-embeddings-v5-text-small", "passage"
+        )
+        assert prompt_name == "document"
+        assert task == "retrieval"
+
+    def test_retrieval_dot_query_alias(self):
+        prompt_name, task = _resolve_jina_task(
+            "jina-embeddings-v5-omni-small", "retrieval.query"
+        )
+        assert prompt_name == "query"
+        assert task == "retrieval"
+
+    def test_retrieval_dot_passage_alias(self):
+        prompt_name, task = _resolve_jina_task(
+            "jina-embeddings-v5-omni-small", "retrieval.passage"
+        )
+        assert prompt_name == "document"
+        assert task == "retrieval"
+
+    def test_invalid_task_raises(self):
+        with pytest.raises(ValueError, match="Invalid task"):
+            _resolve_jina_task("jina-embeddings-v5-text-nano", "nonexistent")
+
+    def test_none_task_defaults_to_retrieval(self):
+        # v5 mandates a task; missing task should default to ``retrieval`` so
+        # OpenAI-compatible clients (that have no notion of a task) still work.
+        prompt_name, task = _resolve_jina_task("jina-embeddings-v5-omni-nano", None)
+        assert prompt_name is None
+        assert task == "retrieval"

--- a/xinference/model/embedding/sentence_transformers/tests/test_jina_v5_omni_shapes.py
+++ b/xinference/model/embedding/sentence_transformers/tests/test_jina_v5_omni_shapes.py
@@ -1,0 +1,94 @@
+# Copyright 2022-2026 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for jina-embeddings-v5-omni input/output shape handling.
+
+These tests exercise the dict/str dispatch path and the tail re-wrap
+interaction without spinning up a real SentenceTransformer model.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+
+@pytest.fixture
+def omni_model():
+    """Build a minimal SentenceTransformerEmbeddingModel-like object.
+
+    Only the bits exercised by ``_create_embedding`` are populated; everything
+    else stays as ``MagicMock`` so unrelated attribute access does not blow up.
+    """
+    from ..core import SentenceTransformerEmbeddingModel
+
+    inst = SentenceTransformerEmbeddingModel.__new__(SentenceTransformerEmbeddingModel)
+    inst.model_family = SimpleNamespace(model_name="jina-embeddings-v5-omni-nano")
+    inst._model_name = "jina-embeddings-v5-omni-nano"
+    inst._model_uid = "uid"
+    inst._embedder = None
+    inst._kwargs = {}
+    # mock the underlying SentenceTransformer.encode
+    inst._model = MagicMock()
+    # default behavior: return (1, 4) ndarray to simulate single-item batch
+    inst._model.encode = MagicMock(
+        side_effect=lambda objs, **kw: np.ones((len(objs), 4), dtype=np.float32)
+    )
+    inst._fix_langchain_openai_inputs = lambda x: x
+    inst._clean_cache_if_needed = lambda *a, **kw: None
+    inst._text_length = lambda s: 1
+    return inst
+
+
+class TestOmniSingleString:
+    """Single ``str`` input must produce a flat 1-D vector, not nested."""
+
+    def test_single_string_returns_flat_vector(self, omni_model):
+        out = omni_model._create_embedding("hello")
+        assert len(out["data"]) == 1
+        emb = out["data"][0]["embedding"]
+        assert isinstance(emb, list)
+        # must be flat list of floats, not nested
+        assert all(isinstance(v, float) for v in emb)
+        assert len(emb) == 4
+
+
+class TestOmniSingleDict:
+    """Single ``dict`` input (e.g. {"image": "..."}) must not iterate keys."""
+
+    def test_single_image_dict_returns_flat_vector(self, omni_model):
+        out = omni_model._create_embedding({"image": "/tmp/x.jpg"})
+        assert len(out["data"]) == 1
+        emb = out["data"][0]["embedding"]
+        assert all(isinstance(v, float) for v in emb)
+        # the underlying encode received the URL, not the dict key
+        called_with = omni_model._model.encode.call_args.args[0]
+        assert called_with == ["/tmp/x.jpg"]
+
+
+class TestOmniList:
+    """List inputs preserve cardinality and ordering."""
+
+    def test_list_of_strings(self, omni_model):
+        out = omni_model._create_embedding(["a", "b", "c"])
+        assert len(out["data"]) == 3
+        for d in out["data"]:
+            assert all(isinstance(v, float) for v in d["embedding"])
+
+    def test_mixed_list_text_and_image_dict(self, omni_model):
+        out = omni_model._create_embedding([{"text": "hello"}, {"image": "/tmp/y.jpg"}])
+        assert len(out["data"]) == 2
+        called_with = omni_model._model.encode.call_args.args[0]
+        assert called_with == ["hello", "/tmp/y.jpg"]


### PR DESCRIPTION
Register the four jina-embeddings-v5 models in model_spec.json:

- jina-embeddings-v5-text-nano   (768 dim,  8192 tokens)
- jina-embeddings-v5-text-small  (1024 dim, 32768 tokens)
- jina-embeddings-v5-omni-nano   (768 dim,  8192 tokens, multimodal)
- jina-embeddings-v5-omni-small  (1024 dim, 32768 tokens, multimodal)

Extend the sentence-transformers backend so v5 works end-to-end:

* _resolve_jina_task handles v5's task parameter (retrieval / text-matching / classification / clustering), maps query/document aliases to v5 prompt_name for the retrieval task, and defaults to retrieval when no task is supplied (OpenAI-compatible clients omit it). Unit tests cover all v5 task and alias variants.

* v5-omni models are loaded with model_kwargs={"default_task": "retrieval"} per the model card, and route through SentenceTransformer.encode (instead of the local tokenize+forward helper) so image / video / audio inputs are dispatched to the matching tower.

* The HTTP embedding API accepts dict inputs of the form {"text" | "image" | "video" | "audio": url_or_b64_or_path} for omni models, mirroring jina-clip-v2 / jina-embeddings-v4 multimodal conventions, and translates OpenAI's `dimensions` request into v5-omni's `truncate_dim` for Matryoshka truncation.