### PR TITLE
feat(core): add model loading state machine to prevent routing to loading models

### DIFF
--- a/xinference/api/restful_api.py
+++ b/xinference/api/restful_api.py
@@ -62,6 +62,7 @@ from ..constants import (
     XINFERENCE_SSE_PING_ATTEMPTS_SECONDS,
 )
 from ..core.event import Event, EventCollectorActor, EventType
+from ..core.exceptions import ModelNotReadyError
 from ..core.supervisor import SupervisorActor
 from ..core.utils import CancelMixin
 from ..types import (
@@ -743,6 +744,12 @@ class RESTfulAPI(CancelMixin):
         try:
             data = await (await self._get_supervisor_ref()).describe_model(model_uid)
             return JSONResponse(content=data)
+        except ModelNotReadyError as e:
+            raise HTTPException(
+                status_code=503,
+                detail=f"Model is loading, please retry later: {e}",
+                headers={"Retry-After": "30"},
+            )
         except ValueError as ve:
             logger.error(str(ve), exc_info=True)
             raise HTTPException(status_code=400, detail=str(ve))
@@ -1676,6 +1683,12 @@ class RESTfulAPI(CancelMixin):
                 raise ValueError("Unknown model")
             await (await self._get_supervisor_ref()).get_model(model_uid)
             return Response()
+        except ModelNotReadyError as e:
+            raise HTTPException(
+                status_code=503,
+                detail=f"Model is loading, please retry later: {e}",
+                headers={"Retry-After": "30"},
+            )
         except ValueError as ve:
             logger.error(str(ve), exc_info=True)
             await self._report_error_event(model_uid, str(ve))
@@ -2381,6 +2394,12 @@ class RESTfulAPI(CancelMixin):
 
         try:
             desc = await (await self._get_supervisor_ref()).describe_model(model_uid)
+        except ModelNotReadyError as e:
+            raise HTTPException(
+                status_code=503,
+                detail=f"Model is loading, please retry later: {e}",
+                headers={"Retry-After": "30"},
+            )
         except ValueError as ve:
             logger.error(str(ve), exc_info=True)
             await self._report_error_event(model_uid, str(ve))

--- a/xinference/api/utils.py
+++ b/xinference/api/utils.py
@@ -24,6 +24,8 @@ from typing import Any, Callable, Optional
 
 from fastapi import HTTPException
 
+from ..core.exceptions import ModelNotReadyError
+
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -135,6 +137,12 @@ async def require_model(
         return await supervisor.get_model(model_uid)
     except HTTPException:
         raise
+    except ModelNotReadyError as e:
+        raise HTTPException(
+            status_code=503,
+            detail=f"Model is loading, please retry later: {e}",
+            headers={"Retry-After": "30"},
+        )
     except ValueError as ve:
         logger.error(str(ve), exc_info=True)
         if report_error_event:

--- a/xinference/core/exceptions.py
+++ b/xinference/core/exceptions.py
@@ -1,0 +1,19 @@
+# Copyright 2022-2026 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+class ModelNotReadyError(Exception):
+    """Raised when a model is still loading and cannot serve requests yet."""
+
+    pass

--- a/xinference/core/model.py
+++ b/xinference/core/model.py
@@ -334,12 +334,14 @@ class ModelActor(xo.StatelessActor, CancelMixin):
 
     def _require_ready(self):
         """Guard for all inference methods: reject if not in ready state."""
-        if self._model_state in ("registering", "loading"):
-            raise ModelNotReadyError(
-                f"Model is {self._model_state}, not ready for inference"
+        if self._model_state != "ready":
+            if self._model_state in ("registering", "loading"):
+                raise ModelNotReadyError(
+                    f"Model is {self._model_state}, not ready for inference"
+                )
+            raise RuntimeError(
+                f"Model is in {self._model_state} state"
             )
-        if self._model_state == "error":
-            raise RuntimeError("Model is in error state")
 
     def __repr__(self) -> str:
         return f"ModelActor({self._replica_model_uid})"
@@ -965,6 +967,7 @@ class ModelActor(xo.StatelessActor, CancelMixin):
         timestamp_granularities: Optional[List[str]] = None,
         **kwargs,
     ):
+        self._require_ready()
         kwargs.pop("request_id", None)
         if hasattr(self._model, "transcriptions"):
             return await self._call_wrapper_json(
@@ -993,6 +996,7 @@ class ModelActor(xo.StatelessActor, CancelMixin):
         timestamp_granularities: Optional[List[str]] = None,
         **kwargs,
     ):
+        self._require_ready()
         kwargs.pop("request_id", None)
         if hasattr(self._model, "translations"):
             return await self._call_wrapper_json(
@@ -1020,6 +1024,7 @@ class ModelActor(xo.StatelessActor, CancelMixin):
         stream: bool = False,
         **kwargs,
     ):
+        self._require_ready()
         kwargs.pop("request_id", None)
         if hasattr(self._model, "speech"):
             return await self._call_wrapper_binary(
@@ -1046,6 +1051,7 @@ class ModelActor(xo.StatelessActor, CancelMixin):
         *args,
         **kwargs,
     ):
+        self._require_ready()
         if hasattr(self._model, "text_to_image"):
             # Get progressor (don't pop request_id, let _call_wrapper handle cancellation)
             request_id = kwargs.get("request_id")
@@ -1070,6 +1076,7 @@ class ModelActor(xo.StatelessActor, CancelMixin):
         self,
         **kwargs,
     ):
+        self._require_ready()
         if hasattr(self._model, "txt2img"):
             progressor = kwargs["progressor"] = await self._get_progressor(
                 kwargs.pop("request_id", None)
@@ -1097,6 +1104,7 @@ class ModelActor(xo.StatelessActor, CancelMixin):
         *args,
         **kwargs,
     ):
+        self._require_ready()
         kwargs["negative_prompt"] = negative_prompt
         if hasattr(self._model, "image_to_image"):
             progressor = kwargs["progressor"] = await self._get_progressor(
@@ -1123,6 +1131,7 @@ class ModelActor(xo.StatelessActor, CancelMixin):
         self,
         **kwargs,
     ):
+        self._require_ready()
         if hasattr(self._model, "img2img"):
             progressor = kwargs["progressor"] = await self._get_progressor(
                 kwargs.pop("request_id", None)
@@ -1151,6 +1160,7 @@ class ModelActor(xo.StatelessActor, CancelMixin):
         *args,
         **kwargs,
     ):
+        self._require_ready()
         kwargs["negative_prompt"] = negative_prompt
         if hasattr(self._model, "inpainting"):
             progressor = kwargs["progressor"] = await self._get_progressor(
@@ -1183,6 +1193,7 @@ class ModelActor(xo.StatelessActor, CancelMixin):
         *args,
         **kwargs,
     ):
+        self._require_ready()
         if hasattr(self._model, "ocr"):
             return await self._call_wrapper_json(
                 self._model.ocr,
@@ -1199,6 +1210,7 @@ class ModelActor(xo.StatelessActor, CancelMixin):
         *args,
         **kwargs,
     ):
+        self._require_ready()
         kwargs.pop("request_id", None)
         if hasattr(self._model, "infer"):
             return await self._call_wrapper_json(
@@ -1219,6 +1231,7 @@ class ModelActor(xo.StatelessActor, CancelMixin):
         *args,
         **kwargs,
     ):
+        self._require_ready()
         progressor = kwargs["progressor"] = await self._get_progressor(
             kwargs.pop("request_id", None)
         )
@@ -1246,6 +1259,7 @@ class ModelActor(xo.StatelessActor, CancelMixin):
         *args,
         **kwargs,
     ):
+        self._require_ready()
         kwargs["negative_prompt"] = negative_prompt
         progressor = kwargs["progressor"] = await self._get_progressor(
             kwargs.pop("request_id", None)
@@ -1276,6 +1290,7 @@ class ModelActor(xo.StatelessActor, CancelMixin):
         *args,
         **kwargs,
     ):
+        self._require_ready()
         kwargs["negative_prompt"] = negative_prompt
         progressor = kwargs["progressor"] = await self._get_progressor(
             kwargs.pop("request_id", None)

--- a/xinference/core/model.py
+++ b/xinference/core/model.py
@@ -53,6 +53,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 from ..device_utils import empty_cache
+from .exceptions import ModelNotReadyError
 from .utils import CancelMixin, json_dumps, log_async
 
 try:
@@ -298,6 +299,7 @@ class ModelActor(xo.StatelessActor, CancelMixin):
             ),
         }
         self._loop: Optional[asyncio.AbstractEventLoop] = None
+        self._model_state: str = "registering"
         # model across workers
         self._n_worker = n_worker
         self._shard = shard
@@ -329,6 +331,15 @@ class ModelActor(xo.StatelessActor, CancelMixin):
         import os
 
         return os.getpid()
+
+    def _require_ready(self):
+        """Guard for all inference methods: reject if not in ready state."""
+        if self._model_state in ("registering", "loading"):
+            raise ModelNotReadyError(
+                f"Model is {self._model_state}, not ready for inference"
+            )
+        if self._model_state == "error":
+            raise RuntimeError("Model is in error state")
 
     def __repr__(self) -> str:
         return f"ModelActor({self._replica_model_uid})"
@@ -440,6 +451,7 @@ class ModelActor(xo.StatelessActor, CancelMixin):
         return isinstance(self._model, SGLANGModel)
 
     async def load(self):
+        self._model_state = "loading"
         try:
             # Change process title for model
             import setproctitle
@@ -477,6 +489,7 @@ class ModelActor(xo.StatelessActor, CancelMixin):
     async def wait_for_load(self):
         if hasattr(self._model, "wait_for_load"):
             await asyncio.to_thread(self._model.wait_for_load)
+        self._model_state = "ready"
 
     def need_create_pools(self):
         return getattr(self._model, "need_create_pools", False)
@@ -512,6 +525,7 @@ class ModelActor(xo.StatelessActor, CancelMixin):
         return self._driver_info
 
     async def stop(self):
+        self._model_state = "stopping"
         if hasattr(self._model, "stop"):
             await asyncio.to_thread(self._model.stop)
         elif hasattr(self._model, "close"):
@@ -783,6 +797,7 @@ class ModelActor(xo.StatelessActor, CancelMixin):
     @xo.generator
     @log_async(logger=logger)
     async def generate(self, prompt: str, *args, **kwargs):
+        self._require_ready()
         # Directly delegate to model, let model decide how to handle (batching or not)
         kwargs.pop("raw_params", None)
         if hasattr(self._model, "generate"):
@@ -809,6 +824,7 @@ class ModelActor(xo.StatelessActor, CancelMixin):
     @xo.generator
     @log_async(logger=logger)
     async def chat(self, messages: List[Dict], *args, **kwargs):
+        self._require_ready()
         start_time = time.time()
         response = None
         try:
@@ -884,6 +900,7 @@ class ModelActor(xo.StatelessActor, CancelMixin):
     @request_limit
     @log_async(logger=logger)
     async def create_embedding(self, input: Union[str, List[str]], *args, **kwargs):
+        self._require_ready()
         kwargs.pop("request_id", None)
         if hasattr(self._model, "create_embedding"):
             return await self._call_wrapper_json(
@@ -920,6 +937,7 @@ class ModelActor(xo.StatelessActor, CancelMixin):
         *args,
         **kwargs,
     ):
+        self._require_ready()
         kwargs.pop("request_id", None)
         if hasattr(self._model, "rerank"):
             return await self._call_wrapper_json(

--- a/xinference/core/model.py
+++ b/xinference/core/model.py
@@ -339,9 +339,7 @@ class ModelActor(xo.StatelessActor, CancelMixin):
                 raise ModelNotReadyError(
                     f"Model is {self._model_state}, not ready for inference"
                 )
-            raise RuntimeError(
-                f"Model is in {self._model_state} state"
-            )
+            raise RuntimeError(f"Model is in {self._model_state} state")
 
     def __repr__(self) -> str:
         return f"ModelActor({self._replica_model_uid})"

--- a/xinference/core/status_guard.py
+++ b/xinference/core/status_guard.py
@@ -29,6 +29,7 @@ class LaunchStatus(Enum):
     TERMINATED = 4
     READY = 5
     ERROR = 6
+    LOADING = 7
 
 
 class ReplicaStatus(BaseModel):
@@ -37,7 +38,8 @@ class ReplicaStatus(BaseModel):
     replica_id: int
     replica_model_uid: str
     worker_address: str
-    status: str  # CREATING, READY, ERROR
+    status: str  # CREATING, LOADING, READY, ERROR, TERMINATING, TERMINATED
+    model_state: str = ""  # registering/loading/ready/error/stopping/stopped
     created_ts: int
     error_message: Optional[str] = None
 

--- a/xinference/core/supervisor.py
+++ b/xinference/core/supervisor.py
@@ -2714,8 +2714,13 @@ class SupervisorActor(xo.StatelessActor):
 
         worker_ref = self._replica_model_uid_to_worker.get(replica_model_uid, None)
         if worker_ref is None:
-            raise ValueError(
-                f"Model not found in the model list, uid: {replica_model_uid}"
+            # replica_info exists but worker route not yet registered —
+            # model is being launched (wait_ready=False), not missing.
+            # Raise ModelNotReadyError (503) instead of ValueError (404)
+            # so the negative cache is not poisoned and clients get a
+            # retry-friendly response.
+            raise ModelNotReadyError(
+                f"Model {model_uid} is launching, not yet ready for inference"
             )
         if isinstance(worker_ref, (list, tuple)):
             # get first worker to fetch information if model across workers
@@ -2761,8 +2766,8 @@ class SupervisorActor(xo.StatelessActor):
         )
         worker_ref = self._replica_model_uid_to_worker.get(replica_model_uid, None)
         if worker_ref is None:
-            raise ValueError(
-                f"Model not found in the model list, uid: {replica_model_uid}"
+            raise ModelNotReadyError(
+                f"Model {model_uid} is launching, not yet ready for inference"
             )
         if isinstance(worker_ref, (list, tuple)):
             # get status from first shard if model has multiple shards across workers

--- a/xinference/core/supervisor.py
+++ b/xinference/core/supervisor.py
@@ -56,6 +56,7 @@ from ..model.utils import (
     get_engine_params_by_name_with_virtual_env,
 )
 from ..types import PeftModelConfig
+from .exceptions import ModelNotReadyError
 from .launch_strategy import IdleFirstLaunchStrategy
 from .metrics import record_metrics
 from .resource import GPUStatus, ResourceStatus
@@ -1748,7 +1749,6 @@ class SupervisorActor(xo.StatelessActor):
                 rank0_address, _port = await worker_ref.launch_rank0_model(
                     _replica_model_uid, xavier_config
                 )
-                self._replica_model_uid_to_worker[_replica_model_uid] = worker_ref
                 store_address = rank0_address.split(":")[0]
                 store_port = _port
 
@@ -1756,6 +1756,7 @@ class SupervisorActor(xo.StatelessActor):
                 await self._status_guard_ref.update_replica_status(
                     model_uid, replica_id, {"status": LaunchStatus.READY.name}
                 )
+                self._replica_model_uid_to_worker[_replica_model_uid] = worker_ref
                 return rank0_address
 
             replica_gpu_idx = (
@@ -1794,8 +1795,10 @@ class SupervisorActor(xo.StatelessActor):
                     xavier_config=xavier_config,
                     **kwargs,
                 )
-                self._replica_model_uid_to_worker[_replica_model_uid] = worker_ref
+                # Wait for engine to be ready BEFORE adding to route table,
+                # so requests are never routed to a still-loading model.
                 await worker_ref.wait_for_load(_replica_model_uid)
+                self._replica_model_uid_to_worker[_replica_model_uid] = worker_ref
 
                 # Update replica status to READY
                 await self._status_guard_ref.update_replica_status(
@@ -2720,10 +2723,15 @@ class SupervisorActor(xo.StatelessActor):
         assert not isinstance(
             worker_ref, (list, tuple)
         ), "worker_ref must be a single worker"
-        return await xo.wait_for(
-            worker_ref.get_model(model_uid=replica_model_uid),
-            XINFERENCE_GET_MODEL_RPC_TIMEOUT,
-        )
+        try:
+            return await xo.wait_for(
+                worker_ref.get_model(model_uid=replica_model_uid),
+                XINFERENCE_GET_MODEL_RPC_TIMEOUT,
+            )
+        except ModelNotReadyError:
+            raise ModelNotReadyError(
+                f"Model {model_uid} is loading, please retry later"
+            )
 
     @log_async(logger=logger)
     async def get_model_status(self, replica_model_uid: str):

--- a/xinference/core/tests/test_model.py
+++ b/xinference/core/tests/test_model.py
@@ -56,6 +56,10 @@ class MockModelActor(ModelActor):
             model=MockModel(),  # type: ignore
             replica_model_uid=replica_model_uid,
         )
+        # This actor is constructed directly with a ready-to-use MockModel
+        # (no launch/load path), so mark it ready to bypass the
+        # _require_ready() guard added by the model state machine.
+        self._model_state = "ready"
         self._lock = asyncio.locks.Lock()
 
     async def __pre_destroy__(self):

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -67,7 +67,6 @@ from ..constants import (
 )
 from ..core.model import ModelActor
 from ..core.status_guard import LaunchStatus
-from .exceptions import ModelNotReadyError
 from ..device_utils import get_available_device_env_name, gpu_count
 from ..model.core import VirtualEnvSettings, create_model_instance
 from ..model.utils import (
@@ -79,6 +78,7 @@ from ..types import PeftModelConfig
 from ..utils import get_pip_config_args, get_real_path
 from .cache_tracker import CacheTrackerActor
 from .event import Event, EventCollectorActor, EventType
+from .exceptions import ModelNotReadyError
 from .metrics import (
     launch_metrics_export_server,
     record_metrics,

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -67,6 +67,7 @@ from ..constants import (
 )
 from ..core.model import ModelActor
 from ..core.status_guard import LaunchStatus
+from .exceptions import ModelNotReadyError
 from ..device_utils import get_available_device_env_name, gpu_count
 from ..model.core import VirtualEnvSettings, create_model_instance
 from ..model.utils import (
@@ -158,6 +159,7 @@ else:
 @dataclass
 class ModelStatus:
     last_error: str = ""
+    model_state: str = ""
 
 
 @dataclass
@@ -2283,6 +2285,11 @@ class WorkerActor(xo.StatelessActor):
                                 raise
                     except Exception:
                         logger.error(f"Failed to load model {model_uid}", exc_info=True)
+                        ms = self._model_uid_to_model_status.get(model_uid)
+                        if ms is None:
+                            ms = ModelStatus()
+                            self._model_uid_to_model_status[model_uid] = ms
+                        ms.model_state = "error"
                         self.release_devices(model_uid=model_uid)
                         for addr in all_subpool_addresses:
                             try:
@@ -2310,7 +2317,9 @@ class WorkerActor(xo.StatelessActor):
                     self._model_uid_to_subpool_pids[model_uid] = subpool_pids
                     model_spec = model.model_family.to_description()
                     self._model_uid_to_model_spec[model_uid] = model_spec
-                    self._model_uid_to_model_status[model_uid] = ModelStatus()
+                    self._model_uid_to_model_status[model_uid] = ModelStatus(
+                        model_state="loading"
+                    )
                     self._model_uid_to_addr[model_uid] = subpool_address
                     self._model_uid_to_recover_count.setdefault(
                         model_uid, MODEL_ACTOR_AUTO_RECOVER_LIMIT
@@ -2373,6 +2382,7 @@ class WorkerActor(xo.StatelessActor):
     async def wait_for_load(self, model_uid: str):
         model_ref = self._model_uid_to_model[model_uid]
         await model_ref.wait_for_load()
+        await self._update_model_state(model_uid, "ready")
 
     @log_sync(logger=logger, level=logging.INFO)
     async def cancel_launch_model(self, model_uid: str):
@@ -2412,6 +2422,7 @@ class WorkerActor(xo.StatelessActor):
         # Terminate model while its launching is not allow
         if model_uid in self._model_uid_launching_guard:
             raise ValueError(f"{model_uid} is launching")
+        await self._update_model_state(model_uid, "stopping")
         # In special cases, if the suffix is `-rank0`, this is the Xavier's rank 0 model actor.
         if model_uid.endswith("-rank0"):
             origin_uid = model_uid.removesuffix("-rank0")
@@ -2509,6 +2520,7 @@ class WorkerActor(xo.StatelessActor):
                 status = LaunchStatus.ERROR.name
             else:
                 status = LaunchStatus.TERMINATED.name
+                await self._update_model_state(model_uid, "stopped")
                 self._model_uid_to_model_status.pop(model_uid, None)
 
             if self._status_guard_ref is None:
@@ -2538,10 +2550,49 @@ class WorkerActor(xo.StatelessActor):
         return {k: v for k, v in self._model_uid_to_model_spec.items()}
 
     @log_sync(logger=logger)
+    async def _update_model_state(self, model_uid: str, state: str):
+        """Update ModelStatus.model_state and sync to StatusGuard."""
+        ms = self._model_uid_to_model_status.get(model_uid)
+        if ms is None:
+            ms = ModelStatus()
+            self._model_uid_to_model_status[model_uid] = ms
+        ms.model_state = state
+        status_map = {
+            "registering": LaunchStatus.CREATING.name,
+            "loading": LaunchStatus.LOADING.name,
+            "ready": LaunchStatus.READY.name,
+            "error": LaunchStatus.ERROR.name,
+            "stopping": LaunchStatus.TERMINATING.name,
+            "stopped": LaunchStatus.TERMINATED.name,
+        }
+        if self._status_guard_ref is not None:
+            try:
+                origin_uid, rank_suffix = parse_replica_model_uid(model_uid)
+                replica_id = rank_suffix - 1 if rank_suffix > 0 else 0
+                await self._status_guard_ref.update_replica_status(
+                    origin_uid,
+                    replica_id,
+                    {
+                        "status": status_map.get(state, LaunchStatus.CREATING.name),
+                        "model_state": state,
+                    },
+                )
+            except Exception:
+                logger.debug(
+                    "Failed to sync model_state to StatusGuard for %s",
+                    model_uid,
+                    exc_info=True,
+                )
+
     def get_model(self, model_uid: str) -> xo.ActorRefType["ModelActor"]:
         model_status = self._model_uid_to_model_status.get(model_uid)
-        if model_status and model_status.last_error:
-            raise Exception(model_status.last_error)
+        if model_status:
+            if model_status.model_state in ("registering", "loading"):
+                raise ModelNotReadyError(
+                    f"Model {model_uid} is {model_status.model_state}"
+                )
+            if model_status.last_error:
+                raise Exception(model_status.last_error)
         model_ref = self._model_uid_to_model.get(model_uid, None)
         if model_ref is None:
             raise ValueError(f"Model not found, uid: {model_uid}")

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -2285,11 +2285,7 @@ class WorkerActor(xo.StatelessActor):
                                 raise
                     except Exception:
                         logger.error(f"Failed to load model {model_uid}", exc_info=True)
-                        ms = self._model_uid_to_model_status.get(model_uid)
-                        if ms is None:
-                            ms = ModelStatus()
-                            self._model_uid_to_model_status[model_uid] = ms
-                        ms.model_state = "error"
+                        await self._update_model_state(model_uid, "error")
                         self.release_devices(model_uid=model_uid)
                         for addr in all_subpool_addresses:
                             try:
@@ -2549,7 +2545,7 @@ class WorkerActor(xo.StatelessActor):
     async def list_models(self) -> Dict[str, Dict[str, Any]]:
         return {k: v for k, v in self._model_uid_to_model_spec.items()}
 
-    @log_sync(logger=logger)
+    @log_async(logger=logger)
     async def _update_model_state(self, model_uid: str, state: str):
         """Update ModelStatus.model_state and sync to StatusGuard."""
         ms = self._model_uid_to_model_status.get(model_uid)
@@ -2590,6 +2586,10 @@ class WorkerActor(xo.StatelessActor):
             if model_status.model_state in ("registering", "loading"):
                 raise ModelNotReadyError(
                     f"Model {model_uid} is {model_status.model_state}"
+                )
+            if model_status.model_state in ("error", "stopping", "stopped"):
+                raise RuntimeError(
+                    f"Model {model_uid} is in {model_status.model_state} state"
                 )
             if model_status.last_error:
                 raise Exception(model_status.last_error)


### PR DESCRIPTION
## Summary

- **Introduce explicit model lifecycle state machine**: `registering → loading → ready → stopping → stopped` (plus `error`), replacing implicit state inference from dict membership. This fixes the race condition where `list_models` shows a model but chat requests return `500 AssertionError: self._engine is None` because the engine is still loading in a background thread.
- **New `ModelNotReadyError` exception** (`xinference/core/exceptions.py`) raised by `ModelActor._require_ready()` guard on all inference methods (generate, chat, create_embedding, rerank) when the model is not yet ready.
- **`LaunchStatus.LOADING`** enum value and **`ReplicaStatus.model_state`** field for fine-grained state tracking visible to supervisors and API consumers.
- **Supervisor race condition fix**: swap order in `_launch_one_model` so `wait_for_load` completes *before* the model is added to the route table (both normal and xavier rank0 paths). Previously, the route table was written before `wait_for_load`, allowing requests to hit a still-loading model.
- **HTTP 503 with `Retry-After: 30`** header for loading-state requests in the API layer (`require_model`). Loading is transient so `ModelNotReadyError` is **not** written to negative cache.
- **`WorkerActor._update_model_state()`** helper syncs state transitions to StatusGuard, with auto-creation of `ModelStatus` entries to support registering/loading states (previously only created after `load()` completed).

## Test plan

- [ ] `pytest xinference/core/tests/ -v --timeout=300` passes
- [ ] Fresh launch: `model_state` transitions through registering → loading → ready
- [ ] Chat during loading: returns HTTP 503 (not 500 AssertionError)
- [ ] OOM self-heal recover: model transitions through error → registering → loading → ready
- [ ] `GET /v1/models` includes `model_state` field
- [ ] Non-LLM models (embedding/rerank): loading state is transient (sub-second), no client-visible impact
- [ ] Multi-replica: only `ready` replicas are routed to
- [ ] Terminate: model transitions through stopping → stopped

## Design notes

- **State authority**: `WorkerActor.ModelStatus.model_state` is the authoritative source (routing decisions). `ModelActor._model_state` is a safety net for direct calls bypassing the worker.
- **Backward compatibility**: `model_state` defaults to empty string for existing data, treated as `ready` (current behavior).
- **`wait_ready=False` async launch**: model is visible in `list_models` (with `model_state=loading`) but not routable until ready. Clients can poll `model_state` to know when it's available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)