### PR TITLE
fix(oauth2): block privilege escalation in user permission grants (#5058)

### DIFF
--- a/xinference/api/oauth2/advanced/routes.py
+++ b/xinference/api/oauth2/advanced/routes.py
@@ -89,18 +89,17 @@ def _reject_permission_escalation(
     operator could mint the ``admin`` superuser scope for themselves or others
     (see security report, Finding 2).
     """
-    if requested_permissions is not None:
-        if not isinstance(requested_permissions, list) or not all(
-            isinstance(p, str) for p in requested_permissions
-        ):
-            raise HTTPException(
-                status_code=400, detail="Permissions must be a list of strings"
-            )
+    if not isinstance(requested_permissions, list) or not all(
+        isinstance(p, str) for p in requested_permissions
+    ):
+        raise HTTPException(
+            status_code=400, detail="Permissions must be a list of strings"
+        )
     _, _, caller_scopes = _get_current_user_from_token(request, auth)
     caller_scopes = caller_scopes or []
     if "admin" in caller_scopes:
         return
-    escalated = [p for p in (requested_permissions or []) if p not in caller_scopes]
+    escalated = [p for p in requested_permissions if p not in caller_scopes]
     if escalated:
         raise HTTPException(
             status_code=403,

--- a/xinference/api/oauth2/advanced/routes.py
+++ b/xinference/api/oauth2/advanced/routes.py
@@ -79,6 +79,27 @@ def _get_current_user_from_token(request: Request, auth: AdvancedAuthService):
     return payload.get("user_id"), payload.get("sub"), payload.get("scopes", [])
 
 
+def _reject_permission_escalation(
+    request: Request, auth: "AdvancedAuthService", requested_permissions
+) -> None:
+    """Prevent privilege escalation when granting user permissions.
+
+    A caller may only grant permissions they themselves hold; the ``admin``
+    scope may grant anything. Without this, a delegated ``users:manage``
+    operator could mint the ``admin`` superuser scope for themselves or others
+    (see security report, Finding 2).
+    """
+    _, _, caller_scopes = _get_current_user_from_token(request, auth)
+    if "admin" in caller_scopes:
+        return
+    escalated = [p for p in (requested_permissions or []) if p not in caller_scopes]
+    if escalated:
+        raise HTTPException(
+            status_code=403,
+            detail=f"Cannot grant permissions you do not hold: {escalated}",
+        )
+
+
 # --- Auth endpoints ---
 
 
@@ -159,6 +180,8 @@ async def create_user(request: Request) -> JSONResponse:
     if not username or not password:
         raise HTTPException(status_code=400, detail="username and password required")
 
+    _reject_permission_escalation(request, auth, permissions)
+
     existing = auth.db.get_user_by_username(username, "local")
     if existing:
         raise HTTPException(status_code=409, detail="User already exists")
@@ -228,6 +251,7 @@ async def update_user(user_id: int, request: Request) -> JSONResponse:
             auth.disable_user(user_id)
 
     if "permissions" in body:
+        _reject_permission_escalation(request, auth, body["permissions"])
         auth.db.set_user_permissions(user_id, body["permissions"])
 
     return JSONResponse(content={"ok": True})
@@ -434,6 +458,7 @@ async def update_user_permissions(user_id: int, request: Request) -> JSONRespons
         raise HTTPException(status_code=404, detail="User not found")
     body = await request.json()
     permissions = body.get("permissions", [])
+    _reject_permission_escalation(request, auth, permissions)
     auth.db.set_user_permissions(user_id, permissions)
     return JSONResponse(content={"ok": True})
 

--- a/xinference/api/oauth2/advanced/routes.py
+++ b/xinference/api/oauth2/advanced/routes.py
@@ -89,7 +89,15 @@ def _reject_permission_escalation(
     operator could mint the ``admin`` superuser scope for themselves or others
     (see security report, Finding 2).
     """
+    if requested_permissions is not None:
+        if not isinstance(requested_permissions, list) or not all(
+            isinstance(p, str) for p in requested_permissions
+        ):
+            raise HTTPException(
+                status_code=400, detail="Permissions must be a list of strings"
+            )
     _, _, caller_scopes = _get_current_user_from_token(request, auth)
+    caller_scopes = caller_scopes or []
     if "admin" in caller_scopes:
         return
     escalated = [p for p in (requested_permissions or []) if p not in caller_scopes]

--- a/xinference/api/tests/test_oauth2_permission_escalation.py
+++ b/xinference/api/tests/test_oauth2_permission_escalation.py
@@ -36,3 +36,18 @@ def test_admin_can_grant_anything(monkeypatch):
 def test_granting_held_permissions_is_allowed(monkeypatch):
     _patch_caller(monkeypatch, ["users:manage", "models:read"])
     routes._reject_permission_escalation(None, None, ["users:manage", "models:read"])
+
+
+@pytest.mark.parametrize("bad", ["admin", 123, True, ["admin", 1]])
+def test_non_list_of_strings_rejected(monkeypatch, bad):
+    _patch_caller(monkeypatch, ["admin"])
+    with pytest.raises(HTTPException) as exc:
+        routes._reject_permission_escalation(None, None, bad)
+    assert exc.value.status_code == 400
+
+
+def test_none_caller_scopes_does_not_crash(monkeypatch):
+    _patch_caller(monkeypatch, None)
+    with pytest.raises(HTTPException) as exc:
+        routes._reject_permission_escalation(None, None, ["admin"])
+    assert exc.value.status_code == 403

--- a/xinference/api/tests/test_oauth2_permission_escalation.py
+++ b/xinference/api/tests/test_oauth2_permission_escalation.py
@@ -3,6 +3,7 @@ they themselves hold (admins may grant anything).
 
     pytest xinference/api/tests/test_oauth2_permission_escalation.py -v
 """
+
 import pytest
 from fastapi import HTTPException
 
@@ -11,7 +12,9 @@ import xinference.api.oauth2.advanced.routes as routes
 
 def _patch_caller(monkeypatch, scopes):
     monkeypatch.setattr(
-        routes, "_get_current_user_from_token", lambda request, auth: (1, "caller", scopes)
+        routes,
+        "_get_current_user_from_token",
+        lambda request, auth: (1, "caller", scopes),
     )
 
 
@@ -30,7 +33,9 @@ def test_cannot_grant_unheld_scope(monkeypatch):
 
 def test_admin_can_grant_anything(monkeypatch):
     _patch_caller(monkeypatch, ["admin"])
-    routes._reject_permission_escalation(None, None, ["admin", "keys:manage", "models:read"])
+    routes._reject_permission_escalation(
+        None, None, ["admin", "keys:manage", "models:read"]
+    )
 
 
 def test_granting_held_permissions_is_allowed(monkeypatch):
@@ -38,7 +43,7 @@ def test_granting_held_permissions_is_allowed(monkeypatch):
     routes._reject_permission_escalation(None, None, ["users:manage", "models:read"])
 
 
-@pytest.mark.parametrize("bad", ["admin", 123, True, ["admin", 1]])
+@pytest.mark.parametrize("bad", [None, "admin", 123, True, ["admin", 1]])
 def test_non_list_of_strings_rejected(monkeypatch, bad):
     _patch_caller(monkeypatch, ["admin"])
     with pytest.raises(HTTPException) as exc:

--- a/xinference/api/tests/test_oauth2_permission_escalation.py
+++ b/xinference/api/tests/test_oauth2_permission_escalation.py
@@ -1,0 +1,38 @@
+"""Regression test for #5058 Finding 2: a caller may only grant permissions
+they themselves hold (admins may grant anything).
+
+    pytest xinference/api/tests/test_oauth2_permission_escalation.py -v
+"""
+import pytest
+from fastapi import HTTPException
+
+import xinference.api.oauth2.advanced.routes as routes
+
+
+def _patch_caller(monkeypatch, scopes):
+    monkeypatch.setattr(
+        routes, "_get_current_user_from_token", lambda request, auth: (1, "caller", scopes)
+    )
+
+
+def test_users_manage_cannot_grant_admin(monkeypatch):
+    _patch_caller(monkeypatch, ["users:manage"])
+    with pytest.raises(HTTPException) as exc:
+        routes._reject_permission_escalation(None, None, ["admin", "keys:manage"])
+    assert exc.value.status_code == 403
+
+
+def test_cannot_grant_unheld_scope(monkeypatch):
+    _patch_caller(monkeypatch, ["users:manage"])
+    with pytest.raises(HTTPException):
+        routes._reject_permission_escalation(None, None, ["models:write"])
+
+
+def test_admin_can_grant_anything(monkeypatch):
+    _patch_caller(monkeypatch, ["admin"])
+    routes._reject_permission_escalation(None, None, ["admin", "keys:manage", "models:read"])
+
+
+def test_granting_held_permissions_is_allowed(monkeypatch):
+    _patch_caller(monkeypatch, ["users:manage", "models:read"])
+    routes._reject_permission_escalation(None, None, ["users:manage", "models:read"])


### PR DESCRIPTION
### What

`create_user`, `update_user`, and `update_user_permissions`
(`xinference/api/oauth2/advanced/routes.py`) write the request-supplied
`permissions` list to the database verbatim. All three only require the
`users:manage` scope, with no check that the caller actually holds the
permissions being granted. Since `admin` bypasses every scope check, a
delegated `users:manage` operator can grant themselves (or anyone) the `admin`
superuser scope — a privilege escalation. This is Finding 2 of #5058.

### Fix

Add `_reject_permission_escalation(request, auth, permissions)` and call it in
the three handlers before persisting permissions. The rule is the standard
no-escalation invariant: a caller may only grant permissions they already hold;
the `admin` scope may grant anything. Granting an unheld scope returns 403.

### Testing

Added `xinference/api/tests/test_oauth2_permission_escalation.py`:

- a `users:manage` caller cannot grant `admin` or any unheld scope (403)
- an `admin` caller can still grant anything (no regression)
- granting only already-held permissions is allowed (delegation still works)

```
pytest xinference/api/tests/test_oauth2_permission_escalation.py -v
```

Scope: this is a minimal anti-escalation guard for Finding 2; maintainers may
wish to tighten the policy further (e.g. restrict permission management to
`admin` only). Other findings in #5058 are out of scope for this PR.

Refs #5058