### PR TITLE
fix(docker): cap fastapi<0.137 in image requirements to match setup.cfg (#5063)

### DIFF
--- a/xinference/deploy/docker/requirements/requirements-base.txt
+++ b/xinference/deploy/docker/requirements/requirements-base.txt
@@ -6,7 +6,7 @@ tqdm>=4.27
 tabulate
 requests
 pydantic>2
-fastapi>=0.110.3
+fastapi>=0.110.3,<0.137  # 0.137 stores include_router routes as _IncludedRouter (no .path), breaking aioprometheus middleware; see setup.cfg
 uvicorn
 huggingface-hub>=0.19.4
 typing_extensions

--- a/xinference/deploy/docker/requirements_cpu/requirements_cpu-base.txt
+++ b/xinference/deploy/docker/requirements_cpu/requirements_cpu-base.txt
@@ -6,7 +6,7 @@ tqdm>=4.27
 tabulate
 requests
 pydantic>2
-fastapi>=0.110.3
+fastapi>=0.110.3,<0.137  # 0.137 stores include_router routes as _IncludedRouter (no .path), breaking aioprometheus middleware; see setup.cfg
 uvicorn
 huggingface-hub>=0.19.4
 typing_extensions


### PR DESCRIPTION
## Summary

Fixes #5063 — every REST endpoint in the Docker images (`xprobe/xinference:latest` and `latest-cpu`) returns **HTTP 500** with:

```
AttributeError: '_IncludedRouter' object has no attribute 'path'
  File ".../aioprometheus/asgi/middleware.py", line 220, in get_full_or_template_path
    return route.path
```

## Root cause

FastAPI **0.137** changed `app.routes` so that `include_router()` sub-routers are stored as `_IncludedRouter` wrappers, which inherit from `BaseRoute` but do **not** expose `.path`. `aioprometheus`'s `MetricsMiddleware` iterates `app.routes` and unconditionally reads `route.path`, so the first matched `_IncludedRouter` raises `AttributeError`, which Starlette turns into a 500 for *every* request.

`setup.cfg` already guards against this:

```
fastapi>=0.110.3,<0.137
```

but the two Docker base requirement files drifted out of sync and still pin only `fastapi>=0.110.3`, so the published images pull FastAPI ≥ 0.137 and break.

## Fix

Add the same `<0.137` upper bound (with an explanatory comment) to the two Docker requirement files so the images match `setup.cfg`:

- `xinference/deploy/docker/requirements/requirements-base.txt`
- `xinference/deploy/docker/requirements_cpu/requirements_cpu-base.txt`

This is the minimal, low-risk change (mirrors the existing `setup.cfg` cap; no behavior change for FastAPI < 0.137 users). A deeper fix would be to upgrade/patch `aioprometheus`, but that is a third-party dependency and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
