### PR TITLE
fix: pin FastAPI below 0.137 for metrics middleware

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ install_requires =
     requests
     aiohttp
     pydantic
-    fastapi>=0.110.3
+    fastapi>=0.110.3,<0.137
     uvicorn
     huggingface-hub>=0.19.4
     typing_extensions


### PR DESCRIPTION
## Summary
- constrain FastAPI to `<0.137` in the base dependencies
- avoid resolving FastAPI 0.137.x until the metrics middleware path is compatible with FastAPI's new router structure

## Root cause
FastAPI 0.137 changed router inclusion internals so `app.routes` can contain an included-router node instead of only normal route objects. `aioprometheus.MetricsMiddleware` iterates matched routes and expects the matched object to expose `.path`, which raises on that new node while metrics are enabled.

## Validation
- `NO_WEB_UI=1 python setup.py --name`
- parsed the updated `fastapi>=0.110.3,<0.137` requirement with `packaging.requirements.Requirement`
- `pre-commit run --files setup.cfg`
- `git diff --check`