### PR TITLE
fix(core): prevent worker metrics loss when cache_tracker init fails

### DIFF
--- a/xinference/core/cache_tracker.py
+++ b/xinference/core/cache_tracker.py
@@ -54,12 +54,19 @@ class CacheTrackerActor(xo.Actor):
             if model_name not in self._model_name_to_version_info:
                 self._model_name_to_version_info[model_name] = model_versions
             else:
-                assert len(model_versions) == len(
-                    self._model_name_to_version_info[model_name]
-                ), "Model version info inconsistency between supervisor and worker"
-                for version, origin_version in zip(
-                    model_versions, self._model_name_to_version_info[model_name]
-                ):
+                existing = self._model_name_to_version_info[model_name]
+                if len(model_versions) != len(existing):
+                    logger.warning(
+                        "Model version info inconsistency for %s: "
+                        "supervisor has %d versions, worker %s reports %d; "
+                        "skipping version sync for this model",
+                        model_name,
+                        len(existing),
+                        address,
+                        len(model_versions),
+                    )
+                    continue
+                for version, origin_version in zip(model_versions, existing):
                     if (
                         version["cache_status"]
                         and version["model_file_location"] is not None

--- a/xinference/core/supervisor.py
+++ b/xinference/core/supervisor.py
@@ -1420,15 +1420,36 @@ class SupervisorActor(xo.StatelessActor):
 
             try:
                 register_fn(model_spec, persist)
-                await self._cache_tracker_ref.record_model_version(
-                    generate_fn(model_spec), self.address
+            except ValueError as e:
+                raise e
+            except Exception as e:
+                unregister_fn(model_spec.model_name, raise_error=False)
+                raise e
+
+            # cache sync is an auxiliary feature; failure must not roll back
+            # the already-successful register_fn. Guard against _cache_tracker_ref
+            # being None (defensive).
+            try:
+                if self._cache_tracker_ref is not None:
+                    await self._cache_tracker_ref.record_model_version(
+                        generate_fn(model_spec), self.address
+                    )
+            except Exception:
+                logger.warning(
+                    "Failed to record model version for %s after registration; "
+                    "cache management may be degraded",
+                    model_spec.model_name,
+                    exc_info=True,
                 )
+
+            # _sync_register_model propagates to all workers. If it fails, the
+            # model will not be registered on the workers, so we must roll back
+            # the supervisor-local registration and propagate the error to keep
+            # the cluster state consistent.
+            try:
                 await self._sync_register_model(
                     model_type, model, persist, model_spec.model_name
                 )
-
-            except ValueError as e:
-                raise e
             except Exception as e:
                 unregister_fn(model_spec.model_name, raise_error=False)
                 raise e

--- a/xinference/core/tests/test_worker.py
+++ b/xinference/core/tests/test_worker.py
@@ -134,6 +134,7 @@ class MockWorkerActor(WorkerActor):
     # --- test helpers for report_status GPU attribution ---
     def set_supervisor_ref_for_test(self, ref):
         self._supervisor_ref = ref
+        self._registered = True
 
     def set_gpu_attribution_tables_for_test(self, pid, subpool, total_devices):
         self._model_uid_to_pid = dict(pid)

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -417,6 +417,12 @@ class WorkerActor(xo.StatelessActor):
             CacheTrackerActor
         ] = None  # type: ignore
         self._progress_tracker_ref: Optional[xo.ActorRefType] = None
+        # Tracks whether this worker has successfully called supervisor.add_worker().
+        # _supervisor_ref being non-None no longer implies registered, because
+        # heartbeat() uses add_worker=False and may populate the ref cache before
+        # registration completes. This flag is the source of truth for registration
+        # state, used by get_supervisor_ref to decide whether add_worker is needed.
+        self._registered: bool = False
 
         # Virtual environment management
         self._virtual_env_manager: XinferenceVirtualEnvManager = None  # type: ignore
@@ -889,7 +895,12 @@ class WorkerActor(xo.StatelessActor):
         """
         from .supervisor import SupervisorActor
 
-        if self._supervisor_ref is not None:
+        # Cache hit: return immediately only when no registration is required,
+        # or the worker has already been registered. When add_worker=True and
+        # _registered=False, we must fall through to perform add_worker even if
+        # the ref is cached (this happens after heartbeat populated the ref via
+        # add_worker=False before registration completed).
+        if self._supervisor_ref is not None and (not add_worker or self._registered):
             return self._supervisor_ref
         try:
             supervisor_ref = await xo.actor_ref(  # type: ignore
@@ -901,15 +912,16 @@ class WorkerActor(xo.StatelessActor):
                 address=self._supervisor_address, uid=SupervisorActor.default_uid()
             )
         # Prevent concurrent operations leads to double initialization, check again.
-        if self._supervisor_ref is not None:
+        if self._supervisor_ref is not None and (not add_worker or self._registered):
             return self._supervisor_ref
         self._supervisor_ref = supervisor_ref
         try:
-            if add_worker:
+            if add_worker and not self._registered:
                 replica_states = self._get_running_replica_states()
                 await supervisor_ref.add_worker(
                     self.address, replica_states=replica_states
                 )
+                self._registered = True
                 if replica_states:
                     logger.info(
                         "Connected to supervisor and replayed %s running model replicas",
@@ -928,6 +940,17 @@ class WorkerActor(xo.StatelessActor):
                 address=self._supervisor_address, uid=CacheTrackerActor.default_uid()
             )
             self._progress_tracker_ref = None
+        except Exception:
+            self._clear_supervisor_refs()
+            raise
+
+        # record_model_version is an auxiliary cache-management feature.
+        # Its failure must NOT block the worker's core heartbeat/status-report
+        # channel. Guard against _cache_tracker_ref being None when the first
+        # try block failed and cleared all refs (defensive: avoids AttributeError).
+        if self._cache_tracker_ref is None:
+            return self._supervisor_ref
+        try:
             # cache_tracker is on supervisor
             from ..model.audio import get_audio_model_descriptions
             from ..model.embedding import get_embedding_model_descriptions
@@ -950,12 +973,19 @@ class WorkerActor(xo.StatelessActor):
                 model_version_infos, self.address
             )
         except Exception:
-            self._clear_supervisor_refs()
-            raise
+            logger.warning(
+                "Failed to record model version info to cache tracker; "
+                "cache management may be degraded",
+                exc_info=True,
+            )
+
         return self._supervisor_ref
 
     def _clear_supervisor_refs(self):
         self._supervisor_ref = None
+        # Reset registration state so the next get_supervisor_ref(add_worker=True)
+        # re-runs add_worker. Keep this in sync with _supervisor_ref lifecycle.
+        self._registered = False
         self._status_guard_ref = None  # type: ignore
         self._event_collector_ref = None  # type: ignore
         self._cache_tracker_ref = None  # type: ignore
@@ -1341,14 +1371,27 @@ class WorkerActor(xo.StatelessActor):
             model_spec = model_spec_cls.parse_raw(model)
             try:
                 register_fn(model_spec, persist)
-                await self._cache_tracker_ref.record_model_version(
-                    generate_fn(model_spec), self.address
-                )
             except ValueError as e:
                 raise e
             except Exception as e:
                 unregister_fn(model_spec.model_name, raise_error=False)
                 raise e
+
+            # cache sync is an auxiliary feature; failure must not roll back
+            # the already-successful register_fn. Guard against _cache_tracker_ref
+            # being None when get_supervisor_ref's core init failed (defensive).
+            try:
+                if self._cache_tracker_ref is not None:
+                    await self._cache_tracker_ref.record_model_version(
+                        generate_fn(model_spec), self.address
+                    )
+            except Exception:
+                logger.warning(
+                    "Failed to record model version for %s after registration; "
+                    "cache management may be degraded",
+                    model_spec.model_name,
+                    exc_info=True,
+                )
         else:
             raise ValueError(f"Unsupported model type: {model_type}")
 
@@ -3101,9 +3144,15 @@ class WorkerActor(xo.StatelessActor):
         """
         Lightweight heartbeat for liveness detection.
         Only sends address to supervisor without collecting resource info.
+        Uses add_worker=False to avoid triggering reconnect initialization
+        (add_worker + record_model_version). Registry recovery is driven solely
+        by report_status -> report_worker_status path, per supervisor's
+        receive_heartbeat design contract (supervisor.py).
         """
         await xo.wait_for(
-            (await self.get_supervisor_ref()).receive_heartbeat(self.address),
+            (await self.get_supervisor_ref(add_worker=False)).receive_heartbeat(
+                self.address
+            ),
             XINFERENCE_TCP_REQUEST_TIMEOUT,
         )
 
@@ -3155,6 +3204,14 @@ class WorkerActor(xo.StatelessActor):
     async def list_cached_models(
         self, model_name: Optional[str] = None
     ) -> List[Dict[Any, Any]]:
+        # Defensive: _cache_tracker_ref may be None if get_supervisor_ref's core
+        # init failed and cleared all refs. Return empty list instead of raising
+        # AttributeError (which would surface as HTTP 500 to the user).
+        if self._cache_tracker_ref is None:
+            logger.warning(
+                "cache_tracker_ref is None, returning empty cached model list"
+            )
+            return []
         lists = await self._cache_tracker_ref.list_cached_models(
             self.address, model_name
         )
@@ -3177,6 +3234,12 @@ class WorkerActor(xo.StatelessActor):
         return cached_models
 
     async def list_deletable_models(self, model_version: str) -> List[str]:
+        # Defensive: see list_cached_models for rationale.
+        if self._cache_tracker_ref is None:
+            logger.warning(
+                "cache_tracker_ref is None, returning empty deletable model list"
+            )
+            return []
         paths = set()
         path = await self._cache_tracker_ref.list_deletable_models(
             model_version, self.address
@@ -3216,6 +3279,10 @@ class WorkerActor(xo.StatelessActor):
         return list(paths)
 
     async def confirm_and_remove_model(self, model_version: str) -> bool:
+        # Defensive: see list_cached_models for rationale.
+        if self._cache_tracker_ref is None:
+            logger.warning("cache_tracker_ref is None, cannot confirm and remove model")
+            return False
         paths = await self.list_deletable_models(model_version)
         for path in paths:
             try:


### PR DESCRIPTION
## Summary

- Worker-level metrics (`workers_total`, `_worker_status`-based gauges) were persistently empty because `get_supervisor_ref` coupled `add_worker` registration with `record_model_version` cache sync inside a single try block. When `record_model_version` raised, `_clear_supervisor_refs` wiped `self._supervisor_ref`, so `report_status` / `heartbeat` could never send worker status — even though the supervisor saw `workers_total=4`.
- Decouple the two concerns: registration is tracked by an explicit `_registered` flag, cache sync is isolated in its own try block and treated as an auxiliary feature whose failure must not tear down the worker↔supervisor channel.
- Harden `cache_tracker` so a version-count mismatch between supervisor and worker becomes a logged skip rather than an `AssertionError` that aborts the whole sync path.
- Isolate `record_model_version` in `supervisor.register_model` / `worker.register_model` so an auxiliary-cache failure does not roll back the already-successful `register_fn`. `register_fn` failures **do** roll back via `unregister_fn` (preserving the origin/main safety guarantee), and `_sync_register_model` failures **do** roll back + propagate (preserving cluster-state consistency).

## Changes

- `xinference/core/worker.py`
  - New `self._registered: bool` flag tracking whether `supervisor.add_worker()` has succeeded.
  - `get_supervisor_ref` cache-hit path returns early only when no registration is required, or the worker is already registered; otherwise falls through to run `add_worker`.
  - `record_model_version` moved into its own try block with a defensive `_cache_tracker_ref is None` guard; failures are logged as warnings, not propagated.
  - `_clear_supervisor_refs` resets `_registered` to keep it in sync with the `_supervisor_ref` lifecycle.
  - `register_model`: `register_fn` failure rolls back via `unregister_fn` (restored per maintainer feedback); `record_model_version` failure is warning-only.
- `xinference/core/cache_tracker.py`
  - `record_model_version`: replace `AssertionError` on version-count mismatch with a `logger.warning` + `continue`, so cache sync degrades instead of crashing.
- `xinference/core/supervisor.py`
  - `register_model`: split the single try block into (1) local `register_fn` (rolls back on failure), (2) `record_model_version` cache sync (warning-only, no rollback), (3) `_sync_register_model` worker propagation (rolls back `register_fn` and re-raises on failure).
- `xinference/core/tests/test_worker.py`
  - `set_supervisor_ref_for_test` now also sets `_registered = True` so tests that inject a fake supervisor ref (without going through `add_worker`) still hit the cache-hit path in `get_supervisor_ref(add_worker=True)`.

## Root cause

`get_supervisor_ref` previously did:

```python
try:
    supervisor_ref = await xo.actor_ref(...)
    if add_worker:
        await supervisor_ref.add_worker(...)
    # ... build model_version_infos ...
    await self._cache_tracker_ref.record_model_version(...)  # ← failure here
except Exception:
    self._clear_supervisor_refs()  # ← wiped _supervisor_ref
    raise
```

So any failure in `record_model_version` (e.g. transient `AssertionError` from a version-count mismatch on a re-reporting worker) cleared `_supervisor_ref`, blocking `heartbeat` and `report_status` for the worker. `workers_total` would still count the worker (because `add_worker` had already run), but every gauge sourced from `_worker_status` would stay empty.

## Test plan

- [x] `black --check` / `flake8` / `isort` on modified files — clean.
- [ ] `pytest xinference/core/tests/test_worker.py -k test_report_status` — verifies the injected-ref cache-hit path works with `_registered=True`. (Cannot run locally due to missing `torchvision`; CI will validate.)
- [ ] Unit test: `get_supervisor_ref` with `add_worker=True` calls `supervisor.add_worker` exactly once across retries when `record_model_version` raises.
- [ ] Unit test: `_cache_tracker_ref is None` does not raise `AttributeError` from `get_supervisor_ref`.
- [ ] Unit test: `cache_tracker.record_model_version` with mismatched version counts logs a warning and continues (no `AssertionError`).
- [ ] Unit test: `supervisor.register_model` / `worker.register_model` rolls back local registration (calls `unregister_fn`) and re-raises when `register_fn` fails.
- [ ] Unit test: `supervisor.register_model` rolls back and re-raises when `_sync_register_model` fails.
- [ ] Manual: on a multi-worker cluster, kill+restart `cache_tracker`; verify worker status gauges stay populated and supervisor logs a warning rather than dropping the worker.

## Dependencies

None. This PR is independent of the dashboard-split work tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)