### PR TITLE
fix(rerank/llama.cpp): honor flat launch kwargs (n_ctx/n_batch/n_ubatch) so rerankers aren't capped at default ubatch (#5001)

### DIFF
--- a/xinference/model/rerank/llama_cpp/core.py
+++ b/xinference/model/rerank/llama_cpp/core.py
@@ -61,6 +61,10 @@ class XllamaCppRerankModel(RerankModel):
     def _sanitize_model_config(self, llamacpp_model_config: Optional[dict]) -> dict:
         if llamacpp_model_config is None:
             llamacpp_model_config = {}
+        else:
+            # Copy so the defaults below are never written back into a
+            # user-supplied ``llamacpp_model_config`` dict that may be reused.
+            llamacpp_model_config = dict(llamacpp_model_config)
 
         llamacpp_model_config.setdefault("rerank", True)
         llamacpp_model_config.setdefault("use_mmap", False)

--- a/xinference/model/rerank/llama_cpp/core.py
+++ b/xinference/model/rerank/llama_cpp/core.py
@@ -45,6 +45,17 @@ class XllamaCppRerankModel(RerankModel):
         self._llm = None
         self._executor: Optional[concurrent.futures.ThreadPoolExecutor] = None
         llamacpp_model_config = self._kwargs.get("llamacpp_model_config")
+        if llamacpp_model_config is None:
+            # Launch-time llama.cpp options (e.g. ``n_ctx``, ``n_batch``,
+            # ``n_ubatch``) arrive as flat kwargs from the CLI / REST API rather
+            # than nested under a ``llamacpp_model_config`` dict. Mirror the LLM
+            # llama.cpp backend, which treats the whole kwargs dict as its model
+            # config, so user-supplied context/batch sizes are honored instead
+            # of silently falling back to defaults (which caps reranking around
+            # the default ubatch size).
+            llamacpp_model_config = {
+                k: v for k, v in self._kwargs.items() if k != "llamacpp_model_config"
+            }
         self._llamacpp_model_config = self._sanitize_model_config(llamacpp_model_config)
 
     def _sanitize_model_config(self, llamacpp_model_config: Optional[dict]) -> dict:

--- a/xinference/model/rerank/llama_cpp/core.py
+++ b/xinference/model/rerank/llama_cpp/core.py
@@ -153,7 +153,9 @@ class XllamaCppRerankModel(RerankModel):
                     else:
                         setattr(params, k, v)
                 except Exception as e:
-                    logger.error("Failed to set the param %s = %s, error: %s", k, v, e)
+                    logger.warning(
+                        "Failed to set the param %s = %s, error: %s", k, v, e
+                    )
             n_threads = self._llamacpp_model_config.get("n_threads", os.cpu_count())
             params.cpuparams.n_threads = n_threads
             params.cpuparams_batch.n_threads = n_threads


### PR DESCRIPTION
### What

The xllamacpp **rerank** backend honors llama.cpp launch options
(`n_ctx`, `n_batch`, `n_ubatch`, ...) only when they are nested under a
`llamacpp_model_config` dict:

```python
llamacpp_model_config = self._kwargs.get("llamacpp_model_config")
self._llamacpp_model_config = self._sanitize_model_config(llamacpp_model_config)
```

But the CLI and REST/OpenAI launch paths deliver these as **flat** kwargs.
The LLM llama.cpp backend handles this by passing the whole kwargs dict in as
its `llamacpp_model_config` (`create_llm_model_instance` calls
`llm_cls(model_uid, llm_family, model_path, kwargs)`), whereas
`create_rerank_model_instance` forwards `**kwargs` and the loader looks only for
the nested key — which is absent, so `_sanitize_model_config(None)` falls back to
defaults.

### Effect

Launching a GGUF reranker with the `llama.cpp` engine and explicit
`--n_ctx 4096 --n_batch 2048 --n_ubatch 2048` **accepts** the flags but loads
the model with default params. Because embedding/rerank in llama.cpp need the
whole sequence to fit in a single ubatch, the effective input is capped near the
default ubatch size (~512 tokens), silently truncating longer query/document
pairs regardless of the model's real context length.

Fixes #5001.

### Change

When no nested `llamacpp_model_config` is supplied, fall back to the flat launch
kwargs (excluding the `llamacpp_model_config` key itself), mirroring the LLM
backend. Explicitly-nested config still takes precedence. The existing
per-key `setattr` loop already guards unknown keys with try/except + logging, so
unrelated kwargs remain harmless.

```python
llamacpp_model_config = self._kwargs.get("llamacpp_model_config")
if llamacpp_model_config is None:
    llamacpp_model_config = {
        k: v for k, v in self._kwargs.items() if k != "llamacpp_model_config"
    }
self._llamacpp_model_config = self._sanitize_model_config(llamacpp_model_config)
```

### Notes

- Scoped to the reported rerank path. The embedding llama.cpp backend
  (`xinference/model/embedding/llama_cpp/core.py`) reads config with the same
  nested-only pattern and likely has the identical latent gap; happy to extend
  this fix there in a follow-up (or this PR) if maintainers prefer.
- `black`/`flake8` clean; pure Python, no runtime/GPU-specific code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
