### PR TITLE
fix(llm): normalize tool_call arguments to dict for Qwen3 family templates

### DIFF
--- a/xinference/model/llm/tests/test_utils.py
+++ b/xinference/model/llm/tests/test_utils.py
@@ -2064,3 +2064,146 @@ class TestEvalLlama3ChatArgumentsSecurity:
         text = '{"function": "test", "args": {}}'
         result = Llama3ToolParser().extract_tool_calls(text)
         assert result == [(text, None, None)]
+
+
+def test_normalize_tool_call_arguments_to_dict():
+    # Pure-function unit test for ChatModelMixin._normalize_tool_call_arguments_to_dict.
+    # Contract: string arguments are parsed to dict; dict passthrough; malformed
+    # JSON and empty strings are left as-is so downstream surfaces a clear error;
+    # None / missing arguments are skipped; non-assistant messages are skipped.
+    messages = [
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "c1",
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "arguments": '{"city":"北京"}',  # OpenAI spec: JSON string
+                    },
+                },
+                {
+                    "id": "c2",
+                    "type": "function",
+                    "function": {
+                        "name": "dict_passthrough",
+                        "arguments": {"already": "dict"},  # already dict, untouched
+                    },
+                },
+                {
+                    "id": "c3",
+                    "type": "function",
+                    "function": {
+                        "name": "malformed",
+                        "arguments": "{not json",  # malformed JSON, left as-is
+                    },
+                },
+                {
+                    "id": "c4",
+                    "type": "function",
+                    "function": {
+                        "name": "empty_str",
+                        "arguments": "",  # empty string, left as-is
+                    },
+                },
+                {
+                    "id": "c5",
+                    "type": "function",
+                    "function": {
+                        "name": "null_args",
+                        "arguments": None,  # null, left as-is
+                    },
+                },
+            ],
+        },
+        {"role": "user", "content": "ignored"},  # non-assistant, skipped
+        "not-a-dict",  # malformed message, skipped
+    ]
+
+    result = ChatModelMixin._normalize_tool_call_arguments_to_dict(
+        [m for m in messages if m != "not-a-dict"] + ["not-a-dict"]
+    )
+
+    assistant_tc = result[0]["tool_calls"]
+    assert assistant_tc[0]["function"]["arguments"] == {"city": "北京"}  # string parsed
+    assert assistant_tc[1]["function"]["arguments"] == {
+        "already": "dict"
+    }  # dict passthrough
+    assert (
+        assistant_tc[2]["function"]["arguments"] == "{not json"
+    )  # malformed preserved
+    assert assistant_tc[3]["function"]["arguments"] == ""  # empty preserved
+    assert assistant_tc[4]["function"]["arguments"] is None  # null preserved
+
+
+def test_qwen3_family_get_full_context_handles_string_arguments():
+    # Regression for the OpenAI-spec string tool_calls.function.arguments crash.
+    # Pre-fix: builtin templates Qwen3-Coder / qwen3.5 / qwen3.6 raised
+    # "Can only get item pairs from a mapping" because their templates iterate
+    # `tool_call.arguments|items` while OpenAI sends arguments as a JSON-encoded
+    # string.
+    from .. import BUILTIN_LLM_FAMILIES
+
+    targets = {"Qwen3-Coder", "qwen3.5", "qwen3.6"}
+    families = {
+        f.model_name: f for f in BUILTIN_LLM_FAMILIES if f.model_name in targets
+    }
+    assert set(families) == targets, f"missing: {targets - set(families)}"
+
+    base_messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "北京天气？"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "c1",
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "arguments": '{"city":"北京"}',  # OpenAI spec: string
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "c1",
+            "content": '{"temp":25,"condition":"晴"}',
+        },
+    ]
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                },
+            },
+        }
+    ]
+
+    for name in targets:
+        fam = families[name]
+        mixin = ChatModelMixin()
+        mixin.model_family = SimpleNamespace(
+            model_name=fam.model_name,
+            model_ability=getattr(fam, "model_ability", ["chat", "tools"]),
+            chat_template=fam.chat_template,
+        )
+        # tokenizer=None forces _build_from_raw_template, which uses the same
+        # ImmutableSandboxedEnvironment as production (and does NOT register
+        # from_json — the constraint that rules out in-template fixes).
+        prompt = mixin.get_full_context(
+            [dict(m) if isinstance(m, dict) else m for m in base_messages],
+            chat_template=fam.chat_template,
+            tokenizer=None,
+            tools=tools,
+        )
+        assert "<parameter=city>" in prompt, f"{name}: parameter block missing"
+        assert "北京" in prompt, f"{name}: argument value missing"

--- a/xinference/model/llm/tests/test_utils.py
+++ b/xinference/model/llm/tests/test_utils.py
@@ -2137,6 +2137,17 @@ def test_normalize_tool_call_arguments_to_dict():
     assert assistant_tc[3]["function"]["arguments"] == ""  # empty preserved
     assert assistant_tc[4]["function"]["arguments"] is None  # null preserved
 
+    # Non-mutating contract: input messages must be unchanged.
+    assert messages[0]["tool_calls"][0]["function"]["arguments"] == (
+        '{"city":"北京"}'
+    ), "_normalize_tool_call_arguments_to_dict mutated input"
+    assert messages[0]["tool_calls"][1]["function"]["arguments"] == {"already": "dict"}
+    assert messages[0]["tool_calls"][2]["function"]["arguments"] == "{not json"
+    assert messages[0]["tool_calls"][3]["function"]["arguments"] == ""
+    assert messages[0]["tool_calls"][4]["function"]["arguments"] is None
+    # The returned list is a new list (callers can mutate it independently).
+    assert result is not messages
+
 
 def test_qwen3_family_get_full_context_handles_string_arguments():
     # Regression for the OpenAI-spec string tool_calls.function.arguments crash.
@@ -2200,10 +2211,14 @@ def test_qwen3_family_get_full_context_handles_string_arguments():
         # ImmutableSandboxedEnvironment as production (and does NOT register
         # from_json — the constraint that rules out in-template fixes).
         prompt = mixin.get_full_context(
-            [dict(m) if isinstance(m, dict) else m for m in base_messages],
+            base_messages,
             chat_template=fam.chat_template,
             tokenizer=None,
             tools=tools,
         )
         assert "<parameter=city>" in prompt, f"{name}: parameter block missing"
         assert "北京" in prompt, f"{name}: argument value missing"
+        # Non-mutating contract: the input messages must be unchanged.
+        assert base_messages[2]["tool_calls"][0]["function"]["arguments"] == (
+            '{"city":"北京"}'
+        ), f"{name}: _normalize_tool_call_arguments_to_dict mutated input"

--- a/xinference/model/llm/tests/test_utils.py
+++ b/xinference/model/llm/tests/test_utils.py
@@ -2116,6 +2116,32 @@ def test_normalize_tool_call_arguments_to_dict():
                         "arguments": None,  # null, left as-is
                     },
                 },
+                {
+                    "id": "c6",
+                    "type": "function",
+                    "function": {
+                        "name": "list_args",
+                        # valid JSON but not an object — left as-is so
+                        # the template raises a clear error
+                        "arguments": "[1, 2, 3]",
+                    },
+                },
+                {
+                    "id": "c7",
+                    "type": "function",
+                    "function": {
+                        "name": "null_json",
+                        "arguments": "null",  # valid JSON null, left as-is
+                    },
+                },
+                {
+                    "id": "c8",
+                    "type": "function",
+                    "function": {
+                        "name": "number_args",
+                        "arguments": "42",  # valid JSON number, left as-is
+                    },
+                },
             ],
         },
         {"role": "user", "content": "ignored"},  # non-assistant, skipped
@@ -2136,6 +2162,11 @@ def test_normalize_tool_call_arguments_to_dict():
     )  # malformed preserved
     assert assistant_tc[3]["function"]["arguments"] == ""  # empty preserved
     assert assistant_tc[4]["function"]["arguments"] is None  # null preserved
+    # Valid JSON but not an object — must be left as-is so the template
+    # raises a clear error rather than silently producing garbage.
+    assert assistant_tc[5]["function"]["arguments"] == "[1, 2, 3]"  # list
+    assert assistant_tc[6]["function"]["arguments"] == "null"  # JSON null
+    assert assistant_tc[7]["function"]["arguments"] == "42"  # JSON number
 
     # Non-mutating contract: input messages must be unchanged.
     assert messages[0]["tool_calls"][0]["function"]["arguments"] == (
@@ -2145,6 +2176,9 @@ def test_normalize_tool_call_arguments_to_dict():
     assert messages[0]["tool_calls"][2]["function"]["arguments"] == "{not json"
     assert messages[0]["tool_calls"][3]["function"]["arguments"] == ""
     assert messages[0]["tool_calls"][4]["function"]["arguments"] is None
+    assert messages[0]["tool_calls"][5]["function"]["arguments"] == "[1, 2, 3]"
+    assert messages[0]["tool_calls"][6]["function"]["arguments"] == "null"
+    assert messages[0]["tool_calls"][7]["function"]["arguments"] == "42"
     # The returned list is a new list (callers can mutate it independently).
     assert result is not messages
 

--- a/xinference/model/llm/utils.py
+++ b/xinference/model/llm/utils.py
@@ -147,6 +147,44 @@ class ChatModelMixin:
         jinja_env.globals["raise_exception"] = raise_exception
         return jinja_env.from_string(chat_template)
 
+    @staticmethod
+    @functools.lru_cache(maxsize=64)
+    def _chat_template_needs_dict_arguments(chat_template: Optional[str]) -> bool:
+        # Detect Coder-style templates that iterate `tool_call.arguments|items`.
+        # Content-driven (not name-driven) so future models copying this
+        # template style are covered automatically.
+        return chat_template is not None and (
+            "tool_call.arguments|items" in chat_template
+        )
+
+    @staticmethod
+    def _normalize_tool_call_arguments_to_dict(messages: List[Dict]) -> List[Dict]:
+        # OpenAI spec sends tool_calls.function.arguments as a JSON-encoded
+        # string, but Coder-style templates (Qwen3-Coder / qwen3.5 / qwen3.6)
+        # require a dict to iterate via `|items`. The HF Jinja sandbox does
+        # not register a `from_json` filter, so we normalize at the message
+        # layer before template rendering.
+        for message in messages:
+            if not isinstance(message, dict) or message.get("role") != "assistant":
+                continue
+            tool_calls = message.get("tool_calls")
+            if not isinstance(tool_calls, list):
+                continue
+            for tc in tool_calls:
+                if not isinstance(tc, dict):
+                    continue
+                fn = tc.get("function")
+                if not isinstance(fn, dict):
+                    continue
+                args = fn.get("arguments")
+                if isinstance(args, str) and args:
+                    try:
+                        fn["arguments"] = json.loads(args)
+                    except json.JSONDecodeError:
+                        # leave as-is so downstream surfaces the malformed JSON
+                        pass
+        return messages
+
     def _build_from_raw_template(
         self, messages: List, chat_template: str, **kwargs
     ) -> str:
@@ -164,6 +202,8 @@ class ChatModelMixin:
         tokenize=False,
         **kwargs,
     ):
+        if self._chat_template_needs_dict_arguments(chat_template):
+            messages = self._normalize_tool_call_arguments_to_dict(messages)
         if (
             "vision" not in self.model_family.model_ability
             and "audio" not in self.model_family.model_ability

--- a/xinference/model/llm/utils.py
+++ b/xinference/model/llm/utils.py
@@ -180,8 +180,14 @@ class ChatModelMixin:
                 normalized.append(message)
                 continue
             # Identify indices that need rewriting (string arguments that
-            # parse successfully). Malformed JSON is left as-is and the
-            # original tool_call is reused.
+            # parse successfully into a JSON object). Malformed JSON and
+            # non-object JSON values (e.g. `"[]"`, `"null"`, `"1"`) are
+            # left as-is: the Qwen templates iterate `tool_call.arguments|items`
+            # which only works on mappings, so non-object values would still
+            # crash downstream — leaving them untouched lets the template
+            # surface the error naturally rather than masking it with a
+            # confusing type mismatch. This matches the contract of the
+            # existing `_normalize_tool_calls` helper.
             rewrites: Dict[int, Dict] = {}
             for i, tc in enumerate(tool_calls):
                 if not isinstance(tc, dict):
@@ -196,6 +202,12 @@ class ChatModelMixin:
                     parsed = json.loads(args)
                 except json.JSONDecodeError:
                     # leave as-is so downstream surfaces the malformed JSON
+                    continue
+                if not isinstance(parsed, dict):
+                    # JSON parsed but not an object (list / number / str /
+                    # null / bool). Leave the original string so the
+                    # template raises a clear error rather than silently
+                    # producing garbage.
                     continue
                 rewrites[i] = {**fn, "arguments": parsed}
             if not rewrites:

--- a/xinference/model/llm/utils.py
+++ b/xinference/model/llm/utils.py
@@ -164,26 +164,49 @@ class ChatModelMixin:
         # require a dict to iterate via `|items`. The HF Jinja sandbox does
         # not register a `from_json` filter, so we normalize at the message
         # layer before template rendering.
+        #
+        # Non-mutating: callers may reuse the input `messages` for history
+        # tracking / logging / serialization, so we deep-copy only the
+        # affected message + tool_call + function dict when a string
+        # argument is successfully parsed. Messages without string
+        # arguments are returned by reference (no copy).
+        normalized: List[Dict] = []
         for message in messages:
             if not isinstance(message, dict) or message.get("role") != "assistant":
+                normalized.append(message)
                 continue
             tool_calls = message.get("tool_calls")
             if not isinstance(tool_calls, list):
+                normalized.append(message)
                 continue
-            for tc in tool_calls:
+            # Identify indices that need rewriting (string arguments that
+            # parse successfully). Malformed JSON is left as-is and the
+            # original tool_call is reused.
+            rewrites: Dict[int, Dict] = {}
+            for i, tc in enumerate(tool_calls):
                 if not isinstance(tc, dict):
                     continue
                 fn = tc.get("function")
                 if not isinstance(fn, dict):
                     continue
                 args = fn.get("arguments")
-                if isinstance(args, str) and args:
-                    try:
-                        fn["arguments"] = json.loads(args)
-                    except json.JSONDecodeError:
-                        # leave as-is so downstream surfaces the malformed JSON
-                        pass
-        return messages
+                if not (isinstance(args, str) and args):
+                    continue
+                try:
+                    parsed = json.loads(args)
+                except json.JSONDecodeError:
+                    # leave as-is so downstream surfaces the malformed JSON
+                    continue
+                rewrites[i] = {**fn, "arguments": parsed}
+            if not rewrites:
+                normalized.append(message)
+                continue
+            new_tool_calls = list(tool_calls)
+            for i, new_fn in rewrites.items():
+                original_tc = tool_calls[i]
+                new_tool_calls[i] = {**original_tc, "function": new_fn}
+            normalized.append({**message, "tool_calls": new_tool_calls})
+        return normalized
 
     def _build_from_raw_template(
         self, messages: List, chat_template: str, **kwargs


### PR DESCRIPTION
## Summary

The builtin chat templates for `Qwen3-Coder`, `qwen3.5`, and `qwen3.6`
iterate over `tool_call.arguments|items`, which crashes when `arguments`
is a JSON-encoded string (the OpenAI spec format) rather than a dict.
Affected requests fail with `Jinja2 error: Can only get item pairs from a
mapping` on any turn that includes a previous tool call.

This PR normalizes string-typed `arguments` to dict at the message layer
in `ChatModelMixin.get_full_context`, before template rendering. The
detection is content-driven (matches `tool_call.arguments|items` in the
template) rather than name-driven, so future templates copied from this
family automatically benefit.

## Background

OpenAI requires `tool_calls[].function.arguments` to be a JSON-encoded
string. The Qwen3-Coder style templates iterate over it with `|items`,
which only works on mappings. The HF Jinja sandbox does not register a
`from_json` filter, so the fix cannot live in the templates themselves.

## Approach

- `_chat_template_needs_dict_arguments(chat_template)` — detects the
  `tool_call.arguments|items` pattern via substring match (lru_cached).
- `_normalize_tool_call_arguments_to_dict(messages)` — for each assistant
  message with `tool_calls`, `json.loads` string-typed `arguments` into a
  dict. Malformed JSON is left as-is so downstream surfaces a clear error.
- Both are invoked at the top of `get_full_context`, before the
  vision/audio branch (so vision models in the same family are covered).

## Edge cases

| Input | Behavior |
|---|---|
| `arguments` is valid JSON string | parsed to dict |
| `arguments` is dict | passthrough (no change) |
| `arguments` is empty string | skipped (preserved as \`\"\"\`) |
| `arguments` is malformed JSON | skipped (preserved; downstream surfaces clear error) |
| `arguments` is None / missing | skipped |
| Non-assistant message with `tool_calls` | skipped |

## Test plan

- [x] \`pytest -vv xinference/model/llm/tests/test_utils.py::test_normalize_tool_call_arguments_to_dict\`
- [x] \`pytest -vv xinference/model/llm/tests/test_utils.py::test_qwen3_family_get_full_context_handles_string_arguments\`
- [x] \`pre-commit run --files xinference/model/llm/utils.py xinference/model/llm/tests/test_utils.py\`
- [ ] Manual: chat completion with a tool-call turn against a Qwen3-Coder model

## Out of scope

- Modifying the builtin templates themselves (HF sandbox lacks \`from_json\`)
- Backfilling \`from_json\` filter via monkey-patch (high coupling risk)
- Non-builtin custom templates (user-supplied templates must still handle
  string arguments themselves)

🤖 Generated with [Claude Code](https://claude.com/claude-code)