### PR TITLE
fix(audio): warn and ignore non-zero temperature for Qwen3-ASR instead of raising

### DIFF
--- a/xinference/model/audio/qwen3_asr.py
+++ b/xinference/model/audio/qwen3_asr.py
@@ -113,7 +113,11 @@ class Qwen3ASRModel:
         **kwargs,
     ):
         if temperature != 0:
-            raise RuntimeError("`temperature` is not supported for Qwen3-ASR")
+            logger.warning(
+                "`temperature` is not supported for Qwen3-ASR and will be "
+                "ignored: %s",
+                temperature,
+            )
         if timestamp_granularities is not None:
             raise RuntimeError(
                 "`timestamp_granularities` is not supported for Qwen3-ASR"


### PR DESCRIPTION
## Summary

`Qwen3ASRModel.transcriptions()` raises `RuntimeError("`temperature` is not supported for Qwen3-ASR")` whenever `temperature != 0`. The default OpenAI-compatible transcription clients (and the OpenAI Python SDK in some configurations) send a non-zero default `temperature` (e.g. `0.7`), so every transcription request fails before any audio is processed.

Traceback from #4996:

```
File "xinference/model/audio/qwen3_asr.py", line 116, in transcriptions
    raise RuntimeError("`temperature` is not supported for Qwen3-ASR")
RuntimeError: `temperature` is not supported for Qwen3-ASR
```

## Fix

Qwen3-ASR genuinely has no sampling temperature, but a non-zero value coming from a standard client should not be a hard failure. This change makes `temperature` behave like the `prompt` argument a few lines below in the same method — **log a warning and ignore it** — so the model stays usable through the OpenAI-compatible API.

```python
if temperature != 0:
    logger.warning(
        "`temperature` is not supported for Qwen3-ASR and will be "
        "ignored: %s",
        temperature,
    )
```

This preserves backward compatibility (the parameter still has no effect) and keeps the change localized, per the repo's contribution guidance. `timestamp_granularities` is intentionally left raising, since it changes the response structure rather than being a benign ignorable default.

Fixes #4996

🤖 Generated with [Claude Code](https://claude.com/claude-code)
