### PR TITLE
fix(core): sync model_serve_count gauge on stream request completion

### DIFF
--- a/xinference/core/model.py
+++ b/xinference/core/model.py
@@ -336,8 +336,13 @@ class ModelActor(xo.StatelessActor, CancelMixin):
     def __getattr__(self, attr: str):
         return getattr(self._model, attr)
 
-    def decrease_serve_count(self):
+    async def decrease_serve_count(self):
         self._serve_count -= 1
+        await self.record_metrics(
+            "model_serve_count",
+            "set",
+            {"labels": self._metrics_labels, "value": self._serve_count},
+        )
 
     @no_type_check
     async def start_transfer_for_vllm(self, rank_addresses: List[str]):

--- a/xinference/core/model.py
+++ b/xinference/core/model.py
@@ -144,7 +144,7 @@ def request_limit(fn):
                 # stream case, let client call model_ref to decrease self._serve_count
                 pass
             else:
-                self._serve_count -= 1
+                self._serve_count = max(0, self._serve_count - 1)
                 await self.record_metrics(
                     "model_serve_count",
                     "set",
@@ -337,7 +337,7 @@ class ModelActor(xo.StatelessActor, CancelMixin):
         return getattr(self._model, attr)
 
     async def decrease_serve_count(self):
-        self._serve_count -= 1
+        self._serve_count = max(0, self._serve_count - 1)
         await self.record_metrics(
             "model_serve_count",
             "set",


### PR DESCRIPTION
## Summary

- `decrease_serve_count` (called by `restful_api.py` for streaming requests) only decremented `_serve_count` without writing the new value back to the Prometheus registry.
- This caused `xinference:model_serve_count` to monotonically increase with every streaming request and never decrease, making the gauge diverge from the actual in-flight request count over time. A worker restart was the only way to reset it.
- Fix: make `decrease_serve_count` async and call `record_metrics` after decrementing, mirroring the non-stream path in the decorator's `finally` block (`model.py:147-153`).

All four call sites in `restful_api.py` (lines 1222, 1365, 1617, 2468) already use `await model.decrease_serve_count()`, so no caller changes are needed.

## Root cause

| Path | `_serve_count` | Prometheus gauge |
|------|----------------|------------------|
| Request enters decorator | +1 | `set` ✓ |
| Non-stream ends (decorator `finally`) | -1 | `set` ✓ |
| Stream ends (`restful_api` `finally` → `decrease_serve_count`) | -1 | **not set** ✗ |

## Test plan

- [ ] Start `xinference-local`, load a streaming-capable LLM
- [ ] Send non-stream requests → verify `xinference:model_serve_count` returns to 0 after each request
- [ ] Send stream requests → verify gauge returns to 0 after each stream completes (**primary verification**)
- [ ] Send concurrent stream requests (N=4) → verify gauge returns to 0 after all streams complete
- [ ] Trigger client disconnect mid-stream → verify gauge returns to 0
- [ ] Exceed `request_limits` → verify gauge does not inflate abnormally

🤖 Generated with [Claude Code](https://claude.com/claude-code)