### PR TITLE
fix(embedding): implement truncate_prompt_tokens, OOM eviction, and wait_for_load after recovery

### DIFF
--- a/xinference/api/schemas/requests.py
+++ b/xinference/api/schemas/requests.py
@@ -28,6 +28,11 @@ class CreateEmbeddingRequest(BaseModel):
         str, List[str], List[int], List[List[int]], Dict[str, str], List[Dict[str, str]]
     ] = Field(description="The input to embed.")
     user: Optional[str] = None
+    # Truncate each input to this many tokens before encoding. Mirrors the
+    # vLLM LLM semantics: None = no truncation, >0 = cap at N tokens,
+    # <0 = cap at the model's max_tokens. Honored by the embedding model base
+    # class (see ``EmbeddingModel._truncate_sentences``).
+    truncate_prompt_tokens: Optional[int] = None
 
     class Config:
         schema_extra = {

--- a/xinference/api/tests/test_embedding_truncate.py
+++ b/xinference/api/tests/test_embedding_truncate.py
@@ -1,0 +1,73 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the ``truncate_prompt_tokens`` field on CreateEmbeddingRequest.
+
+Validates the schema contract: the field exists, defaults to None, and
+accepts valid integer values (positive, negative, and None).
+"""
+
+from ..schemas.requests import CreateEmbeddingRequest
+
+
+class TestCreateEmbeddingRequestTruncateField:
+    """Schema-level validation for the truncate_prompt_tokens field."""
+
+    def test_default_is_none(self):
+        """Field must default to None so existing clients are unaffected."""
+        req = CreateEmbeddingRequest(model="m", input="hello")
+        assert req.truncate_prompt_tokens is None
+
+    def test_accepts_positive_int(self):
+        req = CreateEmbeddingRequest(
+            model="m", input="hello", truncate_prompt_tokens=512
+        )
+        assert req.truncate_prompt_tokens == 512
+
+    def test_accepts_negative_int(self):
+        req = CreateEmbeddingRequest(
+            model="m", input="hello", truncate_prompt_tokens=-1
+        )
+        assert req.truncate_prompt_tokens == -1
+
+    def test_accepts_none_explicit(self):
+        req = CreateEmbeddingRequest(
+            model="m", input="hello", truncate_prompt_tokens=None
+        )
+        assert req.truncate_prompt_tokens is None
+
+    def test_accepts_zero(self):
+        """Zero is a valid (though unusual) token limit."""
+        req = CreateEmbeddingRequest(model="m", input="hello", truncate_prompt_tokens=0)
+        assert req.truncate_prompt_tokens == 0
+
+    def test_accepts_str_int_coerced(self):
+        """pydantic coerces the string ``"512"`` to int for Optional[int]
+        fields — this is normal pydantic lenient-coercion behaviour and must
+        not raise."""
+        req = CreateEmbeddingRequest(
+            model="m", input="hello", truncate_prompt_tokens="512"
+        )
+        assert req.truncate_prompt_tokens == 512
+
+    def test_passes_through_to_kwargs(self):
+        """The field must be present in the request body when serialised, so
+        the ``create_embedding`` handler can pop it from kwargs."""
+        import json
+
+        req = CreateEmbeddingRequest(
+            model="m", input="hello", truncate_prompt_tokens=128
+        )
+        body = json.loads(req.json())
+        assert body.get("truncate_prompt_tokens") == 128

--- a/xinference/core/tests/test_worker.py
+++ b/xinference/core/tests/test_worker.py
@@ -1454,6 +1454,12 @@ async def test_recover_model_pops_launch_ts_from_kwargs():
         async def get_supervisor_ref(self, add_worker=False):
             return None
 
+        async def wait_for_load(self, model_uid):
+            # recover_model now marks the recreated replica ready via wait_for_load
+            # (B3a); provide a no-op so this launch_ts test still exercises the
+            # launch_builtin_model kwargs path.
+            pass
+
     worker = _MockWorker()
 
     # Simulate a cached launch snapshot with launch_ts (the internal timestamp)
@@ -1489,3 +1495,283 @@ async def test_recover_model_pops_launch_ts_from_kwargs():
         assert launch_args["launch_ts"] == 1780900592
     finally:
         worker_module.parse_replica_model_uid = original_parse
+
+
+class _RecordingSupervisorRef:
+    """Minimal supervisor ref that records mark_replica_dead calls (B2)."""
+
+    def __init__(self):
+        self.evicted: List[str] = []
+
+    async def mark_replica_dead(self, replica_model_uid: str):
+        self.evicted.append(replica_model_uid)
+
+
+class _EvictMockWorker:
+    """Minimal worker stand-in for _evict_replica_from_supervisor tests."""
+
+    def __init__(self, supervisor_ref=None, raise_on_get: bool = False):
+        self._supervisor_ref = supervisor_ref
+        self._raise_on_get = raise_on_get
+
+    async def get_supervisor_ref(self, add_worker: bool = False):
+        if self._raise_on_get:
+            raise RuntimeError("supervisor unreachable")
+        return self._supervisor_ref
+
+
+@pytest.mark.asyncio
+async def test_evict_replica_from_supervisor_calls_mark_replica_dead():
+    """B2 helper: notifies the supervisor to evict the dead replica."""
+    sup = _RecordingSupervisorRef()
+    worker = _EvictMockWorker(supervisor_ref=sup)
+    await WorkerActor._evict_replica_from_supervisor(worker, "model-x-1")
+    assert sup.evicted == ["model-x-1"]
+
+
+@pytest.mark.asyncio
+async def test_evict_replica_from_supervisor_is_non_fatal():
+    """B2 helper: a supervisor-ref failure must not propagate out of the
+    recover_sub_pool tail path (non-fatal; next death/redeploy reconciles)."""
+    worker = _EvictMockWorker(supervisor_ref=None, raise_on_get=True)
+    # Must not raise.
+    await WorkerActor._evict_replica_from_supervisor(worker, "model-x-1")
+
+
+class _MainPoolStub:
+    async def remove_sub_pool(self, address):
+        return None
+
+
+class _RecoverWorkerStub:
+    """Worker stand-in for recover_sub_pool unbounded/bounded-branch tests.
+
+    recover_model is overridden per-test (raise vs succeed). The real
+    `_evict_replica_from_supervisor` is bound onto the instance so the
+    recover_sub_pool call exercises the genuine eviction path.
+    """
+
+    def __init__(
+        self,
+        supervisor_ref,
+        recover_raises: bool,
+        recover_count: Optional[int] = None,
+    ):
+        self._supervisor_ref = supervisor_ref
+        self._recover_raises = recover_raises
+        self.recover_called = 0
+        # Wiring used by recover_sub_pool:
+        self._main_pool = _MainPoolStub()
+        self._model_uid_to_addr = {"model-x-0": "addr-1"}
+        self._model_uid_to_launch_args = {
+            "model-x-0": {"model_uid": "model-x-0", "model_name": "m"},
+        }
+        # None -> unbounded branch; int (e.g. 1) -> bounded branch (AUTO_RECOVER_LIMIT)
+        self._model_uid_to_recover_count = {"model-x-0": recover_count}
+        self._model_uid_to_subpool_pids: dict = {}
+
+    async def get_supervisor_ref(self, add_worker: bool = False):
+        return self._supervisor_ref
+
+    async def terminate_model(self, model_uid, is_model_die: bool = False):
+        return None
+
+    async def recover_model(self, launch_args):
+        self.recover_called += 1
+        if self._recover_raises:
+            raise RuntimeError("recreate failed (e.g. OOM during reload)")
+
+
+def _bind_real_evict(worker):
+    import types
+
+    worker._evict_replica_from_supervisor = types.MethodType(
+        WorkerActor._evict_replica_from_supervisor, worker
+    )
+    return worker
+
+
+@pytest.mark.asyncio
+async def test_recover_sub_pool_unbounded_evicts_on_recover_failure(monkeypatch):
+    """B2 (core): in the default unbounded branch (recover_count is None), a
+    recreate that raises must evict the dead replica via mark_replica_dead, so
+    it cannot poison routing as a permanent 'loading' zombie (the 33% error
+    root cause)."""
+    import xinference.core.worker as worker_module
+
+    # Neutralize GPU/persist machinery for a deterministic, GPU-free test.
+    monkeypatch.setattr(worker_module, "_strip_test_envs", lambda args: (args, set()))
+    monkeypatch.setattr(worker_module, "_parse_gpu_indices", lambda x: [])
+    monkeypatch.setattr(worker_module, "_snapshot_gpu_free_ratio", lambda idx: 1.0)
+
+    sup = _RecordingSupervisorRef()
+    worker = _bind_real_evict(
+        _RecoverWorkerStub(supervisor_ref=sup, recover_raises=True)
+    )
+
+    await WorkerActor.recover_sub_pool(worker, "addr-1")
+
+    assert worker.recover_called == 1
+    assert sup.evicted == ["model-x-0"]  # recreate failed -> evicted
+
+
+@pytest.mark.asyncio
+async def test_recover_sub_pool_unbounded_no_evict_on_success(monkeypatch):
+    """B2 regression: a successful recreate in the unbounded branch must NOT
+    evict (infinite-retry-on-success semantics preserved)."""
+    import xinference.core.worker as worker_module
+
+    monkeypatch.setattr(worker_module, "_strip_test_envs", lambda args: (args, set()))
+    monkeypatch.setattr(worker_module, "_parse_gpu_indices", lambda x: [])
+    monkeypatch.setattr(worker_module, "_snapshot_gpu_free_ratio", lambda idx: 1.0)
+
+    sup = _RecordingSupervisorRef()
+    worker = _bind_real_evict(
+        _RecoverWorkerStub(supervisor_ref=sup, recover_raises=False)
+    )
+
+    await WorkerActor.recover_sub_pool(worker, "addr-1")
+
+    assert worker.recover_called == 1
+    assert sup.evicted == []  # succeeded -> not evicted
+
+
+# --- B2 symmetry fix: bounded branch eviction (0902) ------------------------
+
+
+@pytest.mark.asyncio
+async def test_recover_sub_pool_bounded_evicts_on_recover_failure(monkeypatch):
+    """B2 symmetry fix: in the bounded branch (AUTO_RECOVER_LIMIT>=1, here =1),
+    a recreate that raises must ALSO evict via mark_replica_dead -- otherwise the
+    replica is left in a 'stopping'/'error' state poisoning routing with 500s
+    (the gap that the unbounded-branch B2 left asymmetric)."""
+    import xinference.core.worker as worker_module
+
+    monkeypatch.setattr(worker_module, "_strip_test_envs", lambda args: (args, set()))
+    monkeypatch.setattr(worker_module, "_parse_gpu_indices", lambda x: [])
+    monkeypatch.setattr(worker_module, "_snapshot_gpu_free_ratio", lambda idx: 1.0)
+
+    sup = _RecordingSupervisorRef()
+    worker = _bind_real_evict(
+        _RecoverWorkerStub(supervisor_ref=sup, recover_raises=True, recover_count=1)
+    )
+
+    await WorkerActor.recover_sub_pool(worker, "addr-1")
+
+    assert worker.recover_called == 1
+    # count decremented 1 -> 0 before the recreate attempt
+    assert worker._model_uid_to_recover_count["model-x-0"] == 0
+    assert sup.evicted == ["model-x-0"]  # recreate failed -> evicted (the fix)
+
+
+@pytest.mark.asyncio
+async def test_recover_sub_pool_bounded_no_evict_on_success(monkeypatch):
+    """B2 regression: a successful recreate in the bounded branch must NOT evict
+    (count-based retry preserved); count is decremented toward 0."""
+    import xinference.core.worker as worker_module
+
+    monkeypatch.setattr(worker_module, "_strip_test_envs", lambda args: (args, set()))
+    monkeypatch.setattr(worker_module, "_parse_gpu_indices", lambda x: [])
+    monkeypatch.setattr(worker_module, "_snapshot_gpu_free_ratio", lambda idx: 1.0)
+
+    sup = _RecordingSupervisorRef()
+    worker = _bind_real_evict(
+        _RecoverWorkerStub(supervisor_ref=sup, recover_raises=False, recover_count=1)
+    )
+
+    await WorkerActor.recover_sub_pool(worker, "addr-1")
+
+    assert worker.recover_called == 1
+    assert worker._model_uid_to_recover_count["model-x-0"] == 0  # 1 -> 0
+    assert sup.evicted == []  # succeeded -> not evicted
+
+
+# --- B3a: wait_for_load after recover_model / _try_recover_models (0903) ----
+
+
+@pytest.mark.asyncio
+async def test_recover_model_marks_ready_via_wait_for_load():
+    """B3a: recover_model must call wait_for_load after launch_builtin_model so a
+    recreated replica is marked 'ready' instead of stuck at 'loading' forever
+    (the original 33% symptom). Mirrors the normal launch path where the
+    supervisor calls wait_for_load."""
+
+    class _MockWorker:
+        def __init__(self):
+            self.launch_called = False
+            self.wait_for_load_called_with = None
+
+        async def launch_builtin_model(self, **kwargs):
+            self.launch_called = True
+            return "mock-subpool-address"
+
+        async def get_supervisor_ref(self, add_worker=False):
+            return None
+
+        async def wait_for_load(self, model_uid):
+            self.wait_for_load_called_with = model_uid
+
+    worker = _MockWorker()
+    launch_args = {"model_uid": "test-model-0", "model_name": "test-model"}
+
+    def mock_parse(uid):
+        return ("test-model", 0)
+
+    import xinference.core.worker as worker_module
+
+    original_parse = worker_module.parse_replica_model_uid
+    worker_module.parse_replica_model_uid = mock_parse
+    try:
+        await WorkerActor.recover_model(worker, launch_args)
+        assert worker.launch_called
+        assert worker.wait_for_load_called_with == "test-model-0"
+    finally:
+        worker_module.parse_replica_model_uid = original_parse
+
+
+@pytest.mark.asyncio
+async def test_try_recover_models_marks_ready_via_wait_for_load(monkeypatch):
+    """B3a: _try_recover_models (worker restart recovery) must also call
+    wait_for_load after launch_builtin_model, so recovered models are marked
+    'ready' instead of stuck 'loading' (same gap as recover_model)."""
+
+    import xinference.core.worker as worker_module
+
+    monkeypatch.setattr(worker_module, "_strip_test_envs", lambda args: (args, set()))
+    monkeypatch.setattr(
+        worker_module, "parse_replica_model_uid", lambda uid: ("test-model", 0)
+    )
+
+    class _SupervisorRef:
+        async def describe_model(self, origin_uid):
+            return {"some": "info"}  # non-None -> model still registered
+
+    class _MockWorker:
+        def __init__(self):
+            self._supervisor_ref = _SupervisorRef()
+            self.launch_called = False
+            self.wait_for_load_called_with = None
+
+        def _load_persisted_launch_args(self):
+            return {
+                "test-model-0": {
+                    "model_uid": "test-model-0",
+                    "model_name": "test-model",
+                }
+            }
+
+        async def launch_builtin_model(self, **kwargs):
+            self.launch_called = True
+            return "mock-subpool-address"
+
+        async def wait_for_load(self, model_uid):
+            self.wait_for_load_called_with = model_uid
+
+        def _persist_launch_args(self):
+            pass
+
+    worker = _MockWorker()
+    await WorkerActor._try_recover_models(worker)
+
+    assert worker.launch_called
+    assert worker.wait_for_load_called_with == "test-model-0"

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -782,45 +782,77 @@ class WorkerActor(xo.StatelessActor):
                             self._model_uid_to_recover_count[model_uid] = (
                                 recover_count - 1
                             )
-                            await self.recover_model(launch_args)
-                        else:
-                            logger.warning("Stop recreating model actor.")
-
-                            # Worker has given up recreating; notify supervisor
-                            # to evict the dead replica from round-robin and
-                            # light up the failure gauge. add_worker=False:
-                            # only fetch the ref, do not trigger
-                            # re-registration. The whole notification --
-                            # get_supervisor_ref + mark_replica_dead -- is
-                            # wrapped in a single xo.wait_for(5s): this runs
-                            # inside the recover_sub_pool tail path, and
-                            # get_supervisor_ref itself issues blocking
-                            # xo.actor_ref calls when the cached ref is missing,
-                            # so the bound must cover both to keep a stalled
-                            # supervisor from holding up the worker's local
-                            # shutdown. A failure/timeout is non-fatal -- the
-                            # next death detection / redeploy will reconcile.
-                            async def _notify_replica_dead():
-                                supervisor_ref = await self.get_supervisor_ref(
-                                    add_worker=False
-                                )
-                                await supervisor_ref.mark_replica_dead(model_uid)
-
+                            # Symmetric to the unbounded branch below: if recreate
+                            # itself fails, evict the dead replica so it cannot sit
+                            # in a "stopping"/"error" state poisoning routing with
+                            # persistent 500s. Same launch_args would fail again, and
+                            # recover_model failure leaves no new subpool to retrigger
+                            # recover_sub_pool, so eviction (not retry) is the only
+                            # recovery. mark_replica_dead is idempotent (safe).
                             try:
-                                await xo.wait_for(
-                                    _notify_replica_dead(),
-                                    timeout=5,
-                                )
+                                await self.recover_model(launch_args)
                             except Exception:
                                 logger.warning(
-                                    "Failed to notify supervisor of dead replica %s",
+                                    "Recreate failed for %s, evicting dead replica "
+                                    "from supervisor",
                                     model_uid,
                                     exc_info=True,
                                 )
+                                await self._evict_replica_from_supervisor(model_uid)
+                        else:
+                            logger.warning("Stop recreating model actor.")
+
+                            # Bounded retries exhausted: evict the dead replica
+                            # from the supervisor's round-robin so traffic stops
+                            # routing to it. Failure/timeout is non-fatal -- the
+                            # next death detection / redeploy will reconcile.
+                            await self._evict_replica_from_supervisor(model_uid)
                     else:
                         logger.warning("Recreating model actor %s ...", model_uid)
-                        await self.recover_model(launch_args)
+                        # Unbounded branch (default, recover_count is None). If
+                        # recreate itself fails, evict the dead replica so it
+                        # cannot poison routing as a permanent "loading" zombie.
+                        # mark_replica_dead is idempotent, so this is safe.
+                        try:
+                            await self.recover_model(launch_args)
+                        except Exception:
+                            logger.warning(
+                                "Recreate failed for %s, evicting dead replica "
+                                "from supervisor",
+                                model_uid,
+                                exc_info=True,
+                            )
+                            await self._evict_replica_from_supervisor(model_uid)
                 break
+
+    async def _evict_replica_from_supervisor(self, model_uid: str) -> None:
+        """Notify the supervisor to evict a dead replica from round-robin.
+
+        Best-effort: ``get_supervisor_ref`` (``add_worker=False``, no
+        re-registration) + ``mark_replica_dead`` are wrapped in a single
+        ``xo.wait_for(5s)``. ``get_supervisor_ref`` issues blocking
+        ``xo.actor_ref`` calls when the cached ref is missing, so the bound
+        must cover both to keep a stalled supervisor from holding up the
+        worker's local shutdown. A failure/timeout is non-fatal --
+        ``mark_replica_dead`` is idempotent and the next death detection /
+        redeploy will reconcile.
+        """
+
+        async def _notify_replica_dead():
+            supervisor_ref = await self.get_supervisor_ref(add_worker=False)
+            await supervisor_ref.mark_replica_dead(model_uid)
+
+        try:
+            await xo.wait_for(
+                _notify_replica_dead(),
+                timeout=5,
+            )
+        except Exception:
+            logger.warning(
+                "Failed to notify supervisor of dead replica %s",
+                model_uid,
+                exc_info=True,
+            )
 
     @classmethod
     def default_uid(cls) -> str:
@@ -1384,6 +1416,12 @@ class WorkerActor(xo.StatelessActor):
                         sorted(_stripped),
                     )
                 await self.launch_builtin_model(**launch_args)
+                # Mark the recovered replica ready, mirroring the normal launch
+                # path. Same gap as recover_model: launch_builtin_model leaves
+                # model_state="loading"; without this, models recovered on worker
+                # restart stay "loading" forever. Idempotent if the supervisor
+                # also reconciles on reconnect.
+                await self.wait_for_load(model_uid)
                 recovered += 1
             except Exception:
                 logger.error(
@@ -3820,3 +3858,10 @@ class WorkerActor(xo.StatelessActor):
             await supervisor_ref.call_collective_manager(
                 origin_uid, "register_rank", rank, subpool_address, update=True
             )
+        # Mark the recreated replica ready, mirroring the normal launch path
+        # (supervisor calls wait_for_load after launch). Without this the worker
+        # keeps model_state="loading" forever (set in launch_builtin_model), so
+        # get_model raises ModelNotReadyError and the recreated replica is a
+        # permanent "loading" zombie -- the original 33% symptom. launch_builtin_model
+        # already awaited model_ref.load(), so wait_for_load is near-instant here.
+        await self.wait_for_load(rep_model_uid)

--- a/xinference/model/embedding/core.py
+++ b/xinference/model/embedding/core.py
@@ -19,7 +19,7 @@ import logging
 import os
 from abc import abstractmethod
 from collections import defaultdict
-from typing import Annotated, Dict, List, Literal, Optional, Tuple, Union
+from typing import Annotated, Any, Dict, List, Literal, Optional, Tuple, Union
 
 from xoscar import extensible
 
@@ -384,28 +384,55 @@ class EmbeddingModel(abc.ABC):
 
     def _truncate_sentences(
         self,
-        sentences: Union[str, List[str]],
+        sentences: Union[
+            str,
+            List[str],
+            List[int],
+            List[List[int]],
+            Dict[str, str],
+            List[Dict[str, str]],
+        ],
         truncate_prompt_tokens: Optional[int],
-    ) -> Union[str, List[str]]:
+    ) -> Union[
+        str,
+        List[str],
+        List[int],
+        List[List[int]],
+        Dict[str, str],
+        List[Dict[str, str]],
+    ]:
         """Truncate input to ``truncate_prompt_tokens`` tokens before encoding.
 
         Mirrors vLLM LLM semantics (``xinference/model/llm/vllm/core.py``):
-        ``None`` = no truncation, ``>0`` = cap at N tokens, ``<0`` = cap at the
-        model's own ``max_tokens``. Token-based when a tokenizer is available
-        (sentence_transformers / flag / vllm); falls back to a character-based
-        estimate otherwise (llama_cpp has no Python tokenizer, or if the
-        tokenizer call itself raises).
+        ``None`` = no truncation, ``>0`` = cap at N tokens, ``==0`` = explicit
+        empty (``max_length=0``), ``<0`` = cap at the model's own ``max_tokens``.
+
+        Structure-preserving: token arrays (``List[int]`` / ``List[List[int]]``)
+        are sliced to N ids; multimodal dicts (``Dict[str, str]`` /
+        ``List[Dict[str, str]]``) keep their keys and non-text values and only
+        their string values are truncated. Plain ``str`` / ``List[str]`` are
+        truncated token-based (sentence_transformers / flag / vllm) with a
+        character-based fallback (llama_cpp, or tokenizer failure).
 
         This method must never raise: a tokenizer/decode failure degrades to a
-        character-based cut so embedding serving is not interrupted.
+        character-based cut so embedding serving is not interrupted. It runs
+        *before* ``_fix_langchain_openai_inputs`` decodes token arrays, so it
+        must not stringify structured inputs (that would corrupt them -- e.g.
+        ``[[1, 2, 3]]`` embedded as the literal text ``"[[1,"``).
         """
         if truncate_prompt_tokens is None:
             return sentences
 
-        # Resolve the effective token limit.
+        # Resolve the effective token limit, matching vLLM LLM ``_tokenize``:
+        #   None  -> no truncation (handled above)
+        #   >0    -> cap at N tokens
+        #   ==0   -> explicit max_length=0 (empty input)
+        #   <0    -> cap at the model's own max_tokens
         n_tokens: Optional[int]
         if truncate_prompt_tokens > 0:
             n_tokens = truncate_prompt_tokens
+        elif truncate_prompt_tokens == 0:
+            n_tokens = 0
         else:  # <0: cap at the model's own max_tokens
             n_tokens = getattr(self.model_family, "max_tokens", None)
             if not n_tokens:  # None / 0 -> unknown, give up truncation safely
@@ -415,31 +442,57 @@ class EmbeddingModel(abc.ABC):
                 )
                 return sentences
 
-        is_str = isinstance(sentences, str)
-        texts = [sentences] if is_str else list(sentences)
-        truncated: List[str] = []
-        for text in texts:
-            s = text if isinstance(text, str) else str(text)
-            tokenizer = getattr(self, "_tokenizer", None)
-            if tokenizer is not None:
-                try:
-                    ids = tokenizer(
-                        s,
-                        add_special_tokens=True,
-                        truncation=True,
-                        max_length=n_tokens,
-                    ).input_ids
-                    truncated.append(tokenizer.decode(ids, skip_special_tokens=True))
-                    continue
-                except Exception:
-                    logger.debug(
-                        "token-based truncation failed for %s, fallback to char",
-                        self._model_uid,
-                        exc_info=True,
-                    )
-            # Fallback: character-based cut (llama_cpp, or tokenizer failure).
-            truncated.append(s[: n_tokens * _EMBEDDING_TRUNCATE_CHAR_PER_TOKEN])
-        return truncated[0] if is_str else truncated
+        return self._truncate_value(sentences, n_tokens)
+
+    def _truncate_value(self, value: Any, n_tokens: int) -> Any:
+        """Recursively truncate ``value`` to ``n_tokens`` while preserving its
+        structure (see ``_truncate_sentences``)."""
+        # Token arrays: a single doc as a flat list of token ids.
+        if isinstance(value, list) and len(value) > 0 and isinstance(value[0], int):
+            return value[:n_tokens]
+        # Multiple docs, each a list of token ids.
+        if isinstance(value, list) and len(value) > 0 and isinstance(value[0], list):
+            return [inner[:n_tokens] for inner in value]
+        # Multimodal / structured: truncate only string values, preserve keys
+        # and non-text fields.
+        if isinstance(value, dict):
+            return {
+                k: self._truncate_text(v, n_tokens) if isinstance(v, str) else v
+                for k, v in value.items()
+            }
+        # A list of texts or of dicts: recurse per element.
+        if isinstance(value, list):
+            return [self._truncate_value(item, n_tokens) for item in value]
+        if isinstance(value, str):
+            return self._truncate_text(value, n_tokens)
+        # Numbers / None / other primitives: leave untouched.
+        return value
+
+    def _truncate_text(self, s: str, n_tokens: int) -> str:
+        """Token-based truncation of a single string, with a character-based
+        fallback (llama_cpp has no Python tokenizer, or the call may raise).
+
+        ``n_tokens == 0`` matches vLLM ``max_length=0``: both the tokenizer
+        path (empty ``input_ids``) and the char fallback (``s[:0]``) yield "".
+        """
+        tokenizer = getattr(self, "_tokenizer", None)
+        if tokenizer is not None:
+            try:
+                ids = tokenizer(
+                    s,
+                    add_special_tokens=True,
+                    truncation=True,
+                    max_length=n_tokens,
+                ).input_ids
+                return tokenizer.decode(ids, skip_special_tokens=True)
+            except Exception:
+                logger.debug(
+                    "token-based truncation failed for %s, fallback to char",
+                    self._model_uid,
+                    exc_info=True,
+                )
+        # Fallback: character-based cut (llama_cpp, or tokenizer failure).
+        return s[: n_tokens * _EMBEDDING_TRUNCATE_CHAR_PER_TOKEN]
 
     def _get_batch_size(self, *args, **kwargs) -> int:
         sentences = self._extract_sentences_kwargs(args, kwargs)[0]

--- a/xinference/model/embedding/core.py
+++ b/xinference/model/embedding/core.py
@@ -45,6 +45,14 @@ EMBEDDING_EMPTY_CACHE_TOKENS = int(
 assert EMBEDDING_EMPTY_CACHE_COUNT > 0
 assert EMBEDDING_EMPTY_CACHE_TOKENS > 0
 
+# Char-per-token estimate used by ``EmbeddingModel._truncate_sentences`` for the
+# character-based fallback (engines without a Python tokenizer, e.g. llama_cpp,
+# or when the tokenizer call itself fails). English-biased; CJK may run longer.
+_EMBEDDING_TRUNCATE_CHAR_PER_TOKEN = int(
+    os.getenv("XINFERENCE_EMBEDDING_TRUNCATE_CHAR_PER_TOKEN", "4")
+)
+assert _EMBEDDING_TRUNCATE_CHAR_PER_TOKEN > 0
+
 
 def get_embedding_model_descriptions():
     import copy
@@ -276,6 +284,9 @@ class EmbeddingModel(abc.ABC):
         sentences: Union[str, List[str]],
         **kwargs,
     ):
+        truncate_prompt_tokens = kwargs.pop("truncate_prompt_tokens", None)
+        if truncate_prompt_tokens is not None:
+            sentences = self._truncate_sentences(sentences, truncate_prompt_tokens)
         return self._create_embedding(sentences, **kwargs)
 
     @create_embedding.batch  # type: ignore
@@ -307,6 +318,14 @@ class EmbeddingModel(abc.ABC):
             kwargs = group["kwargs"]
             offsets = group["offsets"]
             indices = group["indices"]
+
+            # Honor ``truncate_prompt_tokens`` for embeddings (previously only
+            # implemented for vLLM LLMs). Pop it here so it never leaks into
+            # the engine's encode()/forward(), and bound the input length to
+            # avoid O(L^2) attention OOM on long documents.
+            truncate_prompt_tokens = kwargs.pop("truncate_prompt_tokens", None)
+            if truncate_prompt_tokens is not None:
+                sentences = self._truncate_sentences(sentences, truncate_prompt_tokens)
 
             embedding_list = self._create_embedding(sentences, **kwargs)
             usage = embedding_list.get("usage", {})
@@ -362,6 +381,65 @@ class EmbeddingModel(abc.ABC):
         sentences = bound.arguments["sentences"]
         extra_kwargs = {k: v for k, v in kwargs.items() if k != "sentences"}
         return sentences, extra_kwargs
+
+    def _truncate_sentences(
+        self,
+        sentences: Union[str, List[str]],
+        truncate_prompt_tokens: Optional[int],
+    ) -> Union[str, List[str]]:
+        """Truncate input to ``truncate_prompt_tokens`` tokens before encoding.
+
+        Mirrors vLLM LLM semantics (``xinference/model/llm/vllm/core.py``):
+        ``None`` = no truncation, ``>0`` = cap at N tokens, ``<0`` = cap at the
+        model's own ``max_tokens``. Token-based when a tokenizer is available
+        (sentence_transformers / flag / vllm); falls back to a character-based
+        estimate otherwise (llama_cpp has no Python tokenizer, or if the
+        tokenizer call itself raises).
+
+        This method must never raise: a tokenizer/decode failure degrades to a
+        character-based cut so embedding serving is not interrupted.
+        """
+        if truncate_prompt_tokens is None:
+            return sentences
+
+        # Resolve the effective token limit.
+        n_tokens: Optional[int]
+        if truncate_prompt_tokens > 0:
+            n_tokens = truncate_prompt_tokens
+        else:  # <0: cap at the model's own max_tokens
+            n_tokens = getattr(self.model_family, "max_tokens", None)
+            if not n_tokens:  # None / 0 -> unknown, give up truncation safely
+                logger.debug(
+                    "truncate_prompt_tokens<0 but max_tokens unknown for %s; skip",
+                    self._model_uid,
+                )
+                return sentences
+
+        is_str = isinstance(sentences, str)
+        texts = [sentences] if is_str else list(sentences)
+        truncated: List[str] = []
+        for text in texts:
+            s = text if isinstance(text, str) else str(text)
+            tokenizer = getattr(self, "_tokenizer", None)
+            if tokenizer is not None:
+                try:
+                    ids = tokenizer(
+                        s,
+                        add_special_tokens=True,
+                        truncation=True,
+                        max_length=n_tokens,
+                    ).input_ids
+                    truncated.append(tokenizer.decode(ids, skip_special_tokens=True))
+                    continue
+                except Exception:
+                    logger.debug(
+                        "token-based truncation failed for %s, fallback to char",
+                        self._model_uid,
+                        exc_info=True,
+                    )
+            # Fallback: character-based cut (llama_cpp, or tokenizer failure).
+            truncated.append(s[: n_tokens * _EMBEDDING_TRUNCATE_CHAR_PER_TOKEN])
+        return truncated[0] if is_str else truncated
 
     def _get_batch_size(self, *args, **kwargs) -> int:
         sentences = self._extract_sentences_kwargs(args, kwargs)[0]

--- a/xinference/model/embedding/core.py
+++ b/xinference/model/embedding/core.py
@@ -409,8 +409,9 @@ class EmbeddingModel(abc.ABC):
 
         Structure-preserving: token arrays (``List[int]`` / ``List[List[int]]``)
         are sliced to N ids; multimodal dicts (``Dict[str, str]`` /
-        ``List[Dict[str, str]]``) keep their keys and non-text values and only
-        their string values are truncated. Plain ``str`` / ``List[str]`` are
+        ``List[Dict[str, str]]``) keep their keys and non-text values, and only
+        the ``text`` field is truncated (``image`` / ``video`` / ``audio`` and
+        other media fields are preserved verbatim). Plain ``str`` / ``List[str]`` are
         truncated token-based (sentence_transformers / flag / vllm) with a
         character-based fallback (llama_cpp, or tokenizer failure).
 
@@ -453,11 +454,18 @@ class EmbeddingModel(abc.ABC):
         # Multiple docs, each a list of token ids.
         if isinstance(value, list) and len(value) > 0 and isinstance(value[0], list):
             return [inner[:n_tokens] for inner in value]
-        # Multimodal / structured: truncate only string values, preserve keys
-        # and non-text fields.
+        # Multimodal / structured: truncate ONLY the ``text`` field. The
+        # other Jina multimodal fields (``image`` / ``video`` / ``audio``)
+        # carry URLs, file paths or base64 payloads; truncating them corrupts
+        # the media (e.g. a 222-char base64 was cut to 32 chars at n=8). Keys
+        # and non-text values are preserved verbatim.
         if isinstance(value, dict):
             return {
-                k: self._truncate_text(v, n_tokens) if isinstance(v, str) else v
+                k: (
+                    self._truncate_text(v, n_tokens)
+                    if k == "text" and isinstance(v, str)
+                    else v
+                )
                 for k, v in value.items()
             }
         # A list of texts or of dicts: recurse per element.

--- a/xinference/model/embedding/sentence_transformers/tests/test_truncate_prompt_tokens.py
+++ b/xinference/model/embedding/sentence_transformers/tests/test_truncate_prompt_tokens.py
@@ -235,6 +235,58 @@ def test_truncate_list_of_dicts_preserves_structure():
     assert result[1]["image_url"] == "http://x/y.png"
 
 
+# --- _truncate_sentences: multimodal media fields preserved --------------------
+# Regression (PR #5151 review): only the ``text`` field may be truncated in a
+# multimodal dict. ``image`` / ``video`` / ``audio`` carry URLs, file paths or
+# base64 payloads; truncating them corrupts the media (a 222-char base64 was
+# previously reduced to 32 chars at truncate_prompt_tokens=8).
+
+
+def test_truncate_multimodal_media_fields_preserved():
+    """Dict with all media keys: only ``text`` is bounded, media verbatim."""
+    model = _DummyEmbeddingModel(tokenizer=_StrTokenizer())
+    long_b64 = "data:image/png;base64," + "A" * 200  # 222 chars >> 8*4
+    long_url = "https://example.com/path/" + "x" * 200
+    result = model._truncate_sentences(
+        {
+            "text": LONG_TEXT,
+            "image": long_b64,
+            "video": long_url,
+            "audio": long_url,
+        },
+        8,
+    )
+    assert isinstance(result, dict)
+    assert set(result.keys()) == {"text", "image", "video", "audio"}
+    assert len(result["text"]) <= 8 * 4  # text IS truncated
+    assert result["image"] == long_b64  # media preserved verbatim
+    assert result["video"] == long_url
+    assert result["audio"] == long_url
+
+
+def test_truncate_list_of_multimodal_dicts_preserves_media():
+    """List[Dict[str,str]]: each item's media fields survive; only ``text``
+    is bounded. Covers the char-fallback path (no tokenizer)."""
+    model = _DummyEmbeddingModel(tokenizer=None)
+    long_b64 = "data:image/png;base64," + "B" * 200  # >> 8*CHAR_PER_TOKEN
+    result = model._truncate_sentences([{"text": LONG_TEXT, "image": long_b64}], 8)
+    assert isinstance(result, list) and len(result) == 1
+    assert result[0]["image"] == long_b64
+    assert len(result[0]["text"]) <= 8 * _EMBEDDING_TRUNCATE_CHAR_PER_TOKEN
+
+
+def test_truncate_text_field_in_mixed_dict_is_bounded():
+    """A multimodal dict still has its long ``text`` bounded, so the token
+    budget still applies to the text payload alongside the preserved media."""
+    model = _DummyEmbeddingModel(tokenizer=_StrTokenizer())
+    result = model._truncate_sentences(
+        {"image": "data:image/png;base64," + "A" * 200, "text": LONG_TEXT},
+        4,
+    )
+    assert result["image"] == "data:image/png;base64," + "A" * 200
+    assert len(result["text"]) <= 4 * 4
+
+
 # --- _truncate_sentences: ==0 (vLLM parity: explicit empty) --------------------
 
 

--- a/xinference/model/embedding/sentence_transformers/tests/test_truncate_prompt_tokens.py
+++ b/xinference/model/embedding/sentence_transformers/tests/test_truncate_prompt_tokens.py
@@ -1,0 +1,162 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for ``EmbeddingModel._truncate_sentences`` (B1).
+
+Verifies that the ``truncate_prompt_tokens`` parameter correctly bounds
+input length before encoding, using a mock tokenizer so these tests
+require no GPU, no model download, and no network.
+"""
+
+from unittest.mock import MagicMock
+
+from ...core import _EMBEDDING_TRUNCATE_CHAR_PER_TOKEN, EmbeddingModel
+
+
+class _StrTokenizer:
+    """A minimal tokenizer that models 1 token ≈ 4 characters (English)."""
+
+    def __call__(self, text, **kwargs):
+        max_length = kwargs.get("max_length", None)
+        tokens = [ord(c) for c in text[: max_length * 4]] if max_length else text
+        return MagicMock(input_ids=tokens)
+
+    def decode(self, ids, **kwargs):
+        return "".join(chr(i) if isinstance(i, int) else i for i in ids)
+
+
+class _NoneTokenizer:
+    """A tokenizer that raises on __call__ (simulating a broken/unsupported
+    tokenizer, or an engine that returns a non-callable _tokenizer)."""
+
+    def __call__(self, text, **kwargs):
+        raise RuntimeError("tokenizer unavailable")
+
+
+class _DummyEmbeddingModel(EmbeddingModel):
+    """Minimal EmbeddingModel subclass for testing _truncate_sentences.
+
+    We only need ``_model_uid``, ``model_family`` with a ``max_tokens``
+    attribute, and optionally ``_tokenizer``. Abstract methods are stubbed
+    since the test never exercises them.
+    """
+
+    def __init__(self, *, tokenizer=None, max_tokens=None):
+        self._model_uid = "test-model-0"
+        self._tokenizer = tokenizer
+        self.model_family = MagicMock(max_tokens=max_tokens)
+
+    # Stub abstract methods — never called in these tests.
+    def _create_embedding(self, sentences, **kwargs):
+        raise NotImplementedError
+
+    def check_lib(self):
+        raise NotImplementedError
+
+    def load(self):
+        raise NotImplementedError
+
+    @classmethod
+    def match_json(cls, *args, **kwargs):
+        raise NotImplementedError
+
+
+LONG_TEXT = "Hello world! " * 500  # ~7000 chars, ~1750 tokens (4 char/token)
+
+# --- _truncate_sentences: None -------------------------------------------------
+
+
+def test_truncate_none_unchanged():
+    """truncate_prompt_tokens=None → return sentences intact (no truncation)."""
+    model = _DummyEmbeddingModel(tokenizer=_StrTokenizer())
+    result = model._truncate_sentences(LONG_TEXT, None)
+    assert result is LONG_TEXT  # same object identity
+
+
+# --- _truncate_sentences: >0 (explicit token limit) ----------------------------
+
+
+def test_truncate_positive_with_tokenizer():
+    """truncate_prompt_tokens=8 → input is truncated to ~8 tokens via
+    tokenizer."""
+    model = _DummyEmbeddingModel(tokenizer=_StrTokenizer())
+    result = model._truncate_sentences(LONG_TEXT, 8)
+    assert isinstance(result, str)
+    # With our mock, 8 tokens × 4 char/token = ~32 chars returned
+    assert len(result) <= 8 * 4
+
+
+def test_truncate_positive_fallback_to_char():
+    """truncate_prompt_tokens=8 + no tokenizer → fallback to char-based cut."""
+    model = _DummyEmbeddingModel(tokenizer=None)  # no tokenizer (llama_cpp)
+    result = model._truncate_sentences(LONG_TEXT, 8)
+    assert isinstance(result, str)
+    assert len(result) == 8 * _EMBEDDING_TRUNCATE_CHAR_PER_TOKEN
+
+
+def test_truncate_positive_tokenizer_raises_fallback():
+    """truncate_prompt_tokens=8 + tokenizer raises → fallback to char-based cut
+    without propagating the exception."""
+    model = _DummyEmbeddingModel(tokenizer=_NoneTokenizer())
+    result = model._truncate_sentences(LONG_TEXT, 8)
+    assert isinstance(result, str)
+    assert len(result) == 8 * _EMBEDDING_TRUNCATE_CHAR_PER_TOKEN
+
+
+# --- _truncate_sentences: <0 (model max_tokens) --------------------------------
+
+
+def test_truncate_negative_with_max_tokens():
+    """truncate_prompt_tokens=-1 + model has max_tokens=4 → truncate to 4."""
+    model = _DummyEmbeddingModel(tokenizer=_StrTokenizer(), max_tokens=4)
+    result = model._truncate_sentences(LONG_TEXT, -1)
+    assert isinstance(result, str)
+    assert len(result) <= 4 * 4
+
+
+def test_truncate_negative_max_tokens_unknown_skips():
+    """truncate_prompt_tokens=-1 + model max_tokens=None → skip truncation
+    (defensive: unknown limit should not cause errors)."""
+    model = _DummyEmbeddingModel(tokenizer=_StrTokenizer(), max_tokens=None)
+    result = model._truncate_sentences(LONG_TEXT, -1)
+    # Must return the original string unchanged (not truncate).
+    assert result is LONG_TEXT
+
+
+# --- _truncate_sentences: list[str] input ---------------------------------------
+
+
+def test_truncate_list_input():
+    """truncate_prompt_tokens=4 + list[str] input → each item truncated."""
+    model = _DummyEmbeddingModel(tokenizer=_StrTokenizer())
+    texts = ["This is a long first document.", "And another one, also long."]
+    result = model._truncate_sentences(texts, 4)
+    assert isinstance(result, list)
+    assert len(result) == 2
+    for r in result:
+        assert isinstance(r, str)
+        assert len(r) <= 4 * 4
+
+
+# --- _truncate_sentences: non-string items in list ------------------------------
+
+
+def test_truncate_non_string_items():
+    """truncate_prompt_tokens=4 + list with non-string items → str() cast works."""
+    model = _DummyEmbeddingModel(tokenizer=_StrTokenizer())
+    texts = ["hello", 123]
+    result = model._truncate_sentences(texts, 4)
+    assert isinstance(result, list)
+    assert len(result) == 2

--- a/xinference/model/embedding/sentence_transformers/tests/test_truncate_prompt_tokens.py
+++ b/xinference/model/embedding/sentence_transformers/tests/test_truncate_prompt_tokens.py
@@ -30,7 +30,13 @@ class _StrTokenizer:
 
     def __call__(self, text, **kwargs):
         max_length = kwargs.get("max_length", None)
-        tokens = [ord(c) for c in text[: max_length * 4]] if max_length else text
+        if max_length is not None:
+            # Truncation requested: keep the first max_length tokens (~4 chars
+            # each). max_length=0 models HF "max_length=0, truncation=True" ->
+            # empty input_ids.
+            tokens = [ord(c) for c in text[: max_length * 4]]
+        else:
+            tokens = [ord(c) for c in text]
         return MagicMock(input_ids=tokens)
 
     def decode(self, ids, **kwargs):
@@ -150,13 +156,97 @@ def test_truncate_list_input():
         assert len(r) <= 4 * 4
 
 
-# --- _truncate_sentences: non-string items in list ------------------------------
+# --- _truncate_sentences: non-text primitives are preserved ---------------------
 
 
-def test_truncate_non_string_items():
-    """truncate_prompt_tokens=4 + list with non-string items → str() cast works."""
+def test_truncate_non_text_primitive_preserved():
+    """A non-text primitive inside a list is preserved as-is (not str()'d),
+    since only strings are truncatable text."""
     model = _DummyEmbeddingModel(tokenizer=_StrTokenizer())
     texts = ["hello", 123]
     result = model._truncate_sentences(texts, 4)
     assert isinstance(result, list)
     assert len(result) == 2
+    assert result[1] == 123  # int preserved, not stringified to "123"
+
+
+# --- _truncate_sentences: token arrays (List[int] / List[List[int]]) -----------
+# Regression for the corruption bug: token arrays were str()'d, so [[1,2,3]]
+# was embedded as the literal text "[[1,". They must be sliced to n_tokens ids
+# and passed through to _fix_langchain_openai_inputs intact.
+
+
+def test_truncate_flat_token_array_sliced():
+    """List[int] (one doc as token ids) must be sliced to n_tokens ids, NOT
+    stringified to ['1','2','3']."""
+    model = _DummyEmbeddingModel(tokenizer=_StrTokenizer())
+    result = model._truncate_sentences([1, 2, 3, 4, 5], 3)
+    assert result == [1, 2, 3]
+
+
+def test_truncate_nested_token_array_sliced():
+    """List[List[int]] (several docs as token ids) must slice each inner list,
+    preserving the nested structure so _fix_langchain_openai_inputs can still
+    decode each doc."""
+    model = _DummyEmbeddingModel(tokenizer=_StrTokenizer())
+    result = model._truncate_sentences([[1, 2, 3, 4], [5, 6, 7, 8, 9]], 2)
+    assert result == [[1, 2], [5, 6]]
+
+
+def test_truncate_token_array_not_stringified():
+    """Regression: the sliced result must remain int lists, never str."""
+    model = _DummyEmbeddingModel(tokenizer=_StrTokenizer())
+    result = model._truncate_sentences([[1, 2, 3]], 8)
+    assert isinstance(result, list)
+    assert isinstance(result[0], list)
+    assert all(isinstance(i, int) for i in result[0])
+
+
+# --- _truncate_sentences: multimodal / structured dicts ------------------------
+# Regression: list(dict) iterated keys ({"text":"hello"} -> ["text"]) and
+# str(dict) embedded the literal repr. Only string values may be truncated.
+
+
+def test_truncate_single_dict_preserves_keys():
+    """Dict[str,str] (e.g. {"text": ...}) must truncate only the value,
+    preserving the key."""
+    model = _DummyEmbeddingModel(tokenizer=_StrTokenizer())
+    result = model._truncate_sentences({"text": LONG_TEXT}, 8)
+    assert isinstance(result, dict)
+    assert set(result.keys()) == {"text"}
+    assert len(result["text"]) <= 8 * 4
+
+
+def test_truncate_list_of_dicts_preserves_structure():
+    """List[Dict[str,str]] (multimodal): only string values truncated; keys and
+    non-text values preserved verbatim; structure intact."""
+    model = _DummyEmbeddingModel(tokenizer=_StrTokenizer())
+    result = model._truncate_sentences(
+        [{"text": LONG_TEXT}, {"text": "short", "image_url": "http://x/y.png"}],
+        8,
+    )
+    assert isinstance(result, list)
+    assert len(result) == 2
+    assert isinstance(result[0], dict)
+    assert set(result[0].keys()) == {"text"}
+    assert len(result[0]["text"]) <= 8 * 4
+    # non-string value preserved verbatim, key set unchanged
+    assert set(result[1].keys()) == {"text", "image_url"}
+    assert result[1]["image_url"] == "http://x/y.png"
+
+
+# --- _truncate_sentences: ==0 (vLLM parity: explicit empty) --------------------
+
+
+def test_truncate_zero_yields_empty_char_fallback():
+    """truncate_prompt_tokens=0 + no tokenizer -> char fallback s[:0] == ''.
+    Must NOT silently expand to the model's full max_tokens (the bug)."""
+    model = _DummyEmbeddingModel(tokenizer=None, max_tokens=8192)
+    assert model._truncate_sentences(LONG_TEXT, 0) == ""
+
+
+def test_truncate_zero_yields_empty_with_tokenizer():
+    """truncate_prompt_tokens=0 + tokenizer -> max_length=0 -> empty input_ids
+    -> ''. Matches vLLM (xinference/model/llm/vllm/core.py::_tokenize)."""
+    model = _DummyEmbeddingModel(tokenizer=_StrTokenizer(), max_tokens=8192)
+    assert model._truncate_sentences(LONG_TEXT, 0) == ""


### PR DESCRIPTION
## Summary

Three coupled fixes addressing jina-embeddings-v3 OOM crashes cascading into persistent replica zombies. Combines B1 (truncation), B2 (eviction on failure, both branches), and B3a (wait_for_load after recovery).

## B1: Implement truncate_prompt_tokens for embedding models

`truncate_prompt_tokens` was previously only implemented for vLLM LLMs. For embeddings the parameter was silently accepted and ignored — long documents were processed at full length, triggering O(L²) attention OOM.

**Changes:**
- `embedding/core.py`: Add `_truncate_sentences()` — token-based truncation with character fallback. Never raises. Applied at both choke points.
- `schemas/requests.py`: Add `truncate_prompt_tokens: Optional[int]` field.

## B2: Evict zombie replicas on recovery failure (both branches)

When OOM kills a replica subprocess and auto-recovery itself fails:
- **Unbounded branch** (default `recover_count=None`): silently continued without notifying supervisor → zombie replica stays in routing table.
- **Bounded branch** (`AUTO_RECOVER_LIMIT>=1`): same gap — exception escaped `recover_sub_pool`, leaving "stopping" zombie causing persistent 500s.

**Fix:** Wrap `recover_model` in `try/except` in both branches → call `_evict_replica_from_supervisor` (idempotent `mark_replica_dead`).

## B3a: Mark recreated/recovered replicas "ready" via wait_for_load

`recover_model` and `_try_recover_models` called `launch_builtin_model` (sets `model_state="loading"`) but never called `wait_for_load` to transition to `"ready"` — leaving recreated replicas permanently "loading".

**Fix:** Add `await self.wait_for_load(...)` after `launch_builtin_model` in both methods, mirroring the normal launch path.

## Files changed

| File | Changes |
|------|---------|
| `model/embedding/core.py` | B1: `_truncate_sentences()` + constants + choke points |
| `api/schemas/requests.py` | B1: `truncate_prompt_tokens` field |
| `core/worker.py` | B2: try/except in both branches + B3a: wait_for_load in recover_model and _try_recover_models |
| `model/.../test_truncate_prompt_tokens.py` | 8 B1 unit tests |
| `api/tests/test_embedding_truncate.py` | 7 schema tests |
| `core/tests/test_worker.py` | 10 tests (B2 unbounded/bounded + B3a recover_model/_try_recover_models) |

## Backward compatibility

- `truncate_prompt_tokens` defaults to `None` — existing clients unaffected.
- Unbounded recovery still retries infinitely on success. Behavior only changes on failure.
- `wait_for_load` is idempotent; on an already-loaded model it is near-instant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>