### PR TITLE
refactor: move XINFERENCE_MODEL_ACTOR_AUTO_RECOVER_LIMIT to constants.py

### DIFF
--- a/xinference/constants.py
+++ b/xinference/constants.py
@@ -268,6 +268,14 @@ XINFERENCE_STATUS_GATHER_TIMEOUT = int(
     os.environ.get(XINFERENCE_ENV_STATUS_GATHER_TIMEOUT, 10)
 )
 
+# Model actor auto-recreate budget after a subpool death (e.g. CUDA OOM).
+# None (default) = unbounded retry; int N = recreate up to N times, then evict
+# the replica on the next death. Set via the env var of the same name.
+_raw_recover_limit = os.getenv("XINFERENCE_MODEL_ACTOR_AUTO_RECOVER_LIMIT")
+XINFERENCE_MODEL_ACTOR_AUTO_RECOVER_LIMIT = (
+    int(_raw_recover_limit) if _raw_recover_limit is not None else None
+)
+
 # OTEL resolved values
 XINFERENCE_ENABLE_OTEL = (
     os.getenv(XINFERENCE_ENV_ENABLE_OTEL, "false").strip().lower() == "true"

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -59,6 +59,7 @@ from ..constants import (
     XINFERENCE_LOG_CONSOLE,
     XINFERENCE_LOG_DOWNLOAD_PROGRESS,
     XINFERENCE_MAX_CONCURRENT_LAUNCHES,
+    XINFERENCE_MODEL_ACTOR_AUTO_RECOVER_LIMIT,
     XINFERENCE_MODEL_DOWNLOAD_WORKERS,
     XINFERENCE_STATUS_GATHER_TIMEOUT,
     XINFERENCE_STATUS_REPORT_MULTIPLIER,
@@ -149,13 +150,6 @@ def _exclusive_venv_path_lock(env_path: str):
         fcntl.flock(fd, fcntl.LOCK_UN)
         os.close(fd)
 
-
-MODEL_ACTOR_AUTO_RECOVER_LIMIT: Optional[int]
-_MODEL_ACTOR_AUTO_RECOVER_LIMIT = os.getenv("XINFERENCE_MODEL_ACTOR_AUTO_RECOVER_LIMIT")
-if _MODEL_ACTOR_AUTO_RECOVER_LIMIT is not None:
-    MODEL_ACTOR_AUTO_RECOVER_LIMIT = int(_MODEL_ACTOR_AUTO_RECOVER_LIMIT)
-else:
-    MODEL_ACTOR_AUTO_RECOVER_LIMIT = None
 
 # Strip test-injected envs from cached launch_args before recover.
 # All test-specific env vars MUST use the XINFERENCE_TEST_ prefix so they can be
@@ -3116,7 +3110,7 @@ class WorkerActor(xo.StatelessActor):
                     )
                     self._model_uid_to_addr[model_uid] = subpool_address
                     self._model_uid_to_recover_count.setdefault(
-                        model_uid, MODEL_ACTOR_AUTO_RECOVER_LIMIT
+                        model_uid, XINFERENCE_MODEL_ACTOR_AUTO_RECOVER_LIMIT
                     )
                     self._model_uid_to_launch_args[model_uid] = launch_args
                     # §4.3: Persist for auto-recovery on restart


### PR DESCRIPTION
## Summary

> [!IMPORTANT]
> **Depends on:** #5151 — please review/merge #5151 first.

Pure code-organization refactor: move the `MODEL_ACTOR_AUTO_RECOVER_LIMIT` constant from a local definition in `worker.py` to `constants.py`, the centralized location for `XINFERENCE_*` configuration constants.

## Changes

- **`constants.py`**: Add `XINFERENCE_MODEL_ACTOR_AUTO_RECOVER_LIMIT` (renamed to match the `constants.py` naming convention where the Python symbol matches the env var name). Defaults to `None` (unbounded retry).
- **`worker.py`**: Remove the local `MODEL_ACTOR_AUTO_RECOVER_LIMIT` / `_MODEL_ACTOR_AUTO_RECOVER_LIMIT` definition; import from `constants.py`; update the single usage point.

## Backward compatibility

- **Env var name unchanged**: `XINFERENCE_MODEL_ACTOR_AUTO_RECOVER_LIMIT`
- **Behavior unchanged**: `None` default, `int(N)` for bounded retry
- **No cycle import risk**: `worker.py` already imports from `constants.py`; `constants.py` does not import from `worker.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>