### PR TITLE
feat(metrics): unify worker labels with supervisor and add replica_index

### DIFF
--- a/monitor/dashboard/README.md
+++ b/monitor/dashboard/README.md
@@ -107,7 +107,7 @@ Per-model and per-replica view covering **all model types** (LLM, embedding, rer
 | Per-replica detail table | QPS, concurrency, VRAM per (model, worker) |
 | Trend charts | QPS, concurrency ratio, VRAM, P95, error rate over time |
 
-> **Label alignment:** Worker-side metrics use `model`/`node`/`type` labels, while Supervisor-side metrics use `model_uid`/`worker_address`/`model_type`. The dashboard uses Grafana Transform (Rename by regex + Join by field) to align them within panels. This requires both Worker and Supervisor metrics to reside in the **same Prometheus instance** (different `job` labels).
+> **Label alignment:** Both Worker-side and Supervisor-side metrics now use unified labels (`model_uid`, `worker_address`, `model_type`, and `replica_index`). This allows direct PromQL joins (e.g., `* on (model_uid, replica_index, worker_address)`) within panels without requiring Grafana Transform hacks. This requires both Worker and Supervisor metrics to reside in the **same Prometheus instance** (different `job` labels).
 
 ### 3. LLM Inference SLO (`xinference-llm-slo`)
 

--- a/monitor/dashboard/README.md
+++ b/monitor/dashboard/README.md
@@ -111,7 +111,7 @@ Per-model and per-replica view covering **all model types** (LLM, embedding, rer
 
 ### 3. LLM Inference SLO (`xinference-llm-slo`)
 
-LLM-specific quality metrics (`type="llm"` only). No per-model breakdown (moved to Model Load dashboard).
+LLM-specific quality metrics (`model_type="LLM"` only). No per-model breakdown (moved to Model Load dashboard).
 
 | Panel | Key Metrics |
 |-------|-------------|

--- a/monitor/dashboard/README_zh-CN.md
+++ b/monitor/dashboard/README_zh-CN.md
@@ -107,7 +107,7 @@ docker compose -f dcgm-exporter.yml up -d
 | 每副本明细表 | 每 (model, worker) 的 QPS、并发、显存 |
 | 趋势图 | QPS、并发率、显存、P95、错误率随时间变化 |
 
-> **标签对齐：** Worker 侧指标使用 `model`/`node`/`type` 标签，Supervisor 侧指标使用 `model_uid`/`worker_address`/`model_type`。面板内使用 Grafana Transform（Rename by regex + Join by field）对齐标签。此方式要求 Worker 和 Supervisor 指标位于**同一 Prometheus 实例**中（不同 `job` 标签）。
+> **标签对齐：** Worker 侧和 Supervisor 侧指标现在都使用统一的标签（`model_uid`、`worker_address`、`model_type` 和 `replica_index`）。这允许在面板内直接进行 PromQL 关联（例如 `* on (model_uid, replica_index, worker_address)`），而不再需要 Grafana Transform 转换。此方式要求 Worker 和 Supervisor 指标位于**同一 Prometheus 实例**中（不同 `job` 标签）。
 
 ### 3. LLM 推理 SLO（`xinference-llm-slo`）
 

--- a/monitor/dashboard/README_zh-CN.md
+++ b/monitor/dashboard/README_zh-CN.md
@@ -111,7 +111,7 @@ docker compose -f dcgm-exporter.yml up -d
 
 ### 3. LLM 推理 SLO（`xinference-llm-slo`）
 
-LLM 专属质量指标（仅 `type="llm"`）。不含每模型明细（已迁移到模型负载面板）。
+LLM 专属质量指标（仅 `model_type="LLM"`）。不含每模型明细（已迁移到模型负载面板）。
 
 | 面板 | 关键指标 |
 |------|----------|

--- a/monitor/dashboard/gpu-resources/xinference-grafana-dashboard-gpu-resources-en.json
+++ b/monitor/dashboard/gpu-resources/xinference-grafana-dashboard-gpu-resources-en.json
@@ -450,7 +450,7 @@
       "targets": [
         {
           "expr": "xinference:model_serve_count{cluster=~\"$cluster\"}",
-          "legendFormat": "{{node}} {{model_name}} {{model}}",
+          "legendFormat": "{{worker_address}} {{model_name}} {{model_uid}}",
           "refId": "A"
         }
       ]

--- a/monitor/dashboard/gpu-resources/xinference-grafana-dashboard-gpu-resources-ja.json
+++ b/monitor/dashboard/gpu-resources/xinference-grafana-dashboard-gpu-resources-ja.json
@@ -450,7 +450,7 @@
       "targets": [
         {
           "expr": "xinference:model_serve_count{cluster=~\"$cluster\"}",
-          "legendFormat": "{{node}} {{model_name}} {{model}}",
+          "legendFormat": "{{worker_address}} {{model_name}} {{model_uid}}",
           "refId": "A"
         }
       ]

--- a/monitor/dashboard/gpu-resources/xinference-grafana-dashboard-gpu-resources-ko.json
+++ b/monitor/dashboard/gpu-resources/xinference-grafana-dashboard-gpu-resources-ko.json
@@ -450,7 +450,7 @@
       "targets": [
         {
           "expr": "xinference:model_serve_count{cluster=~\"$cluster\"}",
-          "legendFormat": "{{node}} {{model_name}} {{model}}",
+          "legendFormat": "{{worker_address}} {{model_name}} {{model_uid}}",
           "refId": "A"
         }
       ]

--- a/monitor/dashboard/gpu-resources/xinference-grafana-dashboard-gpu-resources-zh-CN.json
+++ b/monitor/dashboard/gpu-resources/xinference-grafana-dashboard-gpu-resources-zh-CN.json
@@ -450,7 +450,7 @@
       "targets": [
         {
           "expr": "xinference:model_serve_count{cluster=~\"$cluster\"}",
-          "legendFormat": "{{node}} {{model_name}} {{model}}",
+          "legendFormat": "{{worker_address}} {{model_name}} {{model_uid}}",
           "refId": "A"
         }
       ]

--- a/monitor/dashboard/host-resources/xinference-grafana-dashboard-host-resources-en.json
+++ b/monitor/dashboard/host-resources/xinference-grafana-dashboard-host-resources-en.json
@@ -1773,6 +1773,18 @@
       ]
     },
     {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 295
+      },
+      "id": 403,
+      "title": "Worker Resource Usage (Xinference Reported)",
+      "type": "row"
+    },
+    {
       "id": 401,
       "title": "Worker CPU Utilization (Xinference)",
       "type": "timeseries",
@@ -1782,8 +1794,8 @@
       },
       "targets": [
         {
-          "expr": "xinference:worker_cpu_utilization",
-          "legendFormat": "{{instance}}",
+          "expr": "xinference:worker_cpu_utilization{cluster=~\"$cluster\", worker_address=~\"$worker_address\"}",
+          "legendFormat": "{{worker_address}} CPU Usage",
           "refId": "A"
         }
       ],
@@ -1791,11 +1803,76 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 0
+        "y": 296
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "percent"
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0.8
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "maxHeight": 600,
+          "mode": "single",
+          "sort": "none"
         }
       }
     },
@@ -1809,13 +1886,13 @@
       },
       "targets": [
         {
-          "expr": "xinference:worker_memory_used_bytes",
-          "legendFormat": "{{instance}} used",
+          "expr": "xinference:worker_memory_used_bytes{cluster=~\"$cluster\", worker_address=~\"$worker_address\"}",
+          "legendFormat": "{{worker_address}} Used",
           "refId": "A"
         },
         {
-          "expr": "xinference:worker_memory_total_bytes",
-          "legendFormat": "{{instance}} total",
+          "expr": "xinference:worker_memory_total_bytes{cluster=~\"$cluster\", worker_address=~\"$worker_address\"}",
+          "legendFormat": "{{worker_address}} Total",
           "refId": "B"
         }
       ],
@@ -1823,11 +1900,75 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 0
+        "y": 296
       },
       "fieldConfig": {
         "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
           "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "maxHeight": 600,
+          "mode": "single",
+          "sort": "none"
         }
       }
     }

--- a/monitor/dashboard/host-resources/xinference-grafana-dashboard-host-resources-ja.json
+++ b/monitor/dashboard/host-resources/xinference-grafana-dashboard-host-resources-ja.json
@@ -1773,6 +1773,18 @@
       ]
     },
     {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 295
+      },
+      "id": 403,
+      "title": "Worker リソース使用量（Xinference 報告）",
+      "type": "row"
+    },
+    {
       "id": 401,
       "title": "Worker CPU 使用率 (Xinference)",
       "type": "timeseries",
@@ -1782,8 +1794,8 @@
       },
       "targets": [
         {
-          "expr": "xinference:worker_cpu_utilization",
-          "legendFormat": "{{instance}}",
+          "expr": "xinference:worker_cpu_utilization{cluster=~\"$cluster\", worker_address=~\"$worker_address\"}",
+          "legendFormat": "{{worker_address}} CPU Usage",
           "refId": "A"
         }
       ],
@@ -1791,11 +1803,76 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 0
+        "y": 296
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "percent"
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0.8
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "maxHeight": 600,
+          "mode": "single",
+          "sort": "none"
         }
       }
     },
@@ -1809,13 +1886,13 @@
       },
       "targets": [
         {
-          "expr": "xinference:worker_memory_used_bytes",
-          "legendFormat": "{{instance}} used",
+          "expr": "xinference:worker_memory_used_bytes{cluster=~\"$cluster\", worker_address=~\"$worker_address\"}",
+          "legendFormat": "{{worker_address}} Used",
           "refId": "A"
         },
         {
-          "expr": "xinference:worker_memory_total_bytes",
-          "legendFormat": "{{instance}} total",
+          "expr": "xinference:worker_memory_total_bytes{cluster=~\"$cluster\", worker_address=~\"$worker_address\"}",
+          "legendFormat": "{{worker_address}} Total",
           "refId": "B"
         }
       ],
@@ -1823,11 +1900,75 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 0
+        "y": 296
       },
       "fieldConfig": {
         "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
           "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "maxHeight": 600,
+          "mode": "single",
+          "sort": "none"
         }
       }
     }

--- a/monitor/dashboard/host-resources/xinference-grafana-dashboard-host-resources-ko.json
+++ b/monitor/dashboard/host-resources/xinference-grafana-dashboard-host-resources-ko.json
@@ -1773,6 +1773,18 @@
       ]
     },
     {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 295
+      },
+      "id": 403,
+      "title": "Worker 리소스 사용량 (Xinference 보고)",
+      "type": "row"
+    },
+    {
       "id": 401,
       "title": "Worker CPU 사용률 (Xinference)",
       "type": "timeseries",
@@ -1782,8 +1794,8 @@
       },
       "targets": [
         {
-          "expr": "xinference:worker_cpu_utilization",
-          "legendFormat": "{{instance}}",
+          "expr": "xinference:worker_cpu_utilization{cluster=~\"$cluster\", worker_address=~\"$worker_address\"}",
+          "legendFormat": "{{worker_address}} CPU Usage",
           "refId": "A"
         }
       ],
@@ -1791,11 +1803,76 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 0
+        "y": 296
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "percent"
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0.8
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "maxHeight": 600,
+          "mode": "single",
+          "sort": "none"
         }
       }
     },
@@ -1809,13 +1886,13 @@
       },
       "targets": [
         {
-          "expr": "xinference:worker_memory_used_bytes",
-          "legendFormat": "{{instance}} used",
+          "expr": "xinference:worker_memory_used_bytes{cluster=~\"$cluster\", worker_address=~\"$worker_address\"}",
+          "legendFormat": "{{worker_address}} Used",
           "refId": "A"
         },
         {
-          "expr": "xinference:worker_memory_total_bytes",
-          "legendFormat": "{{instance}} total",
+          "expr": "xinference:worker_memory_total_bytes{cluster=~\"$cluster\", worker_address=~\"$worker_address\"}",
+          "legendFormat": "{{worker_address}} Total",
           "refId": "B"
         }
       ],
@@ -1823,11 +1900,75 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 0
+        "y": 296
       },
       "fieldConfig": {
         "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
           "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "maxHeight": 600,
+          "mode": "single",
+          "sort": "none"
         }
       }
     }

--- a/monitor/dashboard/host-resources/xinference-grafana-dashboard-host-resources-zh-CN.json
+++ b/monitor/dashboard/host-resources/xinference-grafana-dashboard-host-resources-zh-CN.json
@@ -1773,6 +1773,18 @@
       ]
     },
     {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 295
+      },
+      "id": 403,
+      "title": "Worker 资源使用（Xinference 上报）",
+      "type": "row"
+    },
+    {
       "id": 401,
       "title": "Worker CPU 利用率 (Xinference)",
       "type": "timeseries",
@@ -1782,8 +1794,8 @@
       },
       "targets": [
         {
-          "expr": "xinference:worker_cpu_utilization",
-          "legendFormat": "{{instance}}",
+          "expr": "xinference:worker_cpu_utilization{cluster=~\"$cluster\", worker_address=~\"$worker_address\"}",
+          "legendFormat": "{{worker_address}} CPU Usage",
           "refId": "A"
         }
       ],
@@ -1791,11 +1803,76 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 0
+        "y": 296
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "percent"
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0.8
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "maxHeight": 600,
+          "mode": "single",
+          "sort": "none"
         }
       }
     },
@@ -1809,13 +1886,13 @@
       },
       "targets": [
         {
-          "expr": "xinference:worker_memory_used_bytes",
-          "legendFormat": "{{instance}} used",
+          "expr": "xinference:worker_memory_used_bytes{cluster=~\"$cluster\", worker_address=~\"$worker_address\"}",
+          "legendFormat": "{{worker_address}} Used",
           "refId": "A"
         },
         {
-          "expr": "xinference:worker_memory_total_bytes",
-          "legendFormat": "{{instance}} total",
+          "expr": "xinference:worker_memory_total_bytes{cluster=~\"$cluster\", worker_address=~\"$worker_address\"}",
+          "legendFormat": "{{worker_address}} Total",
           "refId": "B"
         }
       ],
@@ -1823,11 +1900,75 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 0
+        "y": 296
       },
       "fieldConfig": {
         "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
           "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "maxHeight": 600,
+          "mode": "single",
+          "sort": "none"
         }
       }
     }

--- a/monitor/dashboard/llm-slo/xinference-grafana-dashboard-llm-slo-en.json
+++ b/monitor/dashboard/llm-slo/xinference-grafana-dashboard-llm-slo-en.json
@@ -1031,17 +1031,17 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.50, sum by (le) (rate(time_to_first_token_seconds_bucket{type=\"llm\"}[5m])))",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(xinference:time_to_first_token_seconds_bucket{model_type=\"LLM\"}[5m])))",
           "legendFormat": "P50",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(time_to_first_token_seconds_bucket{type=\"llm\"}[5m])))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(xinference:time_to_first_token_seconds_bucket{model_type=\"LLM\"}[5m])))",
           "legendFormat": "P95",
           "refId": "B"
         },
         {
-          "expr": "histogram_quantile(0.99, sum by (le) (rate(time_to_first_token_seconds_bucket{type=\"llm\"}[5m])))",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(xinference:time_to_first_token_seconds_bucket{model_type=\"LLM\"}[5m])))",
           "legendFormat": "P99",
           "refId": "C"
         }
@@ -1068,17 +1068,17 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.50, sum by (le) (rate(model_request_duration_seconds_bucket{type=\"llm\"}[5m])))",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(xinference:model_request_duration_seconds_bucket{model_type=\"LLM\"}[5m])))",
           "legendFormat": "P50",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(model_request_duration_seconds_bucket{type=\"llm\"}[5m])))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(xinference:model_request_duration_seconds_bucket{model_type=\"LLM\"}[5m])))",
           "legendFormat": "P95",
           "refId": "B"
         },
         {
-          "expr": "histogram_quantile(0.99, sum by (le) (rate(model_request_duration_seconds_bucket{type=\"llm\"}[5m])))",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(xinference:model_request_duration_seconds_bucket{model_type=\"LLM\"}[5m])))",
           "legendFormat": "P99",
           "refId": "C"
         }

--- a/monitor/dashboard/llm-slo/xinference-grafana-dashboard-llm-slo-en.json
+++ b/monitor/dashboard/llm-slo/xinference-grafana-dashboard-llm-slo-en.json
@@ -195,12 +195,12 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(xinference:model_request_total{cluster=~\"$cluster\", type=\"LLM\", model_name=~\"$model_name\", stream=\"true\"}[5m])) by (model_name)",
+          "expr": "sum(rate(xinference:model_request_total{cluster=~\"$cluster\", model_type=\"LLM\", model_name=~\"$model_name\", stream=\"true\"}[5m])) by (model_name)",
           "legendFormat": "{{model_name}} (Streaming)",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(xinference:model_request_total{cluster=~\"$cluster\", type=\"LLM\", model_name=~\"$model_name\", stream=\"false\"}[5m])) by (model_name)",
+          "expr": "sum(rate(xinference:model_request_total{cluster=~\"$cluster\", model_type=\"LLM\", model_name=~\"$model_name\", stream=\"false\"}[5m])) by (model_name)",
           "legendFormat": "{{model_name}} (Non-streaming)",
           "refId": "B"
         }
@@ -295,7 +295,7 @@
       },
       "targets": [
         {
-          "expr": "rate(xinference:model_request_errors_total{cluster=~\"$cluster\", type=\"LLM\", model_name=~\"$model_name\"}[5m]) / rate(xinference:model_request_total{cluster=~\"$cluster\", type=\"LLM\", model_name=~\"$model_name\"}[5m]) * 100",
+          "expr": "rate(xinference:model_request_errors_total{cluster=~\"$cluster\", model_type=\"LLM\", model_name=~\"$model_name\"}[5m]) / rate(xinference:model_request_total{cluster=~\"$cluster\", model_type=\"LLM\", model_name=~\"$model_name\"}[5m]) * 100",
           "legendFormat": "{{model_name}}",
           "refId": "A"
         }
@@ -386,12 +386,12 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.95, sum(rate(xinference:model_request_duration_seconds_bucket{cluster=~\"$cluster\", type=\"LLM\", model_name=~\"$model_name\"}[5m])) by (le, model_name))",
+          "expr": "histogram_quantile(0.95, sum(rate(xinference:model_request_duration_seconds_bucket{cluster=~\"$cluster\", model_type=\"LLM\", model_name=~\"$model_name\"}[5m])) by (le, model_name))",
           "legendFormat": "{{model_name}} P95",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.50, sum(rate(xinference:model_request_duration_seconds_bucket{cluster=~\"$cluster\", type=\"LLM\", model_name=~\"$model_name\"}[5m])) by (le, model_name))",
+          "expr": "histogram_quantile(0.50, sum(rate(xinference:model_request_duration_seconds_bucket{cluster=~\"$cluster\", model_type=\"LLM\", model_name=~\"$model_name\"}[5m])) by (le, model_name))",
           "legendFormat": "{{model_name}} P50",
           "refId": "B"
         }
@@ -481,12 +481,12 @@
       },
       "targets": [
         {
-          "expr": "xinference:model_serve_count{cluster=~\"$cluster\", type=\"LLM\", model_name=~\"$model_name\"}",
+          "expr": "xinference:model_serve_count{cluster=~\"$cluster\", model_type=\"LLM\", model_name=~\"$model_name\"}",
           "legendFormat": "{{model_name}} serving",
           "refId": "A"
         },
         {
-          "expr": "xinference:model_request_limit{cluster=~\"$cluster\", type=\"LLM\", model_name=~\"$model_name\"}",
+          "expr": "xinference:model_request_limit{cluster=~\"$cluster\", model_type=\"LLM\", model_name=~\"$model_name\"}",
           "legendFormat": "{{model_name}} limit",
           "refId": "B"
         }

--- a/monitor/dashboard/llm-slo/xinference-grafana-dashboard-llm-slo-ja.json
+++ b/monitor/dashboard/llm-slo/xinference-grafana-dashboard-llm-slo-ja.json
@@ -1031,17 +1031,17 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.50, sum by (le) (rate(time_to_first_token_seconds_bucket{type=\"llm\"}[5m])))",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(xinference:time_to_first_token_seconds_bucket{model_type=\"LLM\"}[5m])))",
           "legendFormat": "P50",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(time_to_first_token_seconds_bucket{type=\"llm\"}[5m])))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(xinference:time_to_first_token_seconds_bucket{model_type=\"LLM\"}[5m])))",
           "legendFormat": "P95",
           "refId": "B"
         },
         {
-          "expr": "histogram_quantile(0.99, sum by (le) (rate(time_to_first_token_seconds_bucket{type=\"llm\"}[5m])))",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(xinference:time_to_first_token_seconds_bucket{model_type=\"LLM\"}[5m])))",
           "legendFormat": "P99",
           "refId": "C"
         }
@@ -1068,17 +1068,17 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.50, sum by (le) (rate(model_request_duration_seconds_bucket{type=\"llm\"}[5m])))",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(xinference:model_request_duration_seconds_bucket{model_type=\"LLM\"}[5m])))",
           "legendFormat": "P50",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(model_request_duration_seconds_bucket{type=\"llm\"}[5m])))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(xinference:model_request_duration_seconds_bucket{model_type=\"LLM\"}[5m])))",
           "legendFormat": "P95",
           "refId": "B"
         },
         {
-          "expr": "histogram_quantile(0.99, sum by (le) (rate(model_request_duration_seconds_bucket{type=\"llm\"}[5m])))",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(xinference:model_request_duration_seconds_bucket{model_type=\"LLM\"}[5m])))",
           "legendFormat": "P99",
           "refId": "C"
         }

--- a/monitor/dashboard/llm-slo/xinference-grafana-dashboard-llm-slo-ja.json
+++ b/monitor/dashboard/llm-slo/xinference-grafana-dashboard-llm-slo-ja.json
@@ -195,12 +195,12 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(xinference:model_request_total{cluster=~\"$cluster\", type=\"LLM\", model_name=~\"$model_name\", stream=\"true\"}[5m])) by (model_name)",
+          "expr": "sum(rate(xinference:model_request_total{cluster=~\"$cluster\", model_type=\"LLM\", model_name=~\"$model_name\", stream=\"true\"}[5m])) by (model_name)",
           "legendFormat": "{{model_name}} (ストリーミング)",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(xinference:model_request_total{cluster=~\"$cluster\", type=\"LLM\", model_name=~\"$model_name\", stream=\"false\"}[5m])) by (model_name)",
+          "expr": "sum(rate(xinference:model_request_total{cluster=~\"$cluster\", model_type=\"LLM\", model_name=~\"$model_name\", stream=\"false\"}[5m])) by (model_name)",
           "legendFormat": "{{model_name}} (非ストリーミング)",
           "refId": "B"
         }
@@ -295,7 +295,7 @@
       },
       "targets": [
         {
-          "expr": "rate(xinference:model_request_errors_total{cluster=~\"$cluster\", type=\"LLM\", model_name=~\"$model_name\"}[5m]) / rate(xinference:model_request_total{cluster=~\"$cluster\", type=\"LLM\", model_name=~\"$model_name\"}[5m]) * 100",
+          "expr": "rate(xinference:model_request_errors_total{cluster=~\"$cluster\", model_type=\"LLM\", model_name=~\"$model_name\"}[5m]) / rate(xinference:model_request_total{cluster=~\"$cluster\", model_type=\"LLM\", model_name=~\"$model_name\"}[5m]) * 100",
           "legendFormat": "{{model_name}}",
           "refId": "A"
         }
@@ -386,12 +386,12 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.95, sum(rate(xinference:model_request_duration_seconds_bucket{cluster=~\"$cluster\", type=\"LLM\", model_name=~\"$model_name\"}[5m])) by (le, model_name))",
+          "expr": "histogram_quantile(0.95, sum(rate(xinference:model_request_duration_seconds_bucket{cluster=~\"$cluster\", model_type=\"LLM\", model_name=~\"$model_name\"}[5m])) by (le, model_name))",
           "legendFormat": "{{model_name}} P95",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.50, sum(rate(xinference:model_request_duration_seconds_bucket{cluster=~\"$cluster\", type=\"LLM\", model_name=~\"$model_name\"}[5m])) by (le, model_name))",
+          "expr": "histogram_quantile(0.50, sum(rate(xinference:model_request_duration_seconds_bucket{cluster=~\"$cluster\", model_type=\"LLM\", model_name=~\"$model_name\"}[5m])) by (le, model_name))",
           "legendFormat": "{{model_name}} P50",
           "refId": "B"
         }
@@ -481,12 +481,12 @@
       },
       "targets": [
         {
-          "expr": "xinference:model_serve_count{cluster=~\"$cluster\", type=\"LLM\", model_name=~\"$model_name\"}",
+          "expr": "xinference:model_serve_count{cluster=~\"$cluster\", model_type=\"LLM\", model_name=~\"$model_name\"}",
           "legendFormat": "{{model_name}} serving",
           "refId": "A"
         },
         {
-          "expr": "xinference:model_request_limit{cluster=~\"$cluster\", type=\"LLM\", model_name=~\"$model_name\"}",
+          "expr": "xinference:model_request_limit{cluster=~\"$cluster\", model_type=\"LLM\", model_name=~\"$model_name\"}",
           "legendFormat": "{{model_name}} limit",
           "refId": "B"
         }

--- a/monitor/dashboard/llm-slo/xinference-grafana-dashboard-llm-slo-ko.json
+++ b/monitor/dashboard/llm-slo/xinference-grafana-dashboard-llm-slo-ko.json
@@ -1031,17 +1031,17 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.50, sum by (le) (rate(time_to_first_token_seconds_bucket{type=\"llm\"}[5m])))",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(xinference:time_to_first_token_seconds_bucket{model_type=\"LLM\"}[5m])))",
           "legendFormat": "P50",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(time_to_first_token_seconds_bucket{type=\"llm\"}[5m])))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(xinference:time_to_first_token_seconds_bucket{model_type=\"LLM\"}[5m])))",
           "legendFormat": "P95",
           "refId": "B"
         },
         {
-          "expr": "histogram_quantile(0.99, sum by (le) (rate(time_to_first_token_seconds_bucket{type=\"llm\"}[5m])))",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(xinference:time_to_first_token_seconds_bucket{model_type=\"LLM\"}[5m])))",
           "legendFormat": "P99",
           "refId": "C"
         }
@@ -1068,17 +1068,17 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.50, sum by (le) (rate(model_request_duration_seconds_bucket{type=\"llm\"}[5m])))",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(xinference:model_request_duration_seconds_bucket{model_type=\"LLM\"}[5m])))",
           "legendFormat": "P50",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(model_request_duration_seconds_bucket{type=\"llm\"}[5m])))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(xinference:model_request_duration_seconds_bucket{model_type=\"LLM\"}[5m])))",
           "legendFormat": "P95",
           "refId": "B"
         },
         {
-          "expr": "histogram_quantile(0.99, sum by (le) (rate(model_request_duration_seconds_bucket{type=\"llm\"}[5m])))",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(xinference:model_request_duration_seconds_bucket{model_type=\"LLM\"}[5m])))",
           "legendFormat": "P99",
           "refId": "C"
         }

--- a/monitor/dashboard/llm-slo/xinference-grafana-dashboard-llm-slo-ko.json
+++ b/monitor/dashboard/llm-slo/xinference-grafana-dashboard-llm-slo-ko.json
@@ -195,12 +195,12 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(xinference:model_request_total{cluster=~\"$cluster\", type=\"LLM\", model_name=~\"$model_name\", stream=\"true\"}[5m])) by (model_name)",
+          "expr": "sum(rate(xinference:model_request_total{cluster=~\"$cluster\", model_type=\"LLM\", model_name=~\"$model_name\", stream=\"true\"}[5m])) by (model_name)",
           "legendFormat": "{{model_name}} (스트리밍)",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(xinference:model_request_total{cluster=~\"$cluster\", type=\"LLM\", model_name=~\"$model_name\", stream=\"false\"}[5m])) by (model_name)",
+          "expr": "sum(rate(xinference:model_request_total{cluster=~\"$cluster\", model_type=\"LLM\", model_name=~\"$model_name\", stream=\"false\"}[5m])) by (model_name)",
           "legendFormat": "{{model_name}} (비스트리밍)",
           "refId": "B"
         }
@@ -295,7 +295,7 @@
       },
       "targets": [
         {
-          "expr": "rate(xinference:model_request_errors_total{cluster=~\"$cluster\", type=\"LLM\", model_name=~\"$model_name\"}[5m]) / rate(xinference:model_request_total{cluster=~\"$cluster\", type=\"LLM\", model_name=~\"$model_name\"}[5m]) * 100",
+          "expr": "rate(xinference:model_request_errors_total{cluster=~\"$cluster\", model_type=\"LLM\", model_name=~\"$model_name\"}[5m]) / rate(xinference:model_request_total{cluster=~\"$cluster\", model_type=\"LLM\", model_name=~\"$model_name\"}[5m]) * 100",
           "legendFormat": "{{model_name}}",
           "refId": "A"
         }
@@ -386,12 +386,12 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.95, sum(rate(xinference:model_request_duration_seconds_bucket{cluster=~\"$cluster\", type=\"LLM\", model_name=~\"$model_name\"}[5m])) by (le, model_name))",
+          "expr": "histogram_quantile(0.95, sum(rate(xinference:model_request_duration_seconds_bucket{cluster=~\"$cluster\", model_type=\"LLM\", model_name=~\"$model_name\"}[5m])) by (le, model_name))",
           "legendFormat": "{{model_name}} P95",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.50, sum(rate(xinference:model_request_duration_seconds_bucket{cluster=~\"$cluster\", type=\"LLM\", model_name=~\"$model_name\"}[5m])) by (le, model_name))",
+          "expr": "histogram_quantile(0.50, sum(rate(xinference:model_request_duration_seconds_bucket{cluster=~\"$cluster\", model_type=\"LLM\", model_name=~\"$model_name\"}[5m])) by (le, model_name))",
           "legendFormat": "{{model_name}} P50",
           "refId": "B"
         }
@@ -481,12 +481,12 @@
       },
       "targets": [
         {
-          "expr": "xinference:model_serve_count{cluster=~\"$cluster\", type=\"LLM\", model_name=~\"$model_name\"}",
+          "expr": "xinference:model_serve_count{cluster=~\"$cluster\", model_type=\"LLM\", model_name=~\"$model_name\"}",
           "legendFormat": "{{model_name}} serving",
           "refId": "A"
         },
         {
-          "expr": "xinference:model_request_limit{cluster=~\"$cluster\", type=\"LLM\", model_name=~\"$model_name\"}",
+          "expr": "xinference:model_request_limit{cluster=~\"$cluster\", model_type=\"LLM\", model_name=~\"$model_name\"}",
           "legendFormat": "{{model_name}} limit",
           "refId": "B"
         }

--- a/monitor/dashboard/llm-slo/xinference-grafana-dashboard-llm-slo-zh-CN.json
+++ b/monitor/dashboard/llm-slo/xinference-grafana-dashboard-llm-slo-zh-CN.json
@@ -1031,17 +1031,17 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.50, sum by (le) (rate(time_to_first_token_seconds_bucket{type=\"llm\"}[5m])))",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(xinference:time_to_first_token_seconds_bucket{model_type=\"LLM\"}[5m])))",
           "legendFormat": "P50",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(time_to_first_token_seconds_bucket{type=\"llm\"}[5m])))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(xinference:time_to_first_token_seconds_bucket{model_type=\"LLM\"}[5m])))",
           "legendFormat": "P95",
           "refId": "B"
         },
         {
-          "expr": "histogram_quantile(0.99, sum by (le) (rate(time_to_first_token_seconds_bucket{type=\"llm\"}[5m])))",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(xinference:time_to_first_token_seconds_bucket{model_type=\"LLM\"}[5m])))",
           "legendFormat": "P99",
           "refId": "C"
         }
@@ -1068,17 +1068,17 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.50, sum by (le) (rate(model_request_duration_seconds_bucket{type=\"llm\"}[5m])))",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(xinference:model_request_duration_seconds_bucket{model_type=\"LLM\"}[5m])))",
           "legendFormat": "P50",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.95, sum by (le) (rate(model_request_duration_seconds_bucket{type=\"llm\"}[5m])))",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(xinference:model_request_duration_seconds_bucket{model_type=\"LLM\"}[5m])))",
           "legendFormat": "P95",
           "refId": "B"
         },
         {
-          "expr": "histogram_quantile(0.99, sum by (le) (rate(model_request_duration_seconds_bucket{type=\"llm\"}[5m])))",
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(xinference:model_request_duration_seconds_bucket{model_type=\"LLM\"}[5m])))",
           "legendFormat": "P99",
           "refId": "C"
         }

--- a/monitor/dashboard/llm-slo/xinference-grafana-dashboard-llm-slo-zh-CN.json
+++ b/monitor/dashboard/llm-slo/xinference-grafana-dashboard-llm-slo-zh-CN.json
@@ -195,12 +195,12 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(xinference:model_request_total{cluster=~\"$cluster\", type=\"LLM\", model_name=~\"$model_name\", stream=\"true\"}[5m])) by (model_name)",
+          "expr": "sum(rate(xinference:model_request_total{cluster=~\"$cluster\", model_type=\"LLM\", model_name=~\"$model_name\", stream=\"true\"}[5m])) by (model_name)",
           "legendFormat": "{{model_name}} (流式)",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(xinference:model_request_total{cluster=~\"$cluster\", type=\"LLM\", model_name=~\"$model_name\", stream=\"false\"}[5m])) by (model_name)",
+          "expr": "sum(rate(xinference:model_request_total{cluster=~\"$cluster\", model_type=\"LLM\", model_name=~\"$model_name\", stream=\"false\"}[5m])) by (model_name)",
           "legendFormat": "{{model_name}} (非流式)",
           "refId": "B"
         }
@@ -295,7 +295,7 @@
       },
       "targets": [
         {
-          "expr": "rate(xinference:model_request_errors_total{cluster=~\"$cluster\", type=\"LLM\", model_name=~\"$model_name\"}[5m]) / rate(xinference:model_request_total{cluster=~\"$cluster\", type=\"LLM\", model_name=~\"$model_name\"}[5m]) * 100",
+          "expr": "rate(xinference:model_request_errors_total{cluster=~\"$cluster\", model_type=\"LLM\", model_name=~\"$model_name\"}[5m]) / rate(xinference:model_request_total{cluster=~\"$cluster\", model_type=\"LLM\", model_name=~\"$model_name\"}[5m]) * 100",
           "legendFormat": "{{model_name}}",
           "refId": "A"
         }
@@ -386,12 +386,12 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.95, sum(rate(xinference:model_request_duration_seconds_bucket{cluster=~\"$cluster\", type=\"LLM\", model_name=~\"$model_name\"}[5m])) by (le, model_name))",
+          "expr": "histogram_quantile(0.95, sum(rate(xinference:model_request_duration_seconds_bucket{cluster=~\"$cluster\", model_type=\"LLM\", model_name=~\"$model_name\"}[5m])) by (le, model_name))",
           "legendFormat": "{{model_name}} P95",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.50, sum(rate(xinference:model_request_duration_seconds_bucket{cluster=~\"$cluster\", type=\"LLM\", model_name=~\"$model_name\"}[5m])) by (le, model_name))",
+          "expr": "histogram_quantile(0.50, sum(rate(xinference:model_request_duration_seconds_bucket{cluster=~\"$cluster\", model_type=\"LLM\", model_name=~\"$model_name\"}[5m])) by (le, model_name))",
           "legendFormat": "{{model_name}} P50",
           "refId": "B"
         }
@@ -481,12 +481,12 @@
       },
       "targets": [
         {
-          "expr": "xinference:model_serve_count{cluster=~\"$cluster\", type=\"LLM\", model_name=~\"$model_name\"}",
+          "expr": "xinference:model_serve_count{cluster=~\"$cluster\", model_type=\"LLM\", model_name=~\"$model_name\"}",
           "legendFormat": "{{model_name}} serving",
           "refId": "A"
         },
         {
-          "expr": "xinference:model_request_limit{cluster=~\"$cluster\", type=\"LLM\", model_name=~\"$model_name\"}",
+          "expr": "xinference:model_request_limit{cluster=~\"$cluster\", model_type=\"LLM\", model_name=~\"$model_name\"}",
           "legendFormat": "{{model_name}} limit",
           "refId": "B"
         }

--- a/monitor/dashboard/model-load/xinference-grafana-dashboard-model-load-en.json
+++ b/monitor/dashboard/model-load/xinference-grafana-dashboard-model-load-en.json
@@ -1218,6 +1218,39 @@
         "type": "query"
       },
       {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "query_result(xinference:model_info{cluster=~\"$cluster\"})",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Model Type",
+        "multi": true,
+        "name": "model_type",
+        "options": [],
+        "query": {
+          "qryType": 3,
+          "query": "query_result(xinference:model_info{cluster=~\"$cluster\"})",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "/model_type=\"(?<text>[^\"]+)/g",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
         "current": {
           "selected": true,
           "text": [

--- a/monitor/dashboard/model-load/xinference-grafana-dashboard-model-load-en.json
+++ b/monitor/dashboard/model-load/xinference-grafana-dashboard-model-load-en.json
@@ -833,8 +833,8 @@
       },
       "targets": [
         {
-          "expr": "sum by (type) (rate(model_request_total{type=~\"$model_type\"}[5m]))",
-          "legendFormat": "{{type}}",
+          "expr": "sum by (model_type) (rate(xinference:model_request_total{model_type=~\"$model_type\"}[5m]))",
+          "legendFormat": "{{model_type}}",
           "refId": "A"
         }
       ],
@@ -855,8 +855,8 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.95, sum by (le, type) (rate(model_request_duration_seconds_bucket{type=~\"$model_type\"}[5m])))",
-          "legendFormat": "{{type}}",
+          "expr": "histogram_quantile(0.95, sum by (le, model_type) (rate(xinference:model_request_duration_seconds_bucket{model_type=~\"$model_type\"}[5m])))",
+          "legendFormat": "{{model_type}}",
           "refId": "A"
         }
       ],
@@ -882,8 +882,8 @@
       },
       "targets": [
         {
-          "expr": "sum by (type) (rate(model_request_errors_total{type=~\"$model_type\"}[5m])) / sum by (type) (rate(model_request_total{type=~\"$model_type\"}[5m]))",
-          "legendFormat": "{{type}}",
+          "expr": "sum by (model_type) (rate(xinference:model_request_errors_total{model_type=~\"$model_type\"}[5m])) / sum by (model_type) (rate(xinference:model_request_total{model_type=~\"$model_type\"}[5m]))",
+          "legendFormat": "{{model_type}}",
           "refId": "A"
         }
       ],
@@ -909,7 +909,7 @@
       },
       "targets": [
         {
-          "expr": "sum by (model_type) (model_gpu_memory_used_bytes{model_type=~\"$model_type\"})",
+          "expr": "sum by (model_type) (xinference:model_gpu_memory_used_bytes{model_type=~\"$model_type\"})",
           "legendFormat": "{{model_type}}",
           "refId": "A"
         }

--- a/monitor/dashboard/model-load/xinference-grafana-dashboard-model-load-ja.json
+++ b/monitor/dashboard/model-load/xinference-grafana-dashboard-model-load-ja.json
@@ -1218,6 +1218,39 @@
         "type": "query"
       },
       {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "query_result(xinference:model_info{cluster=~\"$cluster\"})",
+        "hide": 0,
+        "includeAll": true,
+        "label": "モデルタイプ",
+        "multi": true,
+        "name": "model_type",
+        "options": [],
+        "query": {
+          "qryType": 3,
+          "query": "query_result(xinference:model_info{cluster=~\"$cluster\"})",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "/model_type=\"(?<text>[^\"]+)/g",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
         "current": {
           "selected": true,
           "text": [

--- a/monitor/dashboard/model-load/xinference-grafana-dashboard-model-load-ja.json
+++ b/monitor/dashboard/model-load/xinference-grafana-dashboard-model-load-ja.json
@@ -833,8 +833,8 @@
       },
       "targets": [
         {
-          "expr": "sum by (type) (rate(model_request_total{type=~\"$model_type\"}[5m]))",
-          "legendFormat": "{{type}}",
+          "expr": "sum by (model_type) (rate(xinference:model_request_total{model_type=~\"$model_type\"}[5m]))",
+          "legendFormat": "{{model_type}}",
           "refId": "A"
         }
       ],
@@ -855,8 +855,8 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.95, sum by (le, type) (rate(model_request_duration_seconds_bucket{type=~\"$model_type\"}[5m])))",
-          "legendFormat": "{{type}}",
+          "expr": "histogram_quantile(0.95, sum by (le, model_type) (rate(xinference:model_request_duration_seconds_bucket{model_type=~\"$model_type\"}[5m])))",
+          "legendFormat": "{{model_type}}",
           "refId": "A"
         }
       ],
@@ -882,8 +882,8 @@
       },
       "targets": [
         {
-          "expr": "sum by (type) (rate(model_request_errors_total{type=~\"$model_type\"}[5m])) / sum by (type) (rate(model_request_total{type=~\"$model_type\"}[5m]))",
-          "legendFormat": "{{type}}",
+          "expr": "sum by (model_type) (rate(xinference:model_request_errors_total{model_type=~\"$model_type\"}[5m])) / sum by (model_type) (rate(xinference:model_request_total{model_type=~\"$model_type\"}[5m]))",
+          "legendFormat": "{{model_type}}",
           "refId": "A"
         }
       ],
@@ -909,7 +909,7 @@
       },
       "targets": [
         {
-          "expr": "sum by (model_type) (model_gpu_memory_used_bytes{model_type=~\"$model_type\"})",
+          "expr": "sum by (model_type) (xinference:model_gpu_memory_used_bytes{model_type=~\"$model_type\"})",
           "legendFormat": "{{model_type}}",
           "refId": "A"
         }

--- a/monitor/dashboard/model-load/xinference-grafana-dashboard-model-load-ko.json
+++ b/monitor/dashboard/model-load/xinference-grafana-dashboard-model-load-ko.json
@@ -1218,6 +1218,39 @@
         "type": "query"
       },
       {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "query_result(xinference:model_info{cluster=~\"$cluster\"})",
+        "hide": 0,
+        "includeAll": true,
+        "label": "모델 유형",
+        "multi": true,
+        "name": "model_type",
+        "options": [],
+        "query": {
+          "qryType": 3,
+          "query": "query_result(xinference:model_info{cluster=~\"$cluster\"})",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "/model_type=\"(?<text>[^\"]+)/g",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
         "current": {
           "selected": true,
           "text": [

--- a/monitor/dashboard/model-load/xinference-grafana-dashboard-model-load-ko.json
+++ b/monitor/dashboard/model-load/xinference-grafana-dashboard-model-load-ko.json
@@ -833,8 +833,8 @@
       },
       "targets": [
         {
-          "expr": "sum by (type) (rate(model_request_total{type=~\"$model_type\"}[5m]))",
-          "legendFormat": "{{type}}",
+          "expr": "sum by (model_type) (rate(xinference:model_request_total{model_type=~\"$model_type\"}[5m]))",
+          "legendFormat": "{{model_type}}",
           "refId": "A"
         }
       ],
@@ -855,8 +855,8 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.95, sum by (le, type) (rate(model_request_duration_seconds_bucket{type=~\"$model_type\"}[5m])))",
-          "legendFormat": "{{type}}",
+          "expr": "histogram_quantile(0.95, sum by (le, model_type) (rate(xinference:model_request_duration_seconds_bucket{model_type=~\"$model_type\"}[5m])))",
+          "legendFormat": "{{model_type}}",
           "refId": "A"
         }
       ],
@@ -882,8 +882,8 @@
       },
       "targets": [
         {
-          "expr": "sum by (type) (rate(model_request_errors_total{type=~\"$model_type\"}[5m])) / sum by (type) (rate(model_request_total{type=~\"$model_type\"}[5m]))",
-          "legendFormat": "{{type}}",
+          "expr": "sum by (model_type) (rate(xinference:model_request_errors_total{model_type=~\"$model_type\"}[5m])) / sum by (model_type) (rate(xinference:model_request_total{model_type=~\"$model_type\"}[5m]))",
+          "legendFormat": "{{model_type}}",
           "refId": "A"
         }
       ],
@@ -909,7 +909,7 @@
       },
       "targets": [
         {
-          "expr": "sum by (model_type) (model_gpu_memory_used_bytes{model_type=~\"$model_type\"})",
+          "expr": "sum by (model_type) (xinference:model_gpu_memory_used_bytes{model_type=~\"$model_type\"})",
           "legendFormat": "{{model_type}}",
           "refId": "A"
         }

--- a/monitor/dashboard/model-load/xinference-grafana-dashboard-model-load-zh-CN.json
+++ b/monitor/dashboard/model-load/xinference-grafana-dashboard-model-load-zh-CN.json
@@ -833,8 +833,8 @@
       },
       "targets": [
         {
-          "expr": "sum by (type) (rate(xinference:model_request_total{cluster=~\"$cluster\", type=~\"$model_type\"}[5m]))",
-          "legendFormat": "{{type}}",
+          "expr": "sum by (model_type) (rate(xinference:model_request_total{model_type=~\"$model_type\"}[5m]))",
+          "legendFormat": "{{model_type}}",
           "refId": "A"
         }
       ],
@@ -855,8 +855,8 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.95, sum by (le, type) (rate(xinference:model_request_duration_seconds_bucket{cluster=~\"$cluster\", type=~\"$model_type\"}[5m])))",
-          "legendFormat": "{{type}}",
+          "expr": "histogram_quantile(0.95, sum by (le, model_type) (rate(xinference:model_request_duration_seconds_bucket{model_type=~\"$model_type\"}[5m])))",
+          "legendFormat": "{{model_type}}",
           "refId": "A"
         }
       ],
@@ -882,8 +882,8 @@
       },
       "targets": [
         {
-          "expr": "sum by (type) (rate(xinference:model_request_errors_total{cluster=~\"$cluster\", type=~\"$model_type\"}[5m])) / sum by (type) (rate(xinference:model_request_total{cluster=~\"$cluster\", type=~\"$model_type\"}[5m]))",
-          "legendFormat": "{{type}}",
+          "expr": "sum by (model_type) (rate(xinference:model_request_errors_total{model_type=~\"$model_type\"}[5m])) / sum by (model_type) (rate(xinference:model_request_total{model_type=~\"$model_type\"}[5m]))",
+          "legendFormat": "{{model_type}}",
           "refId": "A"
         }
       ],
@@ -909,7 +909,7 @@
       },
       "targets": [
         {
-          "expr": "sum by (model_type) (xinference:model_gpu_memory_used_bytes{worker_address=~\"$worker_address\", model_name=~\"$model_name\", model_type=~\"$model_type\"})",
+          "expr": "sum by (model_type) (xinference:model_gpu_memory_used_bytes{model_type=~\"$model_type\"})",
           "legendFormat": "{{model_type}}",
           "refId": "A"
         }
@@ -1213,39 +1213,6 @@
         },
         "refresh": 2,
         "regex": "/model_name=\"(?<text>[^\"]+)/g",
-        "skipUrlSync": false,
-        "sort": 1,
-        "type": "query"
-      },
-      {
-        "allValue": ".*",
-        "current": {
-          "selected": true,
-          "text": [
-            "All"
-          ],
-          "value": [
-            "$__all"
-          ]
-        },
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${datasource}"
-        },
-        "definition": "query_result(xinference:model_request_total{cluster=~\"$cluster\"})",
-        "hide": 0,
-        "includeAll": true,
-        "label": "模型类型",
-        "multi": true,
-        "name": "model_type",
-        "options": [],
-        "query": {
-          "qryType": 3,
-          "query": "query_result(xinference:model_request_total{cluster=~\"$cluster\"})",
-          "refId": "PrometheusVariableQueryEditor-VariableQuery"
-        },
-        "refresh": 2,
-        "regex": "/(?<!\\w)type=\"(?<text>[^\"]+)/g",
         "skipUrlSync": false,
         "sort": 1,
         "type": "query"

--- a/monitor/dashboard/model-load/xinference-grafana-dashboard-model-load-zh-CN.json
+++ b/monitor/dashboard/model-load/xinference-grafana-dashboard-model-load-zh-CN.json
@@ -1218,6 +1218,39 @@
         "type": "query"
       },
       {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "query_result(xinference:model_info{cluster=~\"$cluster\"})",
+        "hide": 0,
+        "includeAll": true,
+        "label": "模型类型",
+        "multi": true,
+        "name": "model_type",
+        "options": [],
+        "query": {
+          "qryType": 3,
+          "query": "query_result(xinference:model_info{cluster=~\"$cluster\"})",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "/model_type=\"(?<text>[^\"]+)/g",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
         "current": {
           "selected": true,
           "text": [

--- a/monitor/metrics/README.md
+++ b/monitor/metrics/README.md
@@ -84,12 +84,14 @@ Worker metrics focus on **per-node inference quality and service load**.
 
 | Metric | Type | Unit | Description |
 |--------|------|------|-------------|
-| `xinference:model_request_total` | Counter | requests | Total model requests (labeled by `model_uid` and `op`) |
+| `xinference:model_request_total` | Counter | requests | Total model requests (labeled by `model_uid`, `replica_index`, `model_type`, `worker_address`) |
 | `xinference:model_request_errors_total` | Counter | requests | Total failed model requests |
 | `xinference:model_request_duration_seconds` | Histogram | seconds | Request duration distribution. Buckets: 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120, +Inf |
 | `xinference:model_serve_count` | Gauge | requests | Number of requests currently being served |
 | `xinference:model_request_limit` | Gauge | requests | Maximum concurrent request limit for the model |
 | `xinference:model_last_load_duration_seconds` | Gauge | seconds | Duration of the last model load (including weight download and initialization) |
+
+**Labels (unified with Supervisor side):** `model_uid` (base uid, no replica suffix), `replica_index` (0-based, `0` for single replica), `model_type` (`LLM`/`embedding`/`rerank`/`image`/`audio`/`video`), `worker_address`, `model_name`, `engine`, `format`, `quantization`, `gpu_index`.
 
 **Use cases:**
 - QPS = `rate(model_request_total)`
@@ -208,7 +210,7 @@ OTEL metrics are semantically equivalent to the Supervisor-side Prometheus metri
 | Operations Scenario | Key Metrics | Dashboard |
 |---------------------|-------------|-----------|
 | **SLO Dashboard** | `time_to_first_token_seconds`, `model_request_duration_seconds`, `model_request_errors_total / model_request_total` | LLM SLO |
-| **Per-Model / Per-Replica Load** | `model_request_total` by (model, node), `model_serve_count`, `model_gpu_memory_used_bytes` | Model Load |
+| **Per-Model / Per-Replica Load** | `model_request_total` by (model_uid, replica_index, worker_address), `model_serve_count`, `model_gpu_memory_used_bytes` | Model Load |
 | **Autoscaling** | `model_serve_count / model_request_limit`, `models_loaded_total` | Model Load / Overview |
 | **Failure Detection & Alerts** | `workers_total`, `model_unexpected_termination`, `model_last_load_duration_seconds` | Overview |
 | **Resource Capacity Planning** | `worker_cpu_utilization`, `worker_memory_used_bytes`, `worker_gpu_utilization_percent`, `worker_gpu_memory_used_bytes` | Host / GPU |

--- a/monitor/metrics/README_zh-CN.md
+++ b/monitor/metrics/README_zh-CN.md
@@ -84,12 +84,14 @@ Worker 端指标主要反映**单节点上的模型推理质量与服务负载**
 
 | 指标名 | 类型 | 单位 | 说明 |
 |--------|------|------|------|
-| `xinference:model_request_total` | Counter | requests | 模型请求总数（按 `model_uid`、`op` 标签区分） |
+| `xinference:model_request_total` | Counter | requests | 模型请求总数（按 `model_uid`、`replica_index`、`model_type`、`worker_address` 标签区分） |
 | `xinference:model_request_errors_total` | Counter | requests | 模型请求失败总数 |
 | `xinference:model_request_duration_seconds` | Histogram | seconds | 请求耗时分布。分桶：0.01、0.025、0.05、0.1、0.25、0.5、1、2.5、5、10、30、60、120、+Inf |
 | `xinference:model_serve_count` | Gauge | requests | 当前正在处理的并发请求数 |
 | `xinference:model_request_limit` | Gauge | requests | 模型配置的最大并发请求上限 |
 | `xinference:model_last_load_duration_seconds` | Gauge | seconds | 最近一次模型加载耗时（含权重下载与初始化） |
+
+**标签（与 Supervisor 端统一）：** `model_uid`（base uid，不含副本后缀）、`replica_index`（0 基，单副本=`0`）、`model_type`（`LLM`/`embedding`/`rerank`/`image`/`audio`/`video`）、`worker_address`、`model_name`、`engine`、`format`、`quantization`、`gpu_index`。
 
 **用途：**
 - QPS = `rate(model_request_total)`
@@ -208,7 +210,7 @@ OTEL 指标与 Supervisor 端 Prometheus 指标语义等价，命名采用 OTLP 
 | 运营场景 | 关键指标 | 对应面板 |
 |----------|----------|----------|
 | **SLO 看板** | `time_to_first_token_seconds`、`model_request_duration_seconds`、`model_request_errors_total / model_request_total` | LLM SLO |
-| **每模型 / 每副本负载** | `model_request_total` by (model, node)、`model_serve_count`、`model_gpu_memory_used_bytes` | 模型负载 |
+| **每模型 / 每副本负载** | `model_request_total` by (model_uid, replica_index, worker_address)、`model_serve_count`、`model_gpu_memory_used_bytes` | 模型负载 |
 | **弹性扩缩容** | `model_serve_count / model_request_limit`、`models_loaded_total` | 模型负载 / 概览 |
 | **故障检测与告警** | `workers_total`、`model_unexpected_termination`、`model_last_load_duration_seconds` | 概览 |
 | **资源容量规划** | `worker_cpu_utilization`、`worker_memory_used_bytes`、`worker_gpu_utilization_percent`、`worker_gpu_memory_used_bytes` | 主机 / GPU |

--- a/xinference/core/model.py
+++ b/xinference/core/model.py
@@ -54,7 +54,7 @@ logger = logging.getLogger(__name__)
 
 from ..device_utils import empty_cache
 from .exceptions import ModelNotReadyError
-from .utils import CancelMixin, json_dumps, log_async
+from .utils import CancelMixin, json_dumps, log_async, parse_replica_model_uid
 
 try:
     from torch.cuda import OutOfMemoryError
@@ -286,12 +286,14 @@ class ModelActor(xo.StatelessActor, CancelMixin):
         else:
             engine_label = model_engine or "unknown"
             format_label = self._model_description.get("model_format", "unknown")
+        _base_uid, _rep_id = parse_replica_model_uid(self._replica_model_uid or "")
         self._metrics_labels = {
-            "type": model_type,
-            "model": self.model_uid(),
+            "model_type": model_type,
+            "model_uid": _base_uid,
+            "replica_index": str(_rep_id),
             "model_name": self._model_description.get("model_name", "unknown"),
             "engine": engine_label,
-            "node": self._worker_address,
+            "worker_address": self._worker_address,
             "format": format_label,
             "quantization": self._model_description.get("quantization", "none"),
             "gpu_index": ",".join(

--- a/xinference/core/tests/test_metrics.py
+++ b/xinference/core/tests/test_metrics.py
@@ -147,4 +147,7 @@ async def test_metrics_exporter_data(setup_cluster):
 
     response = requests.get(metrics_exporter_address)
     assert response.ok
-    assert 'format="ggufv2",gpu_index="",model="qwen1.5-chat"' in response.text
+    assert (
+        'format="ggufv2",gpu_index="",model_name="qwen1.5-chat",'
+        'model_type="LLM",model_uid="qwen1.5-chat"' in response.text
+    )

--- a/xinference/core/tests/test_metrics.py
+++ b/xinference/core/tests/test_metrics.py
@@ -82,12 +82,13 @@ async def test_metrics_exporter_server(setup_cluster):
     # Check the worker metrics collected model metrics.
     model_ref = await supervisor_ref.get_model(model_uid)
     await model_ref.record_metrics(
-        "input_tokens_total_counter", "inc", {"labels": {"model": model_uid}}
+        "input_tokens_total_counter", "inc", {"labels": {"model_uid": model_uid}}
     )
     response = requests.get(metrics_exporter_address)
     assert response.ok
     assert (
-        'xinference:input_tokens_total_counter{model="qwen1.5-chat"} 1' in response.text
+        'xinference:input_tokens_total_counter{model_uid="qwen1.5-chat"} 1'
+        in response.text
     )
 
 


### PR DESCRIPTION
## Summary

Worker-side model metrics used labels `model`, `type`, `node` while supervisor-side used `model_uid`, `model_type`, `worker_address`. This mismatch broke cross-side PromQL joins (the model-load dashboard's per-model tables needed `label_replace` workarounds) and made per-replica breakdown impossible because `model` carried the replica uid suffix.

Rename in `ModelActor._metrics_labels`:
- `model` → `model_uid` (base uid, replica suffix stripped via `parse_replica_model_uid`)
- `type` → `model_type`
- `node` → `worker_address`
- New label: `replica_index` (0-based, `"0"` for single replica)

Also fixes an existing bug where the model-load/llm-slo dashboard PromQL hardcoded `{type="llm"}` (lowercase) which never matched the actual uppercase `LLM` label value; now uses `{model_type="LLM"}`.

## Motivation

1. **Cross-side joins**: the model-load dashboard wants to show per-model QPS (worker-side `model_request_total`) alongside per-model VRAM (supervisor-side `model_gpu_memory_used_bytes`) in the same table. With mismatched label names, this required `label_replace` hacks. After this change, both sides use `model_uid` / `replica_index` / `worker_address`, so a direct `* on (model_uid, replica_index, worker_address) group_left(...)` works.
2. **Per-replica breakdown**: the `每副本明细` (id 406) panel aims to show one row per replica, but `model` was the replica uid (e.g. `qwen1.5-chat-1-0`), so multiple replicas of the same model on the same worker aggregated into one row. Splitting `model` into `model_uid` (base) + `replica_index` lets each replica get its own row.
3. **Label-name consistency**: `type` is a PromQL reserved-ish word and collides with common conventions; `model_type` is unambiguous. `node` is ambiguous (could be hostname); `worker_address` matches the supervisor side.

## Changes

### Code
- `xinference/core/model.py`: `_metrics_labels` renamed as above; imports `parse_replica_model_uid`.
- `xinference/core/tests/test_metrics.py`: label key and assertion updated from `model` to `model_uid`.

### Dashboards (hand-edited JSONs; no generator script in-tree)
- `monitor/dashboard/model-load/*.json` (4 langs): 10 panels updated to use new labels. Also added `xinference:` prefix to 5 metric references (`model_request_total`, `model_request_errors_total`, `model_request_duration_seconds_bucket`, `model_gpu_memory_used_bytes`) that were missing it in newly-added panels (id 401-404).
- `monitor/dashboard/llm-slo/*.json` (4 langs): 12 LLM-specific panels updated; fixes the lowercase `{type="llm"}` bug. Also added `xinference:` prefix to `time_to_first_token_seconds_bucket` and `model_request_duration_seconds_bucket` (id 401-402).
- `monitor/dashboard/host-resources/*.json` (4 langs): worker CPU/memory panels updated to `worker_address`.

### Docs
- `monitor/dashboard/README.md` / `README_zh-CN.md`: updated the "Label alignment" section to reflect that both sides now use unified labels, enabling direct PromQL joins without Grafana Transform hacks.
- `monitor/metrics/README.md` / `README_zh-CN.md`: label tables and use-case queries updated.

### Alert rules
- `monitor/alert/rules-*.yml`: scanned, no references to old labels — no changes needed.

## Breaking change

⚠️ **External Prometheus queries or Grafana dashboards that reference the old `model`, `type`, or `node` labels on worker-side `xinference:*` metrics will break.** These labels are internal to this project, but downstream users with custom queries should update them. Migration:
- `{model="X"}` → `{model_uid="X"}`
- `{type="LLM"}` → `{model_type="LLM"}` (note: lowercase `{type="llm"}` never matched and was a bug)
- `{node="..."}` → `{worker_address="..."}`
- `by (model, node)` → `by (model_uid, replica_index, worker_address)`

## Test plan

- [x] `black --check` / `flake8` / `isort` on modified Python files — clean.
- [x] All 24 dashboard JSONs are valid JSON.
- [x] New labels (`model_uid`/`model_type`/`worker_address`/`replica_index`) present in model-load/llm-slo; old labels (`{model=`, `by (type)`, `{type=`, `{node=`) fully removed.
- [x] All `xinference:` metric prefixes present in model-load/llm-slo (44 references fixed).
- [ ] `pytest xinference/core/tests/test_metrics.py` — requires full model-serving stack (torch, gradio, etc.); the label-key change is a 1-line assertion update, low risk.
- [ ] Manual: launch a multi-replica LLM model; verify the model-load dashboard's `每副本明细` table shows one row per replica with distinct `replica_index`.
- [ ] Manual: verify cross-side joins (worker QPS + supervisor VRAM in the same table) work without `label_replace`.

## Dependencies

**Depends on #5073** (`feat(monitor): split Grafana dashboard into 6 sub-dashboards with config store`). This branch is rebased onto the latest #5073 HEAD (which removed `generate.py` and the original monolithic JSONs). Dashboard JSON edits are hand-applied on top of the 24 sub-dashboard JSONs introduced by #5073.

**Relationship to #5074** (`fix/security-audit-model-name`): sibling PR, also stacked on #5073. The two are independent — #5074 touches `restful_api.py` + `security-audit/` JSONs; this PR touches `core/model.py` + `model-load`/`llm-slo`/`host-resources` JSONs. No conflicts expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)