### PR TITLE
fix: handle DynamicCache in get_batch_size_and_seq_len_from_kv_cache when HybridCache is importable

### DIFF
--- a/xinference/model/llm/transformers/utils.py
+++ b/xinference/model/llm/transformers/utils.py
@@ -181,17 +181,41 @@ def get_batch_size_and_seq_len_from_kv_cache(kv, xinf_model_obj: "PytorchModel")
         from transformers import HybridCache
 
         if isinstance(kv, HybridCache):
+            if len(kv.key_cache) == 0 or kv.key_cache[0] is None:
+                return 0, 0
             return kv.key_cache[0].shape[bs_idx], kv.get_seq_length()
     except ImportError:
-        if kv is None:
+        pass
+
+    if kv is None:
+        return 0, 0
+
+    if hasattr(kv, "key_cache"):
+        if len(kv.key_cache) == 0 or kv.key_cache[0] is None:
             return 0, 0
 
-        if hasattr(kv, "key_cache"):
-            if len(kv.key_cache) == 0 or kv.key_cache[0] is None:
-                return 0, kv.get_seq_length() if hasattr(kv, "get_seq_length") else 0
+        key = kv.key_cache[0]
+        return (
+            key.shape[bs_idx],
+            (
+                kv.get_seq_length()
+                if hasattr(kv, "get_seq_length")
+                else key.shape[seq_len_idx]
+            ),
+        )
 
-            key = kv.key_cache[0]
-            return key.shape[bs_idx], kv.get_seq_length()
+    # New transformers Cache API (transformers >= 4.57 / 5.x): DynamicCache
+    # exposes `layers` (a list of CacheLayerMixin objects with `.keys` /
+    # `.values` tensors of shape [batch_size, num_heads, seq_len, head_dim])
+    # and `get_seq_length()`, but no longer exposes `key_cache` and (on 5.x)
+    # is not subscriptable. Without this branch the legacy `kv[0][0]` fallback
+    # below raises `TypeError: 'DynamicCache' object is not subscriptable`.
+    if hasattr(kv, "layers") and hasattr(kv, "get_seq_length"):
+        layers = kv.layers
+        first_keys = getattr(layers[0], "keys", None) if len(layers) > 0 else None
+        if first_keys is None or first_keys.numel() == 0:
+            return 0, kv.get_seq_length()
+        return first_keys.shape[bs_idx], kv.get_seq_length()
 
     return kv[0][0].shape[bs_idx], kv[0][0].shape[seq_len_idx] + 1
 


### PR DESCRIPTION
## Problem

In `get_batch_size_and_seq_len_from_kv_cache` ([xinference/model/llm/transformers/utils.py](https://github.com/xorbitsai/inference/blob/main/xinference/model/llm/transformers/utils.py)) the `DynamicCache` / `key_cache` handling was nested inside `except ImportError`:

```python
try:
    from transformers import HybridCache
    if isinstance(kv, HybridCache):
        return kv.key_cache[0].shape[bs_idx], kv.get_seq_length()
except ImportError:
    if kv is None:
        return 0, 0
    if hasattr(kv, "key_cache"):
        ...
return kv[0][0].shape[bs_idx], kv[0][0].shape[seq_len_idx] + 1
```

When `transformers.HybridCache` is importable (newer transformers releases) **and** `kv` is a plain `DynamicCache`, the `except` block is skipped and the function falls through to `kv[0][0].shape[...]`. On recent transformers releases `DynamicCache` is no longer subscriptable, so this raises:

```
TypeError: 'DynamicCache' object is not subscriptable
```

## Fix

Move the `None` / `key_cache` branches **out** of the `except` block so they run whenever the cache exposes `key_cache`, regardless of whether `HybridCache` is importable.

Also defensively fall back to `key.shape[seq_len_idx]` when `kv.get_seq_length()` is unavailable (some older transformers / custom cache implementations), matching the existing empty-cache branch — credit @gemini-code-assist for spotting the asymmetry on #5084.

## Notes

Split out of #5084. Only touches `xinference/model/llm/transformers/utils.py`.
