### PR TITLE
feat(audio): add VoxCPM2 model support

### DIFF
--- a/doc/source/models/builtin/audio/index.rst
+++ b/doc/source/models/builtin/audio/index.rst
@@ -88,6 +88,8 @@ The following is a list of built-in audio models in Xinference:
    seaco-paraformer-zh
   
    sensevoicesmall
+
+   voxcpm2
   
    whisper-base
   
@@ -128,4 +130,3 @@ The following is a list of built-in audio models in Xinference:
    whisper-tiny.en
   
    whisper-tiny.en-mlx
-  

--- a/doc/source/models/builtin/audio/voxcpm2.rst
+++ b/doc/source/models/builtin/audio/voxcpm2.rst
@@ -1,0 +1,19 @@
+.. _models_builtin_voxcpm2:
+
+========
+VoxCPM2
+========
+
+- **Model Name:** VoxCPM2
+- **Model Family:** VoxCPM
+- **Abilities:** ['text2audio', 'text2audio_zero_shot', 'text2audio_voice_cloning']
+- **Multilingual:** True
+
+Specifications
+^^^^^^^^^^^^^^
+
+- **Model ID:** openbmb/VoxCPM2
+
+Execute the following command to launch the model::
+
+   xinference launch --model-name VoxCPM2 --model-type audio

--- a/xinference/model/audio/core.py
+++ b/xinference/model/audio/core.py
@@ -31,6 +31,7 @@ from .megatts import MegaTTSModel
 from .melotts import MeloTTSModel
 from .qwen3_asr import Qwen3ASRModel
 from .qwen3_tts import Qwen3TTSModel
+from .voxcpm import VoxCPMModel
 from .whisper import WhisperModel
 from .whisper_mlx import WhisperMLXModel
 
@@ -159,6 +160,7 @@ def create_audio_model_instance(
     Indextts2,
     Qwen3ASRModel,
     Qwen3TTSModel,
+    VoxCPMModel,
 ]:
     from ..cache_manager import CacheManager
 
@@ -184,6 +186,7 @@ def create_audio_model_instance(
         Indextts2,
         Qwen3ASRModel,
         Qwen3TTSModel,
+        VoxCPMModel,
     ]
     if model_spec.model_family == "whisper":
         if not model_spec.engine:
@@ -218,6 +221,8 @@ def create_audio_model_instance(
         model = Qwen3ASRModel(model_uid, model_path, model_spec, **kwargs)
     elif model_spec.model_family == "qwen3_tts":
         model = Qwen3TTSModel(model_uid, model_path, model_spec, **kwargs)
+    elif model_spec.model_family == "VoxCPM":
+        model = VoxCPMModel(model_uid, model_path, model_spec, **kwargs)
     else:
         raise Exception(f"Unsupported audio model family: {model_spec.model_family}")
     return model

--- a/xinference/model/audio/model_spec.json
+++ b/xinference/model/audio/model_spec.json
@@ -1363,5 +1363,55 @@
     },
     "featured": false,
     "updated_at": 1775717207
+  },
+  {
+    "version": 2,
+    "model_name": "VoxCPM2",
+    "model_family": "VoxCPM",
+    "model_ability": [
+      "text2audio",
+      "text2audio_zero_shot",
+      "text2audio_voice_cloning"
+    ],
+    "multilingual": true,
+    "virtualenv": {
+      "packages": [
+        "voxcpm",
+        "#system_torch#",
+        "#system_torchaudio#",
+        "#system_torchcodec#",
+        "#system_numpy#",
+        "soundfile",
+        "librosa",
+        "transformers>=4.36.2",
+        "einops",
+        "huggingface-hub",
+        "modelscope>=1.22.0",
+        "datasets>=3,<4",
+        "inflect",
+        "addict",
+        "wetext",
+        "tqdm",
+        "simplejson",
+        "sortedcontainers",
+        "matplotlib",
+        "funasr",
+        "spaces",
+        "argbind",
+        "safetensors"
+      ]
+    },
+    "model_src": {
+      "huggingface": {
+        "model_id": "openbmb/VoxCPM2",
+        "model_revision": "bffb3df5a29440629464e5e839f4d214c8714c3d"
+      },
+      "modelscope": {
+        "model_id": "OpenBMB/VoxCPM2",
+        "model_revision": "master"
+      }
+    },
+    "updated_at": 1776310211,
+    "featured": true
   }
 ]

--- a/xinference/model/audio/tests/test_voxcpm.py
+++ b/xinference/model/audio/tests/test_voxcpm.py
@@ -1,0 +1,166 @@
+# Copyright 2022-2026 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import wave
+from io import BytesIO
+
+import numpy as np
+
+from xinference.model.audio.voxcpm import VoxCPMModel
+
+
+class _Spec:
+    model_ability = ["text2audio", "text2audio_zero_shot", "text2audio_voice_cloning"]
+
+
+class _FakeTTS:
+    sample_rate = 48000
+
+
+class _FakeModel:
+    def __init__(self):
+        self.tts_model = _FakeTTS()
+        self.kwargs = None
+
+    def generate(self, **kwargs):
+        self.kwargs = kwargs
+        return np.zeros(32, dtype="float32")
+
+    def generate_streaming(self, **kwargs):
+        self.kwargs = kwargs
+        yield np.zeros(16, dtype="float32")
+
+
+class _FakeMultiChunkModel(_FakeModel):
+    def generate_streaming(self, **kwargs):
+        self.kwargs = kwargs
+        for _ in range(2):
+            yield np.zeros(16, dtype="float32")
+
+
+def test_voxcpm_maps_voice_to_control_instruction():
+    model = VoxCPMModel("uid", "/tmp/model", _Spec())
+    model._model = _FakeModel()
+
+    out = model.speech("hello", voice="warm narrator", response_format="pcm")
+
+    assert len(out) == 64
+    assert model._model.kwargs["text"] == "(warm narrator)hello"
+    assert model._model.kwargs["prompt_wav_path"] is None
+    assert model._model.kwargs["reference_wav_path"] is None
+
+
+def test_voxcpm_prompt_speech_uses_temp_reference_file():
+    model = VoxCPMModel("uid", "/tmp/model", _Spec())
+    model._model = _FakeModel()
+
+    out = model.speech(
+        "hello",
+        voice="alloy",
+        response_format="wav",
+        prompt_speech=b"fake wav bytes",
+    )
+
+    temp_path = model._model.kwargs["reference_wav_path"]
+
+    with wave.open(BytesIO(out), "rb") as wav_file:
+        assert wav_file.getframerate() == 48000
+        assert wav_file.getnchannels() == 1
+        assert wav_file.getnframes() == 32
+    assert temp_path is not None
+    assert not os.path.exists(temp_path)
+
+
+def test_voxcpm_pcm_streaming_cleans_up_temp_files():
+    model = VoxCPMModel("uid", "/tmp/model", _Spec())
+    model._model = _FakeModel()
+
+    stream = model.speech(
+        "hello",
+        voice="alloy",
+        response_format="pcm",
+        stream=True,
+        prompt_speech=b"fake wav bytes",
+        prompt_text="reference text",
+    )
+
+    chunks = list(stream)
+    temp_path = model._model.kwargs["reference_wav_path"]
+
+    assert len(chunks) == 1
+    assert len(chunks[0]) == 32
+    assert model._model.kwargs["prompt_wav_path"] == temp_path
+    assert temp_path is not None
+    assert not os.path.exists(temp_path)
+
+
+def test_voxcpm_pcm_streaming_close_cleans_up_unconsumed_temp_files(
+    monkeypatch, tmp_path
+):
+    temp_path = tmp_path / "prompt.wav"
+    monkeypatch.setattr(
+        VoxCPMModel,
+        "_save_temp_audio",
+        staticmethod(lambda audio: temp_path.write_bytes(audio) and str(temp_path)),
+    )
+
+    model = VoxCPMModel("uid", "/tmp/model", _Spec())
+    model._model = _FakeModel()
+
+    stream = model.speech(
+        "hello",
+        voice="alloy",
+        response_format="pcm",
+        stream=True,
+        prompt_speech=b"fake wav bytes",
+        prompt_text="reference text",
+    )
+
+    assert os.path.exists(temp_path)
+
+    stream.close()
+
+    assert not os.path.exists(temp_path)
+
+
+def test_voxcpm_pcm_streaming_close_cleans_up_partially_consumed_temp_files(
+    monkeypatch, tmp_path
+):
+    temp_path = tmp_path / "prompt.wav"
+    monkeypatch.setattr(
+        VoxCPMModel,
+        "_save_temp_audio",
+        staticmethod(lambda audio: temp_path.write_bytes(audio) and str(temp_path)),
+    )
+
+    model = VoxCPMModel("uid", "/tmp/model", _Spec())
+    model._model = _FakeMultiChunkModel()
+
+    stream = model.speech(
+        "hello",
+        voice="alloy",
+        response_format="pcm",
+        stream=True,
+        prompt_speech=b"fake wav bytes",
+        prompt_text="reference text",
+    )
+    first_chunk = next(stream)
+
+    assert len(first_chunk) == 32
+    assert model._model.kwargs["reference_wav_path"] == str(temp_path)
+    assert os.path.exists(temp_path)
+
+    stream.close()
+
+    assert not os.path.exists(temp_path)

--- a/xinference/model/audio/voxcpm.py
+++ b/xinference/model/audio/voxcpm.py
@@ -1,0 +1,360 @@
+# Copyright 2022-2026 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+import os
+import tempfile
+import wave
+from io import BytesIO
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from .core import AudioModelFamilyV2
+
+logger = logging.getLogger(__name__)
+
+
+class _CleanupGenerator:
+    def __init__(self, generator, cleanup):
+        self._generator = generator
+        self._cleanup = cleanup
+        self._closed = False
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        try:
+            return next(self._generator)
+        except StopIteration:
+            self.close()
+            raise
+        except Exception:
+            self.close()
+            raise
+
+    def close(self):
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            close = getattr(self._generator, "close", None)
+            if close is not None:
+                try:
+                    close()
+                except Exception:
+                    pass
+        finally:
+            self._cleanup()
+
+    def __del__(self):
+        try:
+            self.close()
+        except Exception:
+            pass
+
+
+class VoxCPMModel:
+    def __init__(
+        self,
+        model_uid: str,
+        model_path: str,
+        model_spec: "AudioModelFamilyV2",
+        device: Optional[str] = None,
+        **kwargs,
+    ):
+        self.model_family = model_spec
+        self._model_uid = model_uid
+        self._model_path = model_path
+        self._model_spec = model_spec
+        self._device = device
+        self._model = None
+        self._kwargs = kwargs
+
+    @property
+    def model_ability(self):
+        return self._model_spec.model_ability
+
+    @staticmethod
+    def _save_temp_audio(audio: bytes) -> str:
+        with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as f:
+            f.write(audio)
+            return f.name
+
+    @staticmethod
+    def _cleanup_temp_files(temp_files):
+        while temp_files:
+            temp_file = temp_files.pop()
+            try:
+                os.unlink(temp_file)
+            except Exception:
+                pass
+
+    @staticmethod
+    def _as_stream_tensor(chunk):
+        import torch
+
+        tensor = torch.as_tensor(chunk, dtype=torch.float32).cpu()
+        if tensor.dim() == 1:
+            return tensor.unsqueeze(1)
+        if tensor.dim() == 2 and tensor.shape[0] == 1:
+            return tensor.transpose(0, 1)
+        return tensor
+
+    @staticmethod
+    def _as_audio_array(audio):
+        import numpy as np
+
+        try:
+            import torch
+        except ImportError:
+            torch = None  # type: ignore
+
+        if torch is not None and isinstance(audio, torch.Tensor):
+            audio = audio.detach().cpu().numpy()
+
+        audio_array = np.asarray(audio, dtype=np.float32)
+        if audio_array.ndim == 0:
+            audio_array = audio_array.reshape(1)
+        elif audio_array.ndim == 2:
+            if audio_array.shape[0] == 1:
+                audio_array = audio_array[0]
+            elif audio_array.shape[1] == 1:
+                audio_array = audio_array[:, 0]
+            elif audio_array.shape[0] < audio_array.shape[1]:
+                audio_array = audio_array.T
+        elif audio_array.ndim > 2:
+            raise ValueError(f"Unsupported audio shape: {audio_array.shape}")
+
+        return audio_array
+
+    @staticmethod
+    def _float_to_pcm16(audio):
+        import numpy as np
+
+        return (np.clip(audio, -1.0, 1.0) * 32767.0).astype("<i2")
+
+    @classmethod
+    def _audio_to_bytes(cls, response_format: str, sample_rate: int, audio) -> bytes:
+        audio_array = cls._as_audio_array(audio)
+        response_format = response_format.lower()
+
+        if response_format == "pcm":
+            return cls._float_to_pcm16(audio_array).tobytes()
+
+        if audio_array.ndim == 1:
+            channels = 1
+        else:
+            channels = audio_array.shape[1]
+
+        if response_format == "wav":
+            with BytesIO() as out:
+                with wave.open(out, "wb") as wav_file:
+                    wav_file.setnchannels(channels)
+                    wav_file.setsampwidth(2)
+                    wav_file.setframerate(sample_rate)
+                    wav_file.writeframes(cls._float_to_pcm16(audio_array).tobytes())
+                return out.getvalue()
+
+        import soundfile
+
+        with BytesIO() as out:
+            with soundfile.SoundFile(
+                out,
+                "w",
+                sample_rate,
+                channels,
+                format=response_format.upper(),
+            ) as f:
+                f.write(audio_array)
+            return out.getvalue()
+
+    def _get_sample_rate(self) -> int:
+        assert self._model is not None
+        return int(getattr(self._model.tts_model, "sample_rate", 48000))
+
+    def load(self):
+        try:
+            from voxcpm import VoxCPM
+        except ImportError:
+            error_message = "Failed to import module 'voxcpm'"
+            installation_guide = [
+                "Please make sure 'voxcpm' is installed. ",
+                "You can install it by `pip install voxcpm`\n",
+            ]
+            raise ImportError(f"{error_message}\n\n{''.join(installation_guide)}")
+
+        compile_opt = self._kwargs.pop("compile", None)
+        optimize_opt = self._kwargs.pop("optimize", None)
+        optimize = bool(
+            optimize_opt if optimize_opt is not None else compile_opt or False
+        )
+        load_denoiser = bool(self._kwargs.pop("load_denoiser", False))
+        zipenhancer_model_id = self._kwargs.pop("zipenhancer_model_id", None)
+
+        logger.info(
+            "Loading VoxCPM model, optimize=%s, load_denoiser=%s...",
+            optimize,
+            load_denoiser,
+        )
+        load_kwargs = dict(
+            load_denoiser=load_denoiser,
+            optimize=optimize,
+            device=self._device,
+        )
+        if zipenhancer_model_id is not None:
+            load_kwargs["zipenhancer_model_id"] = zipenhancer_model_id
+        self._model = VoxCPM.from_pretrained(
+            self._model_path, **load_kwargs, **self._kwargs
+        )
+
+    def _build_generate_kwargs(
+        self,
+        input: str,
+        voice: str,
+        speed: float,
+        kwargs,
+        temp_files,
+    ):
+        prompt_speech: Optional[bytes] = kwargs.pop("prompt_speech", None)
+        reference_speech: Optional[bytes] = kwargs.pop("reference_speech", None)
+        prompt_text: Optional[str] = kwargs.pop("prompt_text", None)
+        control_instruction: Optional[str] = kwargs.pop(
+            "control_instruction", None
+        ) or kwargs.pop("instruct_text", None)
+
+        prompt_wav_path: Optional[str] = kwargs.pop("prompt_wav_path", None)
+        reference_wav_path: Optional[str] = kwargs.pop("reference_wav_path", None)
+
+        if prompt_speech is not None:
+            prompt_speech_path = self._save_temp_audio(prompt_speech)
+            temp_files.append(prompt_speech_path)
+            if prompt_text:
+                prompt_wav_path = prompt_wav_path or prompt_speech_path
+                reference_wav_path = reference_wav_path or prompt_speech_path
+            else:
+                reference_wav_path = reference_wav_path or prompt_speech_path
+
+        if reference_speech is not None:
+            reference_speech_path = self._save_temp_audio(reference_speech)
+            temp_files.append(reference_speech_path)
+            reference_wav_path = reference_wav_path or reference_speech_path
+
+        openai_voices = {
+            "alloy",
+            "ash",
+            "ballad",
+            "coral",
+            "echo",
+            "fable",
+            "nova",
+            "onyx",
+            "sage",
+            "shimmer",
+            "verse",
+        }
+        if not control_instruction and voice and voice.lower() not in openai_voices:
+            control_instruction = voice
+
+        text = input
+        if control_instruction:
+            control_instruction = control_instruction.replace("(", "").replace(")", "")
+            control_instruction = control_instruction.replace("（", "").replace(
+                "）", ""
+            )
+            text = f"({control_instruction.strip()}){input}"
+
+        generate_kwargs = {
+            "text": text,
+            "prompt_wav_path": prompt_wav_path,
+            "prompt_text": prompt_text,
+            "reference_wav_path": reference_wav_path,
+            "cfg_value": float(kwargs.pop("cfg_value", 2.0)),
+            "inference_timesteps": int(kwargs.pop("inference_timesteps", 10)),
+            "min_len": int(kwargs.pop("min_len", 2)),
+            "max_len": int(kwargs.pop("max_len", 4096)),
+            "normalize": bool(kwargs.pop("normalize", False)),
+            "denoise": bool(kwargs.pop("denoise", False)),
+            "retry_badcase": bool(kwargs.pop("retry_badcase", True)),
+            "retry_badcase_max_times": int(kwargs.pop("retry_badcase_max_times", 3)),
+            "retry_badcase_ratio_threshold": float(
+                kwargs.pop("retry_badcase_ratio_threshold", 6.0)
+            ),
+        }
+
+        if speed != 1.0:
+            logger.warning("VoxCPM does not support speed parameter, ignoring it.")
+
+        if kwargs:
+            logger.warning("Ignoring unsupported VoxCPM speech kwargs: %s", kwargs)
+
+        return generate_kwargs
+
+    def speech(
+        self,
+        input: str,
+        voice: str,
+        response_format: str = "mp3",
+        speed: float = 1.0,
+        stream: bool = False,
+        **kwargs,
+    ):
+        assert self._model is not None
+
+        from .utils import audio_stream_generator
+
+        temp_files = []
+        cleanup_temp_files = True
+        try:
+            generate_kwargs = self._build_generate_kwargs(
+                input=input,
+                voice=voice,
+                speed=speed,
+                kwargs=kwargs,
+                temp_files=temp_files,
+            )
+
+            if stream:
+                sample_rate = self._get_sample_rate()
+                cleanup_temp_files = False
+                cleanup = lambda: self._cleanup_temp_files(temp_files)
+
+                if response_format.lower() == "pcm":
+
+                    def _pcm_stream():
+                        for chunk in self._model.generate_streaming(**generate_kwargs):
+                            yield self._audio_to_bytes(
+                                response_format=response_format,
+                                sample_rate=sample_rate,
+                                audio=chunk,
+                            )
+
+                    return _CleanupGenerator(_pcm_stream(), cleanup)
+
+                stream_generator = audio_stream_generator(
+                    response_format=response_format,
+                    sample_rate=sample_rate,
+                    output_generator=self._model.generate_streaming(**generate_kwargs),
+                    output_chunk_transformer=self._as_stream_tensor,
+                )
+                return _CleanupGenerator(stream_generator, cleanup)
+
+            wav = self._model.generate(**generate_kwargs)
+            return self._audio_to_bytes(
+                response_format=response_format,
+                sample_rate=self._get_sample_rate(),
+                audio=wav,
+            )
+        finally:
+            if cleanup_temp_files:
+                self._cleanup_temp_files(temp_files)


### PR DESCRIPTION
## What this PR does

Adds built-in audio model support for VoxCPM2.

This PR includes:

- a new `VoxCPMModel` wrapper for `openbmb/VoxCPM2`
- built-in model spec registration for Hugging Face and ModelScope
- audio model factory registration for the `VoxCPM` family
- documentation for launching VoxCPM2
- lightweight unit tests covering voice instruction mapping, prompt speech temp file cleanup, and PCM streaming cleanup

## Notes

The VoxCPM2 wrapper supports:

- text-to-audio generation
- voice design via control instructions
- zero-shot / voice cloning with `prompt_speech`
- prompt audio + prompt text cloning
- streaming output

For non-streaming output, VoxCPM2 uses a local encoding path for PCM/WAV output instead of `torchaudio.save`, avoiding runtime failures in environments where `torchaudio` delegates to `torchcodec` but the system CUDA/FFmpeg shared libraries are incomplete.

`speed` is accepted for OpenAI-compatible API compatibility, but VoxCPM2 does not expose a numeric speech-rate parameter in `generate()` / `generate_streaming()`. Non-default values are ignored with a warning; use VoxCPM2 control instructions (for example, `control_instruction="speaking slowly"`) for style or pace control.

## Tests

```bash
python -m pytest xinference/model/audio/tests/test_voxcpm.py -q
python -m py_compile xinference/model/audio/voxcpm.py xinference/model/audio/core.py xinference/model/audio/tests/test_voxcpm.py
python -m json.tool xinference/model/audio/model_spec.json
git diff --check upstream/main...HEAD
```

