### PR TITLE
feat: add Tencent Hy-MT2 series support

### DIFF
--- a/xinference/model/llm/llm_family.json
+++ b/xinference/model/llm/llm_family.json
@@ -32250,5 +32250,287 @@
     "tool_parser": "deepseek-v4",
     "featured": false,
     "updated_at": 1779522876
+  },
+  {
+    "version": 2,
+    "context_length": 262144,
+    "model_name": "Hy-MT2-1.8B",
+    "model_lang": [
+      "en",
+      "zh"
+    ],
+    "model_ability": [
+      "chat"
+    ],
+    "model_description": "Hy-MT2-1.8B is a dense multilingual translation model from Tencent Hunyuan, supporting 33 languages with instruction-following capabilities for complex translation scenarios.",
+    "model_specs": [
+      {
+        "model_format": "pytorch",
+        "model_size_in_billions": 2,
+        "model_src": {
+          "huggingface": {
+            "quantizations": [
+              "none"
+            ],
+            "model_id": "tencent/Hy-MT2-1.8B",
+            "model_revision": "main"
+          },
+          "modelscope": {
+            "quantizations": [
+              "none"
+            ],
+            "model_id": "Tencent-Hunyuan/Hy-MT2-1.8B",
+            "model_revision": "master"
+          }
+        }
+      },
+      {
+        "model_format": "pytorch",
+        "model_size_in_billions": 2,
+        "quantizations": [
+          "fp8"
+        ],
+        "model_src": {
+          "huggingface": {
+            "quantizations": [
+              "fp8"
+            ],
+            "model_id": "tencent/Hy-MT2-1.8B-FP8",
+            "model_revision": "main"
+          },
+          "modelscope": {
+            "quantizations": [
+              "fp8"
+            ],
+            "model_id": "Tencent-Hunyuan/Hy-MT2-1.8B-FP8",
+            "model_revision": "master"
+          }
+        }
+      },
+      {
+        "model_format": "ggufv2",
+        "model_size_in_billions": 2,
+        "model_src": {
+          "huggingface": {
+            "quantizations": [
+              "Q4_K_M",
+              "Q6_K",
+              "Q8_0"
+            ],
+            "model_id": "tencent/Hy-MT2-1.8B-GGUF",
+            "model_file_name_template": "Hy-MT2-1.8B-{quantization}.gguf"
+          },
+          "modelscope": {
+            "quantizations": [
+              "Q4_K_M",
+              "Q6_K",
+              "Q8_0"
+            ],
+            "model_id": "Tencent-Hunyuan/Hy-MT2-1.8B-GGUF",
+            "model_file_name_template": "Hy-MT2-1.8B-{quantization}.gguf"
+          }
+        }
+      }
+    ],
+    "chat_template": "{% if messages[0]['role'] == 'system' %}{% set loop_messages = messages[1:] %}{% set system_message = messages[0]['content'] %}<\uff5chy_begin\u2581of\u2581sentence\uff5c>{{ system_message }}<\uff5chy_place\u2581holder\u2581no\u25813\uff5c>{% else %}{% set loop_messages = messages %}<\uff5chy_begin\u2581of\u2581sentence\uff5c>{% endif %}{% for message in loop_messages %}{% if message['role'] == 'user' %}<\uff5chy_User\uff5c>{{ message['content'] }}{% elif message['role'] == 'assistant' %}<\uff5chy_Assistant\uff5c>{{ message['content'] }}<\uff5chy_place\u2581holder\u2581no\u25812\uff5c>{% endif %}{% endfor %}{% if add_generation_prompt %}<\uff5chy_Assistant\uff5c>{% else %}<\uff5chy_place\u2581holder\u2581no\u25818\uff5c>{% endif %}",
+    "stop_token_ids": [
+      120020
+    ],
+    "architectures": [
+      "HunYuanDenseV1ForCausalLM"
+    ],
+    "model_type": "hunyuan_v1_dense",
+    "virtualenv": {
+      "packages": [
+        "transformers>=4.57.0 ; #engine# == \"Transformers\"",
+        "accelerate>=0.28.0 ; #engine# == \"Transformers\"",
+        "#vllm_dependencies# ; #engine# == \"vllm\"",
+        "#system_numpy# ; #engine# == \"vllm\"",
+        "#sglang_dependencies# ; #engine# == \"sglang\"",
+        "#llama_cpp_dependencies# ; #engine# == \"llama.cpp\""
+      ]
+    },
+    "featured": true,
+    "updated_at": 1781407200
+  },
+  {
+    "version": 2,
+    "context_length": 262144,
+    "model_name": "Hy-MT2-7B",
+    "model_lang": [
+      "en",
+      "zh"
+    ],
+    "model_ability": [
+      "chat"
+    ],
+    "model_description": "Hy-MT2-7B is a dense multilingual translation model from Tencent Hunyuan, supporting 33 languages with balanced performance for general-purpose high-quality translation.",
+    "model_specs": [
+      {
+        "model_format": "pytorch",
+        "model_size_in_billions": 7,
+        "model_src": {
+          "huggingface": {
+            "quantizations": [
+              "none"
+            ],
+            "model_id": "tencent/Hy-MT2-7B",
+            "model_revision": "main"
+          },
+          "modelscope": {
+            "quantizations": [
+              "none"
+            ],
+            "model_id": "Tencent-Hunyuan/Hy-MT2-7B",
+            "model_revision": "master"
+          }
+        }
+      },
+      {
+        "model_format": "pytorch",
+        "model_size_in_billions": 7,
+        "quantizations": [
+          "fp8"
+        ],
+        "model_src": {
+          "huggingface": {
+            "quantizations": [
+              "fp8"
+            ],
+            "model_id": "tencent/Hy-MT2-7B-FP8",
+            "model_revision": "main"
+          },
+          "modelscope": {
+            "quantizations": [
+              "fp8"
+            ],
+            "model_id": "Tencent-Hunyuan/Hy-MT2-7B-FP8",
+            "model_revision": "master"
+          }
+        }
+      },
+      {
+        "model_format": "ggufv2",
+        "model_size_in_billions": 7,
+        "model_src": {
+          "huggingface": {
+            "quantizations": [
+              "Q4_K_M",
+              "Q6_K",
+              "Q8_0"
+            ],
+            "model_id": "tencent/Hy-MT2-7B-GGUF",
+            "model_file_name_template": "Hy-MT2-7B-{quantization}.gguf"
+          },
+          "modelscope": {
+            "quantizations": [
+              "Q4_K_M",
+              "Q6_K",
+              "Q8_0"
+            ],
+            "model_id": "Tencent-Hunyuan/Hy-MT2-7B-GGUF",
+            "model_file_name_template": "Hy-MT2-7B-{quantization}.gguf"
+          }
+        }
+      }
+    ],
+    "chat_template": "{% if messages[0]['role'] == 'system' %}{% set loop_messages = messages[1:] %}{% set system_message = messages[0]['content'] %}<\uff5chy_begin\u2581of\u2581sentence\uff5c>{{ system_message }}<\uff5chy_place\u2581holder\u2581no\u25813\uff5c>{% else %}{% set loop_messages = messages %}<\uff5chy_begin\u2581of\u2581sentence\uff5c>{% endif %}{% for message in loop_messages %}{% if message['role'] == 'user' %}<\uff5chy_User\uff5c>{{ message['content'] }}{% elif message['role'] == 'assistant' %}<\uff5chy_Assistant\uff5c>{{ message['content'] }}<\uff5chy_place\u2581holder\u2581no\u25812\uff5c>{% endif %}{% endfor %}{% if add_generation_prompt %}<\uff5chy_Assistant\uff5c>{% else %}<\uff5chy_place\u2581holder\u2581no\u25818\uff5c>{% endif %}",
+    "stop_token_ids": [
+      120020
+    ],
+    "architectures": [
+      "HunYuanDenseV1ForCausalLM"
+    ],
+    "model_type": "hunyuan_v1_dense",
+    "virtualenv": {
+      "packages": [
+        "transformers>=4.57.0 ; #engine# == \"Transformers\"",
+        "accelerate>=0.28.0 ; #engine# == \"Transformers\"",
+        "#vllm_dependencies# ; #engine# == \"vllm\"",
+        "#system_numpy# ; #engine# == \"vllm\"",
+        "#sglang_dependencies# ; #engine# == \"sglang\"",
+        "#llama_cpp_dependencies# ; #engine# == \"llama.cpp\""
+      ]
+    },
+    "featured": true,
+    "updated_at": 1781407200
+  },
+  {
+    "version": 2,
+    "context_length": 262144,
+    "model_name": "Hy-MT2-30B-A3B",
+    "model_lang": [
+      "en",
+      "zh"
+    ],
+    "model_ability": [
+      "chat"
+    ],
+    "model_description": "Hy-MT2-30B-A3B is a Mixture-of-Experts multilingual translation model from Tencent Hunyuan, supporting 33 languages with SOTA performance for complex professional domains.",
+    "model_specs": [
+      {
+        "model_format": "pytorch",
+        "model_size_in_billions": 30,
+        "model_src": {
+          "huggingface": {
+            "quantizations": [
+              "none"
+            ],
+            "model_id": "tencent/Hy-MT2-30B-A3B",
+            "model_revision": "main"
+          },
+          "modelscope": {
+            "quantizations": [
+              "none"
+            ],
+            "model_id": "Tencent-Hunyuan/Hy-MT2-30B-A3B",
+            "model_revision": "master"
+          }
+        }
+      },
+      {
+        "model_format": "pytorch",
+        "model_size_in_billions": 30,
+        "quantizations": [
+          "fp8"
+        ],
+        "model_src": {
+          "huggingface": {
+            "quantizations": [
+              "fp8"
+            ],
+            "model_id": "tencent/Hy-MT2-30B-A3B-FP8",
+            "model_revision": "main"
+          },
+          "modelscope": {
+            "quantizations": [
+              "fp8"
+            ],
+            "model_id": "Tencent-Hunyuan/Hy-MT2-30B-A3B-FP8",
+            "model_revision": "master"
+          }
+        }
+      }
+    ],
+    "chat_template": "{% if messages[0]['role'] == 'system' %}{% set loop_messages = messages[1:] %}{% set system_message = messages[0]['content'] %}<\uff5chy_begin\u2581of\u2581sentence\uff5c>{{ system_message }}<\uff5chy_place\u2581holder\u2581no\u25813\uff5c>{% else %}{% set loop_messages = messages %}<\uff5chy_begin\u2581of\u2581sentence\uff5c>{% endif %}{% for message in loop_messages %}{% if message['role'] == 'user' %}<\uff5chy_User\uff5c>{{ message['content'] }}{% elif message['role'] == 'assistant' %}<\uff5chy_Assistant\uff5c>{{ message['content'] }}<\uff5chy_place\u2581holder\u2581no\u25812\uff5c>{% endif %}{% endfor %}{% if add_generation_prompt %}<\uff5chy_Assistant\uff5c>{% else %}<\uff5chy_place\u2581holder\u2581no\u25818\uff5c>{% endif %}",
+    "stop_token_ids": [
+      120025,
+      120026
+    ],
+    "architectures": [
+      "HYV3ForCausalLM"
+    ],
+    "model_type": "hy_v3",
+    "virtualenv": {
+      "packages": [
+        "transformers>=4.57.0 ; #engine# == \"Transformers\"",
+        "accelerate>=0.28.0 ; #engine# == \"Transformers\"",
+        "#vllm_dependencies# ; #engine# == \"vllm\"",
+        "#system_numpy# ; #engine# == \"vllm\"",
+        "#sglang_dependencies# ; #engine# == \"sglang\""
+      ]
+    },
+    "featured": true,
+    "updated_at": 1781407200
   }
 ]

--- a/xinference/model/llm/sglang/core.py
+++ b/xinference/model/llm/sglang/core.py
@@ -105,6 +105,8 @@ SGLANG_SUPPORTED_CHAT_MODELS = [
     "DeepseekV2ForCausalLM",
     "DeepseekV3ForCausalLM",
     "Qwen3ForCausalLM",
+    "HunYuanDenseV1ForCausalLM",
+    "HYV3ForCausalLM",
 ]
 SGLANG_SUPPORTED_VISION_MODEL_LIST = [
     "Qwen2_5_VLForConditionalGeneration",

--- a/xinference/model/llm/transformers/hy_mt2.py
+++ b/xinference/model/llm/transformers/hy_mt2.py
@@ -1,0 +1,77 @@
+# Copyright 2022-2026 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import List, Optional, Tuple, Union
+
+from ....types import LoRA, PytorchModelConfig
+from ..llm_family import LLMFamilyV2, LLMSpecV1, register_transformer
+from .core import PytorchChatModel, register_non_default_model
+
+
+@register_transformer
+@register_non_default_model("HunYuanDenseV1ForCausalLM", "HYV3ForCausalLM")
+class HyMT2PytorchModel(PytorchChatModel):
+    """Adapter for Tencent Hunyuan Hy-MT2 multilingual translation models.
+
+    Hy-MT2 ships two architectures:
+      - HunYuanDenseV1ForCausalLM (1.8B / 7B dense)
+      - HYV3ForCausalLM           (30B-A3B MoE)
+
+    Both expose a chat-style interface (the model is "instructed" via a
+    translation prompt) and require the bfloat16 dtype recommended by the
+    upstream README; float16 on Apple MPS triggers an MPSFloatType embedding
+    error inside the custom modeling code, so we pin bfloat16 here.
+    """
+
+    _ARCHITECTURES = {"HunYuanDenseV1ForCausalLM", "HYV3ForCausalLM"}
+
+    def __init__(
+        self,
+        model_uid: str,
+        model_family: "LLMFamilyV2",
+        model_path: str,
+        pytorch_model_config: Optional[PytorchModelConfig] = None,
+        peft_model: Optional[List[LoRA]] = None,
+    ):
+        super().__init__(
+            model_uid,
+            model_family,
+            model_path,
+            pytorch_model_config=pytorch_model_config,
+            peft_model=peft_model,
+        )
+
+    def _sanitize_model_config(
+        self, pytorch_model_config: Optional[PytorchModelConfig]
+    ) -> PytorchModelConfig:
+        config = super()._sanitize_model_config(pytorch_model_config)
+        # Hy-MT2 official README pins bfloat16; the default MPS preferred
+        # dtype (float16) breaks the custom HunYuanDense embedding path.
+        config.setdefault("torch_dtype", "bfloat16")
+        config.setdefault("trust_remote_code", True)
+        return config  # type: ignore
+
+    @classmethod
+    def match_json(
+        cls, llm_family: "LLMFamilyV2", llm_spec: "LLMSpecV1", quantization: str
+    ) -> Union[bool, Tuple[bool, str]]:
+        if llm_spec.model_format not in ["pytorch"]:
+            return False, "Hy-MT2 transformer only supports pytorch format"
+        if not llm_family.has_architecture(*cls._ARCHITECTURES):
+            return (
+                False,
+                "Hy-MT2 transformer only supports architectures: "
+                f"{', '.join(sorted(cls._ARCHITECTURES))}",
+            )
+        return True

--- a/xinference/model/llm/vllm/core.py
+++ b/xinference/model/llm/vllm/core.py
@@ -333,6 +333,11 @@ def _update_vllm_supported_lists() -> None:
         _append_unique(
             VLLM_SUPPORTED_MULTI_MODEL_LIST, "MiniCPMV4_6ForConditionalGeneration"
         )
+        _append_unique(
+            VLLM_SUPPORTED_CHAT_MODELS,
+            "HunYuanDenseV1ForCausalLM",
+            "HYV3ForCausalLM",
+        )
 
     if is_npu_available() and effective_version >= version.parse("0.18.0"):
         _append_unique(VLLM_SUPPORTED_CHAT_MODELS, "DeepseekV4ForCausalLM")


### PR DESCRIPTION
Register Tencent Hunyuan Hy-MT2 multilingual translation models for deployment via Transformers, vLLM, SGLang, and llama.cpp engines.

Models registered (Hy-MT2-1.8B / 7B / 30B-A3B):
- pytorch (none, fp8) and ggufv2 specs with HF + ModelScope sources
- 33 supported languages, 262144 context length
- Embedded the official chat_template.jinja into llm_family.json
- Correct stop_token_ids per model: 1.8B/7B [120020], 30B [120025,120026]

Engine adapters:
- New transformers/hy_mt2.py adapter forces torch_dtype=bfloat16 to avoid the MPSFloatType embedding error on Apple Silicon and enables trust_remote_code for the custom HunYuanDenseV1/HYV3 modeling code.
- vllm/core.py: add HunYuanDenseV1ForCausalLM and HYV3ForCausalLM to the vLLM (>=0.22.0) supported chat models list.
- sglang/core.py: add the same architectures to SGLANG_SUPPORTED_CHAT_MODELS.