### PR TITLE
fix(vllm): silence repeated GuidedDecodingParams info log per request

### DIFF
--- a/xinference/model/llm/vllm/core.py
+++ b/xinference/model/llm/vllm/core.py
@@ -191,9 +191,9 @@ StructuredOutputsParams: Optional[Type[Any]] = None
 
 def _init_guided_decoding_classes() -> None:
     # Also re-invoked from VLLMModel after VLLM_VERSION is reassigned at runtime.
+    # Detect into locals and publish at the end so a concurrent async_generate
+    # coroutine (paused at an await) never observes a transient None.
     global GuidedDecodingParams, StructuredOutputsParams
-    GuidedDecodingParams = None
-    StructuredOutputsParams = None
     if not (
         VLLM_INSTALLED
         and VLLM_VERSION is not None
@@ -211,8 +211,12 @@ def _init_guided_decoding_classes() -> None:
                 VLLM_VERSION,
             )
         return
+
+    local_guided: Optional[Type[Any]] = None
+    local_structured: Optional[Type[Any]] = None
+
     if supports_guided and hasattr(_sampling_params, "GuidedDecodingParams"):
-        GuidedDecodingParams = _sampling_params.GuidedDecodingParams
+        local_guided = _sampling_params.GuidedDecodingParams
     elif supports_guided:
         logger.debug(
             "GuidedDecodingParams not found in vLLM %s, "
@@ -221,13 +225,16 @@ def _init_guided_decoding_classes() -> None:
         )
 
     if hasattr(_sampling_params, "StructuredOutputsParams"):
-        StructuredOutputsParams = _sampling_params.StructuredOutputsParams
-    elif GuidedDecodingParams is None:
+        local_structured = _sampling_params.StructuredOutputsParams
+    elif local_guided is None:
         logger.warning(
             "No guided decoding support found in vLLM %s "
             "(GuidedDecodingParams / StructuredOutputsParams).",
             VLLM_VERSION,
         )
+
+    GuidedDecodingParams = local_guided
+    StructuredOutputsParams = local_structured
 
 
 _init_guided_decoding_classes()

--- a/xinference/model/llm/vllm/core.py
+++ b/xinference/model/llm/vllm/core.py
@@ -185,6 +185,54 @@ def _virtual_env_allows_missing_vllm() -> bool:
     return bool(XINFERENCE_ENABLE_VIRTUAL_ENV)
 
 
+GuidedDecodingParams: Optional[Type[Any]] = None
+StructuredOutputsParams: Optional[Type[Any]] = None
+
+
+def _init_guided_decoding_classes() -> None:
+    # Also re-invoked from VLLMModel after VLLM_VERSION is reassigned at runtime.
+    global GuidedDecodingParams, StructuredOutputsParams
+    GuidedDecodingParams = None
+    StructuredOutputsParams = None
+    if not (
+        VLLM_INSTALLED
+        and VLLM_VERSION is not None
+        and VLLM_VERSION >= version.parse("0.6.3")
+    ):
+        return
+    supports_guided = VLLM_VERSION < version.parse("1.12.0")
+    try:
+        import vllm.sampling_params as _sampling_params
+    except ImportError:
+        if supports_guided:
+            logger.debug(
+                "GuidedDecodingParams not found in vLLM %s, "
+                "trying StructuredOutputsParams fallback.",
+                VLLM_VERSION,
+            )
+        return
+    if supports_guided and hasattr(_sampling_params, "GuidedDecodingParams"):
+        GuidedDecodingParams = _sampling_params.GuidedDecodingParams
+    elif supports_guided:
+        logger.debug(
+            "GuidedDecodingParams not found in vLLM %s, "
+            "trying StructuredOutputsParams fallback.",
+            VLLM_VERSION,
+        )
+
+    if hasattr(_sampling_params, "StructuredOutputsParams"):
+        StructuredOutputsParams = _sampling_params.StructuredOutputsParams
+    elif GuidedDecodingParams is None:
+        logger.warning(
+            "No guided decoding support found in vLLM %s "
+            "(GuidedDecodingParams / StructuredOutputsParams).",
+            VLLM_VERSION,
+        )
+
+
+_init_guided_decoding_classes()
+
+
 def _append_unique(target: List[str], *items: str) -> None:
     for item in items:
         if item not in target:
@@ -458,6 +506,7 @@ class VLLMModel(LLM):
         global VLLM_INSTALLED, VLLM_VERSION
         VLLM_INSTALLED = True
         VLLM_VERSION = version.parse(vllm.__version__)
+        _init_guided_decoding_classes()
         # XINFERENCE_MODEL_UID is injected via the env= dict in
         # xinference.core.worker.WorkerActor._create_subpool so the sub-pool
         # and its vLLM descendants (EngineCore / GPU workers) inherit it. Do
@@ -1343,40 +1392,9 @@ class VLLMModel(LLM):
         )
 
         if VLLM_INSTALLED and VLLM_VERSION >= version.parse("0.6.3"):
-            # guided decoding only available for vllm >= 0.6.3
-            GuidedDecodingParams = None
-            StructuredOutputsParams = None
-            supports_guided = VLLM_VERSION < version.parse("1.12.0")
-            try:
-                import vllm.sampling_params as _sampling_params
-            except ImportError:
-                if supports_guided:
-                    logger.info(
-                        "GuidedDecodingParams not found in vLLM %s, "
-                        "trying StructuredOutputsParams fallback.",
-                        VLLM_VERSION,
-                    )
-            else:
-                if supports_guided and hasattr(
-                    _sampling_params, "GuidedDecodingParams"
-                ):
-                    GuidedDecodingParams = _sampling_params.GuidedDecodingParams
-                elif supports_guided:
-                    logger.info(
-                        "GuidedDecodingParams not found in vLLM %s, "
-                        "trying StructuredOutputsParams fallback.",
-                        VLLM_VERSION,
-                    )
-
-                if hasattr(_sampling_params, "StructuredOutputsParams"):
-                    StructuredOutputsParams = _sampling_params.StructuredOutputsParams
-                elif GuidedDecodingParams is None:
-                    logger.warning(
-                        "No guided decoding support found in vLLM %s "
-                        "(GuidedDecodingParams / StructuredOutputsParams).",
-                        VLLM_VERSION,
-                    )
-
+            # guided decoding only available for vllm >= 0.6.3;
+            # GuidedDecodingParams / StructuredOutputsParams are resolved at
+            # module load by _init_guided_decoding_classes().
             # Extract guided decoding parameters
             guided_params: dict[str, Any] = {}
             guided_json = sanitized_generate_config.pop("guided_json", None)


### PR DESCRIPTION
## Summary

- Resolve `GuidedDecodingParams` / `StructuredOutputsParams` once at module load instead of on every `async_generate()` call.
- Demote the noisy "GuidedDecodingParams not found" log from INFO to DEBUG; keep the WARNING for the no-support-at-all case.
- Re-run detection from `VLLMModel.load` after `VLLM_VERSION` is reassigned during lazy vLLM initialization.

## Root cause

vLLM renamed `GuidedDecodingParams` to `StructuredOutputsParams` somewhere in the 0.x series (confirmed in 0.22.0). The existing version gate `supports_guided = VLLM_VERSION < 1.12.0` still passes for 0.22, but `hasattr(_sampling_params, "GuidedDecodingParams")` returns `False`, so the `elif supports_guided` branch fired an INFO log on **every inference request** because the whole detection block lived inside `async_generate()`.

The `StructuredOutputsParams` fallback works correctly — the message is pure log noise with no functional impact.

## Approach

- Move the detection into a module-level `_init_guided_decoding_classes()` helper that runs once at import.
- `GuidedDecodingParams` / `StructuredOutputsParams` become module globals, read directly by `async_generate()`.
- Hook a re-detection call into `VLLMModel.load` (where `VLLM_VERSION` gets reassigned for the lazy-load case where vLLM was not importable at module import time).
- Side benefit: removes a per-request `import vllm.sampling_params` from the hot path.

## Test plan

- [x] `pre-commit run --files xinference/model/llm/vllm/core.py` (black / flake8 / isort / mypy / codespell all green)
- [x] Module imports cleanly without vLLM installed (`VLLM_INSTALLED=False` path → globals stay `None`)
- [x] Branch-coverage tests for `_init_guided_decoding_classes` (4 cases):
  - vLLM 0.22.0 with only `StructuredOutputsParams` → fallback set, `GuidedDecodingParams=None`
  - vLLM 0.10.0 with only `GuidedDecodingParams` → primary set
  - vLLM 0.5.0 (too old) → both `None`, early return
  - vLLM 1.13.0 (`supports_guided=False`) → `GuidedDecodingParams=None`, `StructuredOutputsParams` still detected
- [ ] End-to-end on a real vLLM 0.22 deployment (Ornith-1.0-35B): confirm no new INFO log per request and `guided_json` still constrains output