### PR TITLE
feat(ui): add JWT utils for permission checks

### DIFF
--- a/xinference/ui/web/ui/src/utils/jwt.js
+++ b/xinference/ui/web/ui/src/utils/jwt.js
@@ -1,0 +1,33 @@
+// JWT parsing + permission helper shared by MenuSide, PermissionGate, and
+// Monitoring. Centralizing the parsing avoids three copies drifting apart
+// when the JWT payload shape changes.
+//
+// Token lives in sessionStorage under the key `token`. The payload is the
+// middle base64 segment of a standard JWT; `scopes` is an array of strings.
+
+export function parseTokenFromSession() {
+  try {
+    const token = sessionStorage.getItem('token')
+    if (!token) return null
+    const payload = JSON.parse(atob(token.split('.')[1]))
+    const scopes = Array.isArray(payload.scopes) ? payload.scopes : []
+    return {
+      username: payload.username || payload.sub || '',
+      scopes,
+    }
+  } catch {
+    return null
+  }
+}
+
+// `admin` is a wildcard — admin users implicitly pass any scope check,
+// mirroring the backend `if "admin" in token_scopes: return` shortcut in
+// both auth_service modules.
+export function hasPermission(scopes, scope) {
+  if (!Array.isArray(scopes)) return false
+  return scopes.includes(scope) || scopes.includes('admin')
+}
+
+export function isAdmin(scopes) {
+  return Array.isArray(scopes) && scopes.includes('admin')
+}


### PR DESCRIPTION
## Summary

Adds \`utils/jwt.js\` with three helpers that the upcoming permission/scope
alignment series will build on:
- \`parseTokenFromSession()\` — reads JWT from \`sessionStorage\`, returns \`{username, scopes}\`
- \`hasPermission(scopes, scope)\` — \`admin\` wildcard bypass + scope membership check, mirroring the backend \`if \"admin\" in token_scopes\` shortcut
- \`isAdmin(scopes)\` — convenience wrapper

No behavior change yet — pure additions. Subsequent PRs in the series will wire these into \`MenuSide\`, \`router\`, and \`monitoring\`.

## Stacked PR note

This is PR 1 of 7 in a stacked series:
- C1 (this PR): \`feat/permission-jwt-utils\` → \`main\`
- C2: \`feat/permission-list-i18n\` → C1
- C3: \`feat/menu-permission-gate\` → C2
- C4: \`feat/scope-rename-alias\` → C3
- C5: \`feat/users-me-live-read\` → C4
- C6: \`feat/permission-guard\` → C5
- C7: \`feat/apikey-live-read-reveal\` → C6

Suggested merge order: C1 → C2 → C3 → C4 → C5 → C6 → C7.

## Test plan

- [x] \`cd xinference/ui/web/ui && npx eslint src/utils/jwt.js\`
- [x] \`npx prettier --check src/utils/jwt.js\`
- [ ] Manual: import in a scratch component, verify \`parseTokenFromSession\` and \`hasPermission\` behave as expected

## Out of scope

- Wiring into \`MenuSide\` / \`router\` / \`monitoring\` (PR-C3)
- Replacing JWT snapshot with live-read \`PermissionsContext\` (PR-C5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)