### PR TITLE
test: trigger CI to verify RTD translation checks (es/ja/fr/etc)

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,5 +1,7 @@
 .. _index:
 
+.. RTD PR-preview check test (es translation) - safe to remove after verification
+
 ======================
 Welcome to Xinference!
 ======================


### PR DESCRIPTION
## Summary
- Trivial no-op doc comment to trigger a fresh CI run
- Verifying which ReadTheDocs translation PR-preview checks currently report status (en, zh-cn, es, ja, fr, de, it, ko, pt-br, zh-tw)

## Test plan
- [ ] Confirm GitHub Actions lint/build jobs pass
- [ ] Confirm `docs/readthedocs.org:inference*` checks appear for all configured languages

This PR is for CI verification only and will be closed without merging.