### PR TITLE
fix(anthropic): honor top-level system prompt and inline system messages (#5037)

### DIFF
--- a/xinference/api/restful_api.py
+++ b/xinference/api/restful_api.py
@@ -1287,7 +1287,7 @@ class RESTfulAPI(CancelMixin):
             normalized.append(msg)
 
         if system_parts:
-            normalized.insert(0, {"role": "system", "content": "".join(system_parts)})
+            normalized.insert(0, {"role": "system", "content": "\n".join(system_parts)})
         return normalized
 
     async def create_message(self, request: Request) -> Response:

--- a/xinference/api/restful_api.py
+++ b/xinference/api/restful_api.py
@@ -1242,6 +1242,54 @@ class RESTfulAPI(CancelMixin):
                 self.handle_request_limit_error(e)
                 raise HTTPException(status_code=500, detail=str(e))
 
+    @staticmethod
+    def _normalize_anthropic_messages(
+        raw_system: Any, messages: Optional[List[dict]]
+    ) -> List[dict]:
+        """Fold the Anthropic top-level ``system`` prompt and any inline
+        ``role: system`` messages into a single leading OpenAI-style system
+        message.
+
+        Anthropic's Messages API carries the system prompt in a top-level
+        ``system`` field, and some clients (notably Claude Code >= 2.1.154)
+        additionally place ``role: system`` entries inside the ``messages``
+        array. xinference dispatches to an OpenAI-style ``chat`` backend, which
+        expects the system prompt as a leading ``{"role": "system"}`` message
+        and only accepts ``user``/``assistant`` roles in the array. Without this
+        normalization the top-level ``system`` prompt is silently dropped (the
+        ``raw_params`` carrying it are discarded before the model is called) and
+        inline system messages trip the role validation below.
+        """
+
+        def _collect(content: Any, parts: List[str]) -> None:
+            if isinstance(content, str):
+                if content:
+                    parts.append(content)
+            elif isinstance(content, list):
+                for block in content:
+                    if not isinstance(block, dict) or block.get("type") != "text":
+                        continue
+                    text = block.get("text") or ""
+                    # Strip Claude Code's per-request billing header; it carries
+                    # a changing hash that would otherwise defeat prefix caching.
+                    if text.startswith("x-anthropic-billing-header"):
+                        continue
+                    parts.append(text)
+
+        system_parts: List[str] = []
+        _collect(raw_system, system_parts)
+
+        normalized: List[dict] = []
+        for msg in messages or []:
+            if msg.get("role") == "system":
+                _collect(msg.get("content"), system_parts)
+                continue
+            normalized.append(msg)
+
+        if system_parts:
+            normalized.insert(0, {"role": "system", "content": "".join(system_parts)})
+        return normalized
+
     async def create_message(self, request: Request) -> Response:
         raw_body = await request.json()
         body = CreateMessage.parse_obj(raw_body)
@@ -1266,6 +1314,13 @@ class RESTfulAPI(CancelMixin):
             kwargs["max_tokens"] = max_tokens_field.default
 
         messages = body.messages and list(body.messages)
+
+        # Fold the top-level `system` prompt and any inline `role: system`
+        # messages into a leading OpenAI-style system message, then drop the
+        # consumed `system` field so it is not forwarded as a stray generation
+        # parameter (which the chat backend discards anyway).
+        messages = self._normalize_anthropic_messages(raw_body.get("system"), messages)
+        raw_kwargs.pop("system", None)
 
         if not messages or messages[-1].get("role") not in ["user", "assistant"]:
             raise HTTPException(

--- a/xinference/core/tests/test_restful_api.py
+++ b/xinference/core/tests/test_restful_api.py
@@ -1562,7 +1562,7 @@ def test_normalize_anthropic_messages_inline_system_merged():
         ],
     )
     assert result == [
-        {"role": "system", "content": "Top.Inline.A.B."},
+        {"role": "system", "content": "Top.\nInline.\nA.\nB."},
         {"role": "user", "content": "Hi"},
     ]
 

--- a/xinference/core/tests/test_restful_api.py
+++ b/xinference/core/tests/test_restful_api.py
@@ -1514,6 +1514,70 @@ def anthropic_setup():
     )
 
 
+def test_normalize_anthropic_messages_top_level_string():
+    """Top-level `system` string becomes a leading system message."""
+    from ...api.restful_api import RESTfulAPI
+
+    result = RESTfulAPI._normalize_anthropic_messages(
+        "Be concise.", [{"role": "user", "content": "Hi"}]
+    )
+    assert result == [
+        {"role": "system", "content": "Be concise."},
+        {"role": "user", "content": "Hi"},
+    ]
+
+
+def test_normalize_anthropic_messages_strips_billing_header():
+    """Claude Code's per-request billing header block is dropped."""
+    from ...api.restful_api import RESTfulAPI
+
+    result = RESTfulAPI._normalize_anthropic_messages(
+        [
+            {"type": "text", "text": "x-anthropic-billing-header: cc_version=2.1.160"},
+            {"type": "text", "text": "You are Claude Code."},
+        ],
+        [{"role": "user", "content": "Hi"}],
+    )
+    assert result[0] == {"role": "system", "content": "You are Claude Code."}
+    assert result[1] == {"role": "user", "content": "Hi"}
+
+
+def test_normalize_anthropic_messages_inline_system_merged():
+    """Inline `role: system` messages are merged with the top-level prompt and
+    removed from the message list (Claude Code >= 2.1.154 compatibility)."""
+    from ...api.restful_api import RESTfulAPI
+
+    result = RESTfulAPI._normalize_anthropic_messages(
+        "Top.",
+        [
+            {"role": "user", "content": "Hi"},
+            {"role": "system", "content": "Inline."},
+            {
+                "role": "system",
+                "content": [
+                    {"type": "text", "text": "A."},
+                    {"type": "text", "text": "B."},
+                ],
+            },
+        ],
+    )
+    assert result == [
+        {"role": "system", "content": "Top.Inline.A.B."},
+        {"role": "user", "content": "Hi"},
+    ]
+
+
+def test_normalize_anthropic_messages_no_system_unchanged():
+    """Requests without any system content are passed through unchanged."""
+    from ...api.restful_api import RESTfulAPI
+
+    messages = [
+        {"role": "user", "content": "Hi"},
+        {"role": "assistant", "content": "Yo"},
+    ]
+    assert RESTfulAPI._normalize_anthropic_messages(None, messages) == messages
+
+
 def test_convert_openai_to_anthropic_with_tools(anthropic_setup):
     """Test conversion of OpenAI response with tool calls to Anthropic format"""
     handler, sample_openai_response_with_tools, _ = anthropic_setup


### PR DESCRIPTION
## What

Makes the Anthropic-compatible `/anthropic/v1/messages` endpoint honor the **top-level `system` prompt** and **inline `role: system` messages**.

Fixes #5037.

## Why

Today the endpoint silently drops the system prompt:

- `create_message` parses the body but never reads the Anthropic top-level `system` field. Because `system` isn't in the `exclude` set, it ends up in `raw_kwargs` and is passed as `raw_params` to `model.chat(...)`.
- `ModelActor.chat` then does `kwargs.pop("raw_params", None)` (`xinference/core/model.py`), so `raw_params` — and with it the entire system prompt — is discarded before the model is ever called.

So a standard Anthropic request that puts instructions in `system` runs **without any system prompt**. Separately, recent Claude Code clients (>= 2.1.154) also place `role: system` entries *inside* the `messages` array, which the OpenAI-style chat backend expects as a single leading system message.

vLLM hit the same incompatibility and fixed it by normalizing these into a leading system message ([vllm-project/vllm#44283](https://github.com/vllm-project/vllm/pull/44283), merged). This PR takes the same approach for xinference.

## What changed

`create_message` now folds the system content into one leading OpenAI-style `{"role": "system", ...}` message before validation/dispatch, via a small testable helper `_normalize_anthropic_messages`:

- Reads the top-level `system` field (string or list of text blocks).
- Merges any inline `role: system` messages from the array (and removes them from the dispatched list).
- Strips Claude Code's per-request `x-anthropic-billing-header` block (it carries a changing hash that defeats prefix caching — same treatment as upstream vLLM).
- Drops the consumed `system` key from `raw_kwargs`.

Requests with no system content are passed through unchanged, so existing behavior is preserved.

## Tests

Added unit tests in `xinference/core/tests/test_restful_api.py` covering: top-level string system, billing-header stripping, inline-system merging (string + list content), and the no-system pass-through case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
