### PR TITLE
fix(embedding): implement truncate_prompt_tokens and prevent OOM zombie replicas

### DIFF
--- a/xinference/api/schemas/requests.py
+++ b/xinference/api/schemas/requests.py
@@ -28,6 +28,11 @@ class CreateEmbeddingRequest(BaseModel):
         str, List[str], List[int], List[List[int]], Dict[str, str], List[Dict[str, str]]
     ] = Field(description="The input to embed.")
     user: Optional[str] = None
+    # Truncate each input to this many tokens before encoding. Mirrors the
+    # vLLM LLM semantics: None = no truncation, >0 = cap at N tokens,
+    # <0 = cap at the model's max_tokens. Honored by the embedding model base
+    # class (see ``EmbeddingModel._truncate_sentences``).
+    truncate_prompt_tokens: Optional[int] = None
 
     class Config:
         schema_extra = {

--- a/xinference/api/tests/test_embedding_truncate.py
+++ b/xinference/api/tests/test_embedding_truncate.py
@@ -1,0 +1,73 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the ``truncate_prompt_tokens`` field on CreateEmbeddingRequest.
+
+Validates the schema contract: the field exists, defaults to None, and
+accepts valid integer values (positive, negative, and None).
+"""
+
+from ..schemas.requests import CreateEmbeddingRequest
+
+
+class TestCreateEmbeddingRequestTruncateField:
+    """Schema-level validation for the truncate_prompt_tokens field."""
+
+    def test_default_is_none(self):
+        """Field must default to None so existing clients are unaffected."""
+        req = CreateEmbeddingRequest(model="m", input="hello")
+        assert req.truncate_prompt_tokens is None
+
+    def test_accepts_positive_int(self):
+        req = CreateEmbeddingRequest(
+            model="m", input="hello", truncate_prompt_tokens=512
+        )
+        assert req.truncate_prompt_tokens == 512
+
+    def test_accepts_negative_int(self):
+        req = CreateEmbeddingRequest(
+            model="m", input="hello", truncate_prompt_tokens=-1
+        )
+        assert req.truncate_prompt_tokens == -1
+
+    def test_accepts_none_explicit(self):
+        req = CreateEmbeddingRequest(
+            model="m", input="hello", truncate_prompt_tokens=None
+        )
+        assert req.truncate_prompt_tokens is None
+
+    def test_accepts_zero(self):
+        """Zero is a valid (though unusual) token limit."""
+        req = CreateEmbeddingRequest(model="m", input="hello", truncate_prompt_tokens=0)
+        assert req.truncate_prompt_tokens == 0
+
+    def test_accepts_str_int_coerced(self):
+        """pydantic coerces the string ``"512"`` to int for Optional[int]
+        fields — this is normal pydantic lenient-coercion behaviour and must
+        not raise."""
+        req = CreateEmbeddingRequest(
+            model="m", input="hello", truncate_prompt_tokens="512"
+        )
+        assert req.truncate_prompt_tokens == 512
+
+    def test_passes_through_to_kwargs(self):
+        """The field must be present in the request body when serialised, so
+        the ``create_embedding`` handler can pop it from kwargs."""
+        import json
+
+        req = CreateEmbeddingRequest(
+            model="m", input="hello", truncate_prompt_tokens=128
+        )
+        body = json.loads(req.json())
+        assert body.get("truncate_prompt_tokens") == 128

--- a/xinference/core/tests/test_worker.py
+++ b/xinference/core/tests/test_worker.py
@@ -1489,3 +1489,136 @@ async def test_recover_model_pops_launch_ts_from_kwargs():
         assert launch_args["launch_ts"] == 1780900592
     finally:
         worker_module.parse_replica_model_uid = original_parse
+
+
+class _RecordingSupervisorRef:
+    """Minimal supervisor ref that records mark_replica_dead calls (B2)."""
+
+    def __init__(self):
+        self.evicted: List[str] = []
+
+    async def mark_replica_dead(self, replica_model_uid: str):
+        self.evicted.append(replica_model_uid)
+
+
+class _EvictMockWorker:
+    """Minimal worker stand-in for _evict_replica_from_supervisor tests."""
+
+    def __init__(self, supervisor_ref=None, raise_on_get: bool = False):
+        self._supervisor_ref = supervisor_ref
+        self._raise_on_get = raise_on_get
+
+    async def get_supervisor_ref(self, add_worker: bool = False):
+        if self._raise_on_get:
+            raise RuntimeError("supervisor unreachable")
+        return self._supervisor_ref
+
+
+@pytest.mark.asyncio
+async def test_evict_replica_from_supervisor_calls_mark_replica_dead():
+    """B2 helper: notifies the supervisor to evict the dead replica."""
+    sup = _RecordingSupervisorRef()
+    worker = _EvictMockWorker(supervisor_ref=sup)
+    await WorkerActor._evict_replica_from_supervisor(worker, "model-x-1")
+    assert sup.evicted == ["model-x-1"]
+
+
+@pytest.mark.asyncio
+async def test_evict_replica_from_supervisor_is_non_fatal():
+    """B2 helper: a supervisor-ref failure must not propagate out of the
+    recover_sub_pool tail path (non-fatal; next death/redeploy reconciles)."""
+    worker = _EvictMockWorker(supervisor_ref=None, raise_on_get=True)
+    # Must not raise.
+    await WorkerActor._evict_replica_from_supervisor(worker, "model-x-1")
+
+
+class _MainPoolStub:
+    async def remove_sub_pool(self, address):
+        return None
+
+
+class _RecoverWorkerStub:
+    """Worker stand-in for recover_sub_pool unbounded-branch tests.
+
+    recover_model is overridden per-test (raise vs succeed). The real
+    `_evict_replica_from_supervisor` is bound onto the instance so the
+    recover_sub_pool call exercises the genuine eviction path.
+    """
+
+    def __init__(self, supervisor_ref, recover_raises: bool):
+        self._supervisor_ref = supervisor_ref
+        self._recover_raises = recover_raises
+        self.recover_called = 0
+        # Wiring used by recover_sub_pool:
+        self._main_pool = _MainPoolStub()
+        self._model_uid_to_addr = {"model-x-0": "addr-1"}
+        self._model_uid_to_launch_args = {
+            "model-x-0": {"model_uid": "model-x-0", "model_name": "m"},
+        }
+        self._model_uid_to_recover_count = {"model-x-0": None}  # unbounded branch
+        self._model_uid_to_subpool_pids: dict = {}
+
+    async def get_supervisor_ref(self, add_worker: bool = False):
+        return self._supervisor_ref
+
+    async def terminate_model(self, model_uid, is_model_die: bool = False):
+        return None
+
+    async def recover_model(self, launch_args):
+        self.recover_called += 1
+        if self._recover_raises:
+            raise RuntimeError("recreate failed (e.g. OOM during reload)")
+
+
+def _bind_real_evict(worker):
+    import types
+
+    worker._evict_replica_from_supervisor = types.MethodType(
+        WorkerActor._evict_replica_from_supervisor, worker
+    )
+    return worker
+
+
+@pytest.mark.asyncio
+async def test_recover_sub_pool_unbounded_evicts_on_recover_failure(monkeypatch):
+    """B2 (core): in the default unbounded branch (recover_count is None), a
+    recreate that raises must evict the dead replica via mark_replica_dead, so
+    it cannot poison routing as a permanent 'loading' zombie (the 33% error
+    root cause)."""
+    import xinference.core.worker as worker_module
+
+    # Neutralize GPU/persist machinery for a deterministic, GPU-free test.
+    monkeypatch.setattr(worker_module, "_strip_test_envs", lambda args: (args, set()))
+    monkeypatch.setattr(worker_module, "_parse_gpu_indices", lambda x: [])
+    monkeypatch.setattr(worker_module, "_snapshot_gpu_free_ratio", lambda idx: 1.0)
+
+    sup = _RecordingSupervisorRef()
+    worker = _bind_real_evict(
+        _RecoverWorkerStub(supervisor_ref=sup, recover_raises=True)
+    )
+
+    await WorkerActor.recover_sub_pool(worker, "addr-1")
+
+    assert worker.recover_called == 1
+    assert sup.evicted == ["model-x-0"]  # recreate failed -> evicted
+
+
+@pytest.mark.asyncio
+async def test_recover_sub_pool_unbounded_no_evict_on_success(monkeypatch):
+    """B2 regression: a successful recreate in the unbounded branch must NOT
+    evict (infinite-retry-on-success semantics preserved)."""
+    import xinference.core.worker as worker_module
+
+    monkeypatch.setattr(worker_module, "_strip_test_envs", lambda args: (args, set()))
+    monkeypatch.setattr(worker_module, "_parse_gpu_indices", lambda x: [])
+    monkeypatch.setattr(worker_module, "_snapshot_gpu_free_ratio", lambda idx: 1.0)
+
+    sup = _RecordingSupervisorRef()
+    worker = _bind_real_evict(
+        _RecoverWorkerStub(supervisor_ref=sup, recover_raises=False)
+    )
+
+    await WorkerActor.recover_sub_pool(worker, "addr-1")
+
+    assert worker.recover_called == 1
+    assert sup.evicted == []  # succeeded -> not evicted

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -786,41 +786,57 @@ class WorkerActor(xo.StatelessActor):
                         else:
                             logger.warning("Stop recreating model actor.")
 
-                            # Worker has given up recreating; notify supervisor
-                            # to evict the dead replica from round-robin and
-                            # light up the failure gauge. add_worker=False:
-                            # only fetch the ref, do not trigger
-                            # re-registration. The whole notification --
-                            # get_supervisor_ref + mark_replica_dead -- is
-                            # wrapped in a single xo.wait_for(5s): this runs
-                            # inside the recover_sub_pool tail path, and
-                            # get_supervisor_ref itself issues blocking
-                            # xo.actor_ref calls when the cached ref is missing,
-                            # so the bound must cover both to keep a stalled
-                            # supervisor from holding up the worker's local
-                            # shutdown. A failure/timeout is non-fatal -- the
+                            # Bounded retries exhausted: evict the dead replica
+                            # from the supervisor's round-robin so traffic stops
+                            # routing to it. Failure/timeout is non-fatal -- the
                             # next death detection / redeploy will reconcile.
-                            async def _notify_replica_dead():
-                                supervisor_ref = await self.get_supervisor_ref(
-                                    add_worker=False
-                                )
-                                await supervisor_ref.mark_replica_dead(model_uid)
-
-                            try:
-                                await xo.wait_for(
-                                    _notify_replica_dead(),
-                                    timeout=5,
-                                )
-                            except Exception:
-                                logger.warning(
-                                    "Failed to notify supervisor of dead replica %s",
-                                    model_uid,
-                                    exc_info=True,
-                                )
+                            await self._evict_replica_from_supervisor(model_uid)
                     else:
                         logger.warning("Recreating model actor %s ...", model_uid)
-                        await self.recover_model(launch_args)
+                        # Unbounded branch (default, recover_count is None). If
+                        # recreate itself fails, evict the dead replica so it
+                        # cannot poison routing as a permanent "loading" zombie.
+                        # mark_replica_dead is idempotent, so this is safe.
+                        try:
+                            await self.recover_model(launch_args)
+                        except Exception:
+                            logger.warning(
+                                "Recreate failed for %s, evicting dead replica "
+                                "from supervisor",
+                                model_uid,
+                                exc_info=True,
+                            )
+                            await self._evict_replica_from_supervisor(model_uid)
                 break
+
+    async def _evict_replica_from_supervisor(self, model_uid: str) -> None:
+        """Notify the supervisor to evict a dead replica from round-robin.
+
+        Best-effort: ``get_supervisor_ref`` (``add_worker=False``, no
+        re-registration) + ``mark_replica_dead`` are wrapped in a single
+        ``xo.wait_for(5s)``. ``get_supervisor_ref`` issues blocking
+        ``xo.actor_ref`` calls when the cached ref is missing, so the bound
+        must cover both to keep a stalled supervisor from holding up the
+        worker's local shutdown. A failure/timeout is non-fatal --
+        ``mark_replica_dead`` is idempotent and the next death detection /
+        redeploy will reconcile.
+        """
+
+        async def _notify_replica_dead():
+            supervisor_ref = await self.get_supervisor_ref(add_worker=False)
+            await supervisor_ref.mark_replica_dead(model_uid)
+
+        try:
+            await xo.wait_for(
+                _notify_replica_dead(),
+                timeout=5,
+            )
+        except Exception:
+            logger.warning(
+                "Failed to notify supervisor of dead replica %s",
+                model_uid,
+                exc_info=True,
+            )
 
     @classmethod
     def default_uid(cls) -> str:

--- a/xinference/model/embedding/core.py
+++ b/xinference/model/embedding/core.py
@@ -45,6 +45,14 @@ EMBEDDING_EMPTY_CACHE_TOKENS = int(
 assert EMBEDDING_EMPTY_CACHE_COUNT > 0
 assert EMBEDDING_EMPTY_CACHE_TOKENS > 0
 
+# Char-per-token estimate used by ``EmbeddingModel._truncate_sentences`` for the
+# character-based fallback (engines without a Python tokenizer, e.g. llama_cpp,
+# or when the tokenizer call itself fails). English-biased; CJK may run longer.
+_EMBEDDING_TRUNCATE_CHAR_PER_TOKEN = int(
+    os.getenv("XINFERENCE_EMBEDDING_TRUNCATE_CHAR_PER_TOKEN", "4")
+)
+assert _EMBEDDING_TRUNCATE_CHAR_PER_TOKEN > 0
+
 
 def get_embedding_model_descriptions():
     import copy
@@ -276,6 +284,9 @@ class EmbeddingModel(abc.ABC):
         sentences: Union[str, List[str]],
         **kwargs,
     ):
+        truncate_prompt_tokens = kwargs.pop("truncate_prompt_tokens", None)
+        if truncate_prompt_tokens is not None:
+            sentences = self._truncate_sentences(sentences, truncate_prompt_tokens)
         return self._create_embedding(sentences, **kwargs)
 
     @create_embedding.batch  # type: ignore
@@ -307,6 +318,14 @@ class EmbeddingModel(abc.ABC):
             kwargs = group["kwargs"]
             offsets = group["offsets"]
             indices = group["indices"]
+
+            # Honor ``truncate_prompt_tokens`` for embeddings (previously only
+            # implemented for vLLM LLMs). Pop it here so it never leaks into
+            # the engine's encode()/forward(), and bound the input length to
+            # avoid O(L^2) attention OOM on long documents.
+            truncate_prompt_tokens = kwargs.pop("truncate_prompt_tokens", None)
+            if truncate_prompt_tokens is not None:
+                sentences = self._truncate_sentences(sentences, truncate_prompt_tokens)
 
             embedding_list = self._create_embedding(sentences, **kwargs)
             usage = embedding_list.get("usage", {})
@@ -362,6 +381,65 @@ class EmbeddingModel(abc.ABC):
         sentences = bound.arguments["sentences"]
         extra_kwargs = {k: v for k, v in kwargs.items() if k != "sentences"}
         return sentences, extra_kwargs
+
+    def _truncate_sentences(
+        self,
+        sentences: Union[str, List[str]],
+        truncate_prompt_tokens: Optional[int],
+    ) -> Union[str, List[str]]:
+        """Truncate input to ``truncate_prompt_tokens`` tokens before encoding.
+
+        Mirrors vLLM LLM semantics (``xinference/model/llm/vllm/core.py``):
+        ``None`` = no truncation, ``>0`` = cap at N tokens, ``<0`` = cap at the
+        model's own ``max_tokens``. Token-based when a tokenizer is available
+        (sentence_transformers / flag / vllm); falls back to a character-based
+        estimate otherwise (llama_cpp has no Python tokenizer, or if the
+        tokenizer call itself raises).
+
+        This method must never raise: a tokenizer/decode failure degrades to a
+        character-based cut so embedding serving is not interrupted.
+        """
+        if truncate_prompt_tokens is None:
+            return sentences
+
+        # Resolve the effective token limit.
+        n_tokens: Optional[int]
+        if truncate_prompt_tokens > 0:
+            n_tokens = truncate_prompt_tokens
+        else:  # <0: cap at the model's own max_tokens
+            n_tokens = getattr(self.model_family, "max_tokens", None)
+            if not n_tokens:  # None / 0 -> unknown, give up truncation safely
+                logger.debug(
+                    "truncate_prompt_tokens<0 but max_tokens unknown for %s; skip",
+                    self._model_uid,
+                )
+                return sentences
+
+        is_str = isinstance(sentences, str)
+        texts = [sentences] if is_str else list(sentences)
+        truncated: List[str] = []
+        for text in texts:
+            s = text if isinstance(text, str) else str(text)
+            tokenizer = getattr(self, "_tokenizer", None)
+            if tokenizer is not None:
+                try:
+                    ids = tokenizer(
+                        s,
+                        add_special_tokens=True,
+                        truncation=True,
+                        max_length=n_tokens,
+                    ).input_ids
+                    truncated.append(tokenizer.decode(ids, skip_special_tokens=True))
+                    continue
+                except Exception:
+                    logger.debug(
+                        "token-based truncation failed for %s, fallback to char",
+                        self._model_uid,
+                        exc_info=True,
+                    )
+            # Fallback: character-based cut (llama_cpp, or tokenizer failure).
+            truncated.append(s[: n_tokens * _EMBEDDING_TRUNCATE_CHAR_PER_TOKEN])
+        return truncated[0] if is_str else truncated
 
     def _get_batch_size(self, *args, **kwargs) -> int:
         sentences = self._extract_sentences_kwargs(args, kwargs)[0]

--- a/xinference/model/embedding/sentence_transformers/tests/test_truncate_prompt_tokens.py
+++ b/xinference/model/embedding/sentence_transformers/tests/test_truncate_prompt_tokens.py
@@ -1,0 +1,162 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for ``EmbeddingModel._truncate_sentences`` (B1).
+
+Verifies that the ``truncate_prompt_tokens`` parameter correctly bounds
+input length before encoding, using a mock tokenizer so these tests
+require no GPU, no model download, and no network.
+"""
+
+from unittest.mock import MagicMock
+
+from ...core import _EMBEDDING_TRUNCATE_CHAR_PER_TOKEN, EmbeddingModel
+
+
+class _StrTokenizer:
+    """A minimal tokenizer that models 1 token ≈ 4 characters (English)."""
+
+    def __call__(self, text, **kwargs):
+        max_length = kwargs.get("max_length", None)
+        tokens = [ord(c) for c in text[: max_length * 4]] if max_length else text
+        return MagicMock(input_ids=tokens)
+
+    def decode(self, ids, **kwargs):
+        return "".join(chr(i) if isinstance(i, int) else i for i in ids)
+
+
+class _NoneTokenizer:
+    """A tokenizer that raises on __call__ (simulating a broken/unsupported
+    tokenizer, or an engine that returns a non-callable _tokenizer)."""
+
+    def __call__(self, text, **kwargs):
+        raise RuntimeError("tokenizer unavailable")
+
+
+class _DummyEmbeddingModel(EmbeddingModel):
+    """Minimal EmbeddingModel subclass for testing _truncate_sentences.
+
+    We only need ``_model_uid``, ``model_family`` with a ``max_tokens``
+    attribute, and optionally ``_tokenizer``. Abstract methods are stubbed
+    since the test never exercises them.
+    """
+
+    def __init__(self, *, tokenizer=None, max_tokens=None):
+        self._model_uid = "test-model-0"
+        self._tokenizer = tokenizer
+        self.model_family = MagicMock(max_tokens=max_tokens)
+
+    # Stub abstract methods — never called in these tests.
+    def _create_embedding(self, sentences, **kwargs):
+        raise NotImplementedError
+
+    def check_lib(self):
+        raise NotImplementedError
+
+    def load(self):
+        raise NotImplementedError
+
+    @classmethod
+    def match_json(cls, *args, **kwargs):
+        raise NotImplementedError
+
+
+LONG_TEXT = "Hello world! " * 500  # ~7000 chars, ~1750 tokens (4 char/token)
+
+# --- _truncate_sentences: None -------------------------------------------------
+
+
+def test_truncate_none_unchanged():
+    """truncate_prompt_tokens=None → return sentences intact (no truncation)."""
+    model = _DummyEmbeddingModel(tokenizer=_StrTokenizer())
+    result = model._truncate_sentences(LONG_TEXT, None)
+    assert result is LONG_TEXT  # same object identity
+
+
+# --- _truncate_sentences: >0 (explicit token limit) ----------------------------
+
+
+def test_truncate_positive_with_tokenizer():
+    """truncate_prompt_tokens=8 → input is truncated to ~8 tokens via
+    tokenizer."""
+    model = _DummyEmbeddingModel(tokenizer=_StrTokenizer())
+    result = model._truncate_sentences(LONG_TEXT, 8)
+    assert isinstance(result, str)
+    # With our mock, 8 tokens × 4 char/token = ~32 chars returned
+    assert len(result) <= 8 * 4
+
+
+def test_truncate_positive_fallback_to_char():
+    """truncate_prompt_tokens=8 + no tokenizer → fallback to char-based cut."""
+    model = _DummyEmbeddingModel(tokenizer=None)  # no tokenizer (llama_cpp)
+    result = model._truncate_sentences(LONG_TEXT, 8)
+    assert isinstance(result, str)
+    assert len(result) == 8 * _EMBEDDING_TRUNCATE_CHAR_PER_TOKEN
+
+
+def test_truncate_positive_tokenizer_raises_fallback():
+    """truncate_prompt_tokens=8 + tokenizer raises → fallback to char-based cut
+    without propagating the exception."""
+    model = _DummyEmbeddingModel(tokenizer=_NoneTokenizer())
+    result = model._truncate_sentences(LONG_TEXT, 8)
+    assert isinstance(result, str)
+    assert len(result) == 8 * _EMBEDDING_TRUNCATE_CHAR_PER_TOKEN
+
+
+# --- _truncate_sentences: <0 (model max_tokens) --------------------------------
+
+
+def test_truncate_negative_with_max_tokens():
+    """truncate_prompt_tokens=-1 + model has max_tokens=4 → truncate to 4."""
+    model = _DummyEmbeddingModel(tokenizer=_StrTokenizer(), max_tokens=4)
+    result = model._truncate_sentences(LONG_TEXT, -1)
+    assert isinstance(result, str)
+    assert len(result) <= 4 * 4
+
+
+def test_truncate_negative_max_tokens_unknown_skips():
+    """truncate_prompt_tokens=-1 + model max_tokens=None → skip truncation
+    (defensive: unknown limit should not cause errors)."""
+    model = _DummyEmbeddingModel(tokenizer=_StrTokenizer(), max_tokens=None)
+    result = model._truncate_sentences(LONG_TEXT, -1)
+    # Must return the original string unchanged (not truncate).
+    assert result is LONG_TEXT
+
+
+# --- _truncate_sentences: list[str] input ---------------------------------------
+
+
+def test_truncate_list_input():
+    """truncate_prompt_tokens=4 + list[str] input → each item truncated."""
+    model = _DummyEmbeddingModel(tokenizer=_StrTokenizer())
+    texts = ["This is a long first document.", "And another one, also long."]
+    result = model._truncate_sentences(texts, 4)
+    assert isinstance(result, list)
+    assert len(result) == 2
+    for r in result:
+        assert isinstance(r, str)
+        assert len(r) <= 4 * 4
+
+
+# --- _truncate_sentences: non-string items in list ------------------------------
+
+
+def test_truncate_non_string_items():
+    """truncate_prompt_tokens=4 + list with non-string items → str() cast works."""
+    model = _DummyEmbeddingModel(tokenizer=_StrTokenizer())
+    texts = ["hello", 123]
+    result = model._truncate_sentences(texts, 4)
+    assert isinstance(result, list)
+    assert len(result) == 2


### PR DESCRIPTION
## Summary

Two coupled fixes for jina-embeddings-v3 OOM crashes cascading into a persistent 33% error rate.

## B1: Implement `truncate_prompt_tokens` for embedding models (root cause fix)

`truncate_prompt_tokens` was previously only implemented for vLLM LLMs (`xinference/model/llm/vllm/core.py:1304`). For embedding models the parameter was silently accepted via kwargs passthrough but never acted on — long documents were processed at full length (up to model `max_tokens`), triggering O(L²) attention OOM on GPU.

**Changes:**
- `embedding/core.py`: Add `_truncate_sentences()` method — token-based truncation when a tokenizer is available, character-based fallback otherwise (llama_cpp, or tokenizer failure). The method **never raises** (catch-all on tokenizer/decode, char fallback). Applied at both choke points (non-batch and batch paths) via `kwargs.pop()` so `truncate_prompt_tokens` never leaks into `encode()/forward()`.
- `schemas/requests.py`: Add `truncate_prompt_tokens: Optional[int]` to `CreateEmbeddingRequest` (defaults to `None` — full backward compatibility).
- 8 unit tests: `None`, `>0`, `<0`, tokenizer failure fallback, no tokenizer fallback, list input, non-string items, unknown max_tokens.

**Verified in production:** `with truncate=512` → prompt_tokens=512; `without` → prompt_tokens=8194 (16× difference, airtight).

## B2: Evict zombie replicas on unbounded recovery failure (cascading fix)

After OOM kills a replica subprocess, the worker auto-recovers via `recover_sub_pool`. When `recover_count` is `None` (the default), recovery is unbounded — but if the recovery itself fails (e.g. the GPU is still OOM), the branch silently continued without notifying the supervisor. The dead replica stayed in the routing table permanently, causing a persistent 33% error rate.

**Changes:**
- `worker.py`: Extract `_evict_replica_from_supervisor()` from the bounded-branch inline closure; call it in the unbounded branch on `recover_model` failure. `mark_replica_dead` is idempotent so repeated/racing calls are safe.
- 4 asyncio tests: eviction call, supervisor failure tolerance (non-fatal), evict-on-failure, no-evict-on-success.

## Backward compatibility

- `truncate_prompt_tokens` defaults to `None` — existing clients completely unaffected.
- Unbounded recovery (`recover_count=None`) still retries infinitely on success. Behavior only changes on *failure*: a dead replica is now evicted from round-robin instead of poisoning routing permanently.

## Testing

- 19 new tests all pass (8 B1 unit + 7 schema + 4 B2 worker).
- All GPU-free, no model download, no network.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>