### PR TITLE
feat: support VibeThinker with transformers/vLLM and harden list_models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,7 @@ celerybeat.pid
 # Environments
 .env
 .venv
+.inference_home
 env/
 venv/
 ENV/

--- a/xinference/core/supervisor.py
+++ b/xinference/core/supervisor.py
@@ -2851,8 +2851,23 @@ class SupervisorActor(xo.StatelessActor):
 
         running_model_info = {parse_replica_model_uid(k)[0]: v for k, v in ret.items()}
         # add replica count
+        stale_uids = []
         for k, v in running_model_info.items():
-            v["replica"] = self._model_uid_to_replica_info[k].replica
+            replica_info = self._model_uid_to_replica_info.get(k)
+            if replica_info is None:
+                # Worker still reports a replica that supervisor no longer
+                # tracks (e.g. failed launch left a stale subprocess). Skip
+                # it instead of raising KeyError, and let recover_sub_pool
+                # clean up later.
+                logger.warning(
+                    "list_models: drop stale running model %s without replica info",
+                    k,
+                )
+                stale_uids.append(k)
+                continue
+            v["replica"] = replica_info.replica
+        for k in stale_uids:
+            running_model_info.pop(k, None)
         return running_model_info
 
     def is_local_deployment(self) -> bool:

--- a/xinference/model/llm/llm_family.json
+++ b/xinference/model/llm/llm_family.json
@@ -32532,5 +32532,84 @@
     },
     "featured": true,
     "updated_at": 1781520058
+  },
+  {
+    "version": 2,
+    "context_length": 131072,
+    "model_name": "vibethinker",
+    "model_lang": [
+      "en",
+      "zh"
+    ],
+    "model_ability": [
+      "chat",
+      "tools"
+    ],
+    "model_description": "VibeThinker is a series of dense reasoning language models developed by WeiboAI. Built on the Qwen2 architecture with a post-training methodology centered on the Spectrum-to-Signal Principle (SSP), VibeThinker demonstrates strong reasoning capabilities in mathematics and coding despite its compact size.",
+    "model_specs": [
+      {
+        "model_format": "pytorch",
+        "model_size_in_billions": "1_5",
+        "model_src": {
+          "huggingface": {
+            "quantizations": [
+              "none"
+            ],
+            "model_id": "WeiboAI/VibeThinker-1.5B"
+          },
+          "modelscope": {
+            "quantizations": [
+              "none"
+            ],
+            "model_id": "WeiboAI/VibeThinker-1.5B"
+          }
+        }
+      },
+      {
+        "model_format": "pytorch",
+        "model_size_in_billions": 3,
+        "model_src": {
+          "huggingface": {
+            "quantizations": [
+              "none"
+            ],
+            "model_id": "WeiboAI/VibeThinker-3B"
+          },
+          "modelscope": {
+            "quantizations": [
+              "none"
+            ],
+            "model_id": "WeiboAI/VibeThinker-3B"
+          }
+        }
+      }
+    ],
+    "chat_template": "{%- if tools %}\n    {{- '<|im_start|>system\\n' }}\n    {%- if messages[0]['role'] == 'system' %}\n        {{- messages[0]['content'] }}\n    {%- else %}\n        {{- 'You are a helpful assistant.' }}\n    {%- endif %}\n    {{- \"\\n\\n# Tools\\n\\nYou may call one or more functions to assist with the user query.\\n\\nYou are provided with function signatures within <tools></tools> XML tags:\\n<tools>\" }}\n    {%- for tool in tools %}\n        {{- \"\\n\" }}\n        {{- tool | tojson }}\n    {%- endfor %}\n    {{- \"\\n</tools>\\n\\nFor each function call, return a json object with function name and arguments within <tool_call></tool_call> XML tags:\\n<tool_call>\\n{\\\"name\\\": <function-name>, \\\"arguments\\\": <args-json-object>}\\n</tool_call><|im_end|>\\n\" }}\n{%- else %}\n    {%- if messages[0]['role'] == 'system' %}\n        {{- '<|im_start|>system\\n' + messages[0]['content'] + '<|im_end|>\\n' }}\n    {%- else %}\n        {{- '<|im_start|>system\\nYou are a helpful assistant.<|im_end|>\\n' }}\n    {%- endif %}\n{%- endif %}\n{%- for message in messages %}\n    {%- if (message.role == \"user\") or (message.role == \"system\" and not loop.first) or (message.role == \"assistant\" and not message.tool_calls) %}\n        {{- '<|im_start|>' + message.role + '\\n' + message.content + '<|im_end|>' + '\\n' }}\n    {%- elif message.role == \"assistant\" %}\n        {{- '<|im_start|>' + message.role }}\n        {%- if message.content %}\n            {{- '\\n' + message.content }}\n        {%- endif %}\n        {%- for tool_call in message.tool_calls %}\n            {%- if tool_call.function is defined %}\n                {%- set tool_call = tool_call.function %}\n            {%- endif %}\n            {{- '\\n<tool_call>\\n{\"name\": \"' }}\n            {{- tool_call.name }}\n            {{- '\", \"arguments\": ' }}\n            {{- tool_call.arguments | tojson }}\n            {{- '}\\n</tool_call>' }}\n        {%- endfor %}\n        {{- '<|im_end|>\\n' }}\n    {%- elif message.role == \"tool\" %}\n        {%- if (loop.index0 == 0) or (messages[loop.index0 - 1].role != \"tool\") %}\n            {{- '<|im_start|>user' }}\n        {%- endif %}\n        {{- '\\n<tool_response>\\n' }}\n        {{- message.content }}\n        {{- '\\n</tool_response>' }}\n        {%- if loop.last or (messages[loop.index0 + 1].role != \"tool\") %}\n            {{- '<|im_end|>\\n' }}\n        {%- endif %}\n    {%- endif %}\n{%- endfor %}\n{%- if add_generation_prompt %}\n    {{- '<|im_start|>assistant\\n' }}\n{%- endif %}\n",
+    "stop_token_ids": [
+      151643,
+      151644,
+      151645
+    ],
+    "stop": [
+      "<|endoftext|>",
+      "<|im_start|>",
+      "<|im_end|>"
+    ],
+    "tool_parser": "qwen",
+    "architectures": [
+      "Qwen2ForCausalLM"
+    ],
+    "model_type": "qwen2",
+    "virtualenv": {
+      "packages": [
+        "#transformers_dependencies# ; #engine# == \"Transformers\"",
+        "#llama_cpp_dependencies# ; #engine# == \"llama.cpp\"",
+        "#sglang_dependencies# ; #engine# == \"sglang\"",
+        "#vllm_dependencies# ; #engine# == \"vllm\"",
+        "#system_numpy# ; #engine# == \"vllm\""
+      ]
+    },
+    "featured": false,
+    "updated_at": 1782480339
   }
 ]

--- a/xinference/model/llm/transformers/utils.py
+++ b/xinference/model/llm/transformers/utils.py
@@ -183,15 +183,17 @@ def get_batch_size_and_seq_len_from_kv_cache(kv, xinf_model_obj: "PytorchModel")
         if isinstance(kv, HybridCache):
             return kv.key_cache[0].shape[bs_idx], kv.get_seq_length()
     except ImportError:
-        if kv is None:
-            return 0, 0
+        pass
 
-        if hasattr(kv, "key_cache"):
-            if len(kv.key_cache) == 0 or kv.key_cache[0] is None:
-                return 0, kv.get_seq_length() if hasattr(kv, "get_seq_length") else 0
+    if kv is None:
+        return 0, 0
 
-            key = kv.key_cache[0]
-            return key.shape[bs_idx], kv.get_seq_length()
+    if hasattr(kv, "key_cache"):
+        if len(kv.key_cache) == 0 or kv.key_cache[0] is None:
+            return 0, kv.get_seq_length() if hasattr(kv, "get_seq_length") else 0
+
+        key = kv.key_cache[0]
+        return key.shape[bs_idx], kv.get_seq_length()
 
     return kv[0][0].shape[bs_idx], kv[0][0].shape[seq_len_idx] + 1
 


### PR DESCRIPTION
* Register VibeThinker 1.5B / 3B (pytorch, none) in llm_family.json with both Transformers and vLLM engines.
* Fix get_batch_size_and_seq_len_from_kv_cache: the DynamicCache key_cache branch was nested inside except ImportError, so when HybridCache is importable but kv is a plain DynamicCache, the function fell through to kv[0][0] and raised 'DynamicCache' object is not subscriptable on newer transformers. Move the DynamicCache handling out of the except block so it runs regardless of HybridCache availability.
* Guard supervisor.list_models against stale replicas: a worker may still report a model that supervisor's _model_uid_to_replica_info no longer tracks (e.g. after a failed launch). Drop those entries with a warning instead of raising KeyError.
* Add .inference_home/ to .gitignore so local XINFERENCE_HOME caches are not committed.