### PR TITLE
fix(llm): install ninja in qwen3.5/qwen3.6 vLLM venv for FlashInfer JIT

### DIFF
--- a/xinference/model/llm/llm_family.json
+++ b/xinference/model/llm/llm_family.json
@@ -30151,6 +30151,7 @@
         "qwen_omni_utils==0.0.9 ; #engine# == \"vllm\"",
         "vllm>=0.17.0 ; #engine# == \"vllm\"",
         "transformers==4.57.6 ; #engine# == \"vllm\"",
+        "ninja ; #engine# == \"vllm\"",
         "#llama_cpp_dependencies# ; #engine# == \"llama.cpp\""
       ]
     },
@@ -30906,6 +30907,7 @@
         "transformers>=5.2.0 ; #engine# == \"Transformers\"",
         "qwen_omni_utils ; #engine# == \"vllm\"",
         "vllm==0.21.0 ; #engine# == \"vllm\"",
+        "ninja ; #engine# == \"vllm\"",
         "#llama_cpp_dependencies# ; #engine# == \"llama.cpp\""
       ]
     },


### PR DESCRIPTION
## Problem

`worker`'s `build_subpool_envs_for_virtual_env()` force-writes `FLASHINFER_NINJA_PATH={venv_bin}/ninja` whenever a dedicated venv is enabled (`xinference/core/utils.py:315`), but the qwen3.5 / qwen3.6 `virtualenv.packages` list never declared `ninja`. The env var pointed at a file that did not exist.

## Impact

For `Qwen3_5MoeForConditionalGeneration` (256 routed experts + hybrid linear/full attention) on Blackwell sm_120, FlashInfer has no prebuilt wheel and JIT-compiles fused_moe / hybrid-attention kernels on first launch via `torch.utils.cpp_extension -> ninja -> nvcc`. With `ninja` missing, FlashInfer falls back to serial compilation and overruns the supervisor hang-detection window, causing cold-start timeouts.

## Fix

Add `ninja` to the vLLM engine slice of both families' `virtualenv.packages` so first launch installs it into the dedicated venv, closing the `FLASHINFER_NINJA_PATH` contract. The `#engine# == "vllm"` marker keeps sglang / Transformers / llama.cpp venvs untouched.

Only qwen3.5 and qwen3.6 share this architecture (`Qwen3_5MoeForConditionalGeneration`) and trigger the `hybrid_kv_cache_page_size` patch; dense models and architectures with prebuilt wheels do not need `ninja`, so the change is scoped to these two families.

## Test plan

- [x] JSON loads: `python -c "import json; json.load(open('xinference/model/llm/llm_family.json'))"`
- [x] `pytest xinference/model/llm/tests/test_llm_family.py::test_deserialize_llm_family_v1` passes (other tests in the file require HuggingFace downloads and are unrelated to this change)
- [ ] (optional, requires Blackwell GPU) launch qwen3.5 with `XINFERENCE_ENABLE_VIRTUAL_ENV=1`, confirm `{venv_bin}/ninja` exists and FlashInfer JIT runs in parallel

🤖 Generated with [Claude Code](https://claude.com/claude-code)