### PR TITLE
fix(embedding): pin peft/transformers for jina-embeddings-v5 series

### DIFF
--- a/xinference/model/embedding/model_spec.json
+++ b/xinference/model/embedding/model_spec.json
@@ -1579,11 +1579,11 @@
       "packages": [
         "sentence_transformers",
         "einops",
-        "peft>=0.15.2",
+        "peft==0.18.1",
         "accelerate>=0.28.0",
         "#system_torchvision# ; #engine# == \"sentence_transformers\"",
         "#system_torch# ; #engine# == \"sentence_transformers\"",
-        "transformers>=4.57.0"
+        "transformers==5.7.0"
       ]
     },
     "updated_at": 1781240042,
@@ -1620,11 +1620,11 @@
       "packages": [
         "sentence_transformers",
         "einops",
-        "peft>=0.15.2",
+        "peft==0.18.1",
         "accelerate>=0.28.0",
         "#system_torchvision# ; #engine# == \"sentence_transformers\"",
         "#system_torch# ; #engine# == \"sentence_transformers\"",
-        "transformers>=4.57.0"
+        "transformers==5.7.0"
       ]
     },
     "updated_at": 1781240043,
@@ -1661,14 +1661,14 @@
       "packages": [
         "sentence_transformers",
         "einops",
-        "peft>=0.15.2",
+        "peft==0.18.1",
         "accelerate>=0.28.0",
         "pillow",
         "librosa",
         "soundfile",
         "#system_torchvision# ; #engine# == \"sentence_transformers\"",
         "#system_torch# ; #engine# == \"sentence_transformers\"",
-        "transformers>=5.0.0"
+        "transformers==5.7.0"
       ]
     },
     "updated_at": 1781240044,
@@ -1705,14 +1705,14 @@
       "packages": [
         "sentence_transformers",
         "einops",
-        "peft>=0.15.2",
+        "peft==0.18.1",
         "accelerate>=0.28.0",
         "pillow",
         "librosa",
         "soundfile",
         "#system_torchvision# ; #engine# == \"sentence_transformers\"",
         "#system_torch# ; #engine# == \"sentence_transformers\"",
-        "transformers>=5.1.0"
+        "transformers==5.7.0"
       ]
     },
     "updated_at": 1781240045,


### PR DESCRIPTION
## Summary
- Pin `peft==0.18.1` and `transformers==5.7.0` for the four jina-embeddings-v5 models (`text-nano`, `text-small`, `omni-nano`, `omni-small`) in `xinference/model/embedding/model_spec.json`.
- Replaces the previous looser bounds (`peft>=0.15.2`, `transformers>=4.57.0` / `>=5.0.0` / `>=5.1.0`) that were observed to cause runtime regressions for these models.

## Test plan
- [ ] `pytest -vv xinference/model/embedding/tests` passes
- [ ] Manually launch one jina-embeddings-v5 model and verify embedding inference works with `transformers==5.7.0` + `peft==0.18.1`
- [ ] Confirm no other embedding models in the same spec file are affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)