### PR TITLE
doc: add security policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,12 +152,13 @@ asv/results
 
 .DS_Store
 
-# Exclude markdown files except README files
+# Exclude markdown files except selected root docs
 *.md
 !README.md
 !README_*.md
 !AGENTS.md
 !CLAUDE.md
+!SECURITY.md
 .history/
 
 # frontend 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,35 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you believe you have found a security vulnerability in Xinference (or xoscar),
+please report it privately through GitHub Security Advisories:
+
+[GitHub Security Advisories](https://github.com/xorbitsai/inference/security/advisories/new)
+
+We follow a coordinated vulnerability disclosure process and appreciate
+responsible security research.
+
+Please do not report security vulnerabilities through public GitHub issues,
+discussions, or pull requests.
+
+When submitting a report, please include:
+
+- Description of the vulnerability
+- Steps to reproduce
+- Affected versions
+- Potential impact
+- Suggested mitigation or fix, if available
+
+We will acknowledge receipt as soon as possible and work with you to validate
+and resolve the issue.
+
+## Public Disclosure
+
+Please avoid publicly disclosing vulnerability details until a fix has been
+released or we have coordinated disclosure together.
+
+## Security Updates
+
+Security fixes may be released through normal project releases and GitHub
+Security Advisories.


### PR DESCRIPTION
## Summary
- Add a root SECURITY.md with private vulnerability reporting guidance.
- Include coordinated vulnerability disclosure wording and the GitHub Security Advisories link.
- Allow SECURITY.md through the repo markdown ignore rule.

## Validation
- git diff --check -- .gitignore SECURITY.md
- pre-commit run --files .gitignore SECURITY.md