### PR TITLE
feat(ui): expand ALL_PERMISSIONS list and add i18n keys

### DIFF
--- a/xinference/ui/web/ui/src/locales/en.json
+++ b/xinference/ui/web/ui/src/locales/en.json
@@ -473,7 +473,10 @@
     "cache_list": "List Cache",
     "cache_delete": "Delete Cache",
     "virtualenv_list": "List Virtualenv",
-    "virtualenv_delete": "Delete Virtualenv"
+    "virtualenv_delete": "Delete Virtualenv",
+    "models_register": "Register / Unregister Models",
+    "logs_list": "View Logs",
+    "monitor_view": "View Monitoring"
   },
   "apikeyManagement": {
     "title": "API Key Management",

--- a/xinference/ui/web/ui/src/locales/ja.json
+++ b/xinference/ui/web/ui/src/locales/ja.json
@@ -466,7 +466,10 @@
     "cache_list": "キャッシュ表示",
     "cache_delete": "キャッシュ削除",
     "virtualenv_list": "仮想環境表示",
-    "virtualenv_delete": "仮想環境削除"
+    "virtualenv_delete": "仮想環境削除",
+    "models_register": "モデル登録/解除",
+    "logs_list": "ログ表示",
+    "monitor_view": "モニタリング表示"
   },
   "apikeyManagement": {
     "title": "API Key 管理",

--- a/xinference/ui/web/ui/src/locales/ko.json
+++ b/xinference/ui/web/ui/src/locales/ko.json
@@ -466,7 +466,10 @@
     "cache_list": "캐시 보기",
     "cache_delete": "캐시 삭제",
     "virtualenv_list": "가상환경 보기",
-    "virtualenv_delete": "가상환경 삭제"
+    "virtualenv_delete": "가상환경 삭제",
+    "models_register": "모델 등록/해제",
+    "logs_list": "로그 보기",
+    "monitor_view": "모니터링 보기"
   },
   "apikeyManagement": {
     "title": "API Key 관리",

--- a/xinference/ui/web/ui/src/locales/zh.json
+++ b/xinference/ui/web/ui/src/locales/zh.json
@@ -473,7 +473,10 @@
     "cache_list": "查看缓存",
     "cache_delete": "删除缓存",
     "virtualenv_list": "查看虚拟环境",
-    "virtualenv_delete": "删除虚拟环境"
+    "virtualenv_delete": "删除虚拟环境",
+    "models_register": "注册/注销模型",
+    "logs_list": "查看日志",
+    "monitor_view": "查看监控"
   },
   "apikeyManagement": {
     "title": "API Key 管理",

--- a/xinference/ui/web/ui/src/scenes/user_management/index.js
+++ b/xinference/ui/web/ui/src/scenes/user_management/index.js
@@ -32,11 +32,16 @@ import Title from '../../components/Title'
 
 const ALL_PERMISSIONS = [
   { group: 'admin', items: ['admin'] },
-  { group: 'models', items: ['models:list', 'models:read', 'models:write'] },
+  {
+    group: 'models',
+    items: ['models:list', 'models:read', 'models:write', 'models:register'],
+  },
   { group: 'keys', items: ['keys:create', 'keys:manage'] },
   { group: 'users', items: ['users:manage'] },
   { group: 'cache', items: ['cache:list', 'cache:delete'] },
   { group: 'virtualenv', items: ['virtualenv:list', 'virtualenv:delete'] },
+  { group: 'logs', items: ['logs:list'] },
+  { group: 'monitor', items: ['monitor:view'] },
 ]
 
 const ALL_PERMISSION_VALUES = ALL_PERMISSIONS.flatMap((g) => g.items)


### PR DESCRIPTION
## Summary

Adds three new permissions to the user management UI so the upcoming scope alignment series can wire backend routes to them:
- \`models:register\` (in \`models\` group)
- \`logs:list\` (new \`logs\` group)
- \`monitor:view\` (new \`monitor\` group)

Adds matching \`permissions.*\` i18n keys in en/zh/ja/ko locales.

No behavior change yet — admins can now assign the new scopes, but no frontend or backend code consumes them until subsequent PRs land.

## Depends on

- #5131 (PR-C1: must merge first)

## Stacked PR note

PR 2 of 7. Base branch: \`feat/permission-jwt-utils\`. Once #5131 merges, this PR will be retargeted to \`main\`.

Suggested merge order: C1 (#5131) → C2 (this PR) → C3 → C4 → C5 → C6 → C7.

## Test plan

- [x] \`cd xinference/ui/web/ui && npx eslint src/scenes/user_management/index.js\`
- [x] \`npx prettier --check src/scenes/user_management/index.js src/locales/{en,zh,ja,ko}.json\`
- [ ] Manual: log in as admin, open user management, verify the 3 new permission entries appear with localized labels in all 4 locales

## Out of scope

- Backend route scope renames (PR-C4)
- Menu visibility by permission (PR-C3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)