### PR TITLE
ci: fix Metal CI failures with latest MLX on macOS 26 runners

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -164,13 +164,11 @@ jobs:
         include:
           # macos-latest now resolves to macOS 26, where mlx>=0.31's Metal
           # "nax" kernels fail to load on the runner's virtualized GPU
-          # ([metal::Device] Unable to load kernel ..._nax_...). Pin Metal
-          # jobs to macOS 15 and to the last mlx/mlx-lm/mlx-vlm combination
-          # that worked there until the MLX stack supports macOS 26.
-          - { os: macos-15, module: metal-llm, python-version: "3.10" }
-          - { os: macos-15, module: metal-whisper, python-version: "3.10" }
-          - { os: macos-15, module: metal-f5tts, python-version: "3.10" }
-          - { os: macos-15, module: metal-distributed, python-version: "3.10" }
+          # ([metal::Device] Unable to load kernel ..._nax_...). Pin the
+          # Metal job to macOS 15 and to the last mlx/mlx-lm/mlx-vlm
+          # combination that worked there until the MLX stack supports
+          # macOS 26.
+          - { os: macos-15, module: metal, python-version: "3.10" }
 
     steps:
       - name: Check out code
@@ -218,7 +216,7 @@ jobs:
           fi
           pip install -e ".[dev]"
           pip install "xllamacpp>=0.2.0"
-          if [[ "$MODULE" == metal* ]]; then
+          if [ "$MODULE" == "metal" ]; then
             conda install -c conda-forge "ffmpeg<7"
             pip install "mlx>=0.22.0,<0.31"
             pip install "mlx-lm<0.31"
@@ -311,13 +309,10 @@ jobs:
               "$@"
           }
 
-          if [ "$MODULE" == "metal-llm" ]; then
-            run_pytest xinference/model/llm/mlx/tests/test_mlx.py
-          elif [ "$MODULE" == "metal-whisper" ]; then
-            run_pytest xinference/model/audio/tests/test_whisper_mlx.py
-          elif [ "$MODULE" == "metal-f5tts" ]; then
-            run_pytest xinference/model/audio/tests/test_f5tts_mlx.py
-          elif [ "$MODULE" == "metal-distributed" ]; then
+          if [ "$MODULE" == "metal" ]; then
+            run_pytest xinference/model/llm/mlx/tests/test_mlx.py && \
+            run_pytest xinference/model/audio/tests/test_whisper_mlx.py && \
+            run_pytest xinference/model/audio/tests/test_f5tts_mlx.py && \
             run_pytest xinference/model/llm/mlx/tests/test_distributed_model.py
           else
             run_pytest \

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -162,13 +162,7 @@ jobs:
           - { os: windows-latest, python-version: 3.11 }
           - { os: windows-latest, python-version: 3.12 }
         include:
-          # macos-latest now resolves to macOS 26, where mlx>=0.31's Metal
-          # "nax" kernels fail to load on the runner's virtualized GPU
-          # ([metal::Device] Unable to load kernel ..._nax_...). Pin the
-          # Metal job to macOS 15 and to the last mlx/mlx-lm/mlx-vlm
-          # combination that worked there until the MLX stack supports
-          # macOS 26.
-          - { os: macos-15, module: metal, python-version: "3.10" }
+          - { os: macos-latest, module: metal, python-version: "3.10" }
 
     steps:
       - name: Check out code
@@ -218,13 +212,9 @@ jobs:
           pip install "xllamacpp>=0.2.0"
           if [ "$MODULE" == "metal" ]; then
             conda install -c conda-forge "ffmpeg<7"
-            pip install "mlx>=0.22.0,<0.31"
-            pip install "mlx-lm<0.31"
-            pip install "mlx-vlm>=0.3.4,<0.4"
-            # mlx-lm<0.31 calls AutoTokenizer.register() the old way, which
-            # transformers>=5.13 broke (expects a class, not a string, for
-            # config_class); mlx-lm<0.31 itself requires transformers>=5.0.0.
-            pip install "transformers>=5.0.0,<5.13"
+            pip install "mlx>=0.22.0"
+            pip install mlx-lm
+            pip install "mlx-vlm>=0.3.4"
             pip install mlx-whisper
             pip install f5-tts-mlx
             pip install qwen-vl-utils!=0.0.9

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -162,7 +162,15 @@ jobs:
           - { os: windows-latest, python-version: 3.11 }
           - { os: windows-latest, python-version: 3.12 }
         include:
-          - { os: macos-latest, module: metal, python-version: "3.10" }
+          # macos-latest now resolves to macOS 26, where mlx>=0.31's Metal
+          # "nax" kernels fail to load on the runner's virtualized GPU
+          # ([metal::Device] Unable to load kernel ..._nax_...). Pin Metal
+          # jobs to macOS 15 and to the last mlx/mlx-lm/mlx-vlm combination
+          # that worked there until the MLX stack supports macOS 26.
+          - { os: macos-15, module: metal-llm, python-version: "3.10" }
+          - { os: macos-15, module: metal-whisper, python-version: "3.10" }
+          - { os: macos-15, module: metal-f5tts, python-version: "3.10" }
+          - { os: macos-15, module: metal-distributed, python-version: "3.10" }
 
     steps:
       - name: Check out code
@@ -210,12 +218,15 @@ jobs:
           fi
           pip install -e ".[dev]"
           pip install "xllamacpp>=0.2.0"
-          if [ "$MODULE" == "metal" ]; then
+          if [[ "$MODULE" == metal* ]]; then
             conda install -c conda-forge "ffmpeg<7"
-            pip install "mlx>=0.22.0"
-            pip install mlx-lm
-            pip install "transformers<4.54"
-            pip install "mlx-vlm>=0.3.4"
+            pip install "mlx>=0.22.0,<0.31"
+            pip install "mlx-lm<0.31"
+            pip install "mlx-vlm>=0.3.4,<0.4"
+            # mlx-lm<0.31 calls AutoTokenizer.register() the old way, which
+            # transformers>=5.13 broke (expects a class, not a string, for
+            # config_class); mlx-lm<0.31 itself requires transformers>=5.0.0.
+            pip install "transformers>=5.0.0,<5.13"
             pip install mlx-whisper
             pip install f5-tts-mlx
             pip install qwen-vl-utils!=0.0.9
@@ -300,10 +311,13 @@ jobs:
               "$@"
           }
 
-          if [ "$MODULE" == "metal" ]; then
+          if [ "$MODULE" == "metal-llm" ]; then
             run_pytest xinference/model/llm/mlx/tests/test_mlx.py
+          elif [ "$MODULE" == "metal-whisper" ]; then
             run_pytest xinference/model/audio/tests/test_whisper_mlx.py
+          elif [ "$MODULE" == "metal-f5tts" ]; then
             run_pytest xinference/model/audio/tests/test_f5tts_mlx.py
+          elif [ "$MODULE" == "metal-distributed" ]; then
             run_pytest xinference/model/llm/mlx/tests/test_distributed_model.py
           else
             run_pytest \

--- a/xinference/model/audio/f5tts_mlx.py
+++ b/xinference/model/audio/f5tts_mlx.py
@@ -23,13 +23,15 @@ from typing import TYPE_CHECKING, Literal, Optional, Union
 import numpy as np
 from tqdm import tqdm
 
+from .utils import MLXModelThreadMixin
+
 if TYPE_CHECKING:
     from .core import AudioModelFamilyV2
 
 logger = logging.getLogger(__name__)
 
 
-class F5TTSMLXModel:
+class F5TTSMLXModel(MLXModelThreadMixin):
     def __init__(
         self,
         model_uid: str,
@@ -38,6 +40,7 @@ class F5TTSMLXModel:
         device: Optional[str] = None,
         **kwargs,
     ):
+        super().__init__()
         self.model_family = model_spec
         self._model_uid = model_uid
         self._model_path = model_path
@@ -52,6 +55,9 @@ class F5TTSMLXModel:
         return self._model_spec.model_ability
 
     def load(self):
+        self._run_on_mlx_thread(self._load)
+
+    def _load(self):
         try:
             import mlx.core as mx
             from f5_tts_mlx.cfm import F5TTS
@@ -124,7 +130,10 @@ class F5TTSMLXModel:
 
         self._model = f5tts
 
-    def speech(
+    def speech(self, *args, **kwargs):
+        return self._run_on_mlx_thread(self._speech, *args, **kwargs)
+
+    def _speech(
         self,
         input: str,
         voice: str,

--- a/xinference/model/audio/kokoro_mlx.py
+++ b/xinference/model/audio/kokoro_mlx.py
@@ -19,13 +19,15 @@ from typing import TYPE_CHECKING, Optional
 
 import numpy as np
 
+from .utils import MLXModelThreadMixin
+
 if TYPE_CHECKING:
     from .core import AudioModelFamilyV2
 
 logger = logging.getLogger(__name__)
 
 
-class KokoroMLXModel:
+class KokoroMLXModel(MLXModelThreadMixin):
     def __init__(
         self,
         model_uid: str,
@@ -34,6 +36,7 @@ class KokoroMLXModel:
         device: Optional[str] = None,
         **kwargs,
     ):
+        super().__init__()
         self.model_family = model_spec
         self._model_uid = model_uid
         self._model_path = model_path
@@ -47,6 +50,9 @@ class KokoroMLXModel:
         return self._model_spec.model_ability
 
     def load(self):
+        self._run_on_mlx_thread(self._load)
+
+    def _load(self):
         try:
             from mlx_audio.tts.models.kokoro import KokoroPipeline as KokoroPipeline
             from mlx_audio.tts.utils import load_model
@@ -65,7 +71,10 @@ class KokoroMLXModel:
             lang_code=lang_code, model=model, repo_id="prince-canuma/Kokoro-82M"
         )
 
-    def speech(
+    def speech(self, *args, **kwargs):
+        return self._run_on_mlx_thread(self._speech, *args, **kwargs)
+
+    def _speech(
         self,
         input: str,
         voice: str,

--- a/xinference/model/audio/utils.py
+++ b/xinference/model/audio/utils.py
@@ -17,12 +17,37 @@ import logging
 import typing
 import wave
 from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
 
 import numpy as np
 import torch
 from packaging import version
 
 logger = logging.getLogger(__name__)
+
+
+class MLXModelThreadMixin:
+    """Pin every call into an MLX model to a single dedicated thread.
+
+    MLX binds its default GPU stream to the OS thread that first touches
+    it. ``ModelActor`` runs synchronous model methods (``load``, and the
+    per-request inference methods) via ``asyncio.to_thread``, which uses a
+    shared thread pool executor and gives no guarantee that two calls for
+    the same model land on the same thread. When ``load()`` and a later
+    inference call run on different threads, MLX raises
+    ``RuntimeError: There is no Stream(gpu, N) in current thread`` and
+    crashes the worker process. Routing every call through one persistent
+    thread avoids this.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.__mlx_executor: typing.Optional[ThreadPoolExecutor] = None
+
+    def _run_on_mlx_thread(self, fn: Callable, *args, **kwargs):
+        if self.__mlx_executor is None:
+            self.__mlx_executor = ThreadPoolExecutor(max_workers=1)
+        return self.__mlx_executor.submit(fn, *args, **kwargs).result()
 
 
 def _extract_pcm_from_wav_bytes(wav_bytes):

--- a/xinference/model/audio/whisper_mlx.py
+++ b/xinference/model/audio/whisper_mlx.py
@@ -17,13 +17,15 @@ import logging
 import tempfile
 from typing import TYPE_CHECKING, List, Optional
 
+from .utils import MLXModelThreadMixin
+
 if TYPE_CHECKING:
     from .core import AudioModelFamilyV2
 
 logger = logging.getLogger(__name__)
 
 
-class WhisperMLXModel:
+class WhisperMLXModel(MLXModelThreadMixin):
     def __init__(
         self,
         model_uid: str,
@@ -32,6 +34,7 @@ class WhisperMLXModel:
         device: Optional[str] = None,
         **kwargs,
     ):
+        super().__init__()
         self.model_family = model_spec
         self._model_uid = model_uid
         self._model_path = model_path
@@ -46,6 +49,9 @@ class WhisperMLXModel:
         return self._model_spec.model_ability
 
     def load(self):
+        self._run_on_mlx_thread(self._load)
+
+    def _load(self):
         use_lightning = self._kwargs.get("use_lightning", "auto")
         if use_lightning not in ("auto", True, False, None):
             raise ValueError("use_lightning can only be True, False, None or auto")
@@ -132,7 +138,10 @@ class WhisperMLXModel:
             task="translate",
         )
 
-    def _call(
+    def _call(self, *args, **kwargs):
+        return self._run_on_mlx_thread(self._call_impl, *args, **kwargs)
+
+    def _call_impl(
         self,
         audio: bytes,
         language: Optional[str] = None,

--- a/xinference/model/llm/mlx/distributed_models/core.py
+++ b/xinference/model/llm/mlx/distributed_models/core.py
@@ -30,6 +30,30 @@ logger = logging.getLogger(__name__)
 DEBUG_DISTRIBUTED_MLX = bool(int(os.getenv("XINFERENCE_DEBUG_DISTRIBUTED_MLX", "0")))
 
 
+def _to_wire(result: "mx.array"):
+    """Encode an mx.array for the inter-shard exchange.
+
+    Must run on the compute thread: np.array() evaluates and copies there,
+    on the stream that owns the pending graph. numpy has no bfloat16 and
+    np.array() on a bfloat16 mx.array raises, so ship its raw bits as
+    uint16 and let _from_wire restore the dtype.
+    """
+    if result.dtype == mx.bfloat16:
+        return np.array(result.view(mx.uint16)), True
+    return np.array(result), False
+
+
+def _from_wire(payload) -> "mx.array":
+    """Decode an inter-shard payload back into an mx.array.
+
+    Must run on the compute thread so the new mx.array belongs to the
+    stream that will evaluate it.
+    """
+    data, is_bf16 = payload
+    result = mx.array(data)
+    return result.view(mx.bfloat16) if is_bf16 else result
+
+
 class ReceiverActor(xo.StatelessActor):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -43,11 +67,11 @@ class ReceiverActor(xo.StatelessActor):
     async def send(self, data):
         # no need to use async function,
         # but make it more convenient to patch this function for test purpose
-        # NOTE: the payload is a numpy array and is queued untouched. This
-        # coroutine runs on the event-loop thread; constructing an mx.array
-        # here would bind it to this thread's stream, and evaluating it later
-        # from the compute thread fails on mlx>=0.31 with 'There is no
-        # Stream(gpu, N) in current thread'.
+        # NOTE: the payload is a _to_wire() tuple and is queued untouched.
+        # This coroutine runs on the event-loop thread; constructing an
+        # mx.array here would bind it to this thread's stream, and
+        # evaluating it later from the compute thread fails on mlx>=0.31
+        # with 'There is no Stream(gpu, N) in current thread'.
         self._recv_queue.put_nowait(data)
 
     async def recv(self):
@@ -94,10 +118,9 @@ class DistributedModelMixin:
                 "Start to send %s partial result to rank %d", self.model_uid, last_rank
             )
 
-        # np.array() evaluates and copies on this (compute) thread, whose
-        # stream owns the pending graph. mx.array payloads must never cross
-        # threads on mlx>=0.31.
-        payload = np.array(result)
+        # Encode on this (compute) thread: mx.array payloads must never
+        # cross threads on mlx>=0.31.
+        payload = _to_wire(result)
 
         async def send():
             receiver_ref = await xo.actor_ref(
@@ -120,9 +143,9 @@ class DistributedModelMixin:
             logger.debug("Wait for partial result from prev shard %d", self.rank + 1)
         coro = self._receiver_ref.recv()
         result = asyncio.run_coroutine_threadsafe(coro, self.loop).result()
-        # The payload arrives as numpy; convert on this (compute) thread so
-        # the new mx.array belongs to the stream that will evaluate it.
-        result = mx.array(result)
+        # Decode on this (compute) thread so the new mx.array belongs to
+        # the stream that will evaluate it.
+        result = _from_wire(result)
         if DEBUG_DISTRIBUTED_MLX:
             logger.debug(
                 "Received partial result from prev shard %d, shape %s",
@@ -135,8 +158,8 @@ class DistributedModelMixin:
         if DEBUG_DISTRIBUTED_MLX:
             logger.debug("broadcast result from driver")
 
-        # Same as _send_stage_result: numpy over the wire.
-        payload = np.array(result)
+        # Same as _send_stage_result: encode on the compute thread.
+        payload = _to_wire(result)
 
         async def broadcast(rank: int):
             assert self.model_uid is not None
@@ -165,8 +188,8 @@ class DistributedModelMixin:
         )
         ref = asyncio.run_coroutine_threadsafe(coro, self.loop).result()
         result = asyncio.run_coroutine_threadsafe(ref.recv(), loop=self.loop).result()
-        # The payload arrives as numpy; convert on this (compute) thread.
-        return mx.array(result)
+        # Decode on this (compute) thread.
+        return _from_wire(result)
 
     def pipeline(self):
         pipeline_size, rank = self.world_size, self.rank

--- a/xinference/model/llm/mlx/distributed_models/core.py
+++ b/xinference/model/llm/mlx/distributed_models/core.py
@@ -17,6 +17,7 @@ import logging
 import os
 from typing import TYPE_CHECKING, Dict, Optional
 
+import numpy as np
 import xoscar as xo
 from xoscar.utils import lazy_import
 
@@ -39,11 +40,14 @@ class ReceiverActor(xo.StatelessActor):
     def gen_uid(cls, uid: str, rank: int):
         return f"Receiver-{uid}-{rank}"
 
-    async def send(self, data: "mx.array"):
+    async def send(self, data):
         # no need to use async function,
         # but make it more convenient to patch this function for test purpose
-        if not isinstance(data, mx.array):
-            data = mx.array(data)
+        # NOTE: the payload is a numpy array and is queued untouched. This
+        # coroutine runs on the event-loop thread; constructing an mx.array
+        # here would bind it to this thread's stream, and evaluating it later
+        # from the compute thread fails on mlx>=0.31 with 'There is no
+        # Stream(gpu, N) in current thread'.
         self._recv_queue.put_nowait(data)
 
     async def recv(self):
@@ -90,12 +94,17 @@ class DistributedModelMixin:
                 "Start to send %s partial result to rank %d", self.model_uid, last_rank
             )
 
+        # np.array() evaluates and copies on this (compute) thread, whose
+        # stream owns the pending graph. mx.array payloads must never cross
+        # threads on mlx>=0.31.
+        payload = np.array(result)
+
         async def send():
             receiver_ref = await xo.actor_ref(
                 uid=ReceiverActor.gen_uid(self.model_uid, last_rank),
                 address=self.rank_to_addresses[last_rank],
             )
-            return await receiver_ref.send(result)
+            return await receiver_ref.send(payload)
 
         asyncio.run_coroutine_threadsafe(send(), self.loop).result()
         if DEBUG_DISTRIBUTED_MLX:
@@ -111,6 +120,9 @@ class DistributedModelMixin:
             logger.debug("Wait for partial result from prev shard %d", self.rank + 1)
         coro = self._receiver_ref.recv()
         result = asyncio.run_coroutine_threadsafe(coro, self.loop).result()
+        # The payload arrives as numpy; convert on this (compute) thread so
+        # the new mx.array belongs to the stream that will evaluate it.
+        result = mx.array(result)
         if DEBUG_DISTRIBUTED_MLX:
             logger.debug(
                 "Received partial result from prev shard %d, shape %s",
@@ -123,6 +135,9 @@ class DistributedModelMixin:
         if DEBUG_DISTRIBUTED_MLX:
             logger.debug("broadcast result from driver")
 
+        # Same as _send_stage_result: numpy over the wire.
+        payload = np.array(result)
+
         async def broadcast(rank: int):
             assert self.model_uid is not None
             assert self.rank_to_addresses is not None
@@ -131,7 +146,7 @@ class DistributedModelMixin:
                 uid=ReceiverActor.gen_uid(self.model_uid, rank),
                 address=self.rank_to_addresses[rank],
             )
-            await receiver.send(result)
+            await receiver.send(payload)
 
         async def broadcast_all():
             coros = []
@@ -149,7 +164,9 @@ class DistributedModelMixin:
             uid=ReceiverActor.gen_uid(self.model_uid, self.rank), address=self.address
         )
         ref = asyncio.run_coroutine_threadsafe(coro, self.loop).result()
-        return asyncio.run_coroutine_threadsafe(ref.recv(), loop=self.loop).result()
+        result = asyncio.run_coroutine_threadsafe(ref.recv(), loop=self.loop).result()
+        # The payload arrives as numpy; convert on this (compute) thread.
+        return mx.array(result)
 
     def pipeline(self):
         pipeline_size, rank = self.world_size, self.rank

--- a/xinference/model/llm/mlx/tests/test_distributed_model.py
+++ b/xinference/model/llm/mlx/tests/test_distributed_model.py
@@ -151,7 +151,10 @@ async def test_distributed(setup_pool):
     t1 = asyncio.create_task(shard0.generate("hello", max_tokens=3))
     t2 = asyncio.create_task(shard1.generate("hello", max_tokens=3))
     await asyncio.sleep(0)
-    await t2
-    result = await t1
+    # gather() surfaces the first shard failure immediately. Awaiting the
+    # shards one by one deadlocks instead: when one shard dies mid-pipeline,
+    # its peer blocks forever on the tensor exchange, and the exception is
+    # never observed (seen as a 50-minute silent hang on CI).
+    result, _ = await asyncio.gather(t1, t2)
 
     assert result is not None

--- a/xinference/model/llm/mlx/tests/test_distributed_model.py
+++ b/xinference/model/llm/mlx/tests/test_distributed_model.py
@@ -109,6 +109,24 @@ async def setup_pool():
     sys.platform != "darwin" or platform.processor() != "arm",
     reason="MLX only works for Apple silicon chip",
 )
+def test_wire_roundtrip():
+    """The inter-shard exchange must survive every dtype models ship with,
+    including bfloat16, which numpy cannot represent directly."""
+    import mlx.core as mx
+
+    from ..distributed_models.core import _from_wire, _to_wire
+
+    for dtype in (mx.bfloat16, mx.float16, mx.float32):
+        arr = mx.random.normal((3, 5)).astype(dtype)
+        restored = _from_wire(_to_wire(arr))
+        assert restored.dtype == arr.dtype
+        assert mx.array_equal(restored, arr).item()
+
+
+@pytest.mark.skipif(
+    sys.platform != "darwin" or platform.processor() != "arm",
+    reason="MLX only works for Apple silicon chip",
+)
 @pytest.mark.asyncio
 async def test_distributed(setup_pool):
     from huggingface_hub import snapshot_download

--- a/xinference/model/llm/mlx/tests/test_distributed_model.py
+++ b/xinference/model/llm/mlx/tests/test_distributed_model.py
@@ -85,10 +85,21 @@ class ModelActor(xo.StatelessActor):
         return await asyncio.to_thread(self._generate, prompt, **kwargs)
 
 
+# xo.create_actor_pool/create_actor fork worker subprocesses without any
+# built-in timeout. On a loaded CI runner this can hit a fork+GIL race and
+# hang forever (seen hanging until pytest's own --timeout, tens of minutes
+# later, with every thread blocked in os.waitpid). Wrap each call so a stuck
+# fork fails fast and points at the actual stage instead of a generic
+# pytest-timeout with no context.
+_POOL_CREATE_TIMEOUT = 90
+_ACTOR_CREATE_TIMEOUT = 60
+
+
 @pytest_asyncio.fixture
 async def setup_pool():
-    pool = await xo.create_actor_pool(
-        f"127.0.0.1:{xo.utils.get_next_port()}", n_process=2
+    pool = await asyncio.wait_for(
+        xo.create_actor_pool(f"127.0.0.1:{xo.utils.get_next_port()}", n_process=2),
+        timeout=_POOL_CREATE_TIMEOUT,
     )
     async with pool:
         yield pool
@@ -106,23 +117,29 @@ async def test_distributed(setup_pool):
 
     model_path = snapshot_download("mlx-community/Qwen2.5-0.5B-Instruct-4bit")
 
-    shard0 = await xo.create_actor(
-        ModelActor,
-        0,
-        "qwen2.5-instruct",
-        model_path,
-        address=pool.external_address,
-        allocate_strategy=xo.allocate_strategy.ProcessIndex(1),
-        uid="model_0",
+    shard0 = await asyncio.wait_for(
+        xo.create_actor(
+            ModelActor,
+            0,
+            "qwen2.5-instruct",
+            model_path,
+            address=pool.external_address,
+            allocate_strategy=xo.allocate_strategy.ProcessIndex(1),
+            uid="model_0",
+        ),
+        timeout=_ACTOR_CREATE_TIMEOUT,
     )
-    shard1 = await xo.create_actor(
-        ModelActor,
-        1,
-        "qwen2.5-instruct",
-        model_path,
-        address=pool.external_address,
-        allocate_strategy=xo.allocate_strategy.ProcessIndex(2),
-        uid="model_1",
+    shard1 = await asyncio.wait_for(
+        xo.create_actor(
+            ModelActor,
+            1,
+            "qwen2.5-instruct",
+            model_path,
+            address=pool.external_address,
+            allocate_strategy=xo.allocate_strategy.ProcessIndex(2),
+            uid="model_1",
+        ),
+        timeout=_ACTOR_CREATE_TIMEOUT,
     )
     rank_addresses = {0: shard0.address, 1: shard1.address}
     await shard0.set_rank_addresses(rank_addresses)


### PR DESCRIPTION
## Summary

`macos-latest` runners migrated to macOS 26, and the Metal CI job started failing across every suite. The root cause is not an OS or dependency-resolution issue: mlx >= 0.31 binds lazy arrays and streams to the OS thread that creates them, and several of our MLX call paths touch the same model from different threads. This PR fixes those call paths so the Metal job runs green on `macos-latest` with the **latest unpinned** mlx / mlx-lm / mlx-vlm.

### Fixes

- **Audio models (whisper / f5-tts / kokoro)**: `ModelActor` runs synchronous model methods via `asyncio.to_thread`, so `load()` and later inference calls could land on different threads and crash the worker with `RuntimeError: There is no Stream(gpu, N) in current thread`. Added `MLXModelThreadMixin` to route every call for a model instance through one persistent single-thread executor.
- **Distributed pipeline parallelism**: shard-to-shard tensor exchange constructed `mx.array` payloads on the actor event-loop thread, so the receiving compute thread's `mx.eval` failed with the same stream error. The failing shard's exception then sat in an unawaited task while its peer blocked forever on the exchange — on CI this surfaced as a silent 50-minute hang in `test_distributed_model` with no traceback. Tensors now cross shards as numpy: the sender converts on its compute thread (forcing evaluation on the stream that owns the graph) and the receiver converts back on its own compute thread.
- **`test_distributed_model` robustness**: await the two shard generations with `asyncio.gather` so a single-shard failure surfaces immediately instead of deadlocking the peer, and wrap `xo.create_actor_pool` / `xo.create_actor` with timeouts so a stuck fork fails fast instead of eating the whole pytest timeout.

### CI workflow

- Keep the runner on `macos-latest` and the MLX stack unpinned (latest mlx / mlx-lm / mlx-vlm).
- Drop the stale `transformers<4.54` pin, which conflicts with mlx-lm >= 0.31's `transformers>=5.0.0` requirement.
- Chain the four Metal suites explicitly with `&&`.

### Verification

The distributed hang was reproduced and the fix verified locally on macOS 26 / Apple Silicon with mlx 0.32.0 + mlx-lm 0.31.3 (the exact versions the runner resolves): a standalone equivalent of `test_distributed_model` hangs before the change and completes after. The full Metal job (`build_test_job (macos-latest, metal, 3.10)`) is green on CI with all four suites passing.
