### PR TITLE
fix: drop stale running models without replica info in supervisor.list_models

### DIFF
--- a/xinference/core/supervisor.py
+++ b/xinference/core/supervisor.py
@@ -2851,8 +2851,23 @@ class SupervisorActor(xo.StatelessActor):
 
         running_model_info = {parse_replica_model_uid(k)[0]: v for k, v in ret.items()}
         # add replica count
+        stale_uids = []
         for k, v in running_model_info.items():
-            v["replica"] = self._model_uid_to_replica_info[k].replica
+            replica_info = self._model_uid_to_replica_info.get(k)
+            if replica_info is None:
+                # Worker still reports a replica that supervisor no longer
+                # tracks (e.g. failed launch left a stale subprocess). Skip
+                # it instead of raising KeyError, and let recover_sub_pool
+                # clean up later.
+                logger.warning(
+                    "list_models: drop stale running model %s without replica info",
+                    k,
+                )
+                stale_uids.append(k)
+                continue
+            v["replica"] = replica_info.replica
+        for k in stale_uids:
+            running_model_info.pop(k, None)
         return running_model_info
 
     def is_local_deployment(self) -> bool:


### PR DESCRIPTION
## Problem

`SupervisorActor.list_models` ([xinference/core/supervisor.py](https://github.com/xorbitsai/inference/blob/main/xinference/core/supervisor.py)) joins worker-reported running models against `self._model_uid_to_replica_info[k].replica`:

```python
for k, v in running_model_info.items():
    v["replica"] = self._model_uid_to_replica_info[k].replica
```

If a worker still reports a model that the supervisor no longer tracks — for example because a previous launch failed but left a subprocess behind — the dict lookup raises `KeyError`. The whole `list_models` call then dies, which hides every other healthy model from the Web UI / API.

## Fix

Use `.get()` and skip the stale entry with a warning instead of crashing. Eventual cleanup is still done by `recover_sub_pool`; this change just keeps `list_models` resilient so users can see the rest of their running models in the meantime.

## Notes

Split out of #5084. Only touches `xinference/core/supervisor.py`.
