### PR TITLE
fix(oauth2): verify JWT expiration in AuthService (#5058)

### DIFF
--- a/xinference/api/oauth2/auth_service.py
+++ b/xinference/api/oauth2/auth_service.py
@@ -95,7 +95,7 @@ class AuthService:
                     token,
                     self._config.auth_config.secret_key,
                     algorithms=[self._config.auth_config.algorithm],
-                    options={"verify_exp": False},  # TODO: supports token expiration
+                    options={"verify_exp": True},  # reject expired tokens
                 )
                 username: str = payload.get("sub")
                 if username is None:

--- a/xinference/api/tests/test_oauth2_token_expiration.py
+++ b/xinference/api/tests/test_oauth2_token_expiration.py
@@ -1,42 +1,61 @@
-"""Regression test for #5058 Finding 1: JWTs issued by create_access_token
-must be rejected once expired (the decode path now uses verify_exp=True).
+"""Regression tests for rejecting expired OAuth2 JWT access tokens."""
 
-    pytest xinference/api/tests/test_oauth2_token_expiration.py -v
-"""
+import json
 from datetime import timedelta
 
 import pytest
-from jose import ExpiredSignatureError, jwt
+from fastapi import HTTPException
+from fastapi.security import SecurityScopes
 
+from xinference.api.oauth2.auth_service import AuthService
+from xinference.api.oauth2.types import AuthConfig, AuthStartupConfig, User
 from xinference.api.oauth2.utils import create_access_token
 
 _SECRET = "unit-test-secret"
 _ALG = "HS256"
 
 
-def _decode(token: str):
-    # same decode contract as AuthService.__call__ (verify_exp enabled by the fix)
-    return jwt.decode(token, _SECRET, algorithms=[_ALG], options={"verify_exp": True})
+@pytest.fixture
+def auth_service(tmp_path):
+    auth_config = AuthConfig(
+        algorithm=_ALG,
+        secret_key=_SECRET,
+        token_expire_in_minutes=30,
+    )
+    user = User(
+        username="alice",
+        password="pass",
+        permissions=["models:read"],
+        api_keys=["sk-123456789abcd"],
+    )
+    startup_config = AuthStartupConfig(auth_config=auth_config, user_config=[user])
+    auth_config_file = tmp_path / "auth_config.json"
+    auth_config_file.write_text(json.dumps(startup_config.dict()))
+    return AuthService(str(auth_config_file))
 
 
-def test_expired_token_is_rejected():
+def test_expired_token_is_rejected(auth_service):
     token = create_access_token(
-        data={"sub": "helpdesk", "scopes": ["users:manage"]},
+        data={"sub": "alice", "scopes": ["models:read"]},
         secret_key=_SECRET,
         algorithm=_ALG,
         expires_delta=timedelta(minutes=-5),
     )
-    with pytest.raises(ExpiredSignatureError):
-        _decode(token)
+    with pytest.raises(HTTPException) as exc_info:
+        auth_service(SecurityScopes(scopes=["models:read"]), token)
+
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.detail == "Could not validate credentials"
 
 
-def test_valid_token_is_accepted():
+def test_valid_token_is_accepted(auth_service):
     token = create_access_token(
         data={"sub": "alice", "scopes": ["models:read"]},
         secret_key=_SECRET,
         algorithm=_ALG,
         expires_delta=timedelta(minutes=30),
     )
-    payload = _decode(token)
-    assert payload["sub"] == "alice"
-    assert payload["scopes"] == ["models:read"]
+    user = auth_service(SecurityScopes(scopes=["models:read"]), token)
+
+    assert user.username == "alice"
+    assert user.permissions == ["models:read"]

--- a/xinference/api/tests/test_oauth2_token_expiration.py
+++ b/xinference/api/tests/test_oauth2_token_expiration.py
@@ -1,0 +1,42 @@
+"""Regression test for #5058 Finding 1: JWTs issued by create_access_token
+must be rejected once expired (the decode path now uses verify_exp=True).
+
+    pytest xinference/api/tests/test_oauth2_token_expiration.py -v
+"""
+from datetime import timedelta
+
+import pytest
+from jose import JWTError, jwt
+
+from xinference.api.oauth2.utils import create_access_token
+
+_SECRET = "unit-test-secret"
+_ALG = "HS256"
+
+
+def _decode(token: str):
+    # same decode contract as AuthService.__call__ (verify_exp enabled by the fix)
+    return jwt.decode(token, _SECRET, algorithms=[_ALG], options={"verify_exp": True})
+
+
+def test_expired_token_is_rejected():
+    token = create_access_token(
+        data={"sub": "helpdesk", "scopes": ["users:manage"]},
+        secret_key=_SECRET,
+        algorithm=_ALG,
+        expires_delta=timedelta(minutes=-5),
+    )
+    with pytest.raises(JWTError):
+        _decode(token)
+
+
+def test_valid_token_is_accepted():
+    token = create_access_token(
+        data={"sub": "alice", "scopes": ["models:read"]},
+        secret_key=_SECRET,
+        algorithm=_ALG,
+        expires_delta=timedelta(minutes=30),
+    )
+    payload = _decode(token)
+    assert payload["sub"] == "alice"
+    assert payload["scopes"] == ["models:read"]

--- a/xinference/api/tests/test_oauth2_token_expiration.py
+++ b/xinference/api/tests/test_oauth2_token_expiration.py
@@ -6,7 +6,7 @@ must be rejected once expired (the decode path now uses verify_exp=True).
 from datetime import timedelta
 
 import pytest
-from jose import JWTError, jwt
+from jose import ExpiredSignatureError, jwt
 
 from xinference.api.oauth2.utils import create_access_token
 
@@ -26,7 +26,7 @@ def test_expired_token_is_rejected():
         algorithm=_ALG,
         expires_delta=timedelta(minutes=-5),
     )
-    with pytest.raises(JWTError):
+    with pytest.raises(ExpiredSignatureError):
         _decode(token)
 
 


### PR DESCRIPTION
### What

`AuthService.__call__` decodes JWTs with `options={"verify_exp": False}`
(`xinference/api/oauth2/auth_service.py:98`, marked `# TODO: supports token
expiration`):

```python
payload = jwt.decode(
    token,
    self._config.auth_config.secret_key,
    algorithms=[self._config.auth_config.algorithm],
    options={"verify_exp": False},   # exp claim never checked
)
```

`create_access_token` already embeds an `exp` claim, but the decode path never
checks it, so **every issued JWT is valid forever** — a leaked token keeps
working even after a password change or permission revocation. This is Finding 1
of #5058.

### Fix

Enable expiration verification (`verify_exp: True`). `python-jose` raises
`ExpiredSignatureError` (a subclass of `JWTError`) for expired tokens, which the
existing `except (JWTError, ValidationError)` already turns into a 401, so no
other change is needed.

### Testing

Added `xinference/api/tests/test_oauth2_token_expiration.py`: a token from
`create_access_token` with a negative `expires_delta` is rejected; a valid token
is still accepted.

```
pytest xinference/api/tests/test_oauth2_token_expiration.py -v
```

Scope: this PR fixes Finding 1 (eternal tokens) only. The other findings in
#5058 (permission-grant privilege escalation, etc.) are separate and out of
scope for this change.

Refs #5058