### PR TITLE
fix(device_utils): tolerate unsupported nvmlDeviceGetUtilizationRates in WSL2

### DIFF
--- a/xinference/device_utils.py
+++ b/xinference/device_utils.py
@@ -196,13 +196,22 @@ def _get_info_by_pynvml(gpu_id: int) -> Dict[str, float]:
         mem_info = pynvml.nvmlDeviceGetMemoryInfo_v2(handler)
     except (pynvml.NVMLError, AttributeError):
         mem_info = nvmlDeviceGetMemoryInfo(handler)
-    utilization = nvmlDeviceGetUtilizationRates(handler)
+    # nvmlDeviceGetUtilizationRates() is not supported in every environment
+    # (notably NVIDIA's WSL2 NVML, which raises NVML_ERROR_UNKNOWN /
+    # NVML_ERROR_NOT_SUPPORTED for utilization queries even when memory queries
+    # succeed). A failed utilization query should not discard the whole device's
+    # memory info, so degrade gracefully to 0% utilization instead of letting the
+    # exception drop the GPU from detection entirely.
+    try:
+        util = nvmlDeviceGetUtilizationRates(handler).gpu
+    except pynvml.NVMLError:
+        util = 0
     return {
         "name": gpu_name,
         "total": mem_info.total,
         "used": mem_info.used,
         "free": mem_info.free,
-        "util": utilization.gpu,
+        "util": util,
     }
 
 


### PR DESCRIPTION
### What

`_get_info_by_pynvml()` calls `nvmlDeviceGetUtilizationRates(handler)` without guarding it. In some environments — most notably NVIDIA's **WSL2** NVML — that call raises `NVML_ERROR_UNKNOWN` / `NVML_ERROR_NOT_SUPPORTED` even though `nvmlDeviceGetMemoryInfo*` and `nvmlDeviceGetName` succeed.

Because the exception escapes `_get_info_by_pynvml`, it is caught by `_collect_gpu_info_with_env`, which logs `Fail to get GPU info: Unknown Error` and returns `{}`. `get_nvidia_gpu_info()` then sees an empty (non-error) result and returns it directly, so **the entire GPU is dropped from detection** despite CUDA being fully functional.

This matches the symptom in #5069: `nvidia-smi` / `nvcc` work inside the container, but Xinference logs `Fail to get GPU info: Unknown Error` on a loop and reports no GPU.

### Fix

Wrap the utilization query the same way the existing code already guards `nvmlDeviceGetMemoryInfo_v2` just above it: if the utilization call fails, degrade gracefully to `util = 0` instead of letting the exception discard the device's name and memory info.

```python
try:
    util = nvmlDeviceGetUtilizationRates(handler).gpu
except pynvml.NVMLError:
    util = 0
```

Memory/name reporting (the fields that actually gate model placement) keeps working; utilization simply reads 0% where NVML can't provide it.

### Notes

- Scope is a single function in `xinference/device_utils.py`; no behavior change on platforms where the call already succeeds.
- I don't have a WSL2 box to reproduce the exact `Unknown Error`, but the failure mode (an unguarded NVML sub-call dropping the whole device) is structural and the mitigation mirrors the existing GB10 memory-info fallback pattern right above it.

Fixes #5069

🤖 Generated with [Claude Code](https://claude.com/claude-code)
