### PR TITLE
feat(vllm): serialize vLLM engine construction to avoid flashinfer JIT deadlock

### DIFF
--- a/xinference/model/llm/vllm/core.py
+++ b/xinference/model/llm/vllm/core.py
@@ -24,6 +24,7 @@ import sys
 import threading
 import time
 import uuid
+from contextlib import contextmanager
 from functools import partial
 from typing import (
     TYPE_CHECKING,
@@ -163,6 +164,27 @@ except ImportError:
     VLLM_VERSION = None
 
 DEFAULT_VLLM_VERSION = version.parse("0.21.0")
+
+# Architectures known to trigger flashinfer fused_moe JIT deadlock on
+# Blackwell sm_120 when multiple replicas launch concurrently. The lock
+# serializes engine construction (which includes cuda graph capture +
+# JIT) so the first process fills the flashinfer cache and subsequent
+# processes hit the cache without racing on flashinfer's internal
+# `fused_moe_120.lock`.
+_FLASHINFER_WARMUP_ARCHES = frozenset(
+    {
+        "Qwen3_5MoeForConditionalGeneration",
+    }
+)
+
+# Env var to disable the serialization for debugging / fallback.
+_DISABLE_WARMUP_ENV = "XINFERENCE_DISABLE_FLASHINFER_WARMUP"
+
+# Per-process lock-acquisition timeout (seconds). Cold compile on
+# Blackwell sm_120 + MoE-256 may take 30+ min; cache hits finish in <1s.
+_FLASHINFER_WARMUP_TIMEOUT = int(
+    os.getenv("XINFERENCE_FLASHINFER_WARMUP_TIMEOUT", "1800")
+)
 
 
 def _get_effective_vllm_version() -> version.Version:
@@ -483,6 +505,115 @@ class VLLMModel(LLM):
         # For older versions, check the environment variable
         return envs.is_set("VLLM_USE_V1") and envs.VLLM_USE_V1
 
+    @contextmanager
+    def _serialize_flashinfer_jit(self):
+        """Cross-process lock to serialize vLLM engine construction.
+
+        Why: Qwen3_5MoeForConditionalGeneration (qwen3.5 / qwen3.6) on
+        Blackwell sm_120 triggers flashinfer fused_moe JIT during
+        ``AsyncLLMEngine.from_engine_args`` (cuda graph capture phase),
+        not on first inference. With multi-instance launches (e.g.
+        2 replicas x TP=4 = 8 worker processes), all processes race on
+        flashinfer's internal ``fused_moe_120.lock`` and deadlock. This
+        wrapper forces serialization around the engine-construction call
+        so the first process compiles and fills the cache, and subsequent
+        processes get cache hits without lock contention.
+
+        Non-target architectures / disabled via env: yield without locking.
+
+        Thread-safety: uses ``fcntl.LOCK_NB`` + ``time.sleep`` polling
+        (NOT ``signal.SIGALRM``) so it works inside ``_loading_thread``
+        which runs in a non-main thread.
+
+        Failure mode: if the lock cannot be acquired within timeout, the
+        engine is constructed without the lock (falls back to original
+        racing behavior). Engine construction MUST proceed regardless.
+        """
+        if os.name == "nt":
+            yield
+            return
+
+        if os.getenv(_DISABLE_WARMUP_ENV) == "1":
+            logger.debug(
+                "flashinfer jit serialize skipped via %s for model %s",
+                _DISABLE_WARMUP_ENV,
+                self.model_uid,
+            )
+            yield
+            return
+
+        architectures = getattr(self.model_family, "architectures", []) or []
+        if not any(a in _FLASHINFER_WARMUP_ARCHES for a in architectures):
+            yield
+            return
+
+        import fcntl
+
+        from ....constants import XINFERENCE_CACHE_DIR
+
+        matched_arch = next(a for a in architectures if a in _FLASHINFER_WARMUP_ARCHES)
+        lock_dir = os.path.join(XINFERENCE_CACHE_DIR, "flashinfer_warmup")
+        os.makedirs(lock_dir, exist_ok=True)
+        # Keyed by architecture name (not model_uid): flashinfer cache is
+        # keyed by GPU arch + kernel variant, so same arch -> same cache ->
+        # same lock is correct.
+        lock_path = os.path.join(lock_dir, f"{matched_arch}.lock")
+
+        logger.info(
+            "flashinfer jit serialize START model=%s arch=%s lock=%s",
+            self.model_uid,
+            matched_arch,
+            lock_path,
+        )
+        t0 = time.time()
+        fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o644)
+        lock_acquired = False
+        try:
+            # Poll with LOCK_NB instead of blocking LOCK_EX: fcntl.flock has
+            # no native timeout, and signal.alarm() does not work in non-main
+            # threads (ValueError: signal only works in main thread of the
+            # main interpreter). LOCK_NB + sleep is fully thread-safe.
+            deadline = t0 + _FLASHINFER_WARMUP_TIMEOUT
+            while True:
+                try:
+                    fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    lock_acquired = True
+                    break
+                except (BlockingIOError, OSError):
+                    if time.time() >= deadline:
+                        logger.warning(
+                            "flashinfer jit serialize TIMEOUT model=%s "
+                            "after %.1fs - continuing without lock "
+                            "(may race on flashinfer cache)",
+                            self.model_uid,
+                            time.time() - t0,
+                        )
+                        break
+                    time.sleep(0.5)
+
+            if lock_acquired:
+                logger.info(
+                    "flashinfer jit serialize LOCK ACQUIRED model=%s waited=%.1fs",
+                    self.model_uid,
+                    time.time() - t0,
+                )
+
+            try:
+                yield
+            finally:
+                if lock_acquired:
+                    try:
+                        fcntl.flock(fd, fcntl.LOCK_UN)
+                    except Exception:
+                        pass
+        finally:
+            os.close(fd)
+            logger.info(
+                "flashinfer jit serialize DONE model=%s elapsed=%.1fs",
+                self.model_uid,
+                time.time() - t0,
+            )
+
     def load(self):
         try:
             import vllm
@@ -670,9 +801,12 @@ class VLLMModel(LLM):
                                         loop=loop,
                                     )
 
-                            self._engine = XinferenceAsyncLLMEngine.from_engine_args(
-                                engine_args
-                            )
+                            with self._serialize_flashinfer_jit():
+                                self._engine = (
+                                    XinferenceAsyncLLMEngine.from_engine_args(
+                                        engine_args
+                                    )
+                                )
                         else:
                             from vllm.v1.executor.abstract import Executor
 
@@ -700,7 +834,10 @@ class VLLMModel(LLM):
                                 executor_cls.supports_async_scheduling = lambda: True  # type: ignore
                             # patch vllm Executor.get_class
                             Executor.get_class = lambda vllm_config: executor_cls
-                            self._engine = AsyncLLMEngine.from_engine_args(engine_args)
+                            with self._serialize_flashinfer_jit():
+                                self._engine = AsyncLLMEngine.from_engine_args(
+                                    engine_args
+                                )
                 except Exception:
                     logger.exception("Creating vllm engine failed")
                     self._loading_error = sys.exc_info()
@@ -725,7 +862,8 @@ class VLLMModel(LLM):
                 # lock state causing deadlock. spawn creates a clean process.
                 os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
                 try:
-                    self._engine = AsyncLLMEngine.from_engine_args(engine_args)
+                    with self._serialize_flashinfer_jit():
+                        self._engine = AsyncLLMEngine.from_engine_args(engine_args)
                 except Exception:
                     logger.exception("Creating vllm engine failed")
                     self._loading_error = sys.exc_info()

--- a/xinference/model/llm/vllm/core.py
+++ b/xinference/model/llm/vllm/core.py
@@ -547,6 +547,7 @@ class VLLMModel(LLM):
             yield
             return
 
+        import errno
         import fcntl
 
         from ....constants import XINFERENCE_CACHE_DIR
@@ -579,7 +580,28 @@ class VLLMModel(LLM):
                     fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
                     lock_acquired = True
                     break
-                except (BlockingIOError, OSError):
+                except OSError as e:
+                    # Distinguish "lock held by another process" from
+                    # "filesystem does not support locking" (e.g. NFS,
+                    # ENOTSUP / ENOSYS). The former is retryable; the
+                    # latter must abort immediately to avoid hanging
+                    # for the full timeout on a fundamentally broken
+                    # cache path.
+                    retryable = e.errno in (
+                        errno.EAGAIN,
+                        errno.EWOULDBLOCK,
+                        errno.EACCES,
+                    )
+                    if not retryable:
+                        logger.warning(
+                            "flashinfer jit serialize UNSUPPORTED FS "
+                            "model=%s errno=%d (%s) - continuing without "
+                            "lock (may race on flashinfer cache)",
+                            self.model_uid,
+                            e.errno,
+                            e.strerror or str(e),
+                        )
+                        break
                     if time.time() >= deadline:
                         logger.warning(
                             "flashinfer jit serialize TIMEOUT model=%s "

--- a/xinference/model/llm/vllm/tests/test_core_chat_model.py
+++ b/xinference/model/llm/vllm/tests/test_core_chat_model.py
@@ -1691,16 +1691,25 @@ class TestFlashinferWarmup:
                 raise _Boom("simulated engine construction failure")
 
         # Re-enter: would deadlock if previous call leaked the lock.
-        # Use a short timeout to fail fast.
+        # Use a short timeout to fail fast. Also assert the re-entry is
+        # fast (<1s) — if the lock was leaked, the second call would
+        # block for the full 2s timeout and still pass the assertion
+        # without this timing check.
+        import time
+
         import xinference.model.llm.vllm.core as core_mod
 
         original_timeout = core_mod._FLASHINFER_WARMUP_TIMEOUT
         core_mod._FLASHINFER_WARMUP_TIMEOUT = 2
+        t0 = time.time()
         try:
             with serialize_model._serialize_flashinfer_jit():
                 pass
         finally:
             core_mod._FLASHINFER_WARMUP_TIMEOUT = original_timeout
+        assert (
+            time.time() - t0 < 1.0
+        ), "Re-entry took too long — previous call may have leaked the lock"
 
     def test_serialize_yields_without_engine(self, serialize_model):
         """Context manager yields regardless of self._engine state.
@@ -1714,3 +1723,32 @@ class TestFlashinferWarmup:
         assert not hasattr(serialize_model, "_engine")
         with serialize_model._serialize_flashinfer_jit():
             pass
+
+    def test_serialize_unsupported_filesystem(self, serialize_model, monkeypatch):
+        """Should proceed immediately without hanging if flock is
+        unsupported (e.g. NFS with ENOTSUP / ENOSYS).
+
+        Without the errno-based distinction, this would hang for the
+        full _FLASHINFER_WARMUP_TIMEOUT (1800s default) before giving
+        up — a serious operational hazard on network filesystems.
+        """
+        import errno
+        import fcntl
+        import time
+
+        serialize_model.model_family.architectures = [
+            "Qwen3_5MoeForConditionalGeneration"
+        ]
+
+        def mock_flock(fd, op):
+            raise OSError(errno.ENOTSUP, "Operation not supported")
+
+        monkeypatch.setattr(fcntl, "flock", mock_flock)
+
+        t0 = time.time()
+        with serialize_model._serialize_flashinfer_jit():
+            pass
+        # Should not wait for the 1800s default timeout.
+        assert time.time() - t0 < 1.0, (
+            "Lock acquisition on unsupported filesystem hung instead of " "failing fast"
+        )

--- a/xinference/model/llm/vllm/tests/test_core_chat_model.py
+++ b/xinference/model/llm/vllm/tests/test_core_chat_model.py
@@ -1604,3 +1604,113 @@ class TestVLLMSanitizeGenerateConfig:
 
         sanitized = VLLMChatModel._sanitize_generate_config({})
         assert sanitized["guided_json"] is None
+
+
+class TestFlashinferWarmup:
+    """Tests for VLLMModel._serialize_flashinfer_jit() context manager.
+
+    Validates the cross-process lock that serializes vLLM engine
+    construction to prevent flashinfer fused_moe_120.lock deadlock on
+    Qwen3_5MoeForConditionalGeneration (qwen3.5 / qwen3.6) when multiple
+    replicas launch concurrently on Blackwell sm_120.
+    """
+
+    @pytest.fixture
+    def serialize_model(self, monkeypatch, tmp_path):
+        # Redirect XINFERENCE_CACHE_DIR to a per-test tmp path so the
+        # fixture doesn't write lock files into the real user cache.
+        monkeypatch.setattr("xinference.constants.XINFERENCE_CACHE_DIR", str(tmp_path))
+
+        from ..core import VLLMModel
+
+        model = object.__new__(VLLMModel)
+        model.model_family = MagicMock()
+        model.model_uid = "test-serialize-0"
+        return model
+
+    def test_serialize_skips_unsupported_arch(self, serialize_model):
+        """Non-Qwen3_5Moe architectures yield without creating lock dir."""
+        serialize_model.model_family.architectures = ["LlamaForCausalLM"]
+        with serialize_model._serialize_flashinfer_jit():
+            pass
+        import os
+
+        from xinference.constants import XINFERENCE_CACHE_DIR
+
+        lock_dir = os.path.join(XINFERENCE_CACHE_DIR, "flashinfer_warmup")
+        assert not os.path.exists(lock_dir)
+
+    def test_serialize_acquires_lock_for_qwen3_5_moe(self, serialize_model):
+        """Qwen3_5MoeForConditionalGeneration creates & releases lock file."""
+        serialize_model.model_family.architectures = [
+            "Qwen3_5MoeForConditionalGeneration"
+        ]
+        with serialize_model._serialize_flashinfer_jit():
+            pass
+        import os
+
+        from xinference.constants import XINFERENCE_CACHE_DIR
+
+        lock_path = os.path.join(
+            XINFERENCE_CACHE_DIR,
+            "flashinfer_warmup",
+            "Qwen3_5MoeForConditionalGeneration.lock",
+        )
+        assert os.path.exists(lock_path)
+
+    def test_serialize_disabled_via_env(self, serialize_model, monkeypatch):
+        """XINFERENCE_DISABLE_FLASHINFER_WARMUP=1 must skip lock creation."""
+        monkeypatch.setenv("XINFERENCE_DISABLE_FLASHINFER_WARMUP", "1")
+        serialize_model.model_family.architectures = [
+            "Qwen3_5MoeForConditionalGeneration"
+        ]
+        with serialize_model._serialize_flashinfer_jit():
+            pass
+        import os
+
+        from xinference.constants import XINFERENCE_CACHE_DIR
+
+        lock_dir = os.path.join(XINFERENCE_CACHE_DIR, "flashinfer_warmup")
+        assert not os.path.exists(lock_dir)
+
+    def test_serialize_releases_lock_on_exception(self, serialize_model):
+        """Lock must be released even if engine construction raises.
+
+        Verified by re-entering the context: if first call leaked the lock,
+        the second call would block until timeout.
+        """
+        serialize_model.model_family.architectures = [
+            "Qwen3_5MoeForConditionalGeneration"
+        ]
+
+        class _Boom(Exception):
+            pass
+
+        with pytest.raises(_Boom):
+            with serialize_model._serialize_flashinfer_jit():
+                raise _Boom("simulated engine construction failure")
+
+        # Re-enter: would deadlock if previous call leaked the lock.
+        # Use a short timeout to fail fast.
+        import xinference.model.llm.vllm.core as core_mod
+
+        original_timeout = core_mod._FLASHINFER_WARMUP_TIMEOUT
+        core_mod._FLASHINFER_WARMUP_TIMEOUT = 2
+        try:
+            with serialize_model._serialize_flashinfer_jit():
+                pass
+        finally:
+            core_mod._FLASHINFER_WARMUP_TIMEOUT = original_timeout
+
+    def test_serialize_yields_without_engine(self, serialize_model):
+        """Context manager yields regardless of self._engine state.
+
+        _serialize_flashinfer_jit wraps engine construction, so it must
+        not depend on self._engine existence.
+        """
+        serialize_model.model_family.architectures = [
+            "Qwen3_5MoeForConditionalGeneration"
+        ]
+        assert not hasattr(serialize_model, "_engine")
+        with serialize_model._serialize_flashinfer_jit():
+            pass


### PR DESCRIPTION
## Summary

When deploying MoE architectures (e.g. \`Qwen3_5MoeForConditionalGeneration\`)
on GPU architectures without prebuilt flashinfer wheels (e.g. Blackwell
sm_120), multiple worker processes concurrently trigger JIT compilation
of fused_moe kernels during \`AsyncLLMEngine.from_engine_args\` (cuda graph
capture phase). flashinfer serializes JIT via \`filelock\`; if the lock
holder enters a CUDA/cutlass resource deadlock, the remaining workers
retry forever, resulting in a fleet-wide \`futex_wait_queue\` deadlock
within minutes of launch.

This PR adds a \`_serialize_flashinfer_jit()\` context manager on
\`VLLMModel\` that wraps the three \`from_engine_args\` call sites so
engine construction is serialized per-architecture.

## Approach

1. **Architecture-gated**: only MoE arches in \`_FLASHINFER_WARMUP_ARCHES\`
   frozenset (currently \`Qwen3_5MoeForConditionalGeneration\`)
2. **Cross-process lock**: \`fcntl.flock\` on
   \`{XINFERENCE_CACHE_DIR}/flashinfer_warmup/{arch}.lock\`
3. **Thread-safe timeout**: uses \`LOCK_NB\` + \`time.sleep\` polling
   (NOT \`signal.SIGALRM\`) so it works inside \`_loading_thread\` which
   runs in a non-main thread
4. **Failure mode**: on timeout, logs warning and proceeds without the
   lock (engine construction MUST proceed regardless)
5. **Kill switch**: \`XINFERENCE_DISABLE_FLASHINFER_WARMUP=1\`
6. **Windows guard**: \`if os.name == \"nt\": yield; return\`

The first process to acquire the lock compiles and fills the flashinfer
cache; subsequent processes hit the cache and pass through quickly
without racing on flashinfer's internal \`fused_moe_120.lock\`.

## Design decisions

| Decision | Choice | Rationale |
|---|---|---|
| Lock impl | \`fcntl.flock(LOCK_EX \\| LOCK_NB)\` (stdlib) | No new dep; thread-safe polling |
| Lock path | \`{cache_dir}/flashinfer_warmup/{arch}.lock\` | Per-arch, not per-model (flashinfer cache is keyed by GPU arch + kernel variant) |
| Timeout impl | \`LOCK_NB\` + \`sleep\` polling | \`signal.alarm()\` does not work in non-main threads (\`_loading_thread\`) |
| Failure mode | log warning + proceed | Engine construction MUST proceed regardless of lock acquisition |
| Kill switch | env var | Allows quick disable for debugging |
| Windows | early return | fcntl unavailable on Windows |

## Test cases

| Test | Verifies |
|---|---|
| \`test_serialize_skips_unsupported_arch\` | Non-MoE arch passthrough; no lock dir created |
| \`test_serialize_acquires_lock_for_qwen3_5_moe\` | MoE arch creates & releases lock file |
| \`test_serialize_disabled_via_env\` | Env var disables lock creation |
| \`test_serialize_releases_lock_on_exception\` | Lock released even if engine construction raises |
| \`test_serialize_yields_without_engine\` | Context manager yields regardless of \`self._engine\` state |

## Test plan

- [x] \`pytest -vv xinference/model/llm/vllm/tests/test_core_chat_model.py::TestFlashinferWarmup\` (5/5 passed)
- [x] \`pre-commit run --files xinference/model/llm/vllm/core.py xinference/model/llm/vllm/tests/test_core_chat_model.py\`
- [ ] Multi-instance PoC on Blackwell sm_120 with \`Qwen3_5MoeForConditionalGeneration\` (tracked separately; see follow-up issue)

## Out of scope

- Generalizing to other MoE architectures (extensible via the frozenset)
- Making warmup prompts configurable (YAGNI for now)
- Integrating with external precompile tools (follow-up)
- supervisor hang-detection tuning (only if construction > 600s in practice)

🤖 Generated with [Claude Code](https://claude.com/claude-code)