### PR TITLE
fix(core): harden sub-pool creation and clean GPU orphans on startup

### DIFF
--- a/xinference/constants.py
+++ b/xinference/constants.py
@@ -255,6 +255,17 @@ XINFERENCE_MAX_CONCURRENT_LAUNCHES = max(
     1, int(os.environ.get(XINFERENCE_ENV_MAX_CONCURRENT_LAUNCHES, 5))
 )
 
+# Sub-pool creation timeout in seconds. Only covers fork+exec+import xoscar+
+# bind port+write shm, NOT model weight download (which happens in
+# create_model_instance after _create_subpool). Normal sub-pool creation < 1s;
+# 60s is 60x+ headroom. On timeout: kill leftover subprocess + release GPU +
+# raise TimeoutError so launch_builtin_model's try/finally runs the failure
+# path and the supervisor's _workers_launching counter decrements. Tunable for
+# extreme environments (slow NFS, vLLM version upgrade slowing import, etc.).
+XINFERENCE_SUBPOOL_LAUNCH_TIMEOUT = int(
+    os.environ.get("XINFERENCE_SUBPOOL_LAUNCH_TIMEOUT", "60")
+)
+
 # Status gather timeout in seconds (for collecting GPU info, etc.)
 # Default: 10 seconds, increased from original 5 seconds
 XINFERENCE_STATUS_GATHER_TIMEOUT = int(

--- a/xinference/core/tests/test_subpool_hardening.py
+++ b/xinference/core/tests/test_subpool_hardening.py
@@ -1,0 +1,393 @@
+# Copyright 2022-2026 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for sub-pool creation hardening (H1/H2/H3/C/G).
+
+Covers:
+- _create_subpool normal path (env injection, VRAM check skipped, no timeout)
+- _create_subpool timeout (C): raises asyncio.TimeoutError, release_devices
+  called, leftover sub_pool child killed
+- _create_subpool serialization (H3): concurrent calls do not overlap
+  append_sub_pool
+- _create_subpool env injection (G): XINFERENCE_MODEL_UID in env, os.environ
+  not mutated
+- _kill_gpu_orphans_by_ppid (H2/H1 helper): PPID==1 + vllm cmdline killed;
+  live-worker child (PPID != 1) and non-vllm cmdline spared
+- _cleanup_gpu_orphans_on_startup (H1): nvml failure degrades gracefully;
+  no orphans returns cleanly; orphan present triggers SIGKILL path
+- _nvml_init_with_timeout: success path on the current platform
+"""
+
+import asyncio
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _make_worker():
+    """Build a WorkerActor shell without running __init__ (which starts a
+    metrics server, isolation thread, etc.). Only the attributes touched by
+    _create_subpool / _cleanup_gpu_orphans_on_startup are wired.
+    """
+    from collections import defaultdict
+
+    from xinference.core.worker import WorkerActor
+
+    self = object.__new__(WorkerActor)
+    self._subpool_creation_lock = asyncio.Lock()
+    self._main_pool = MagicMock()
+    self._ensure_subpool_monitor = MagicMock(return_value=_noop_coro())
+    self.release_devices = MagicMock()
+    self.address = "test:1"
+    # allocate_devices_with_gpu_idx reads these; populate enough state for the
+    # gpu_idx=[...] path to succeed without real device accounting.
+    self._total_gpu_devices = list(range(8))
+    self._gpu_to_model_uids = defaultdict(set)
+    self._user_specified_gpu_to_model_uids = defaultdict(set)
+    self._allow_multi_replica_per_gpu = True
+    return self
+
+
+async def _noop_coro():
+    return None
+
+
+async def _hang_coro(*args, **kwargs):
+    # A coroutine that never completes, used to drive the timeout path.
+    await asyncio.Event().wait()
+
+
+@pytest.fixture
+def patched_subpool_deps(monkeypatch):
+    """Patch the module-level GPU/timeout dependencies of _create_subpool so
+    tests need no GPU and run in milliseconds."""
+    import xinference.core.worker as w
+
+    monkeypatch.setattr(w, "_snapshot_gpu_free_ratio", lambda devs: 0.95)
+    monkeypatch.setattr(w, "_kill_gpu_orphans_by_ppid", _async_return([]))
+    # Bound the timeout tightly for the hang test; harmless for the fast path.
+    monkeypatch.setattr(w, "XINFERENCE_SUBPOOL_LAUNCH_TIMEOUT", 0.2)
+    # Use asyncio.wait_for instead of xo.wait_for so tests do not depend on
+    # xoscar actor-call cancellation internals.
+    monkeypatch.setattr(w.xo, "wait_for", asyncio.wait_for)
+
+
+def _async_return(value):
+    async def _coro(*args, **kwargs):
+        return value
+
+    return _coro
+
+
+# ---------------------------------------------------------------------------
+# C: timeout
+# ---------------------------------------------------------------------------
+
+
+async def test_create_subpool_timeout_releases_devices_and_kills_leftover(
+    patched_subpool_deps,
+):
+    self = _make_worker()
+    self._main_pool.append_sub_pool = _hang_coro
+
+    # Mock psutil so the leftover-child kill path is exercised without real
+    # processes. One child matches (PPID == my pid, start_sub_pool cmdline),
+    # one does not (PPID != my pid).
+    my_pid = os.getpid()
+    matching = MagicMock()
+    matching.info = {
+        "pid": 9991,
+        "ppid": my_pid,
+        "cmdline": ["python", "-m", "xoscar", "start_sub_pool", "-sn", "x"],
+    }
+    other = MagicMock()
+    other.info = {"pid": 9992, "ppid": my_pid + 1, "cmdline": ["unrelated"]}
+    mock_psutil = MagicMock()
+    mock_psutil.process_iter.return_value = [matching, other]
+    mock_psutil.NoSuchProcess = ProcessLookupError
+    mock_psutil.AccessDenied = PermissionError
+
+    with patch.dict("sys.modules", {"psutil": mock_psutil}):
+        with pytest.raises(asyncio.TimeoutError):
+            await self._create_subpool("model-1", model_type="LLM", gpu_idx=[0])
+
+    # GPU allocation table must be released so the next launch is not blocked.
+    self.release_devices.assert_called_once_with(model_uid="model-1")
+    # Only the matching child is killed.
+    matching.kill.assert_called_once()
+    other.kill.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# H3: serialization
+# ---------------------------------------------------------------------------
+
+
+async def test_create_subpool_serializes_append_sub_pool(patched_subpool_deps):
+    self = _make_worker()
+
+    in_flight = 0
+    max_in_flight = 0
+    call_order: list = []
+
+    async def _tracked_append(env=None, start_python=None):
+        nonlocal in_flight, max_in_flight
+        in_flight += 1
+        max_in_flight = max(max_in_flight, in_flight)
+        call_order.append(("start", in_flight))
+        await asyncio.sleep(0.05)
+        in_flight -= 1
+        call_order.append(("end", in_flight))
+        return f"addr:{len(call_order)}"
+
+    self._main_pool.append_sub_pool = _tracked_append
+
+    await asyncio.gather(
+        self._create_subpool("m-a", model_type="LLM", gpu_idx=[0]),
+        self._create_subpool("m-b", model_type="LLM", gpu_idx=[1]),
+        self._create_subpool("m-c", model_type="LLM", gpu_idx=[2]),
+    )
+
+    # append_sub_pool must never run concurrently.
+    assert max_in_flight == 1
+
+
+# ---------------------------------------------------------------------------
+# G: env injection
+# ---------------------------------------------------------------------------
+
+
+async def test_create_subpool_injects_model_uid_env(patched_subpool_deps):
+    self = _make_worker()
+    captured: dict = {}
+
+    async def _capture_append(env=None, start_python=None):
+        captured["env"] = dict(env)
+        return "addr:1"
+
+    self._main_pool.append_sub_pool = _capture_append
+
+    os.environ.pop("XINFERENCE_MODEL_UID", None)
+    await self._create_subpool("my-model", model_type="LLM", gpu_idx=[0])
+
+    # The sub-pool env dict carries the tag...
+    assert captured["env"]["XINFERENCE_MODEL_UID"] == "my-model"
+    # ...and the worker main process's os.environ is left untouched.
+    assert "XINFERENCE_MODEL_UID" not in os.environ
+
+
+# ---------------------------------------------------------------------------
+# Normal path
+# ---------------------------------------------------------------------------
+
+
+async def test_create_subpool_normal_path_skips_vram_check(patched_subpool_deps):
+    self = _make_worker()
+    self._main_pool.append_sub_pool = _async_return("addr:1")
+
+    addr, devices = await self._create_subpool(
+        "model-1", model_type="LLM", gpu_idx=[0, 1]
+    )
+    assert addr == "addr:1"
+    assert devices == ["0", "1"]
+    self._ensure_subpool_monitor.assert_awaited_once()
+    self.release_devices.assert_not_called()
+
+
+async def test_create_subpool_vram_low_triggers_orphan_kill(monkeypatch):
+    import xinference.core.worker as w
+
+    monkeypatch.setattr(w, "XINFERENCE_SUBPOOL_LAUNCH_TIMEOUT", 5)
+    monkeypatch.setattr(w.xo, "wait_for", asyncio.wait_for)
+    killed_calls: list = []
+    monkeypatch.setattr(w, "_kill_gpu_orphans_by_ppid", _track_kill(killed_calls))
+
+    # First snapshot (initial check) returns low ratio to trigger the cleanup
+    # path; all subsequent calls (poll loop + post-loop log) return healthy.
+    calls = {"n": 0}
+
+    def _ratio(devs):
+        calls["n"] += 1
+        return 0.10 if calls["n"] == 1 else 0.95
+
+    monkeypatch.setattr(w, "_snapshot_gpu_free_ratio", _ratio)
+
+    self = _make_worker()
+    self._main_pool.append_sub_pool = _async_return("addr:1")
+    await self._create_subpool("model-1", model_type="LLM", gpu_idx=[0])
+    assert killed_calls, "expected _kill_gpu_orphans_by_ppid to be invoked"
+
+
+def _track_kill(sink):
+    async def _coro(devices, model_uid=""):
+        sink.append((tuple(devices), model_uid))
+        return [4242]
+
+    return _coro
+
+
+# ---------------------------------------------------------------------------
+# H2/H1 helper: _kill_gpu_orphans_by_ppid
+# ---------------------------------------------------------------------------
+
+
+async def test_kill_gpu_orphans_by_ppid_filters_by_ppid_and_cmdline(monkeypatch):
+    import xinference.core.worker as w
+
+    procs: dict = {}
+
+    def _make(pid, ppid, cmdline):
+        m = MagicMock()
+        m.ppid.return_value = ppid
+        m.is_running.return_value = True
+        m.status.return_value = "running"
+        m.cmdline.return_value = cmdline
+        procs[pid] = m
+        return m
+
+    # 100: orphan vLLM (PPID==1, vllm cmdline) → killed
+    _make(100, 1, ["python", "-m", "vllm"])
+    # 200: live worker child (PPID != 1) → spared
+    _make(200, 9999, ["python", "-m", "vllm"])
+    # 300: orphan but non-vllm cmdline → spared
+    _make(300, 1, ["python", "unrelated_app.py"])
+
+    mock_psutil = MagicMock()
+
+    def _process(pid):
+        if pid in procs:
+            return procs[pid]
+        raise ProcessLookupError(pid)
+
+    mock_psutil.Process.side_effect = _process
+    mock_psutil.NoSuchProcess = ProcessLookupError
+    mock_psutil.AccessDenied = PermissionError
+    mock_psutil.STATUS_ZOMBIE = "zombie"
+
+    with patch("xinference.core.worker._snapshot_gpu_occupying_pids") as mock_snap:
+        mock_snap.return_value = {100, 200, 300}
+        with patch.dict("sys.modules", {"psutil": mock_psutil}):
+            with patch("os.kill") as mock_kill:
+                killed = await w._kill_gpu_orphans_by_ppid([0])
+
+    assert killed == [100]
+    # SIGTERM then SIGKILL for pid 100 only.
+    killed_signals = [c.args[1] for c in mock_kill.call_args_list if c.args[0] == 100]
+    import signal as _signal
+
+    assert _signal.SIGTERM in killed_signals
+    assert _signal.SIGKILL in killed_signals
+
+
+async def test_kill_gpu_orphans_by_ppid_no_orphans_returns_empty(monkeypatch):
+    import xinference.core.worker as w
+
+    with patch("xinference.core.worker._snapshot_gpu_occupying_pids") as mock_snap:
+        mock_snap.return_value = set()
+        with patch("os.kill") as mock_kill:
+            killed = await w._kill_gpu_orphans_by_ppid([0])
+    assert killed == []
+    mock_kill.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# H1: _cleanup_gpu_orphans_on_startup
+# ---------------------------------------------------------------------------
+
+
+async def test_startup_cleanup_nvml_failure_degrades(monkeypatch):
+    import xinference.core.worker as w
+
+    monkeypatch.setattr(w, "_nvml_init_with_timeout", lambda timeout=10: False)
+    self = _make_worker()
+    # Must not raise and must not attempt any snapshot/kill.
+    with patch("xinference.core.worker._snapshot_gpu_occupying_pids") as mock_snap:
+        await self._cleanup_gpu_orphans_on_startup()
+    mock_snap.assert_not_called()
+
+
+async def test_startup_cleanup_no_orphans_returns_cleanly(monkeypatch):
+    import xinference.core.worker as w
+
+    monkeypatch.setattr(w, "_nvml_init_with_timeout", lambda timeout=10: True)
+    monkeypatch.setattr(
+        "xinference.core.worker._snapshot_gpu_occupying_pids", lambda devs: set()
+    )
+    monkeypatch.setattr(
+        "xinference.core.worker._snapshot_gpu_free_ratio", lambda devs: 0.95
+    )
+    self = _make_worker()
+    await self._cleanup_gpu_orphans_on_startup()  # must not raise
+
+
+async def test_startup_cleanup_kills_orphans(monkeypatch):
+    import xinference.core.worker as w
+
+    monkeypatch.setattr(w, "_nvml_init_with_timeout", lambda timeout=10: True)
+
+    # nvmlDeviceGetCount inside the method (pynvml is imported locally).
+    mock_pynvml = MagicMock()
+    mock_pynvml.nvmlDeviceGetCount.return_value = 1
+    monkeypatch.setattr(
+        "xinference.core.worker._snapshot_gpu_occupying_pids", lambda devs: {500}
+    )
+    monkeypatch.setattr(
+        "xinference.core.worker._snapshot_gpu_free_ratio", lambda devs: 0.95
+    )
+
+    orphan = MagicMock()
+    orphan.ppid.return_value = 1
+    orphan.is_running.return_value = True
+    orphan.status.return_value = "running"
+    orphan.cmdline.return_value = ["python", "-m", "vllm"]
+    mock_psutil = MagicMock()
+    mock_psutil.Process.return_value = orphan
+    mock_psutil.NoSuchProcess = ProcessLookupError
+    mock_psutil.AccessDenied = PermissionError
+    mock_psutil.STATUS_ZOMBIE = "zombie"
+
+    self = _make_worker()
+    with patch.dict("sys.modules", {"pynvml": mock_pynvml, "psutil": mock_psutil}):
+        with patch("os.kill") as mock_kill:
+            await self._cleanup_gpu_orphans_on_startup()
+
+    import signal as _signal
+
+    sigs = [c.args[1] for c in mock_kill.call_args_list if c.args[0] == 500]
+    assert _signal.SIGTERM in sigs
+    assert _signal.SIGKILL in sigs
+
+
+# ---------------------------------------------------------------------------
+# _nvml_init_with_timeout
+# ---------------------------------------------------------------------------
+
+
+def test_nvml_init_with_timeout_success():
+    import xinference.core.worker as w
+
+    mock_pynvml = MagicMock()
+    with patch.dict("sys.modules", {"pynvml": mock_pynvml}):
+        assert w._nvml_init_with_timeout(timeout=2) is True
+    mock_pynvml.nvmlInit.assert_called_once()
+
+
+def test_nvml_init_with_timeout_failure_returns_false():
+    import xinference.core.worker as w
+
+    mock_pynvml = MagicMock()
+    mock_pynvml.nvmlInit.side_effect = RuntimeError("driver down")
+    with patch.dict("sys.modules", {"pynvml": mock_pynvml}):
+        assert w._nvml_init_with_timeout(timeout=2) is False

--- a/xinference/core/tests/test_subpool_hardening.py
+++ b/xinference/core/tests/test_subpool_hardening.py
@@ -36,16 +36,27 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 
-def _make_worker():
-    """Build a WorkerActor shell without running __init__ (which starts a
-    metrics server, isolation thread, etc.). Only the attributes touched by
-    _create_subpool / _cleanup_gpu_orphans_on_startup are wired.
+class _WorkerStub:
+    """Plain stand-in for WorkerActor.
+
+    Instantiating WorkerActor directly is unsafe: xoscar's
+    StatelessActor.__new__ forbids construction outside an actor pool
+    (``object.__new__(WorkerActor)`` raises TypeError). We bind the real
+    WorkerActor methods onto this stub so the code under test runs verbatim,
+    with only the attributes they read populated.
     """
+
+    pass
+
+
+def _make_worker():
+    """Build a _WorkerStub with the real WorkerActor methods bound and the
+    attributes they read populated."""
     from collections import defaultdict
 
     from xinference.core.worker import WorkerActor
 
-    self = object.__new__(WorkerActor)
+    self = _WorkerStub()
     self._subpool_creation_lock = asyncio.Lock()
     self._main_pool = MagicMock()
     self._ensure_subpool_monitor = MagicMock(return_value=_noop_coro())
@@ -57,6 +68,14 @@ def _make_worker():
     self._gpu_to_model_uids = defaultdict(set)
     self._user_specified_gpu_to_model_uids = defaultdict(set)
     self._allow_multi_replica_per_gpu = True
+    # Bind the real methods so the code under test runs verbatim.
+    self.allocate_devices_with_gpu_idx = (
+        WorkerActor.allocate_devices_with_gpu_idx.__get__(self)
+    )
+    self._create_subpool = WorkerActor._create_subpool.__get__(self)
+    self._cleanup_gpu_orphans_on_startup = (
+        WorkerActor._cleanup_gpu_orphans_on_startup.__get__(self)
+    )
     return self
 
 
@@ -250,7 +269,7 @@ async def test_kill_gpu_orphans_by_ppid_filters_by_ppid_and_cmdline(monkeypatch)
 
     def _make(pid, ppid, cmdline):
         m = MagicMock()
-        m.pid = pid  # plain int so os.kill(p.pid, ...) and call-arg checks work
+        m.pid = pid  # plain int: production code appends p.pid to the killed list
         m.ppid.return_value = ppid
         m.is_running.return_value = True
         m.status.return_value = "running"
@@ -280,16 +299,14 @@ async def test_kill_gpu_orphans_by_ppid_filters_by_ppid_and_cmdline(monkeypatch)
     with patch("xinference.core.worker._snapshot_gpu_occupying_pids") as mock_snap:
         mock_snap.return_value = {100, 200, 300}
         with patch.dict("sys.modules", {"psutil": mock_psutil}):
-            with patch("os.kill") as mock_kill:
-                killed = await w._kill_gpu_orphans_by_ppid([0])
+            killed = await w._kill_gpu_orphans_by_ppid([0])
 
     assert killed == [100]
-    # SIGTERM then SIGKILL for pid 100 only.
-    killed_signals = [c.args[1] for c in mock_kill.call_args_list if c.args[0] == 100]
-    import signal as _signal
-
-    assert _signal.SIGTERM in killed_signals
-    assert _signal.SIGKILL in killed_signals
+    # pid 100 (orphan vLLM) gets terminate() then kill(); 200 and 300 are spared.
+    procs[100].terminate.assert_called_once()
+    procs[100].kill.assert_called_once()
+    procs[200].kill.assert_not_called()
+    procs[300].kill.assert_not_called()
 
 
 async def test_kill_gpu_orphans_by_ppid_no_orphans_returns_empty(monkeypatch):
@@ -297,10 +314,8 @@ async def test_kill_gpu_orphans_by_ppid_no_orphans_returns_empty(monkeypatch):
 
     with patch("xinference.core.worker._snapshot_gpu_occupying_pids") as mock_snap:
         mock_snap.return_value = set()
-        with patch("os.kill") as mock_kill:
-            killed = await w._kill_gpu_orphans_by_ppid([0])
+        killed = await w._kill_gpu_orphans_by_ppid([0])
     assert killed == []
-    mock_kill.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -349,7 +364,7 @@ async def test_startup_cleanup_kills_orphans(monkeypatch):
     )
 
     orphan = MagicMock()
-    orphan.pid = 500  # plain int so os.kill(p.pid, ...) and call-arg checks work
+    orphan.pid = 500  # plain int: production code appends p.pid to the killed list
     orphan.ppid.return_value = 1
     orphan.is_running.return_value = True
     orphan.status.return_value = "running"
@@ -362,14 +377,11 @@ async def test_startup_cleanup_kills_orphans(monkeypatch):
 
     self = _make_worker()
     with patch.dict("sys.modules", {"pynvml": mock_pynvml, "psutil": mock_psutil}):
-        with patch("os.kill") as mock_kill:
-            await self._cleanup_gpu_orphans_on_startup()
+        await self._cleanup_gpu_orphans_on_startup()
 
-    import signal as _signal
-
-    sigs = [c.args[1] for c in mock_kill.call_args_list if c.args[0] == 500]
-    assert _signal.SIGTERM in sigs
-    assert _signal.SIGKILL in sigs
+    # orphan (pid 500) gets terminate() then kill() via _kill_gpu_orphans_by_ppid.
+    orphan.terminate.assert_called_once()
+    orphan.kill.assert_called_once()
 
 
 # ---------------------------------------------------------------------------

--- a/xinference/core/tests/test_subpool_hardening.py
+++ b/xinference/core/tests/test_subpool_hardening.py
@@ -73,6 +73,9 @@ def _make_worker():
         WorkerActor.allocate_devices_with_gpu_idx.__get__(self)
     )
     self._create_subpool = WorkerActor._create_subpool.__get__(self)
+    self._append_sub_pool_protected = WorkerActor._append_sub_pool_protected.__get__(
+        self
+    )
     self._cleanup_gpu_orphans_on_startup = (
         WorkerActor._cleanup_gpu_orphans_on_startup.__get__(self)
     )
@@ -243,6 +246,101 @@ async def test_create_subpool_vram_low_triggers_orphan_kill(monkeypatch):
     self._main_pool.append_sub_pool = _async_return("addr:1")
     await self._create_subpool("model-1", model_type="LLM", gpu_idx=[0])
     assert killed_calls, "expected _kill_gpu_orphans_by_ppid to be invoked"
+
+
+# ---------------------------------------------------------------------------
+# _append_sub_pool_protected: the single protected append_sub_pool entrypoint.
+# All three call sites (_create_subpool, need_create_pools gather,
+# launch_rank0_model) route through it, so H3/C coverage of the helper itself
+# also covers those sites.
+# ---------------------------------------------------------------------------
+
+
+async def test_append_sub_pool_protected_serializes_concurrent_calls(
+    patched_subpool_deps,
+):
+    """The gather pattern used by need_create_pools must not let
+    append_sub_pool run concurrently — exactly the H3 deadlock scenario."""
+    self = _make_worker()
+
+    in_flight = 0
+    max_in_flight = 0
+
+    async def _tracked_append(env=None, start_python=None):
+        nonlocal in_flight, max_in_flight
+        in_flight += 1
+        max_in_flight = max(max_in_flight, in_flight)
+        await asyncio.sleep(0.05)
+        in_flight -= 1
+        return f"addr:{max_in_flight}"
+
+    self._main_pool.append_sub_pool = _tracked_append
+
+    # Mirror the need_create_pools gather: multiple concurrent appends.
+    addrs = await asyncio.gather(
+        self._append_sub_pool_protected(model_uid="m-a"),
+        self._append_sub_pool_protected(model_uid="m-b"),
+        self._append_sub_pool_protected(model_uid="m-c"),
+    )
+    assert max_in_flight == 1, "append_sub_pool must be serialized"
+    assert len(addrs) == 3
+
+
+async def test_append_sub_pool_protected_timeout_kills_leftover_and_reraises(
+    patched_subpool_deps,
+):
+    """C: on timeout the helper SIGKILLs leftover start_sub_pool children
+    (PPID == this worker) and re-raises so callers run their own cleanup."""
+    self = _make_worker()
+    self._main_pool.append_sub_pool = _hang_coro
+
+    my_pid = os.getpid()
+    matching = MagicMock()
+    matching.info = {
+        "pid": 7701,
+        "ppid": my_pid,
+        "cmdline": ["python", "-m", "xoscar", "start_sub_pool", "-sn", "y"],
+    }
+    other = MagicMock()
+    other.info = {"pid": 7702, "ppid": my_pid + 1, "cmdline": ["unrelated"]}
+    mock_psutil = MagicMock()
+    mock_psutil.process_iter.return_value = [matching, other]
+    mock_psutil.NoSuchProcess = ProcessLookupError
+    mock_psutil.AccessDenied = PermissionError
+
+    with patch.dict("sys.modules", {"psutil": mock_psutil}):
+        with pytest.raises(asyncio.TimeoutError):
+            await self._append_sub_pool_protected(model_uid="rank0-model")
+
+    matching.kill.assert_called_once()
+    other.kill.assert_not_called()
+
+
+async def test_append_sub_pool_protected_does_not_log_env_values(
+    patched_subpool_deps, caplog
+):
+    """env may carry secrets; the timeout log must emit keys only, never
+    values. Uses the timeout path because that is where env is logged."""
+    import logging
+
+    self = _make_worker()
+    self._main_pool.append_sub_pool = _hang_coro
+    mock_psutil = MagicMock()
+    mock_psutil.process_iter.return_value = []
+    mock_psutil.NoSuchProcess = ProcessLookupError
+    mock_psutil.AccessDenied = PermissionError
+
+    secret_env = {"CUDA_VISIBLE_DEVICES": "0", "OPENAI_API_KEY": "sk-secret-xyz"}
+    with patch.dict("sys.modules", {"psutil": mock_psutil}):
+        with caplog.at_level(logging.ERROR, logger="xinference.core.worker"):
+            with pytest.raises(asyncio.TimeoutError):
+                await self._append_sub_pool_protected(
+                    env=secret_env, model_uid="m-secret"
+                )
+
+    blob = "\n".join(r.getMessage() for r in caplog.records)
+    assert "sk-secret-xyz" not in blob, "env value leaked in timeout log"
+    assert "OPENAI_API_KEY" in blob, "env key name should be logged"
 
 
 def _track_kill(sink):

--- a/xinference/core/tests/test_subpool_hardening.py
+++ b/xinference/core/tests/test_subpool_hardening.py
@@ -250,6 +250,7 @@ async def test_kill_gpu_orphans_by_ppid_filters_by_ppid_and_cmdline(monkeypatch)
 
     def _make(pid, ppid, cmdline):
         m = MagicMock()
+        m.pid = pid  # plain int so os.kill(p.pid, ...) and call-arg checks work
         m.ppid.return_value = ppid
         m.is_running.return_value = True
         m.status.return_value = "running"
@@ -348,6 +349,7 @@ async def test_startup_cleanup_kills_orphans(monkeypatch):
     )
 
     orphan = MagicMock()
+    orphan.pid = 500  # plain int so os.kill(p.pid, ...) and call-arg checks work
     orphan.ppid.return_value = 1
     orphan.is_running.return_value = True
     orphan.status.return_value = "running"
@@ -391,3 +393,24 @@ def test_nvml_init_with_timeout_failure_returns_false():
     mock_pynvml.nvmlInit.side_effect = RuntimeError("driver down")
     with patch.dict("sys.modules", {"pynvml": mock_pynvml}):
         assert w._nvml_init_with_timeout(timeout=2) is False
+
+
+def test_nvml_init_with_timeout_background_thread_falls_back():
+    """signal.signal only works in the main thread; a background-thread caller
+    must fall back to a direct nvmlInit instead of raising ValueError."""
+    import threading
+
+    import xinference.core.worker as w
+
+    mock_pynvml = MagicMock()
+    result: dict = {}
+
+    def _run():
+        with patch.dict("sys.modules", {"pynvml": mock_pynvml}):
+            result["ok"] = w._nvml_init_with_timeout(timeout=2)
+
+    t = threading.Thread(target=_run)
+    t.start()
+    t.join()
+    assert result["ok"] is True
+    mock_pynvml.nvmlInit.assert_called_once()

--- a/xinference/core/tests/test_subpool_hardening.py
+++ b/xinference/core/tests/test_subpool_hardening.py
@@ -31,7 +31,7 @@ Covers:
 
 import asyncio
 import os
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -59,7 +59,7 @@ def _make_worker():
     self = _WorkerStub()
     self._subpool_creation_lock = asyncio.Lock()
     self._main_pool = MagicMock()
-    self._ensure_subpool_monitor = MagicMock(return_value=_noop_coro())
+    self._ensure_subpool_monitor = AsyncMock()
     self.release_devices = MagicMock()
     self.address = "test:1"
     # allocate_devices_with_gpu_idx reads these; populate enough state for the
@@ -77,10 +77,6 @@ def _make_worker():
         WorkerActor._cleanup_gpu_orphans_on_startup.__get__(self)
     )
     return self
-
-
-async def _noop_coro():
-    return None
 
 
 async def _hang_coro(*args, **kwargs):

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -62,6 +62,7 @@ from ..constants import (
     XINFERENCE_MODEL_DOWNLOAD_WORKERS,
     XINFERENCE_STATUS_GATHER_TIMEOUT,
     XINFERENCE_STATUS_REPORT_MULTIPLIER,
+    XINFERENCE_SUBPOOL_LAUNCH_TIMEOUT,
     XINFERENCE_TCP_REQUEST_TIMEOUT,
     XINFERENCE_VIRTUAL_ENV_DIR,
     XINFERENCE_VIRTUAL_ENV_SKIP_INSTALLED,
@@ -168,6 +169,9 @@ _PERSIST_RETRY_MAX = 3
 _VRAM_RECLAIM_TIMEOUT = 30
 # VRAM free ratio threshold — ratio >= this means "released".
 _VRAM_READY_RATIO = 0.90
+# nvmlInit timeout (seconds) — bounds a stuck GPU driver so worker startup
+# and pre-launch VRAM checks cannot hang indefinitely.
+_NVML_INIT_TIMEOUT = 10
 
 
 def _strip_test_envs(launch_args: dict) -> Tuple[dict, Set[str]]:
@@ -372,6 +376,126 @@ async def _kill_orphan_gpu_pids(
     return killed
 
 
+def _nvml_init_with_timeout(timeout: int = _NVML_INIT_TIMEOUT) -> bool:
+    """Initialize pynvml with a timeout guard.
+
+    nvmlInit is a blocking C call that asyncio.wait_for cannot cancel. On
+    Unix we use SIGALRM to bound it so a stuck GPU driver cannot hang worker
+    startup. On Windows SIGALRM is unavailable; we call nvmlInit directly
+    (Windows rarely runs vLLM, and the no-lock degradation is acceptable).
+
+    Returns True on success, False on failure or timeout (caller degrades
+    gracefully). The original SIGALRM handler is always restored.
+    """
+    if os.name == "nt":
+        try:
+            import pynvml
+
+            pynvml.nvmlInit()
+            return True
+        except Exception:
+            return False
+
+    import pynvml
+
+    def _alarm_handler(signum, frame):
+        raise TimeoutError("nvmlInit timed out")
+
+    _old_handler = signal.getsignal(signal.SIGALRM)
+    try:
+        signal.signal(signal.SIGALRM, _alarm_handler)
+        signal.alarm(timeout)
+        try:
+            pynvml.nvmlInit()
+            return True
+        except Exception:
+            return False
+        finally:
+            signal.alarm(0)
+    finally:
+        signal.signal(signal.SIGALRM, _old_handler)
+
+
+async def _kill_gpu_orphans_by_ppid(
+    device_indices: list,
+    model_uid: str = "",
+) -> List[int]:
+    """SIGKILL GPU-occupying processes whose parent is init (PPID == 1).
+
+    Used at worker startup (H1) and pre-launch VRAM recheck (H2). Unlike
+    _kill_orphan_gpu_pids (which uses post - pre diff and would mis-kill
+    other workers' vLLM processes on shared GPUs), this only targets true
+    orphans: processes whose parent has died and been reparented to PID 1.
+
+    A process is killed only if ALL hold:
+      1. occupies GPU memory on one of device_indices (per NVML)
+      2. PPID == 1 (parent dead, reparented to init)
+      3. cmdline contains vllm / enginecore / start_sub_pool
+         (prevents PID-reuse misidentification of unrelated processes)
+
+    cmdline is re-checked immediately before SIGKILL to defend against PID
+    reuse between the snapshot and the kill. SIGTERM is sent first, then
+    after a 1s grace, SIGKILL is applied to survivors.
+    """
+    import psutil
+
+    occupying_pids = _snapshot_gpu_occupying_pids(device_indices)
+    orphan_pids: List[int] = []
+    for pid in occupying_pids:
+        if pid == os.getpid():
+            continue
+        try:
+            p = psutil.Process(pid)
+            if p.ppid() != 1:
+                continue
+            cmd = " ".join(p.cmdline()).lower()
+            if not any(k in cmd for k in ("vllm", "enginecore", "start_sub_pool")):
+                continue
+            orphan_pids.append(pid)
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            continue
+
+    if not orphan_pids:
+        return []
+
+    logger.warning(
+        "Found %d vLLM orphan(s) on GPUs %s: %s",
+        len(orphan_pids),
+        device_indices,
+        sorted(orphan_pids),
+    )
+
+    for pid in orphan_pids:
+        try:
+            os.kill(pid, signal.SIGTERM)
+        except (ProcessLookupError, PermissionError):
+            continue
+    await asyncio.sleep(1.0)
+
+    killed: List[int] = []
+    for pid in orphan_pids:
+        try:
+            p = psutil.Process(pid)
+            if not p.is_running() or p.status() == psutil.STATUS_ZOMBIE:
+                continue
+            cmd = " ".join(p.cmdline()).lower()
+            if not any(k in cmd for k in ("vllm", "enginecore", "start_sub_pool")):
+                continue
+            os.kill(pid, signal.SIGKILL)
+            killed.append(pid)
+            logger.warning("SIGKILL orphan pid %s on GPUs %s", pid, device_indices)
+        except (
+            psutil.NoSuchProcess,
+            psutil.AccessDenied,
+            ProcessLookupError,
+            PermissionError,
+        ):
+            continue
+        except Exception:
+            logger.debug("Kill pid %s failed", pid, exc_info=True)
+    return killed
+
+
 @dataclass
 class ModelStatus:
     last_error: str = ""
@@ -489,6 +613,13 @@ class WorkerActor(xo.StatelessActor):
 
         self._lock = asyncio.Lock()
         self._persist_lock = asyncio.Lock()
+        # Serializes MainActorPool.append_sub_pool calls. xoscar's
+        # append_sub_pool has no internal lock; concurrent fork+exec under
+        # XINFERENCE_MAX_CONCURRENT_LAUNCHES>1 can deadlock on fork+GIL and
+        # block the event loop (which also disables the sub-pool creation
+        # timeout below). The lock only covers append_sub_pool (milliseconds),
+        # not download or model load, so launch throughput is unaffected.
+        self._subpool_creation_lock = asyncio.Lock()
         self._persist_launch_args_dirty_uids: Set[str] = set()
         self._persist_retry_count: Dict[str, int] = {}
 
@@ -733,6 +864,133 @@ class WorkerActor(xo.StatelessActor):
         family_copy.model_specs = [target_spec]
         return family_copy
 
+    async def _cleanup_gpu_orphans_on_startup(self) -> None:
+        """Best-effort cleanup of vLLM GPU orphans left by a previous worker.
+
+        vLLM EngineCore / GPU worker processes have no _check_ppid thread, so
+        when the worker dies they are reparented to PID 1 and keep holding
+        VRAM. The next worker's first sub-pool creation can then deadlock in
+        CUDA init. This scans all GPUs at startup and SIGKILLs processes that
+        (a) occupy GPU memory, (b) have PPID == 1, and (c) have a vLLM-like
+        cmdline. nvmlInit is bounded by _nvml_init_with_timeout so a stuck
+        driver cannot block startup. Never raises — failures degrade to a
+        warning and rely on H2/C as backstops.
+        """
+        if not _nvml_init_with_timeout():
+            logger.warning(
+                "Startup GPU orphan cleanup skipped: pynvml init failed or "
+                "timed out (%ss). If the previous worker left vLLM orphans, "
+                "launch may hang. Manual check: nvidia-smi + "
+                "ps -eo pid,ppid,cmd | grep vllm",
+                _NVML_INIT_TIMEOUT,
+            )
+            return
+
+        try:
+            import pynvml
+
+            try:
+                device_count = pynvml.nvmlDeviceGetCount()
+                all_devices = list(range(device_count))
+            finally:
+                try:
+                    pynvml.nvmlShutdown()
+                except Exception:
+                    pass
+        except Exception:
+            logger.warning(
+                "Startup GPU orphan cleanup: nvmlDeviceGetCount failed",
+                exc_info=True,
+            )
+            return
+
+        if not all_devices:
+            return
+
+        occupying_pids = _snapshot_gpu_occupying_pids(all_devices)
+        if not occupying_pids:
+            logger.info("Startup GPU orphan cleanup: no GPU-occupying processes found")
+            return
+
+        import psutil
+
+        orphan_pids: List[int] = []
+        for pid in occupying_pids:
+            if pid == os.getpid():
+                continue
+            try:
+                p = psutil.Process(pid)
+                if p.ppid() != 1:
+                    continue
+                cmd = " ".join(p.cmdline()).lower()
+                if not any(k in cmd for k in ("vllm", "enginecore", "start_sub_pool")):
+                    continue
+                orphan_pids.append(pid)
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                continue
+
+        if not orphan_pids:
+            logger.info(
+                "Startup GPU orphan cleanup: %d GPU-occupying process(es) "
+                "found, none are vLLM orphans (all have live parents or "
+                "non-matching cmdline)",
+                len(occupying_pids),
+            )
+            return
+
+        logger.warning(
+            "Startup GPU orphan cleanup: found %d vLLM orphan(s) on GPUs, "
+            "killing: %s",
+            len(orphan_pids),
+            sorted(orphan_pids),
+        )
+        for pid in orphan_pids:
+            try:
+                os.kill(pid, signal.SIGTERM)
+            except (ProcessLookupError, PermissionError):
+                continue
+        await asyncio.sleep(1.0)
+        for pid in orphan_pids:
+            try:
+                p = psutil.Process(pid)
+                if not p.is_running() or p.status() == psutil.STATUS_ZOMBIE:
+                    continue
+                cmd = " ".join(p.cmdline()).lower()
+                if not any(k in cmd for k in ("vllm", "enginecore", "start_sub_pool")):
+                    logger.debug(
+                        "Startup skip pid %s: cmdline changed: %s",
+                        pid,
+                        cmd[:100],
+                    )
+                    continue
+                os.kill(pid, signal.SIGKILL)
+                logger.warning("Startup SIGKILL orphan pid %s", pid)
+            except (
+                psutil.NoSuchProcess,
+                psutil.AccessDenied,
+                ProcessLookupError,
+                PermissionError,
+            ):
+                continue
+            except Exception:
+                logger.debug("Startup kill pid %s failed", pid, exc_info=True)
+
+        try:
+            _free_ratio = _snapshot_gpu_free_ratio(all_devices)
+            if 0 <= _free_ratio < _VRAM_READY_RATIO:
+                _vram_deadline = time.monotonic() + _VRAM_RECLAIM_TIMEOUT
+                while time.monotonic() < _vram_deadline:
+                    await asyncio.sleep(1.0)
+                    _free_ratio = _snapshot_gpu_free_ratio(all_devices)
+                    if _free_ratio < 0 or _free_ratio >= _VRAM_READY_RATIO:
+                        break
+                logger.info(
+                    "Startup VRAM reclaim: min_free_ratio=%.2f after orphan " "cleanup",
+                    _free_ratio if _free_ratio >= 0 else -1,
+                )
+        except Exception:
+            logger.debug("Startup VRAM poll failed", exc_info=True)
+
     async def __post_create__(self):
         from ..model.audio import (
             CustomAudioModelFamilyV2,
@@ -848,6 +1106,15 @@ class WorkerActor(xo.StatelessActor):
                 self._periodical_report_status(), loop=self._isolation.loop
             )
         logger.info(f"Xinference worker {self.address} started")
+
+        # H1: asynchronously clean up vLLM GPU orphans left by a previous
+        # worker that died without reaping its sub-pool descendants. vLLM
+        # EngineCore / GPU workers have no _check_ppid, so on worker death
+        # they are reparented to PID 1 and keep holding VRAM; the next
+        # launch's sub-pool then deadlocks in CUDA init. Runs after
+        # registration so it never blocks the worker from serving; H2 is the
+        # per-launch backstop if an orphan appears later.
+        asyncio.create_task(self._cleanup_gpu_orphans_on_startup())
 
         # Report build/config info for this worker
         from xinference.constants import XINFERENCE_HOME as _xf_home
@@ -1345,9 +1612,127 @@ class WorkerActor(xo.StatelessActor):
             )
             env[env_name] = ",".join([str(dev) for dev in devices])
 
-        subpool_address = await self._main_pool.append_sub_pool(
-            env=env, start_python=start_python
+        # G: inject model_uid into the sub-pool env dict (not os.environ).
+        # os.environ mutation is thread-unsafe under concurrent launches and
+        # ineffective (the sub-pool is forked from this env dict). Passing it
+        # here lets the sub-pool and its vLLM descendants inherit the tag.
+        env["XINFERENCE_MODEL_UID"] = model_uid
+
+        # H2: pre-launch VRAM recheck. _cleanup_gpu_orphans_on_startup runs at
+        # worker start, but orphans may appear between startup and this launch
+        # (e.g. another worker on the same host died). If free VRAM on the
+        # target GPUs is below the ready ratio, scan for PPID==1 vLLM orphans
+        # and SIGKILL them, then poll VRAM release. PPID==1 (not the diff
+        # heuristic used by _kill_orphan_gpu_pids) avoids mis-killing another
+        # live worker's vLLM processes on shared GPUs. Best-effort: any error
+        # is logged and the launch proceeds (the timeout below is the backstop).
+        _target_device_ints = [int(d) for d in devices] if devices else []
+        if _target_device_ints:
+            try:
+                _free_ratio = _snapshot_gpu_free_ratio(_target_device_ints)
+                if 0 <= _free_ratio < _VRAM_READY_RATIO:
+                    logger.warning(
+                        "Pre-launch VRAM low for model %s on GPUs %s: "
+                        "free_ratio=%.2f (target %.2f), scanning for orphans",
+                        model_uid,
+                        _target_device_ints,
+                        _free_ratio,
+                        _VRAM_READY_RATIO,
+                    )
+                    _killed = await _kill_gpu_orphans_by_ppid(
+                        _target_device_ints, model_uid=model_uid
+                    )
+                    if _killed:
+                        logger.warning(
+                            "Pre-launch killed %d GPU orphan(s) for model %s: %s",
+                            len(_killed),
+                            model_uid,
+                            _killed,
+                        )
+                        _vram_deadline = time.monotonic() + _VRAM_RECLAIM_TIMEOUT
+                        while time.monotonic() < _vram_deadline:
+                            await asyncio.sleep(1.0)
+                            _free_ratio = _snapshot_gpu_free_ratio(_target_device_ints)
+                            if _free_ratio < 0 or _free_ratio >= _VRAM_READY_RATIO:
+                                break
+                        logger.info(
+                            "Pre-launch VRAM after cleanup for model %s: "
+                            "free_ratio=%.2f",
+                            model_uid,
+                            _snapshot_gpu_free_ratio(_target_device_ints),
+                        )
+            except Exception:
+                logger.debug(
+                    "Pre-launch VRAM check failed for model %s",
+                    model_uid,
+                    exc_info=True,
+                )
+
+        # H3 + C: serialize sub-pool creation and bound it with a timeout.
+        # H3: append_sub_pool has no internal lock; concurrent fork+exec
+        # deadlocks on fork+GIL and blocks the event loop, which also
+        # disables the xo.wait_for timeout callback. The asyncio.Lock
+        # serializes only append_sub_pool (milliseconds), not download/load.
+        # C: a single fork that deadlocks in CUDA init would otherwise hang
+        # the actor forever. xo.wait_for raises asyncio.TimeoutError after
+        # XINFERENCE_SUBPOOL_LAUNCH_TIMEOUT; we clean up and re-raise so the
+        # supervisor's _workers_launching counter decrements.
+        logger.debug(
+            "Creating subpool for model %s, start_python=%s, env=%s",
+            model_uid,
+            start_python,
+            env,
         )
+        async with self._subpool_creation_lock:
+            try:
+                subpool_address = await xo.wait_for(
+                    self._main_pool.append_sub_pool(env=env, start_python=start_python),
+                    timeout=XINFERENCE_SUBPOOL_LAUNCH_TIMEOUT,
+                )
+            except asyncio.TimeoutError:
+                logger.error(
+                    "Subpool creation timed out after %ss for model %s "
+                    "(likely fork-unsafe state in worker; restart worker to "
+                    "recover). start_python=%s, env=%s",
+                    XINFERENCE_SUBPOOL_LAUNCH_TIMEOUT,
+                    model_uid,
+                    start_python,
+                    env,
+                )
+                # (1) Kill leftover sub_pool child processes. xo.wait_for only
+                # cancels the future; the forked child may still be alive
+                # holding GPU memory. Match PPID == this worker's pid and
+                # cmdline containing start_sub_pool. Best-effort.
+                try:
+                    import psutil
+
+                    _my_pid = os.getpid()
+                    for _p in psutil.process_iter(["pid", "ppid", "cmdline"]):
+                        _info = _p.info
+                        if _info["ppid"] != _my_pid:
+                            continue
+                        _cmd = " ".join(_info.get("cmdline") or []).lower()
+                        if "start_sub_pool" in _cmd:
+                            try:
+                                _p.kill()
+                                logger.warning(
+                                    "Killed leftover sub_pool process after "
+                                    "timeout: pid=%s",
+                                    _info["pid"],
+                                )
+                            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                                continue
+                except Exception:
+                    logger.debug(
+                        "Failed to kill leftover sub_pool process", exc_info=True
+                    )
+                # (2) Release devices allocated above; otherwise the GPU
+                # allocation table leaks and the next launch on the same GPUs
+                # reports them as occupied.
+                self.release_devices(model_uid=model_uid)
+                # (3) Re-raise so launch_builtin_model's try/finally runs the
+                # failure path and the supervisor marks the replica ERROR.
+                raise
         await self._ensure_subpool_monitor()
         return subpool_address, [str(dev) for dev in devices]
 

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -474,8 +474,8 @@ async def _kill_gpu_orphans_by_ppid(
 
     for p in orphan_processes:
         try:
-            os.kill(p.pid, signal.SIGTERM)
-        except (ProcessLookupError, PermissionError):
+            p.terminate()
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
             continue
     await asyncio.sleep(1.0)
 
@@ -487,15 +487,13 @@ async def _kill_gpu_orphans_by_ppid(
             cmd = " ".join(p.cmdline()).lower()
             if not any(k in cmd for k in ("vllm", "enginecore", "start_sub_pool")):
                 continue
-            os.kill(p.pid, signal.SIGKILL)
+            # Use psutil.kill() rather than os.kill(pid, signal.SIGKILL):
+            # signal.SIGKILL is undefined on Windows, and psutil's kill() is
+            # cross-platform (TerminateProcess on Windows).
+            p.kill()
             killed.append(p.pid)
             logger.warning("SIGKILL orphan pid %s on GPUs %s", p.pid, device_indices)
-        except (
-            psutil.NoSuchProcess,
-            psutil.AccessDenied,
-            ProcessLookupError,
-            PermissionError,
-        ):
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
             continue
         except Exception:
             logger.debug("Kill pid %s failed", p.pid, exc_info=True)

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -1537,6 +1537,70 @@ class WorkerActor(xo.StatelessActor):
         # monitor task per worker process.
         await self._main_pool.start_monitor()
 
+    async def _append_sub_pool_protected(
+        self,
+        env: Optional[Dict[str, str]] = None,
+        start_python: Optional[str] = None,
+        model_uid: str = "",
+    ) -> str:
+        """Append a sub-pool under _subpool_creation_lock with a launch timeout.
+
+        All append_sub_pool call sites must route through this helper so they
+        are uniformly protected against (H3) concurrent fork+GIL deadlock and
+        (C) single-fork CUDA-init hang. The lock serializes only the
+        append_sub_pool call (milliseconds), not download/load.
+
+        On timeout, leftover start_sub_pool children (PPID == this worker) are
+        SIGKILLed best-effort and asyncio.TimeoutError is re-raised so the
+        caller can run its own failure-path cleanup (e.g. release_devices).
+        env keys are logged (never values) because env may carry secrets.
+        """
+        async with self._subpool_creation_lock:
+            try:
+                return await xo.wait_for(
+                    self._main_pool.append_sub_pool(env=env, start_python=start_python),
+                    timeout=XINFERENCE_SUBPOOL_LAUNCH_TIMEOUT,
+                )
+            except asyncio.TimeoutError:
+                logger.error(
+                    "Subpool creation timed out after %ss for model %s "
+                    "(likely fork-unsafe state in worker; restart worker to "
+                    "recover). start_python=%s, env_keys=%s",
+                    XINFERENCE_SUBPOOL_LAUNCH_TIMEOUT,
+                    model_uid,
+                    start_python,
+                    sorted(env.keys()) if env else [],
+                )
+                # Kill leftover sub_pool child processes. xo.wait_for only
+                # cancels the future; the forked child may still be alive
+                # holding GPU memory. Match PPID == this worker's pid and
+                # cmdline containing start_sub_pool. Best-effort.
+                try:
+                    import psutil
+
+                    _my_pid = os.getpid()
+                    for _p in psutil.process_iter(["pid", "ppid", "cmdline"]):
+                        _info = _p.info
+                        if _info["ppid"] != _my_pid:
+                            continue
+                        _cmd = " ".join(_info.get("cmdline") or []).lower()
+                        if "start_sub_pool" in _cmd:
+                            try:
+                                _p.kill()
+                                logger.warning(
+                                    "Killed leftover sub_pool process after "
+                                    "timeout: pid=%s",
+                                    _info["pid"],
+                                )
+                            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                                continue
+                except Exception:
+                    logger.debug(
+                        "Failed to kill leftover sub_pool process",
+                        exc_info=True,
+                    )
+                raise
+
     async def _create_subpool(
         self,
         model_uid: str,
@@ -1632,61 +1696,21 @@ class WorkerActor(xo.StatelessActor):
         # XINFERENCE_SUBPOOL_LAUNCH_TIMEOUT; we clean up and re-raise so the
         # supervisor's _workers_launching counter decrements.
         logger.debug(
-            "Creating subpool for model %s, start_python=%s, env=%s",
+            "Creating subpool for model %s, start_python=%s, env_keys=%s",
             model_uid,
             start_python,
-            env,
+            sorted(env.keys()) if env else [],
         )
-        async with self._subpool_creation_lock:
-            try:
-                subpool_address = await xo.wait_for(
-                    self._main_pool.append_sub_pool(env=env, start_python=start_python),
-                    timeout=XINFERENCE_SUBPOOL_LAUNCH_TIMEOUT,
-                )
-            except asyncio.TimeoutError:
-                logger.error(
-                    "Subpool creation timed out after %ss for model %s "
-                    "(likely fork-unsafe state in worker; restart worker to "
-                    "recover). start_python=%s, env=%s",
-                    XINFERENCE_SUBPOOL_LAUNCH_TIMEOUT,
-                    model_uid,
-                    start_python,
-                    env,
-                )
-                # (1) Kill leftover sub_pool child processes. xo.wait_for only
-                # cancels the future; the forked child may still be alive
-                # holding GPU memory. Match PPID == this worker's pid and
-                # cmdline containing start_sub_pool. Best-effort.
-                try:
-                    import psutil
-
-                    _my_pid = os.getpid()
-                    for _p in psutil.process_iter(["pid", "ppid", "cmdline"]):
-                        _info = _p.info
-                        if _info["ppid"] != _my_pid:
-                            continue
-                        _cmd = " ".join(_info.get("cmdline") or []).lower()
-                        if "start_sub_pool" in _cmd:
-                            try:
-                                _p.kill()
-                                logger.warning(
-                                    "Killed leftover sub_pool process after "
-                                    "timeout: pid=%s",
-                                    _info["pid"],
-                                )
-                            except (psutil.NoSuchProcess, psutil.AccessDenied):
-                                continue
-                except Exception:
-                    logger.debug(
-                        "Failed to kill leftover sub_pool process", exc_info=True
-                    )
-                # (2) Release devices allocated above; otherwise the GPU
-                # allocation table leaks and the next launch on the same GPUs
-                # reports them as occupied.
-                self.release_devices(model_uid=model_uid)
-                # (3) Re-raise so launch_builtin_model's try/finally runs the
-                # failure path and the supervisor marks the replica ERROR.
-                raise
+        try:
+            subpool_address = await self._append_sub_pool_protected(
+                env=env, start_python=start_python, model_uid=model_uid
+            )
+        except asyncio.TimeoutError:
+            # Release devices allocated above; otherwise the GPU allocation
+            # table leaks and the next launch on the same GPUs reports them
+            # as occupied. (Leftover-child kill is handled inside the helper.)
+            self.release_devices(model_uid=model_uid)
+            raise
         await self._ensure_subpool_monitor()
         return subpool_address, [str(dev) for dev in devices]
 
@@ -2966,9 +2990,10 @@ class WorkerActor(xo.StatelessActor):
                             env_value = ",".join(devices)
                             for device in devices:
                                 coros.append(
-                                    self._main_pool.append_sub_pool(
+                                    self._append_sub_pool_protected(
                                         env={env_name: env_value},
                                         start_python=subpool_python_path,
+                                        model_uid=model_uid,
                                     )
                                 )
                             pool_addresses = await asyncio.gather(*coros)
@@ -3716,7 +3741,7 @@ class WorkerActor(xo.StatelessActor):
     ) -> Tuple[str, int]:
         from ..model.llm.vllm.xavier.collective_manager import Rank0ModelActor
 
-        subpool_address = await self._main_pool.append_sub_pool()
+        subpool_address = await self._append_sub_pool_protected(model_uid=rep_model_uid)
         await self._ensure_subpool_monitor()
 
         store_address = subpool_address.split(":")[0]

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -383,11 +383,16 @@ def _nvml_init_with_timeout(timeout: int = _NVML_INIT_TIMEOUT) -> bool:
     Unix we use SIGALRM to bound it so a stuck GPU driver cannot hang worker
     startup. On Windows SIGALRM is unavailable; we call nvmlInit directly
     (Windows rarely runs vLLM, and the no-lock degradation is acceptable).
+    signal.signal also requires the main thread; in background-thread
+    contexts (some test setups, customized deployments) we fall back to a
+    direct nvmlInit rather than raising ValueError.
 
     Returns True on success, False on failure or timeout (caller degrades
     gracefully). The original SIGALRM handler is always restored.
     """
-    if os.name == "nt":
+    import threading
+
+    if os.name == "nt" or threading.current_thread() is not threading.main_thread():
         try:
             import pynvml
 
@@ -435,12 +440,14 @@ async def _kill_gpu_orphans_by_ppid(
 
     cmdline is re-checked immediately before SIGKILL to defend against PID
     reuse between the snapshot and the kill. SIGTERM is sent first, then
-    after a 1s grace, SIGKILL is applied to survivors.
+    after a 1s grace, SIGKILL is applied to survivors. psutil.Process
+    objects are retained across the grace sleep so is_running() detects
+    PID reuse via create_time comparison rather than re-resolving the PID.
     """
     import psutil
 
     occupying_pids = _snapshot_gpu_occupying_pids(device_indices)
-    orphan_pids: List[int] = []
+    orphan_processes: List["psutil.Process"] = []
     for pid in occupying_pids:
         if pid == os.getpid():
             continue
@@ -451,39 +458,38 @@ async def _kill_gpu_orphans_by_ppid(
             cmd = " ".join(p.cmdline()).lower()
             if not any(k in cmd for k in ("vllm", "enginecore", "start_sub_pool")):
                 continue
-            orphan_pids.append(pid)
+            orphan_processes.append(p)
         except (psutil.NoSuchProcess, psutil.AccessDenied):
             continue
 
-    if not orphan_pids:
+    if not orphan_processes:
         return []
 
     logger.warning(
         "Found %d vLLM orphan(s) on GPUs %s: %s",
-        len(orphan_pids),
+        len(orphan_processes),
         device_indices,
-        sorted(orphan_pids),
+        sorted(p.pid for p in orphan_processes),
     )
 
-    for pid in orphan_pids:
+    for p in orphan_processes:
         try:
-            os.kill(pid, signal.SIGTERM)
+            os.kill(p.pid, signal.SIGTERM)
         except (ProcessLookupError, PermissionError):
             continue
     await asyncio.sleep(1.0)
 
     killed: List[int] = []
-    for pid in orphan_pids:
+    for p in orphan_processes:
         try:
-            p = psutil.Process(pid)
             if not p.is_running() or p.status() == psutil.STATUS_ZOMBIE:
                 continue
             cmd = " ".join(p.cmdline()).lower()
             if not any(k in cmd for k in ("vllm", "enginecore", "start_sub_pool")):
                 continue
-            os.kill(pid, signal.SIGKILL)
-            killed.append(pid)
-            logger.warning("SIGKILL orphan pid %s on GPUs %s", pid, device_indices)
+            os.kill(p.pid, signal.SIGKILL)
+            killed.append(p.pid)
+            logger.warning("SIGKILL orphan pid %s on GPUs %s", p.pid, device_indices)
         except (
             psutil.NoSuchProcess,
             psutil.AccessDenied,
@@ -492,7 +498,7 @@ async def _kill_gpu_orphans_by_ppid(
         ):
             continue
         except Exception:
-            logger.debug("Kill pid %s failed", pid, exc_info=True)
+            logger.debug("Kill pid %s failed", p.pid, exc_info=True)
     return killed
 
 
@@ -907,29 +913,16 @@ class WorkerActor(xo.StatelessActor):
         if not all_devices:
             return
 
+        # Pre-snapshot for diagnostics: distinguish "GPU empty" from
+        # "GPU busy but no orphans". _kill_gpu_orphans_by_ppid re-snapshots
+        # internally for the actual kill decision.
         occupying_pids = _snapshot_gpu_occupying_pids(all_devices)
         if not occupying_pids:
             logger.info("Startup GPU orphan cleanup: no GPU-occupying processes found")
             return
 
-        import psutil
-
-        orphan_pids: List[int] = []
-        for pid in occupying_pids:
-            if pid == os.getpid():
-                continue
-            try:
-                p = psutil.Process(pid)
-                if p.ppid() != 1:
-                    continue
-                cmd = " ".join(p.cmdline()).lower()
-                if not any(k in cmd for k in ("vllm", "enginecore", "start_sub_pool")):
-                    continue
-                orphan_pids.append(pid)
-            except (psutil.NoSuchProcess, psutil.AccessDenied):
-                continue
-
-        if not orphan_pids:
+        killed = await _kill_gpu_orphans_by_ppid(all_devices)
+        if not killed:
             logger.info(
                 "Startup GPU orphan cleanup: %d GPU-occupying process(es) "
                 "found, none are vLLM orphans (all have live parents or "
@@ -937,43 +930,6 @@ class WorkerActor(xo.StatelessActor):
                 len(occupying_pids),
             )
             return
-
-        logger.warning(
-            "Startup GPU orphan cleanup: found %d vLLM orphan(s) on GPUs, "
-            "killing: %s",
-            len(orphan_pids),
-            sorted(orphan_pids),
-        )
-        for pid in orphan_pids:
-            try:
-                os.kill(pid, signal.SIGTERM)
-            except (ProcessLookupError, PermissionError):
-                continue
-        await asyncio.sleep(1.0)
-        for pid in orphan_pids:
-            try:
-                p = psutil.Process(pid)
-                if not p.is_running() or p.status() == psutil.STATUS_ZOMBIE:
-                    continue
-                cmd = " ".join(p.cmdline()).lower()
-                if not any(k in cmd for k in ("vllm", "enginecore", "start_sub_pool")):
-                    logger.debug(
-                        "Startup skip pid %s: cmdline changed: %s",
-                        pid,
-                        cmd[:100],
-                    )
-                    continue
-                os.kill(pid, signal.SIGKILL)
-                logger.warning("Startup SIGKILL orphan pid %s", pid)
-            except (
-                psutil.NoSuchProcess,
-                psutil.AccessDenied,
-                ProcessLookupError,
-                PermissionError,
-            ):
-                continue
-            except Exception:
-                logger.debug("Startup kill pid %s failed", pid, exc_info=True)
 
         try:
             _free_ratio = _snapshot_gpu_free_ratio(all_devices)
@@ -1659,7 +1615,7 @@ class WorkerActor(xo.StatelessActor):
                             "Pre-launch VRAM after cleanup for model %s: "
                             "free_ratio=%.2f",
                             model_uid,
-                            _snapshot_gpu_free_ratio(_target_device_ints),
+                            _free_ratio,
                         )
             except Exception:
                 logger.debug(

--- a/xinference/model/llm/vllm/core.py
+++ b/xinference/model/llm/vllm/core.py
@@ -458,9 +458,13 @@ class VLLMModel(LLM):
         global VLLM_INSTALLED, VLLM_VERSION
         VLLM_INSTALLED = True
         VLLM_VERSION = version.parse(vllm.__version__)
-        # Expose model_uid to child processes (vLLM workers, EngineCore)
-        # so orphan cleanup can identify them on shared GPUs.
-        os.environ["XINFERENCE_MODEL_UID"] = self.model_uid
+        # XINFERENCE_MODEL_UID is injected via the env= dict in
+        # xinference.core.worker.WorkerActor._create_subpool so the sub-pool
+        # and its vLLM descendants (EngineCore / GPU workers) inherit it. Do
+        # NOT set os.environ here: load() runs in a worker thread under
+        # concurrent launches, and os.environ.__setitem__ -> putenv is not
+        # thread-safe; moreover the sub-pool was already forked by the time
+        # this runs, so a main-process env mutation would never reach it.
         _update_vllm_supported_lists()
 
         from ..llm_family import LlamaCppLLMSpecV2


### PR DESCRIPTION
## Summary

Harden worker sub-pool creation against hangs and clean up vLLM GPU orphans left by a previous worker. Five fixes on top of current `main`:

- **H3 — serialize `append_sub_pool`** with an `asyncio.Lock`. xoscar's `MainActorPool.append_sub_pool` has no internal lock; under `XINFERENCE_MAX_CONCURRENT_LAUNCHES>1`, concurrent `create_subprocess_exec` calls deadlock on fork+GIL and block the event loop (which also disables the timeout callback below). The lock covers only `append_sub_pool` (milliseconds), not download/load — launch throughput is unaffected.
- **C — sub-pool creation timeout** (`XINFERENCE_SUBPOOL_LAUNCH_TIMEOUT=60s`, tunable). A single fork that deadlocks in CUDA init would otherwise hang the actor forever. On timeout: psutil-kill leftover `start_sub_pool` children (PPID == this worker), `release_devices`, and re-raise so `launch_builtin_model`'s `try/finally` runs the failure path and the supervisor's `_workers_launching` counter decrements. Scope is a single launch; co-located models are not affected. H3 is what makes C reachable — without serialization, the fork deadlock blocks the event loop and the `xo.wait_for` callback never fires.
- **H2 — pre-launch VRAM recheck**. If free VRAM on the target GPUs is `< 0.90`, SIGKILL PPID==1 vLLM orphans (cmdline-matched) and poll VRAM release. PPID==1 (not the existing diff heuristic) avoids mis-killing another live worker's vLLM processes on shared GPUs (`allow_multi_replica_per_gpu=True`). Best-effort; any error is logged and the launch proceeds.
- **H1 — startup orphan cleanup**. `__post_create__` dispatches an async task that scans all GPUs for PPID==1 vLLM orphans (the previous worker's EngineCore/GPU workers, reparented to init) and SIGKILLs them. `nvmlInit` is bounded by a `SIGALRM` guard (`_nvml_init_with_timeout`) so a stuck GPU driver cannot block startup. Runs after registration; never blocks the worker from serving.
- **G — fix `XINFERENCE_MODEL_UID` injection**. `VLLMModel.load()` previously set `os.environ["XINFERENCE_MODEL_UID"]` from a worker thread — a `putenv` race under concurrent launches, and ineffective anyway because the sub-pool was already forked. The tag is now injected via the `env=` dict in `_create_subpool`, so the sub-pool and its vLLM descendants inherit it.

## Motivation

Production incident: multi-replica vLLM launches (e.g. `qwen3.6` 2 replicas, or `jina-embeddings-v5` 8 replicas with `XINFERENCE_MAX_CONCURRENT_LAUNCHES=5`) hang the worker actor indefinitely. Root causes, in order of severity:

1. **Concurrent fork deadlock (H3)** — 5 launches enter `_create_subpool` concurrently; `append_sub_pool` is unlocked, so 5 `create_subprocess_exec` calls race on fork+GIL, block the event loop, and disable C's timeout callback. Serializing sub-pool creation eliminated the hang in testing (8 replicas, ~13s each).
2. **Cross-restart GPU orphans (H1)** — when a worker dies, its vLLM EngineCore/GPU workers (no `_check_ppid`) are reparented to PID 1 and keep holding VRAM. The next worker's first sub-pool creation deadlocks in CUDA init. "First restart hangs, second restart succeeds" because the second restart benefits from driver/OOM cleanup of the orphans.
3. **Single-fork CUDA-init deadlock (C)** — even without concurrency, a fork-unsafe worker state (vllm/torch already imported, CUDA context initialized) can deadlock a single sub-pool fork. Without a timeout, the actor hangs forever; the supervisor's launching exemption (`_workers_launching`) prevents self-healing.
4. **`os.environ` race (G)** — real `putenv` thread-safety bug; also made the model-uid tag invisible to the sub-pool's vLLM descendants.

## Changes

| File | Change |
|---|---|
| `xinference/constants.py` | Add `XINFERENCE_SUBPOOL_LAUNCH_TIMEOUT` (default 60s, env-tunable). |
| `xinference/core/worker.py` | `_create_subpool`: `asyncio.Lock` (H3) + `xo.wait_for` timeout (C) + VRAM recheck (H2) + `env` injection (G). New `_cleanup_gpu_orphans_on_startup` (H1) dispatched from `__post_create__`. New helpers `_nvml_init_with_timeout`, `_kill_gpu_orphans_by_ppid` (PPID-based, distinct from the existing diff-based `_kill_orphan_gpu_pids`). New `__init__` attr `_subpool_creation_lock`. Internal thresholds `_NVML_INIT_TIMEOUT=10` (module-level, not env-exposed). |
| `xinference/model/llm/vllm/core.py` | Remove `os.environ["XINFERENCE_MODEL_UID"] = self.model_uid` in `load()` (G). **The `XINFERENCE_TRUST_REMOTE_CODE` security gate (PR #5027) is untouched.** |
| `xinference/core/tests/test_subpool_hardening.py` | New mock-based test suite (no GPU required). |

## Backward compatibility

- One new env var `XINFERENCE_SUBPOOL_LAUNCH_TIMEOUT` (default 60s). Old users get the hardening with no config change. Normal sub-pool creation is <1s (fork+exec+import xoscar+bind+write shm; weight download happens later in `create_model_instance`), so 60s is 60x+ headroom.
- `XINFERENCE_MAX_CONCURRENT_LAUNCHES` can stay at its default 5; H3 serializes only sub-pool creation, download/load remain concurrent.
- `_kill_gpu_orphans_by_ppid` only targets PPID==1 + vLLM-cmdline processes, so live workers and their children are never killed, including on shared-GPU multi-worker hosts.
- Supervisor is not modified — `_workers_launching`, reverse-channel detection, and `_handle_dead_worker` are unchanged.
- `XINFERENCE_MODEL_UID` semantics unchanged (still present in the sub-pool child env); only the setting mechanism is corrected.

## Not in scope

The local "B2 [A]/[B]/[C]" orphan-cleanup blocks from the `feather-customized-2-9-0` branch are deliberately not backported here. `main` already has its own GPU helpers (`_snapshot_gpu_occupying_pids`, `_kill_orphan_gpu_pids`, `_snapshot_gpu_free_ratio`, `_wait_pids_dead`) and its own `recover_sub_pool` / `terminate_model` cleanup; re-introducing the 2-9-0 blocks verbatim would duplicate and conflict. This PR adds the missing pieces (startup cleanup, pre-launch recheck, serialization, timeout) on top of what `main` already has.

## Test plan

- [x] `pre-commit run --files <modified>` — black/flake8/isort/mypy/codespell all pass.
- [x] `xinference/core/tests/test_subpool_hardening.py` — mock-based, covers: C timeout (raises + `release_devices` + leftover-child kill), H3 serialization (no overlap across 3 concurrent calls), G env injection (env dict carries the tag; `os.environ` untouched), H2 PPID filter (live-worker child and non-vllm cmdline spared), H1 startup cleanup (nvml failure degrades; orphan SIGKILL path), `_nvml_init_with_timeout` success/failure. **Cannot run locally without `torch`/`torchvision` (same constraint as the existing `test_launch_orphan_cleanup.py`); CI installs the full extras.**
- [ ] CI matrix (Linux/macOS/Windows) — Windows verifies the no-`SIGALRM` degradation path does not crash at import.
- [ ] Manual: multi-replica vLLM launch (e.g. 8 replicas, `MAX_CONCURRENT_LAUNCHES=5`) — no hang, all replicas up.
- [ ] Manual: `kill -9` the worker while a vLLM model is running, restart, launch again — startup orphan cleanup runs and the launch succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)