### PR TITLE
doc: update Read the Docs build image

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,7 +5,7 @@ sphinx:
    configuration: doc/source/conf.py
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
     python: "3.10"
 


### PR DESCRIPTION
## What

- Update the Read the Docs build image from `ubuntu-20.04` to `ubuntu-24.04`.

## Why

Read the Docs no longer accepts `ubuntu-20.04` in `build.os`, so docs builds fail during config validation before Sphinx runs.

## Validation

- Parsed `.readthedocs.yaml` locally and verified `build.os` resolves to `ubuntu-24.04`.
- Ran `pre-commit run --files .readthedocs.yaml` (no configured hooks apply to this YAML file).
