### PR TITLE
fix(vllm): force spawn for single-GPU EngineCore and fix health check scheduling

### DIFF
--- a/xinference/model/llm/vllm/core.py
+++ b/xinference/model/llm/vllm/core.py
@@ -68,7 +68,7 @@ from ..utils import (
     ChatModelMixin,
     generate_completion_chunk,
 )
-from .utils import vllm_check
+from .utils import AsyncEngineDeadError, vllm_check
 
 logger = logging.getLogger(__name__)
 
@@ -654,12 +654,21 @@ class VLLMModel(LLM):
                 **self._model_config,
             )
             self._enable_v1_if_supported(engine_args)
-            self._engine = AsyncLLMEngine.from_engine_args(engine_args)
 
-        self._check_health_task = None
-        if hasattr(self._engine, "check_health"):
-            # vLLM introduced `check_health` since v0.4.1
-            self._check_health_task = self._loop.create_task(self._check_healthy())
+            def _load():
+                # Force spawn to avoid fork deadlock: vLLM v1 creates
+                # EngineCore via fork, which inherits parent's multi-thread
+                # lock state causing deadlock. spawn creates a clean process.
+                os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
+                try:
+                    self._engine = AsyncLLMEngine.from_engine_args(engine_args)
+                except:  # noqa: E722
+                    logger.exception("Creating vllm engine failed")
+                    self._loading_error = sys.exc_info()
+
+            self._loading_thread = threading.Thread(target=_load)
+            self._loading_thread.start()
+            self._loading_thread.join(1)
 
     def wait_for_load(self):
         if self._loading_thread:
@@ -672,6 +681,28 @@ class VLLMModel(LLM):
         # if shard > 0, the engine will be inited in another process
         if self._engine:
             self._set_context_length()
+
+        # Create health check here after engine is fully ready.
+        # Previously in load(), but self._engine was None after
+        # _loading_thread.join(1) for threaded paths (multi-GPU
+        # and single-GPU), causing health check to be silently
+        # skipped. This fix applies to ALL vLLM models that use
+        # _loading_thread (both multi-GPU and single-GPU).
+        # Use call_soon_threadsafe + create_task instead of
+        # run_coroutine_threadsafe: the latter wraps the coroutine
+        # in a concurrent.futures.Future whose exceptions are
+        # silently swallowed if nobody checks the Future. create_task
+        # produces an asyncio.Task whose unhandled exceptions are
+        # logged by the asyncio default exception handler.
+        self._check_health_task = None
+        if self._engine and hasattr(self._engine, "check_health") and self._loop:
+            logger.info(
+                "Creating vLLM health check task for model %s",
+                self.model_uid,
+            )
+            self._loop.call_soon_threadsafe(
+                self._loop.create_task, self._check_healthy()
+            )
 
     def _set_context_length(self):
         if not self._is_vllm_v1():
@@ -780,6 +811,10 @@ class VLLMModel(LLM):
         logger.info("Stopping vLLM engine")
         if self._check_health_task:
             self._check_health_task.cancel()
+        # Wait for loading thread to finish so EngineCore subprocess
+        # can be properly shut down below.
+        if self._loading_thread and self._loading_thread.is_alive():
+            self._loading_thread.join(timeout=30)
         if self._engine:
             if not self._is_vllm_v1():
                 # v0
@@ -797,14 +832,12 @@ class VLLMModel(LLM):
         await self._engine.init_xavier()
 
     async def _check_healthy(self, interval: int = 30):
-        from vllm.engine.async_llm_engine import AsyncEngineDeadError
-
-        logger.debug("Begin to check health of vLLM")
+        logger.info("Begin to check health of vLLM")
 
         while self._engine is not None:
             try:
                 await self._engine.check_health()
-            except (AsyncEngineDeadError, RuntimeError):
+            except RuntimeError:
                 logger.info("Detecting vLLM is not health, prepare to quit the process")
                 try:
                     self.stop()

--- a/xinference/model/llm/vllm/core.py
+++ b/xinference/model/llm/vllm/core.py
@@ -637,7 +637,7 @@ class VLLMModel(LLM):
                             # patch vllm Executor.get_class
                             Executor.get_class = lambda vllm_config: executor_cls
                             self._engine = AsyncLLMEngine.from_engine_args(engine_args)
-                except:  # noqa: E722
+                except Exception:
                     logger.exception("Creating vllm engine failed")
                     self._loading_error = sys.exc_info()
 
@@ -662,7 +662,7 @@ class VLLMModel(LLM):
                 os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
                 try:
                     self._engine = AsyncLLMEngine.from_engine_args(engine_args)
-                except:  # noqa: E722
+                except Exception:
                     logger.exception("Creating vllm engine failed")
                     self._loading_error = sys.exc_info()
 
@@ -700,9 +700,14 @@ class VLLMModel(LLM):
                 "Creating vLLM health check task for model %s",
                 self.model_uid,
             )
-            self._loop.call_soon_threadsafe(
-                self._loop.create_task, self._check_healthy()
-            )
+
+            def _start_health_check():
+                if self._engine is not None:
+                    self._check_health_task = self._loop.create_task(
+                        self._check_healthy()
+                    )
+
+            self._loop.call_soon_threadsafe(_start_health_check)
 
     def _set_context_length(self):
         if not self._is_vllm_v1():

--- a/xinference/model/llm/vllm/core.py
+++ b/xinference/model/llm/vllm/core.py
@@ -373,6 +373,7 @@ class VLLMModel(LLM):
         self._driver_info = model_config.pop("driver_info", None)  # type: ignore
         self._loading_thread: Optional[threading.Thread] = None
         self._loading_error = None
+        self._check_health_task = None
         # variables used for distributed inference and multiple GPUs
         self._pool_addresses = None
         self._worker_addresses: Optional[Dict[int, List[str]]] = None

--- a/xinference/model/llm/vllm/core.py
+++ b/xinference/model/llm/vllm/core.py
@@ -846,7 +846,7 @@ class VLLMModel(LLM):
                 logger.info("Detecting vLLM is not health, prepare to quit the process")
                 try:
                     self.stop()
-                except:  # noqa: E722
+                except Exception:
                     # ignore error when stop
                     pass
                 # Just kill the process and let xinference auto-recover the model

--- a/xinference/model/llm/vllm/core.py
+++ b/xinference/model/llm/vllm/core.py
@@ -68,7 +68,7 @@ from ..utils import (
     ChatModelMixin,
     generate_completion_chunk,
 )
-from .utils import AsyncEngineDeadError, vllm_check
+from .utils import vllm_check
 
 logger = logging.getLogger(__name__)
 

--- a/xinference/model/llm/vllm/utils.py
+++ b/xinference/model/llm/vllm/utils.py
@@ -20,9 +20,11 @@ logger = logging.getLogger(__name__)
 
 try:
     from vllm.engine.async_llm_engine import AsyncEngineDeadError
-except ImportError:
+except Exception:
     # vLLM 0.19.0+ removed AsyncEngineDeadError from this module.
     # It is a subclass of RuntimeError, so except RuntimeError suffices.
+    # Use except Exception (not just ImportError) to handle partial/broken
+    # vllm installations where module init may raise non-ImportError errors.
     AsyncEngineDeadError = RuntimeError  # type: ignore[assignment,misc]
 
 

--- a/xinference/model/llm/vllm/utils.py
+++ b/xinference/model/llm/vllm/utils.py
@@ -23,13 +23,10 @@ try:
 except ImportError:
     # vLLM 0.19.0+ removed AsyncEngineDeadError from this module.
     # It is a subclass of RuntimeError, so except RuntimeError suffices.
-    AsyncEngineDeadError = None  # type: ignore[assignment,misc]
+    AsyncEngineDeadError = RuntimeError  # type: ignore[assignment,misc]
 
 
 def vllm_check(fn):
-    if AsyncEngineDeadError is None:
-        return fn
-
     @functools.wraps(fn)
     async def _async_wrapper(self, *args, **kwargs):
         try:

--- a/xinference/model/llm/vllm/utils.py
+++ b/xinference/model/llm/vllm/utils.py
@@ -33,7 +33,7 @@ def vllm_check(fn):
     async def _async_wrapper(self, *args, **kwargs):
         try:
             return await fn(self, *args, **kwargs)
-        except (AsyncEngineDeadError, RuntimeError):
+        except AsyncEngineDeadError:
             logger.info("Detecting vLLM is not health, prepare to quit the process")
             try:
                 self.stop()

--- a/xinference/model/llm/vllm/utils.py
+++ b/xinference/model/llm/vllm/utils.py
@@ -18,18 +18,23 @@ import os
 
 logger = logging.getLogger(__name__)
 
+try:
+    from vllm.engine.async_llm_engine import AsyncEngineDeadError
+except ImportError:
+    # vLLM 0.19.0+ removed AsyncEngineDeadError from this module.
+    # It is a subclass of RuntimeError, so except RuntimeError suffices.
+    AsyncEngineDeadError = None  # type: ignore[assignment,misc]
+
 
 def vllm_check(fn):
-    try:
-        from vllm.engine.async_llm_engine import AsyncEngineDeadError
-    except Exception:
+    if AsyncEngineDeadError is None:
         return fn
 
     @functools.wraps(fn)
     async def _async_wrapper(self, *args, **kwargs):
         try:
             return await fn(self, *args, **kwargs)
-        except AsyncEngineDeadError:
+        except (AsyncEngineDeadError, RuntimeError):
             logger.info("Detecting vLLM is not health, prepare to quit the process")
             try:
                 self.stop()


### PR DESCRIPTION
## Summary

- **Force spawn for single-GPU vLLM v1 EngineCore creation** to avoid fork deadlock. When `tensor_parallel_size=1`, vLLM's `MultiprocExecutor` creates EngineCore via `mp.get_context("fork").Process()`, inheriting the parent's multi-thread lock state and causing permanent deadlock in the request processing loop. Setting `VLLM_WORKER_MULTIPROC_METHOD=spawn` creates a clean process. vLLM natively supports this env var (`vllm/envs.py`) and ZMQ IPC uses path strings, so spawn is safe.
- **Move health check creation from `load()` to `wait_for_load()`** — the old code created it when `self._engine` was still `None` for threaded paths (both multi-GPU and single-GPU), silently skipping health check entirely.
- **Fix `AsyncEngineDeadError` import compatibility** — removed from `vllm.engine.async_llm_engine` in vLLM 0.19.0+. Module-level `try/except` in `utils.py` with `RuntimeError` fallback in `_check_healthy()`.
- **Use `call_soon_threadsafe` + `create_task`** instead of `run_coroutine_threadsafe` — the latter wraps coroutines in `concurrent.futures.Future` whose exceptions are silently swallowed; `create_task` produces `asyncio.Task` with visible exceptions.
- **Wait for loading thread in `stop()`** before shutting down the engine, preventing orphan EngineCore subprocesses.

## Test plan

- [x] Single-GPU Qwen3-8B (BF16): 3 consecutive chat requests succeed (previously hung indefinitely)
- [x] Single-GPU Llama-3.1-8B (BF16): chat requests succeed
- [x] `"Begin to check health of vLLM"` log appears for the first time (previously 0 occurrences across all deployments)
- [x] No `Task exception was never retrieved` errors
- [x] Multi-GPU (TP=2) deployment unaffected (uses `XinferenceDistributedExecutorV1`, no fork)
- [ ] `pytest xinference/model/llm/vllm/tests/` passes

## Root cause analysis

Single-GPU vLLM v1 deployments (Qwen3-8B, Llama-3.1-8B, Qwen2.5-Instruct) experienced permanent request hangs:
- Model loaded successfully, CUDA graphs captured
- Any inference request hung indefinitely with no error logs
- EngineCore subprocess stayed alive (stats telemetry continued)
- `serve request count` kept incrementing, no timeout

The fork deadlock occurs because the parent process (ModelActor subpool) has multiple active threads (MainThread event loop, `_loading_thread`, asyncio workers). Fork copies all memory including lock states, but the child only has one thread — it cannot release locks held by the other threads.

Multi-GPU deployments are unaffected because they use `XinferenceDistributedExecutorV1` (xoscar actors, no fork).

🤖 Generated with [Claude Code](https://claude.com/claude-code)