### PR TITLE
fix(auth): advanced-auth live-read via DB-current permissions

### DIFF
--- a/doc/source/user_guide/auth_system.rst
+++ b/doc/source/user_guide/auth_system.rst
@@ -165,6 +165,36 @@ Add the following two HTTP status codes:
 For the command line, SDK, or web UI users, there will be clear information prompts when encountering authorization and permissions issues.
 
 
+Advanced authentication (DB-backed)
+====================================
+When the advanced authentication system is enabled, users, permissions, API
+keys, and refresh tokens are stored in a database rather than the static
+``auth_config.json`` file. This section documents two behaviors that
+operators should know.
+
+Permission changes take effect without re-login
+-----------------------------------------------
+For advanced-auth JWT requests, route scope checks read the user's
+**current** permissions from the database on every request, not the
+scopes baked into the JWT at login. Granting or revoking a permission
+takes effect on the user's next API call — no re-login required.
+
+This applies to JWT-based browser sessions. API keys are also live-read
+(they always have been).
+
+Configurable access-token lifetime
+-----------------------------------
+The access-token lifetime defaults to 30 minutes and can be overridden
+with the ``XINFERENCE_ACCESS_TOKEN_EXPIRE_MINUTES`` environment variable:
+
+.. code-block::
+
+    export XINFERENCE_ACCESS_TOKEN_EXPIRE_MINUTES=10
+
+A shorter lifetime shrinks the token-theft window. The refresh token
+lifetime is 7 days and is not currently configurable.
+
+
 Note
 ====
 This feature is still in an experimental stage.

--- a/xinference/api/oauth2/advanced/auth_service.py
+++ b/xinference/api/oauth2/advanced/auth_service.py
@@ -70,9 +70,19 @@ def _get_client_ip(request: Request) -> str:
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token", auto_error=False)
 
-ACCESS_TOKEN_EXPIRE_MINUTES = int(
-    os.environ.get("XINFERENCE_ACCESS_TOKEN_EXPIRE_MINUTES", "30")
-)
+try:
+    ACCESS_TOKEN_EXPIRE_MINUTES = int(
+        os.environ.get("XINFERENCE_ACCESS_TOKEN_EXPIRE_MINUTES", "30")
+    )
+    if ACCESS_TOKEN_EXPIRE_MINUTES <= 0:
+        raise ValueError("must be positive")
+except (TypeError, ValueError):
+    logger.warning(
+        "XINFERENCE_ACCESS_TOKEN_EXPIRE_MINUTES must be a positive integer "
+        "(got %r); falling back to 30 minutes.",
+        os.environ.get("XINFERENCE_ACCESS_TOKEN_EXPIRE_MINUTES"),
+    )
+    ACCESS_TOKEN_EXPIRE_MINUTES = 30
 REFRESH_TOKEN_EXPIRE_DAYS = 7
 JWT_ALGORITHM = "HS256"
 

--- a/xinference/api/oauth2/advanced/auth_service.py
+++ b/xinference/api/oauth2/advanced/auth_service.py
@@ -591,11 +591,23 @@ class AdvancedAuthService:
         if api_key_entry:
             return api_key_entry.has_model_access(model_uid, model_type)
         payload = self.verify_access_token(token)
-        if payload:
-            scopes = payload.get("scopes", [])
-            if "admin" in scopes or "models:read" in scopes:
-                return True
-        return False
+        if not payload:
+            return False
+        # Live-read: use DB-current permissions for consistency with the
+        # route-level scope check in __call__. Otherwise an admin granting
+        # models:read after login would pass Security(scopes=["models:read"])
+        # but still 403 here because the JWT snapshot lacks it.
+        user_id = payload.get("user_id")
+        username = payload.get("sub")
+        user = None
+        if user_id:
+            user = self._db.get_user_by_id(user_id)
+        elif username:
+            user = self._db.get_user_by_username(username)
+        if not user or not user.get("enabled"):
+            return False
+        db_scopes = user.get("permissions", [])
+        return "admin" in db_scopes or "models:read" in db_scopes
 
     # --- User disable cascade ---
 

--- a/xinference/api/oauth2/advanced/auth_service.py
+++ b/xinference/api/oauth2/advanced/auth_service.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import base64
 import logging
+import os
 import secrets
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional
@@ -69,7 +70,9 @@ def _get_client_ip(request: Request) -> str:
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token", auto_error=False)
 
-ACCESS_TOKEN_EXPIRE_MINUTES = 30
+ACCESS_TOKEN_EXPIRE_MINUTES = int(
+    os.environ.get("XINFERENCE_ACCESS_TOKEN_EXPIRE_MINUTES", "30")
+)
 REFRESH_TOKEN_EXPIRE_DAYS = 7
 JWT_ALGORITHM = "HS256"
 
@@ -552,9 +555,14 @@ class AdvancedAuthService:
                 _audit("success", user=username or "", auth_type="jwt")
             return user
 
-        token_scopes = _normalize_scopes(token_scopes)
+        # Live-read: use DB-current permissions (already loaded above) instead
+        # of the JWT snapshot. The advanced-auth path loads the user from DB on
+        # every request to verify existence/enabled, so user["permissions"] is
+        # already in hand at zero extra DB cost. This makes admin permission
+        # changes take effect on the next request rather than the next login.
+        db_scopes = _normalize_scopes(user.get("permissions", []))
         for scope in security_scopes.scopes:
-            if scope not in token_scopes:
+            if scope not in db_scopes:
                 _audit("insufficient_scope", user=username or "", auth_type="jwt")
                 raise HTTPException(
                     status_code=status.HTTP_403_FORBIDDEN,

--- a/xinference/api/tests/test_oauth2_advanced_live_read.py
+++ b/xinference/api/tests/test_oauth2_advanced_live_read.py
@@ -166,3 +166,35 @@ def test_refresh_token_rotation_invalidates_old(auth_service):
 
     second = auth_service.refresh_access_token(refresh_token)
     assert second is None
+
+
+def test_validate_model_access_grant_after_login(auth_service):
+    """``validate_model_access`` reflects DB-current permissions for JWTs.
+
+    If admin grants ``models:read`` after login, the JWT still lacks it,
+    but ``validate_model_access`` must read DB and grant access — otherwise
+    the route-level ``Security(scopes=["models:read"])`` would pass while
+    ``_check_model_access`` 403s, leaving the grant ineffective for
+    inference endpoints.
+    """
+    user_id = _create_user(auth_service, "erin", [])
+    token = auth_service.create_access_token(user_id, "erin", [])
+    # Admin grants models:read in DB after login.
+    auth_service.db.set_user_permissions(user_id, ["models:read"])
+
+    assert auth_service.validate_model_access(token, "any-model", "LLM") is True
+
+
+def test_validate_model_access_revoke_after_login(auth_service):
+    """Revocation must also take effect in ``validate_model_access``.
+
+    JWT still carries ``models:read`` (snapshot), but DB revoked it.
+    ``validate_model_access`` must return False so the model request is
+    denied, consistent with the route-level DB scope check.
+    """
+    user_id = _create_user(auth_service, "frank", ["models:read"])
+    token = auth_service.create_access_token(user_id, "frank", ["models:read"])
+    # Admin revokes models:read in DB after login.
+    auth_service.db.set_user_permissions(user_id, [])
+
+    assert auth_service.validate_model_access(token, "any-model", "LLM") is False

--- a/xinference/api/tests/test_oauth2_advanced_live_read.py
+++ b/xinference/api/tests/test_oauth2_advanced_live_read.py
@@ -1,0 +1,168 @@
+"""Regression tests for advanced-auth live-read permission enforcement.
+
+Verifies that ``AdvancedAuthService.__call__`` checks route scopes against
+the user's DB-current permissions rather than the scopes baked into the JWT.
+This makes admin permission changes (grant/revoke) take effect on the next
+request instead of requiring the user to re-login.
+
+Also covers the refresh path: ``refresh_access_token`` must re-read
+permissions from DB and bake them into the new access token, with refresh
+token rotation invalidating the old token.
+
+    pytest xinference/api/tests/test_oauth2_advanced_live_read.py -v
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+from fastapi.security import SecurityScopes
+from jose import jwt
+
+from xinference.api.oauth2.advanced.auth_service import (
+    JWT_ALGORITHM,
+    AdvancedAuthService,
+)
+
+
+def _make_request(path: str = "/v1/admin/keys"):
+    request = MagicMock()
+    request.url.path = path
+    request.method = "GET"
+    request.headers = {"content-type": "application/json", "content-length": "0"}
+    request.client.host = "127.0.0.1"
+    request.body = AsyncMock(return_value=b"{}")
+    return request
+
+
+@pytest.fixture
+def auth_service(tmp_path):
+    db_path = str(tmp_path / "auth.db")
+    service = AdvancedAuthService(
+        db_path=db_path,
+        jwt_secret_key="unit-test-secret",
+        encryption_key="unit-test-encryption-key",
+    )
+    return service
+
+
+def _create_user(auth_service, username, permissions):
+    from xinference.api.oauth2.advanced.crypto import get_password_hash
+
+    user_id = auth_service.db.create_user(
+        username=username,
+        password_hash=get_password_hash("pass"),
+        source="local",
+        enabled=1,
+        must_change_password=0,
+        permissions=permissions,
+    )
+    return user_id
+
+
+@pytest.mark.asyncio
+async def test_jwt_scope_check_uses_db_permissions_revoke(auth_service):
+    """JWT has ``keys:create`` but DB revoked it → 403.
+
+    Proves the scope check reads DB-current permissions, not the JWT
+    snapshot. Without live-read, this request would succeed (JWT still
+    has ``keys:create``) and the revocation wouldn't take effect until
+    token expiry.
+    """
+    user_id = _create_user(auth_service, "alice", ["keys:create", "models:read"])
+    token = auth_service.create_access_token(
+        user_id, "alice", ["keys:create", "models:read"]
+    )
+    # Admin revokes keys:create in the DB after login.
+    auth_service.db.set_user_permissions(user_id, ["models:read"])
+
+    with pytest.raises(HTTPException) as exc:
+        await auth_service(
+            _make_request(),
+            SecurityScopes(scopes=["keys:create"]),
+            token,
+        )
+    assert exc.value.status_code == 403
+    assert exc.value.detail == "Not enough permissions"
+
+
+@pytest.mark.asyncio
+async def test_jwt_scope_check_uses_db_permissions_grant(auth_service):
+    """JWT lacks ``keys:create`` but DB granted it → 200.
+
+    The mirror of the revoke case: a newly-granted permission takes effect
+    immediately on the next request, without waiting for token refresh.
+    """
+    user_id = _create_user(auth_service, "bob", ["models:read"])
+    token = auth_service.create_access_token(user_id, "bob", ["models:read"])
+    # Admin grants keys:create in the DB after login.
+    auth_service.db.set_user_permissions(user_id, ["models:read", "keys:create"])
+
+    user = await auth_service(
+        _make_request(),
+        SecurityScopes(scopes=["keys:create"]),
+        token,
+    )
+    assert user["username"] == "bob"
+
+
+@pytest.mark.asyncio
+async def test_admin_bypass_still_uses_jwt(auth_service):
+    """Admin bypass at L550 checks JWT scopes, not DB permissions.
+
+    This is by design: the ``admin`` wildcard stays in the JWT and cannot
+    be revoked mid-session via DB changes. If a deployment needs to
+    revoke admin mid-session, that's a separate issue (e.g., disable the
+    user account, which IS checked against DB at L546).
+    """
+    user_id = _create_user(auth_service, "admin2", ["admin", "models:read"])
+    token = auth_service.create_access_token(
+        user_id, "admin2", ["admin", "models:read"]
+    )
+    # Even if DB no longer lists admin, the JWT still carries it.
+    auth_service.db.set_user_permissions(user_id, ["models:read"])
+
+    user = await auth_service(
+        _make_request(),
+        SecurityScopes(scopes=["users:manage"]),
+        token,
+    )
+    assert user["username"] == "admin2"
+
+
+def test_refresh_re_reads_permissions_from_db(auth_service):
+    """``refresh_access_token`` bakes DB-current permissions into the new JWT.
+
+    Independent of the live-read scope check, the refresh path must also
+    re-read permissions so that tokens issued post-refresh reflect the
+    latest DB state.
+    """
+    user_id = _create_user(auth_service, "carol", ["models:read"])
+    refresh_token = auth_service.create_refresh_token(user_id)
+    # Grant keys:create after the initial refresh token was issued.
+    auth_service.db.set_user_permissions(user_id, ["models:read", "keys:create"])
+
+    result = auth_service.refresh_access_token(refresh_token)
+    assert result is not None
+    payload = jwt.decode(
+        result["access_token"],
+        "unit-test-secret",
+        algorithms=[JWT_ALGORITHM],
+    )
+    assert "keys:create" in payload["scopes"]
+    assert "models:read" in payload["scopes"]
+
+
+def test_refresh_token_rotation_invalidates_old(auth_service):
+    """Refresh token rotation: the old refresh token is invalidated on use.
+
+    A second refresh with the same (now-rotated) refresh token must fail.
+    """
+    user_id = _create_user(auth_service, "dave", ["models:read"])
+    refresh_token = auth_service.create_refresh_token(user_id)
+
+    first = auth_service.refresh_access_token(refresh_token)
+    assert first is not None
+
+    second = auth_service.refresh_access_token(refresh_token)
+    assert second is None

--- a/xinference/ui/web/ui/src/components/MenuSide.js
+++ b/xinference/ui/web/ui/src/components/MenuSide.js
@@ -90,15 +90,32 @@ const MenuSide = () => {
       })
       .catch(() => setEsEnabled(false))
 
-    // Parse username + scopes from JWT token (live-read via
-    // PermissionsContext lands in a follow-up PR; for now JWT snapshot
-    // is sufficient because the backend still enforces scopes).
+    // Parse username + scopes from JWT token. The backend (advanced auth)
+    // enforces scopes against DB-current permissions on every request, so
+    // the menu's role is just to reflect what the current token allows.
     const parsed = parseTokenFromSession()
     if (parsed) {
       setCurrentUser(parsed.username)
       setScopes(parsed.scopes)
     }
   }, [endPoint])
+
+  // Re-parse JWT when the access token is refreshed by fetchWrapper, so the
+  // menu recomputes permission-gated items without a page reload.
+  useEffect(() => {
+    const handler = () => {
+      const parsed = parseTokenFromSession()
+      if (parsed) {
+        setCurrentUser(parsed.username)
+        setScopes(parsed.scopes)
+      } else {
+        setScopes([])
+        setCurrentUser('')
+      }
+    }
+    window.addEventListener('auth-refreshed', handler)
+    return () => window.removeEventListener('auth-refreshed', handler)
+  }, [])
 
   const navItems = [
     {

--- a/xinference/ui/web/ui/src/components/fetchWrapper.js
+++ b/xinference/ui/web/ui/src/components/fetchWrapper.js
@@ -53,6 +53,9 @@ const tryRefreshToken = async () => {
           sessionStorage.setItem('refresh_token', data.refresh_token)
         }
         processQueue(true)
+        // Notify listeners (e.g., MenuSide) that the token was refreshed so
+        // they can re-read permissions from the new JWT without a page reload.
+        window.dispatchEvent(new Event('auth-refreshed'))
         return true
       }
       processQueue(false)


### PR DESCRIPTION
## Summary

Closes #5134.

Implements the plan @qinxuye approved in [issue #5134](https://github.com/xorbitsai/inference/issues/5134#issuecomment-4882053727): for advanced-auth JWT requests, the route scope check now reads the user's **DB-current** permissions instead of the scopes baked into the JWT. Admin permission changes (grant/revoke) take effect on the user's next request — no re-login required.

### Why this works at zero extra DB cost

The advanced-auth `__call__` path already loads the user from DB on every JWT request (`auth_service.py:534-536`) to verify the user still exists and is enabled. That DB row already contains `permissions`, so switching the scope check from `token_scopes` to `user["permissions"]` is a one-field change with no additional DB query. (My earlier claim that Option A would add per-request DB cost was wrong — I had conflated the basic-auth path, which uses in-memory `user_config`, with the advanced-auth path, which already hits the DB. Thanks to @qinxuye for the correction.)

## Changes

### Backend

**1. `xinference/api/oauth2/advanced/auth_service.py:558-569` — scope check uses DB permissions**

```python
# before
token_scopes = _normalize_scopes(token_scopes)
for scope in security_scopes.scopes:
    if scope not in token_scopes:
        ...

# after
db_scopes = _normalize_scopes(user.get("permissions", []))
for scope in security_scopes.scopes:
    if scope not in db_scopes:
        ...
```

- `user` is already loaded at L534-536 (DB row, includes `permissions`).
- Admin bypass at L550 still uses `token_scopes` — unchanged by design (the `admin` wildcard stays in the JWT; if mid-session admin revocation is needed, disable the user account, which IS checked against DB at L546).
- Basic auth path (`oauth2/auth_service.py`) untouched — no DB, snapshot semantics.

**2. `xinference/api/oauth2/advanced/auth_service.py:72` — configurable access-token lifetime**

```python
ACCESS_TOKEN_EXPIRE_MINUTES = int(
    os.environ.get("XINFERENCE_ACCESS_TOKEN_EXPIRE_MINUTES", "30")
)
```

Default unchanged at 30. With live-read, shorter lifetime is no longer load-bearing for permission propagation — it's pure hardening. Deployments can tighten the token-theft window independently via env var.

### Frontend

**3. `fetchWrapper.js` — emit `auth-refreshed` event after successful refresh**

```js
processQueue(true)
window.dispatchEvent(new Event('auth-refreshed'))
return true
```

**4. `MenuSide.js` — re-parse JWT on `auth-refreshed`**

Adds a `useEffect` that listens for `auth-refreshed` and calls `parseTokenFromSession()` + `setScopes()` / `setCurrentUser()`, so permission-gated menu items recompute without a page reload.

## Known limitation (pre-existing, not a regression)

Direct `fetch()` calls outside `fetchWrapper` (in `logs`, `security_settings`, `change_password`, `monitoring/MonitorConfigDialog`, `apikey_management`) do not auto-refresh on token expiry. This is pre-existing behavior — those pages signal `auth-status=401` and prompt re-login.

With this PR, those paths still get **correct permission enforcement** while the token is valid (the backend now checks DB permissions, so even a stale-scope JWT gets the right answer). Converting these direct-fetch paths to go through `fetchWrapper` is a follow-up cleanup, out of scope for #5134.

## Tests

New file `xinference/api/tests/test_oauth2_advanced_live_read.py` (5 tests, all passing):

- `test_jwt_scope_check_uses_db_permissions_revoke` — JWT has `keys:create`, DB revoked it → 403. Proves scope check reads DB, not JWT.
- `test_jwt_scope_check_uses_db_permissions_grant` — JWT lacks `keys:create`, DB granted it → 200. Newly-granted permission works immediately.
- `test_admin_bypass_still_uses_jwt` — admin bypass checks JWT, not DB (documents the L550 design choice).
- `test_refresh_re_reads_permissions_from_db` — `refresh_access_token` bakes DB-current permissions into the new access token.
- `test_refresh_token_rotation_invalidates_old` — second refresh with the rotated refresh token fails.

Existing auth tests (32 in `test_oauth2_token_expiration`, `test_oauth2_admin_target_takeover`, `test_oauth2_permission_escalation`, `test_oauth2_scope_alias_migration`) all still pass — no regression.

## Compatibility

- Existing 30-min access tokens remain valid until natural expiry; with live-read, their scopes are no longer authoritative, so behavior flips to live-read immediately on deploy.
- Refresh tokens (7 days) continue working.
- No forced logout on upgrade.
- Default `ACCESS_TOKEN_EXPIRE_MINUTES=30` unchanged — deployments wanting the old behavior need do nothing.

## Out of scope

- Basic auth path (`oauth2/auth_service.py`) — no DB, snapshot semantics, unchanged.
- `/v1/users/me` endpoint (C5 from the original mega-PR) — not needed; backend live-read + frontend `auth-refreshed` event cover the use case.
- Refresh-token lifetime / JWT algorithm — unchanged.
- Converting direct-`fetch()` pages to `fetchWrapper` — follow-up.

## Test plan

- [x] `pytest xinference/api/tests/test_oauth2_advanced_live_read.py -vv` — 5 passed
- [x] `pytest xinference/api/tests/test_oauth2_{token_expiration,admin_target_takeover,permission_escalation,scope_alias_migration}.py -vv` — 32 passed, no regression
- [ ] Manual UI verification: login → admin changes permissions in another tab → menu updates after next API call triggers a refresh (requires running the full stack; not done in this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)