### PR TITLE
ci: narrow GPU test group detection to paths that actually affect GPU tests

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -94,8 +94,8 @@ jobs:
             full=true
           else
             # Map each changed path to the GPU test group(s) it affects.
-            # Paths matching no pattern (docs, examples, web UI, deploy
-            # configs, other workflows, ...) do not need GPU CI at all.
+            # Paths matching no pattern (docs, examples, web UI, other
+            # workflows, ...) do not need GPU CI at all.
             while IFS= read -r file; do
               case "$file" in
                 xinference/model/audio/*) audio=true ;;
@@ -110,9 +110,10 @@ jobs:
                 # Every GPU test launches models through a real RESTful API
                 # server subprocess and the xinference/client/ package (see
                 # conftest.py's `setup` fixture), so changes to either affect
-                # every family. xinference/core/ is the actor runtime shared
-                # by every model family. Any of the three affects every group.
-                xinference/core/*|xinference/api/*|xinference/client/*) full=true; break ;;
+                # every family. The same fixture starts the test cluster through
+                # xinference/deploy/, and xinference/core/ is the actor runtime
+                # shared by every model family. Any of these affects every group.
+                xinference/core/*|xinference/api/*|xinference/client/*|xinference/deploy/*) full=true; break ;;
                 # Model families not broken out above (flexible, video, ...)
                 # and top-level files directly under xinference/model/ have
                 # no dedicated GPU test group; play it safe and run every group.

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -94,8 +94,8 @@ jobs:
             full=true
           else
             # Map each changed path to the GPU test group(s) it affects.
-            # Paths matching no pattern (docs, examples, web UI, other
-            # workflows, ...) do not need GPU CI at all.
+            # Paths matching no pattern (docs, examples, web UI, deploy
+            # configs, other workflows, ...) do not need GPU CI at all.
             while IFS= read -r file; do
               case "$file" in
                 xinference/model/audio/*) audio=true ;;
@@ -107,9 +107,19 @@ jobs:
                 xinference/thirdparty/*) audio=true ;;
                 # The web UI never affects GPU tests.
                 xinference/ui/*) ;;
-                # Anything else in the package, the build config, or this
-                # workflow affects every family.
-                .github/workflows/python.yaml|setup.py|setup.cfg|pyproject.toml|xinference/*) full=true; break ;;
+                # Every GPU test launches models through a real RESTful API
+                # server subprocess and the xinference/client/ package (see
+                # conftest.py's `setup` fixture), so changes to either affect
+                # every family. xinference/core/ is the actor runtime shared
+                # by every model family. Any of the three affects every group.
+                xinference/core/*|xinference/api/*|xinference/client/*) full=true; break ;;
+                # Model families not broken out above (flexible, video, ...)
+                # and top-level files directly under xinference/model/ have
+                # no dedicated GPU test group; play it safe and run every group.
+                xinference/model/*) full=true; break ;;
+                # The rest of the package (deploy/, docs, examples, other
+                # top-level modules) is not exercised by any GPU test.
+                .github/workflows/python.yaml|setup.py|setup.cfg|pyproject.toml) full=true; break ;;
               esac
             done < changed-files.txt
           fi


### PR DESCRIPTION
## Summary

- The `changes` job's diff-to-group mapping fell back to a full GPU run (`llm embedding image audio`) for **any** changed path under `xinference/` via a blanket `xinference/*` catch-all — including paths no GPU test ever executes, like `xinference/deploy/` or other top-level modules with no dedicated test group. That wastes billed `gpu-t4` runner minutes on changes the GPU suite can't observe.
- Verified which paths GPU tests actually exercise before narrowing anything: `conftest.py`'s `setup` fixture spins up a real `xinference/api/restful_api.py` server subprocess, and essentially every GPU test (continuous batching, embedding, image, all 9 audio files) talks to it through `xinference/client/`. So `xinference/core/*` (the actor runtime shared by every model family), `xinference/api/*`, and `xinference/client/*` all still need to trigger every group — narrowing those away would have created real blind spots.
- Added an explicit fallback for model families with no dedicated GPU test group (`xinference/model/flexible/*`, `xinference/model/video/*`, ...) and top-level files directly under `xinference/model/` (`batch.py`, `core.py`, ...): still runs every group, erring on the side of caution rather than silently skipping GPU CI for untested families.
- Paths outside all of the above (`xinference/deploy/*`, and any other top-level module not covered by an existing pattern) no longer force a full run.

## Test plan
- [x] Simulated the new `case` matching logic against representative path sets (single-family changes, `core`/`api`/`client` changes, unclassified `model/` families, `deploy/`-only changes, mixed changes) and confirmed the `gpu`/`groups` outputs match the intended behavior.
- [ ] Not run: an actual GitHub Actions run (requires a real PR diff against `main` to exercise `git diff`) — please confirm the `changes` job output on this PR looks correct.