### PR TITLE
feat(embedding): support BCE embeddings with vLLM

### DIFF
--- a/xinference/model/embedding/model_spec.json
+++ b/xinference/model/embedding/model_spec.json
@@ -1058,12 +1058,14 @@
         }
       }
     ],
-    "updated_at": 1769418300,
+    "updated_at": 1783506669,
     "featured": false,
     "virtualenv": {
       "packages": [
         "#sentence_transformers_dependencies# ; #engine# == \"sentence_transformers\"",
-        "#system_torchvision# ; #engine# == \"sentence_transformers\""
+        "#system_torchvision# ; #engine# == \"sentence_transformers\"",
+        "#vllm_dependencies# ; #engine# == \"vllm\"",
+        "#system_numpy# ; #engine# == \"vllm\""
       ]
     }
   },

--- a/xinference/model/embedding/tests/test_embedding_models.py
+++ b/xinference/model/embedding/tests/test_embedding_models.py
@@ -21,7 +21,7 @@ import pytest
 
 from ..cache_manager import EmbeddingCacheManager as CacheManager
 from ..core import EmbeddingModelFamilyV2, TransformersEmbeddingSpecV1
-from ..embed_family import EMBEDDING_ENGINES
+from ..embed_family import BUILTIN_EMBEDDING_MODELS, EMBEDDING_ENGINES
 
 TEST_MODEL_SPEC = EmbeddingModelFamilyV2(
     version=2,
@@ -81,10 +81,16 @@ def test_engine_supported():
 
 
 def test_bce_embedding_vllm_engine_params_with_virtualenv():
-    from ....model.utils import get_engine_params_by_name_with_virtual_env
+    from ....model.utils import (
+        _collect_virtualenv_engine_markers,
+        get_engine_params_by_name_with_virtual_env,
+    )
     from .. import _install
 
     _install()
+    family = BUILTIN_EMBEDDING_MODELS["bce-embedding-base_v1"][0]
+    assert "vllm" in _collect_virtualenv_engine_markers(family)
+
     params = get_engine_params_by_name_with_virtual_env(
         "embedding", "bce-embedding-base_v1", enable_virtual_env=True
     )

--- a/xinference/model/embedding/tests/test_embedding_models.py
+++ b/xinference/model/embedding/tests/test_embedding_models.py
@@ -21,6 +21,7 @@ import pytest
 
 from ..cache_manager import EmbeddingCacheManager as CacheManager
 from ..core import EmbeddingModelFamilyV2, TransformersEmbeddingSpecV1
+from ..embed_family import EMBEDDING_ENGINES
 
 TEST_MODEL_SPEC = EmbeddingModelFamilyV2(
     version=2,
@@ -70,7 +71,6 @@ TEST_MODEL_SPEC_FROM_MODELSCOPE = EmbeddingModelFamilyV2(
         )
     ],
 )
-from ..embed_family import EMBEDDING_ENGINES
 
 
 def test_engine_supported():
@@ -78,6 +78,22 @@ def test_engine_supported():
     assert model_name in EMBEDDING_ENGINES
     assert "flag" in EMBEDDING_ENGINES[model_name]
     assert "sentence_transformers" in EMBEDDING_ENGINES[model_name]
+
+
+def test_bce_embedding_vllm_engine_params_with_virtualenv():
+    from ....model.utils import get_engine_params_by_name_with_virtual_env
+    from .. import _install
+
+    _install()
+    params = get_engine_params_by_name_with_virtual_env(
+        "embedding", "bce-embedding-base_v1", enable_virtual_env=True
+    )
+    assert isinstance(params, dict)
+    assert "vllm" in params
+    assert isinstance(params["vllm"], list)
+    assert params["vllm"]
+    assert params["vllm"][0]["model_format"] == "pytorch"
+    assert params["vllm"][0]["quantization"] == "none"
 
 
 async def test_model_from_modelscope():

--- a/xinference/model/embedding/vllm/core.py
+++ b/xinference/model/embedding/vllm/core.py
@@ -24,7 +24,7 @@ from ...utils import check_dependency_available
 from ..core import EmbeddingModel, EmbeddingModelFamilyV2, EmbeddingSpecV1
 
 logger = logging.getLogger(__name__)
-SUPPORTED_MODELS_PREFIXES = ["bge", "gte", "text2vec", "m3e", "gte", "Qwen3"]
+SUPPORTED_MODELS_PREFIXES = ["bge", "gte", "text2vec", "m3e", "Qwen3", "bce"]
 
 
 class VLLMEmbeddingModel(EmbeddingModel, BatchMixin):
@@ -316,7 +316,7 @@ class VLLMEmbeddingModel(EmbeddingModel, BatchMixin):
         if prefix not in SUPPORTED_MODELS_PREFIXES:
             return (
                 False,
-                f"Model family {model_family.model_name} is not in the supported prefix list for vLLM embeddings",
+                f"Model family {model_family.model_name} is not in the supported model prefix list for vLLM embeddings",
             )
         return True
 

--- a/xinference/model/rerank/vllm/core.py
+++ b/xinference/model/rerank/vllm/core.py
@@ -22,7 +22,7 @@ from ..core import (
 
 QWEN3_RERANK_TEMPLATE = int(os.getenv("XINFERENCE_QWEN3_RERANK_TEMPLATE", "1"))
 logger = logging.getLogger(__name__)
-SUPPORTED_MODELS_PREFIXES = ["bge", "gte", "text2vec", "m3e", "gte", "Qwen3"]
+SUPPORTED_MODELS_PREFIXES = ["bge", "gte", "text2vec", "m3e", "Qwen3"]
 
 
 class VLLMRerankModel(RerankModel, BatchMixin):


### PR DESCRIPTION
## Summary

- Add the `bce` prefix to the vLLM embedding compatibility list.
- Add the vLLM virtual-environment dependencies to `bce-embedding-base_v1`, matching xorbitsai/xinference-backend#50.
- Add regression coverage for BCE vLLM engine discovery and dependency markers.
- Remove the adjacent duplicate `gte` entry from the vLLM rerank prefix list.

This ports the shared code structure and model metadata from xorbitsai/xinference-backend#50.

## Release note

- Support deploying `bce-embedding-base_v1` with the vLLM embedding engine.

Closes #5157

## Validation

- `pytest -q xinference/model/embedding/tests/test_embedding_models.py::test_bce_embedding_vllm_engine_params_with_virtualenv`
- `pre-commit run --files xinference/model/embedding/model_spec.json xinference/model/embedding/tests/test_embedding_models.py xinference/model/embedding/vllm/core.py xinference/model/rerank/vllm/core.py`
- `python -m json.tool xinference/model/embedding/model_spec.json`
- `git diff --check`