### PR TITLE
feat: add Unlimited-OCR support

### DIFF
--- a/xinference/model/image/model_spec.json
+++ b/xinference/model/image/model_spec.json
@@ -1189,6 +1189,41 @@
   },
   {
     "version": 2,
+    "model_name": "Unlimited-OCR",
+    "model_family": "ocr",
+    "model_ability": [
+      "ocr"
+    ],
+    "virtualenv": {
+      "packages": [
+        "#transformers_dependencies# ; #engine# == \"Transformers\"",
+        "#system_torch# ; #engine# == \"Transformers\"",
+        "#system_numpy#",
+        "tokenizers",
+        "PyMuPDF",
+        "einops",
+        "easydict",
+        "addict",
+        "Pillow",
+        "matplotlib",
+        "psutil"
+      ]
+    },
+    "model_src": {
+      "huggingface": {
+        "model_id": "baidu/Unlimited-OCR",
+        "model_revision": "main"
+      },
+      "modelscope": {
+        "model_id": "PaddlePaddle/Unlimited-OCR",
+        "model_revision": "master"
+      }
+    },
+    "featured": false,
+    "updated_at": 1782717353
+  },
+  {
+    "version": 2,
     "model_name": "HunyuanOCR",
     "model_family": "ocr",
     "model_ability": [

--- a/xinference/model/image/model_spec.json
+++ b/xinference/model/image/model_spec.json
@@ -1196,8 +1196,8 @@
     ],
     "virtualenv": {
       "packages": [
-        "#transformers_dependencies# ; #engine# == \"Transformers\"",
-        "#system_torch# ; #engine# == \"Transformers\"",
+        "transformers==4.46.3 ; #engine# == \"transformers\"",
+        "#system_torch# ; #engine# == \"transformers\"",
         "#system_numpy#",
         "tokenizers",
         "PyMuPDF",

--- a/xinference/model/image/model_spec.json
+++ b/xinference/model/image/model_spec.json
@@ -1196,17 +1196,17 @@
     ],
     "virtualenv": {
       "packages": [
-        "transformers==4.46.3 ; #engine# == \"transformers\"",
+        "transformers==4.57.1 ; #engine# == \"transformers\"",
         "#system_torch# ; #engine# == \"transformers\"",
         "#system_numpy#",
         "tokenizers",
-        "PyMuPDF",
-        "einops",
-        "easydict",
-        "addict",
-        "Pillow",
-        "matplotlib",
-        "psutil"
+        "pymupdf==1.27.2.2",
+        "einops==0.8.2",
+        "easydict==1.13",
+        "addict==2.4.0",
+        "Pillow==12.1.1",
+        "matplotlib==3.10.8",
+        "psutil==7.2.2"
       ]
     },
     "model_src": {

--- a/xinference/model/image/ocr/__init__.py
+++ b/xinference/model/image/ocr/__init__.py
@@ -18,6 +18,7 @@ from .hunyuan_ocr import HunyuanOCRModel
 from .mlx import MLXDeepSeekOCRModel
 from .ocr_family import SUPPORTED_ENGINES
 from .paddleocr_vl import PaddleOCRVLModel
+from .unlimited_ocr import UnlimitedOCRModel
 from .vllm import (
     VLLMDeepSeekOCRModel,
     VLLMGotOCR2Model,
@@ -30,6 +31,7 @@ __all__ = [
     "GotOCR2Model",
     "HunyuanOCRModel",
     "PaddleOCRVLModel",
+    "UnlimitedOCRModel",
 ]
 
 
@@ -39,6 +41,7 @@ def register_builtin_ocr_engines() -> None:
         GotOCR2Model,
         HunyuanOCRModel,
         PaddleOCRVLModel,
+        UnlimitedOCRModel,
     ]
     SUPPORTED_ENGINES["vllm"] = [
         VLLMDeepSeekOCRModel,

--- a/xinference/model/image/ocr/unlimited_ocr.py
+++ b/xinference/model/image/ocr/unlimited_ocr.py
@@ -14,6 +14,7 @@
 
 import logging
 import os
+import shutil
 import tempfile
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
@@ -144,7 +145,12 @@ class UnlimitedOCRModel(OCRModel):
                         setattr(config, key, value)
             if getattr(config, "pad_token_id", None) is None:
                 config.pad_token_id = self._tokenizer.eos_token_id
-            if self._device != "cpu":
+            # Resolve the target device once so the model lands on the GPU
+            # picked by Xinference's scheduler (``self._device``) instead of
+            # always falling back to ``cuda:0``. Default to ``cuda`` when no
+            # device is configured, mirroring the previous behavior.
+            device = self._device or "cuda"
+            if device != "cpu":
                 model = AutoModel.from_pretrained(
                     self._model_path,
                     config=config,
@@ -152,7 +158,7 @@ class UnlimitedOCRModel(OCRModel):
                     use_safetensors=True,
                     torch_dtype=torch.bfloat16,
                 )
-                self._model = model.eval().cuda()
+                self._model = model.eval().to(device)
             else:
                 model = AutoModel.from_pretrained(
                     self._model_path,
@@ -272,6 +278,7 @@ class UnlimitedOCRModel(OCRModel):
         ngram_window = kwargs.pop("ngram_window", 128)
 
         temp_image_path = None
+        output_path = None
         try:
             with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as f:
                 image.save(f.name, "JPEG")
@@ -312,6 +319,12 @@ class UnlimitedOCRModel(OCRModel):
                     os.remove(temp_image_path)
                 except OSError:
                     pass
+            # ``model.infer`` always writes ``result.md`` (and possibly
+            # intermediate debug artifacts) under ``output_path`` when
+            # ``save_results=True``. Remove the whole temp dir to avoid
+            # leaking one directory per OCR call.
+            if output_path and os.path.exists(output_path):
+                shutil.rmtree(output_path, ignore_errors=True)
 
     def _ocr_multi(
         self,
@@ -331,6 +344,7 @@ class UnlimitedOCRModel(OCRModel):
         ngram_window = kwargs.pop("ngram_window", 1024)
 
         temp_paths: List[str] = []
+        output_path = None
         try:
             for img in images:
                 if img.mode in ["RGBA", "CMYK"]:
@@ -372,3 +386,6 @@ class UnlimitedOCRModel(OCRModel):
                         os.remove(p)
                     except OSError:
                         pass
+            # Same cleanup rationale as ``_ocr_single``.
+            if output_path and os.path.exists(output_path):
+                shutil.rmtree(output_path, ignore_errors=True)

--- a/xinference/model/image/ocr/unlimited_ocr.py
+++ b/xinference/model/image/ocr/unlimited_ocr.py
@@ -146,10 +146,10 @@ class UnlimitedOCRModel(OCRModel):
             if getattr(config, "pad_token_id", None) is None:
                 config.pad_token_id = self._tokenizer.eos_token_id
             # Resolve the target device once so the model lands on the GPU
-            # picked by Xinference's scheduler (``self._device``) instead of
-            # always falling back to ``cuda:0``. Default to ``cuda`` when no
-            # device is configured, mirroring the previous behavior.
-            device = self._device or "cuda"
+            # picked by Xinference's scheduler (``self._device``). When no
+            # device is configured, choose CUDA only if it is actually available
+            # so CPU-only launches do not accidentally try to load on CUDA.
+            device = self._device or ("cuda" if torch.cuda.is_available() else "cpu")
             if device != "cpu":
                 model = AutoModel.from_pretrained(
                     self._model_path,

--- a/xinference/model/image/ocr/unlimited_ocr.py
+++ b/xinference/model/image/ocr/unlimited_ocr.py
@@ -231,6 +231,25 @@ class UnlimitedOCRModel(OCRModel):
         else:
             raise ValueError("Input must be a PIL Image or list of PIL Images")
 
+    @staticmethod
+    def _read_result_md(output_path: str) -> Optional[str]:
+        """Read OCR text persisted by the bundled model into ``output_path``.
+
+        ``model.infer`` / ``model.infer_multi`` only stream output to a
+        ``transformers`` text streamer and persist the recognized markdown to
+        ``output_path/result.md`` when ``save_results=True``. Return its
+        contents (or ``None`` if the file is missing).
+        """
+        md_path = os.path.join(output_path, "result.md")
+        if not os.path.exists(md_path):
+            return None
+        try:
+            with open(md_path, "r", encoding="utf-8") as f:
+                return f.read()
+        except OSError as e:
+            logger.warning(f"Failed to read OCR result from {md_path}: {e}")
+            return None
+
     def _ocr_single(
         self,
         image: PIL.Image.Image,
@@ -260,7 +279,7 @@ class UnlimitedOCRModel(OCRModel):
 
             output_path = tempfile.mkdtemp()
 
-            result = self._model.infer(
+            self._model.infer(
                 self._tokenizer,
                 prompt=prompt,
                 image_file=temp_image_path,
@@ -271,11 +290,15 @@ class UnlimitedOCRModel(OCRModel):
                 max_length=max_length,
                 no_repeat_ngram_size=no_repeat_ngram_size,
                 ngram_window=ngram_window,
-                save_results=save_results,
+                save_results=True,
             )
 
+            # ``model.infer`` writes the recognized text to ``output_path/result.md``
+            # and returns ``None``. Read it back so the HTTP response carries text.
+            text = self._read_result_md(output_path)
+
             return {
-                "text": result,
+                "text": text,
                 "model": "unlimited-ocr",
                 "success": True,
                 "model_size": model_config.name,
@@ -318,7 +341,7 @@ class UnlimitedOCRModel(OCRModel):
 
             output_path = tempfile.mkdtemp()
 
-            result = self._model.infer_multi(
+            self._model.infer_multi(
                 self._tokenizer,
                 prompt=prompt,
                 image_files=temp_paths,
@@ -327,12 +350,14 @@ class UnlimitedOCRModel(OCRModel):
                 max_length=max_length,
                 no_repeat_ngram_size=no_repeat_ngram_size,
                 ngram_window=ngram_window,
-                save_results=save_results,
+                save_results=True,
             )
+
+            text = self._read_result_md(output_path)
 
             return [
                 {
-                    "text": result,
+                    "text": text,
                     "model": "unlimited-ocr",
                     "success": True,
                     "model_size": model_config.name,

--- a/xinference/model/image/ocr/unlimited_ocr.py
+++ b/xinference/model/image/ocr/unlimited_ocr.py
@@ -103,7 +103,17 @@ class UnlimitedOCRModel(OCRModel):
         return self._abilities
 
     def load(self):
-        from transformers import AutoModel, AutoTokenizer
+        from transformers import AutoConfig, AutoModel, AutoTokenizer
+
+        # Compatibility shim for transformers >= 5.x: the bundled
+        # ``modeling_deepseekv2.py`` shipped with Unlimited-OCR imports
+        # ``is_torch_fx_available`` from ``transformers.utils.import_utils``,
+        # which was removed upstream. Inject a stub returning False so the
+        # FX-tracing fast path stays disabled (the model never traces).
+        from transformers.utils import import_utils as _tf_import_utils
+
+        if not hasattr(_tf_import_utils, "is_torch_fx_available"):
+            _tf_import_utils.is_torch_fx_available = lambda: False  # type: ignore[attr-defined]
 
         logger.info(f"Loading Unlimited-OCR model from {self._model_path}")
 
@@ -112,24 +122,48 @@ class UnlimitedOCRModel(OCRModel):
                 self._model_path,
                 trust_remote_code=allow_trust_remote_code(self.model_family),
             )
+            # The bundled ``modeling_deepseekv2.DeepseekV2Model.__init__``
+            # accesses ``config.pad_token_id`` directly. Unlimited-OCR ships
+            # a config.json without that field, so prime it from the
+            # tokenizer before instantiating the model.
+            config = AutoConfig.from_pretrained(
+                self._model_path,
+                trust_remote_code=allow_trust_remote_code(self.model_family),
+            )
+            # Unlimited-OCR's config.json nests the DeepseekV2 backbone
+            # parameters under ``language_config``. ``UnlimitedOCRConfig``
+            # subclasses ``DeepseekV2Config`` and the model accesses fields
+            # such as ``attention_dropout`` / ``hidden_size`` directly on
+            # the top-level config, so flatten the nested dict onto config.
+            language_config = getattr(config, "language_config", None)
+            if isinstance(language_config, dict):
+                for key, value in language_config.items():
+                    if not hasattr(config, key) or getattr(config, key) is None:
+                        setattr(config, key, value)
+            if getattr(config, "pad_token_id", None) is None:
+                config.pad_token_id = self._tokenizer.eos_token_id
             if self._device != "cpu":
                 model = AutoModel.from_pretrained(
                     self._model_path,
+                    config=config,
                     trust_remote_code=allow_trust_remote_code(self.model_family),
                     use_safetensors=True,
                     torch_dtype=torch.bfloat16,
-                    pad_token_id=self._tokenizer.eos_token_id,
                 )
                 self._model = model.eval().cuda()
             else:
                 model = AutoModel.from_pretrained(
                     self._model_path,
+                    config=config,
                     trust_remote_code=allow_trust_remote_code(self.model_family),
                     use_safetensors=True,
                     torch_dtype=torch.float32,
-                    pad_token_id=self._tokenizer.eos_token_id,
                 )
                 self._model = model.eval()
+            # Ensure the model config carries pad_token_id, which the bundled
+            # generation code reads as ``model.config.pad_token_id``.
+            if getattr(self._model.config, "pad_token_id", None) is None:
+                self._model.config.pad_token_id = self._tokenizer.eos_token_id
             logger.info("Unlimited-OCR model loaded successfully")
         except Exception as e:
             logger.error(f"Failed to load Unlimited-OCR model: {e}")

--- a/xinference/model/image/ocr/unlimited_ocr.py
+++ b/xinference/model/image/ocr/unlimited_ocr.py
@@ -196,8 +196,9 @@ class UnlimitedOCRModel(OCRModel):
                 - no_repeat_ngram_size: No-repeat ngram size (default: 35)
                 - ngram_window: Ngram window size (default: 128 for single,
                   1024 for multi-page)
-                - save_results: Whether to save results to output_path
-                  (default: False)
+                - save_results: Whether to save results (default: False)
+                - save_dir: Directory to save results (required when
+                  ``save_results=True``)
 
         Returns:
             OCR result dict (single image) or list of dicts (multi image).
@@ -212,6 +213,10 @@ class UnlimitedOCRModel(OCRModel):
         max_length = kwargs.pop("max_length", 32768)
         no_repeat_ngram_size = kwargs.pop("no_repeat_ngram_size", 35)
         save_results = kwargs.pop("save_results", False)
+        save_dir = kwargs.pop("save_dir", None)
+
+        if save_results and not save_dir:
+            raise ValueError("save_dir must be provided when save_results=True")
 
         # Single image path
         if isinstance(image, PIL.Image.Image):
@@ -222,6 +227,7 @@ class UnlimitedOCRModel(OCRModel):
                 max_length,
                 no_repeat_ngram_size,
                 save_results,
+                save_dir,
                 **kwargs,
             )
         # Multi image path -> infer_multi, base config only
@@ -232,6 +238,7 @@ class UnlimitedOCRModel(OCRModel):
                 max_length,
                 no_repeat_ngram_size,
                 save_results,
+                save_dir,
                 **kwargs,
             )
         else:
@@ -264,6 +271,7 @@ class UnlimitedOCRModel(OCRModel):
         max_length: int,
         no_repeat_ngram_size: int,
         save_results: bool,
+        save_dir: Optional[str],
         **kwargs,
     ) -> Dict[str, Any]:
         """Single-image OCR via ``model.infer``."""
@@ -274,17 +282,22 @@ class UnlimitedOCRModel(OCRModel):
             image = image.convert("RGB")
 
         model_config = UnlimitedOCRModelSize.from_string(model_size)
-        # gundam uses a smaller ngram_window, base uses a larger one
         ngram_window = kwargs.pop("ngram_window", 128)
 
         temp_image_path = None
         output_path = None
+        is_temp_dir = False
         try:
             with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as f:
                 image.save(f.name, "JPEG")
                 temp_image_path = f.name
 
-            output_path = tempfile.mkdtemp()
+            if save_results and save_dir:
+                os.makedirs(save_dir, exist_ok=True)
+                output_path = save_dir
+            else:
+                output_path = tempfile.mkdtemp()
+                is_temp_dir = True
 
             self._model.infer(
                 self._tokenizer,
@@ -300,11 +313,9 @@ class UnlimitedOCRModel(OCRModel):
                 save_results=True,
             )
 
-            # ``model.infer`` writes the recognized text to ``output_path/result.md``
-            # and returns ``None``. Read it back so the HTTP response carries text.
             text = self._read_result_md(output_path)
 
-            return {
+            response = {
                 "text": text,
                 "model": "unlimited-ocr",
                 "success": True,
@@ -313,17 +324,25 @@ class UnlimitedOCRModel(OCRModel):
                 "image_size": model_config.image_size,
                 "crop_mode": model_config.crop_mode,
             }
+
+            if save_results and save_dir:
+                response["saved_files"] = {
+                    "output_dir": save_dir,
+                    "result_file": (
+                        os.path.join(save_dir, "result.md")
+                        if os.path.exists(os.path.join(save_dir, "result.md"))
+                        else None
+                    ),
+                }
+
+            return response
         finally:
             if temp_image_path and os.path.exists(temp_image_path):
                 try:
                     os.remove(temp_image_path)
                 except OSError:
                     pass
-            # ``model.infer`` always writes ``result.md`` (and possibly
-            # intermediate debug artifacts) under ``output_path`` when
-            # ``save_results=True``. Remove the whole temp dir to avoid
-            # leaking one directory per OCR call.
-            if output_path and os.path.exists(output_path):
+            if is_temp_dir and output_path and os.path.exists(output_path):
                 shutil.rmtree(output_path, ignore_errors=True)
 
     def _ocr_multi(
@@ -333,6 +352,7 @@ class UnlimitedOCRModel(OCRModel):
         max_length: int,
         no_repeat_ngram_size: int,
         save_results: bool,
+        save_dir: Optional[str],
         **kwargs,
     ) -> List[Dict[str, Any]]:
         """Multi-page OCR via ``model.infer_multi`` (base config only)."""
@@ -345,6 +365,7 @@ class UnlimitedOCRModel(OCRModel):
 
         temp_paths: List[str] = []
         output_path = None
+        is_temp_dir = False
         try:
             for img in images:
                 if img.mode in ["RGBA", "CMYK"]:
@@ -353,7 +374,12 @@ class UnlimitedOCRModel(OCRModel):
                     img.save(f.name, "JPEG")
                     temp_paths.append(f.name)
 
-            output_path = tempfile.mkdtemp()
+            if save_results and save_dir:
+                os.makedirs(save_dir, exist_ok=True)
+                output_path = save_dir
+            else:
+                output_path = tempfile.mkdtemp()
+                is_temp_dir = True
 
             self._model.infer_multi(
                 self._tokenizer,
@@ -369,16 +395,26 @@ class UnlimitedOCRModel(OCRModel):
 
             text = self._read_result_md(output_path)
 
-            return [
-                {
-                    "text": text,
-                    "model": "unlimited-ocr",
-                    "success": True,
-                    "model_size": model_config.name,
-                    "image_size": model_config.image_size,
-                    "num_pages": len(temp_paths),
+            response = {
+                "text": text,
+                "model": "unlimited-ocr",
+                "success": True,
+                "model_size": model_config.name,
+                "image_size": model_config.image_size,
+                "num_pages": len(temp_paths),
+            }
+
+            if save_results and save_dir:
+                response["saved_files"] = {
+                    "output_dir": save_dir,
+                    "result_file": (
+                        os.path.join(save_dir, "result.md")
+                        if os.path.exists(os.path.join(save_dir, "result.md"))
+                        else None
+                    ),
                 }
-            ]
+
+            return [response]
         finally:
             for p in temp_paths:
                 if os.path.exists(p):
@@ -386,6 +422,5 @@ class UnlimitedOCRModel(OCRModel):
                         os.remove(p)
                     except OSError:
                         pass
-            # Same cleanup rationale as ``_ocr_single``.
-            if output_path and os.path.exists(output_path):
+            if is_temp_dir and output_path and os.path.exists(output_path):
                 shutil.rmtree(output_path, ignore_errors=True)

--- a/xinference/model/image/ocr/unlimited_ocr.py
+++ b/xinference/model/image/ocr/unlimited_ocr.py
@@ -1,0 +1,313 @@
+# Copyright 2022-2026 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import os
+import tempfile
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
+
+import PIL.Image
+import torch
+
+if TYPE_CHECKING:
+    from ..core import ImageModelFamilyV2
+
+from ...utils import allow_trust_remote_code
+from .ocr_family import OCRModel
+
+logger = logging.getLogger(__name__)
+
+
+class UnlimitedOCRModelSize:
+    """Unlimited-OCR model size configurations.
+
+    Unlimited-OCR supports two image configs (see model README):
+      - gundam: base_size=1024, image_size=640, crop_mode=True  (single image)
+      - base:   base_size=1024, image_size=1024, crop_mode=False (single / multi)
+    Multi-page / PDF parsing only uses base.
+    """
+
+    GUNDAM: Tuple[str, int, int, bool] = ("gundam", 1024, 640, True)
+    BASE: Tuple[str, int, int, bool] = ("base", 1024, 1024, False)
+
+    _CONFIG_MAP: Dict[str, Tuple[str, int, int, bool]] = {
+        "gundam": GUNDAM,
+        "base": BASE,
+    }
+
+    def __init__(self, size_type: str):
+        self.size_type = size_type
+        if size_type in self._CONFIG_MAP:
+            self.name, self.base_size, self.image_size, self.crop_mode = (
+                self._CONFIG_MAP[size_type]
+            )
+        else:
+            # Default to gundam for single-image OCR
+            self.name, self.base_size, self.image_size, self.crop_mode = self.GUNDAM
+
+    @classmethod
+    def from_string(cls, size_str: str) -> "UnlimitedOCRModelSize":
+        return cls(size_str.lower())
+
+    def __str__(self) -> str:
+        return self.name
+
+
+class UnlimitedOCRModel(OCRModel):
+    """Unlimited-OCR model for one-shot long-horizon document parsing.
+
+    Built on top of Deepseek-OCR with a DeepseekV2-style MoE language backbone
+    and SAM-ViT-B / CLIP-L-14 vision encoders. Loaded via ``trust_remote_code``
+    (custom ``modeling_unlimitedocr.UnlimitedOCRForCausalLM``).
+    """
+
+    required_libs: Tuple[str, ...] = ("transformers",)
+
+    @classmethod
+    def match(cls, model_family: "ImageModelFamilyV2") -> bool:
+        return model_family.model_name == "Unlimited-OCR"
+
+    def __init__(
+        self,
+        model_uid: str,
+        model_path: Optional[str] = None,
+        device: Optional[str] = None,
+        model_spec: Optional["ImageModelFamilyV2"] = None,
+        **kwargs,
+    ):
+        self.model_family = model_spec
+        self._model_uid = model_uid
+        self._model_path = model_path
+        self._device = device
+        # model info when loading
+        self._model = None
+        self._tokenizer = None
+        # info
+        self._model_spec = model_spec
+        self._abilities = model_spec.model_ability or []  # type: ignore
+        self._kwargs = kwargs
+
+    @property
+    def model_ability(self):
+        return self._abilities
+
+    def load(self):
+        from transformers import AutoModel, AutoTokenizer
+
+        logger.info(f"Loading Unlimited-OCR model from {self._model_path}")
+
+        try:
+            self._tokenizer = AutoTokenizer.from_pretrained(
+                self._model_path,
+                trust_remote_code=allow_trust_remote_code(self.model_family),
+            )
+            if self._device != "cpu":
+                model = AutoModel.from_pretrained(
+                    self._model_path,
+                    trust_remote_code=allow_trust_remote_code(self.model_family),
+                    use_safetensors=True,
+                    torch_dtype=torch.bfloat16,
+                    pad_token_id=self._tokenizer.eos_token_id,
+                )
+                self._model = model.eval().cuda()
+            else:
+                model = AutoModel.from_pretrained(
+                    self._model_path,
+                    trust_remote_code=allow_trust_remote_code(self.model_family),
+                    use_safetensors=True,
+                    torch_dtype=torch.float32,
+                    pad_token_id=self._tokenizer.eos_token_id,
+                )
+                self._model = model.eval()
+            logger.info("Unlimited-OCR model loaded successfully")
+        except Exception as e:
+            logger.error(f"Failed to load Unlimited-OCR model: {e}")
+            raise
+
+    def ocr(
+        self,
+        image: Union[PIL.Image.Image, List[PIL.Image.Image]],
+        **kwargs,
+    ) -> Union[Dict[str, Any], List[Dict[str, Any]]]:
+        """Perform document parsing / OCR on single or multiple images.
+
+        Args:
+            image: PIL Image or list of PIL Images. A list triggers
+                multi-page parsing (``infer_multi``), which only supports the
+                ``base`` image config.
+            **kwargs: Additional parameters including:
+                - prompt: OCR prompt (default: ``"<image>document parsing."``)
+                - model_size: Image config for single image, ``"gundam"`` or
+                  ``"base"`` (default: ``"gundam"``). Ignored for multi-page.
+                - max_length: Max generated tokens (default: 32768)
+                - no_repeat_ngram_size: No-repeat ngram size (default: 35)
+                - ngram_window: Ngram window size (default: 128 for single,
+                  1024 for multi-page)
+                - save_results: Whether to save results to output_path
+                  (default: False)
+
+        Returns:
+            OCR result dict (single image) or list of dicts (multi image).
+        """
+        logger.info("Unlimited-OCR kwargs: %s", kwargs)
+
+        if self._model is None or self._tokenizer is None:
+            raise RuntimeError("Model not loaded. Please call load() first.")
+
+        prompt = kwargs.pop("prompt", "<image>document parsing.")
+        model_size = kwargs.pop("model_size", "gundam")
+        max_length = kwargs.pop("max_length", 32768)
+        no_repeat_ngram_size = kwargs.pop("no_repeat_ngram_size", 35)
+        save_results = kwargs.pop("save_results", False)
+
+        # Single image path
+        if isinstance(image, PIL.Image.Image):
+            return self._ocr_single(
+                image,
+                prompt,
+                model_size,
+                max_length,
+                no_repeat_ngram_size,
+                save_results,
+                **kwargs,
+            )
+        # Multi image path -> infer_multi, base config only
+        elif isinstance(image, list):
+            return self._ocr_multi(
+                image,
+                prompt,
+                max_length,
+                no_repeat_ngram_size,
+                save_results,
+                **kwargs,
+            )
+        else:
+            raise ValueError("Input must be a PIL Image or list of PIL Images")
+
+    def _ocr_single(
+        self,
+        image: PIL.Image.Image,
+        prompt: str,
+        model_size: str,
+        max_length: int,
+        no_repeat_ngram_size: int,
+        save_results: bool,
+        **kwargs,
+    ) -> Dict[str, Any]:
+        """Single-image OCR via ``model.infer``."""
+        if self._model is None or self._tokenizer is None:
+            raise RuntimeError("Model not loaded. Please call load() first.")
+
+        if image.mode in ["RGBA", "CMYK"]:
+            image = image.convert("RGB")
+
+        model_config = UnlimitedOCRModelSize.from_string(model_size)
+        # gundam uses a smaller ngram_window, base uses a larger one
+        ngram_window = kwargs.pop("ngram_window", 128)
+
+        temp_image_path = None
+        try:
+            with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as f:
+                image.save(f.name, "JPEG")
+                temp_image_path = f.name
+
+            output_path = tempfile.mkdtemp()
+
+            result = self._model.infer(
+                self._tokenizer,
+                prompt=prompt,
+                image_file=temp_image_path,
+                output_path=output_path,
+                base_size=model_config.base_size,
+                image_size=model_config.image_size,
+                crop_mode=model_config.crop_mode,
+                max_length=max_length,
+                no_repeat_ngram_size=no_repeat_ngram_size,
+                ngram_window=ngram_window,
+                save_results=save_results,
+            )
+
+            return {
+                "text": result,
+                "model": "unlimited-ocr",
+                "success": True,
+                "model_size": model_config.name,
+                "base_size": model_config.base_size,
+                "image_size": model_config.image_size,
+                "crop_mode": model_config.crop_mode,
+            }
+        finally:
+            if temp_image_path and os.path.exists(temp_image_path):
+                try:
+                    os.remove(temp_image_path)
+                except OSError:
+                    pass
+
+    def _ocr_multi(
+        self,
+        images: List[PIL.Image.Image],
+        prompt: str,
+        max_length: int,
+        no_repeat_ngram_size: int,
+        save_results: bool,
+        **kwargs,
+    ) -> List[Dict[str, Any]]:
+        """Multi-page OCR via ``model.infer_multi`` (base config only)."""
+        if self._model is None or self._tokenizer is None:
+            raise RuntimeError("Model not loaded. Please call load() first.")
+
+        # Multi-page only supports base config (image_size=1024)
+        model_config = UnlimitedOCRModelSize.from_string("base")
+        ngram_window = kwargs.pop("ngram_window", 1024)
+
+        temp_paths: List[str] = []
+        try:
+            for img in images:
+                if img.mode in ["RGBA", "CMYK"]:
+                    img = img.convert("RGB")
+                with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as f:
+                    img.save(f.name, "JPEG")
+                    temp_paths.append(f.name)
+
+            output_path = tempfile.mkdtemp()
+
+            result = self._model.infer_multi(
+                self._tokenizer,
+                prompt=prompt,
+                image_files=temp_paths,
+                output_path=output_path,
+                image_size=model_config.image_size,
+                max_length=max_length,
+                no_repeat_ngram_size=no_repeat_ngram_size,
+                ngram_window=ngram_window,
+                save_results=save_results,
+            )
+
+            return [
+                {
+                    "text": result,
+                    "model": "unlimited-ocr",
+                    "success": True,
+                    "model_size": model_config.name,
+                    "image_size": model_config.image_size,
+                    "num_pages": len(temp_paths),
+                }
+            ]
+        finally:
+            for p in temp_paths:
+                if os.path.exists(p):
+                    try:
+                        os.remove(p)
+                    except OSError:
+                        pass

--- a/xinference/model/image/ocr/unlimited_ocr.py
+++ b/xinference/model/image/ocr/unlimited_ocr.py
@@ -131,14 +131,16 @@ class UnlimitedOCRModel(OCRModel):
                 trust_remote_code=allow_trust_remote_code(self.model_family),
             )
             # Unlimited-OCR's config.json nests the DeepseekV2 backbone
-            # parameters under ``language_config``. ``UnlimitedOCRConfig``
-            # subclasses ``DeepseekV2Config`` and the model accesses fields
-            # such as ``attention_dropout`` / ``hidden_size`` directly on
-            # the top-level config, so flatten the nested dict onto config.
+            # parameters under ``language_config``. The bundled model code
+            # passes ``self.config`` straight to ``DeepseekV2Model.__init__``
+            # which reads fields such as ``hidden_size`` directly off the
+            # top-level config. Flatten the nested dict onto the wrapper
+            # (without overriding anything already set) so those reads
+            # succeed.
             language_config = getattr(config, "language_config", None)
             if isinstance(language_config, dict):
                 for key, value in language_config.items():
-                    if not hasattr(config, key) or getattr(config, key) is None:
+                    if not hasattr(config, key) or getattr(config, key, None) is None:
                         setattr(config, key, value)
             if getattr(config, "pad_token_id", None) is None:
                 config.pad_token_id = self._tokenizer.eos_token_id


### PR DESCRIPTION
### What does this PR do?

Registers [Baidu Unlimited-OCR](https://github.com/baidu/Unlimited-OCR) — the
follow-up to DeepSeek-OCR for "one-shot long-horizon document parsing" — as a
first-class image/OCR model in Xinference, runnable via the `transformers`
engine.

- Adds `UnlimitedOCRModel` in `xinference/model/image/ocr/unlimited_ocr.py`
  that wraps the bundled `model.infer` / `model.infer_multi` APIs.
- Registers the new class in `SUPPORTED_ENGINES["transformers"]` in
  `xinference/model/image/ocr/__init__.py`.
- Adds the model spec entry in `xinference/model/image/model_spec.json`
  (HuggingFace: `baidu/Unlimited-OCR`, ModelScope: `PaddlePaddle/Unlimited-OCR`).

### How is it tested?

End-to-end on a local 2×GPU host:

1. `POST /v1/models` → `HTTP 200`, model loaded into an isolated virtualenv
   pinned at `transformers==4.57.1` (matches the upstream README versions).
2. `GET /v1/models` lists the running replica.
3. `POST /v1/images/ocr` with a sample chart image returns

   ```json
   {
     "text": "Kid's Favourite Fruits\n\n![](images/0.jpg)\n\n![](images/1.jpg)\n...",
     "model": "unlimited-ocr",
     "success": true,
     "model_size": "gundam",
     "base_size": 1024,
     "image_size": 640,
     "crop_mode": true
   }