### PR TITLE
fix(supervisor): resolve comma-separated worker_ip in sharded launch (#5138)

### DIFF
--- a/xinference/core/supervisor.py
+++ b/xinference/core/supervisor.py
@@ -2101,14 +2101,13 @@ class SupervisorActor(xo.StatelessActor):
             # by ``_choose_worker`` and the ``n_worker`` count reflects real
             # workers. An entry may be a bare IP or an already-qualified
             # ``ip:port`` worker address; both are accepted.
-            if isinstance(worker_ip, list):
-                requested = [
-                    str(item).strip() for item in worker_ip if str(item).strip()
-                ]
-            else:
-                requested = [
-                    item.strip() for item in str(worker_ip).split(",") if item.strip()
-                ]
+            raw_entries = worker_ip if isinstance(worker_ip, list) else [worker_ip]
+            requested = [
+                entry.strip()
+                for item in raw_entries
+                for entry in str(item).split(",")
+                if entry.strip()
+            ]
             ip_to_addresses: Dict[str, List[str]] = {}
             for addr in self._worker_address_to_worker:
                 ip_to_addresses.setdefault(addr.split(":")[0], []).append(addr)
@@ -2123,6 +2122,7 @@ class SupervisorActor(xo.StatelessActor):
                         f"Worker ip address {entry} is not in the cluster."
                     )
                 available_workers.extend(matched)
+            available_workers = list(dict.fromkeys(available_workers))
 
         async def _launch_model():
             # Validation of n_worker, intercept if it is greater than the available workers.

--- a/xinference/core/supervisor.py
+++ b/xinference/core/supervisor.py
@@ -2113,9 +2113,7 @@ class SupervisorActor(xo.StatelessActor):
             for ip in requested_ips:
                 matched = ip_to_addresses.get(ip)
                 if not matched:
-                    raise ValueError(
-                        f"Worker ip address {ip} is not in the cluster."
-                    )
+                    raise ValueError(f"Worker ip address {ip} is not in the cluster.")
                 available_workers.extend(matched)
 
         async def _launch_model():

--- a/xinference/core/supervisor.py
+++ b/xinference/core/supervisor.py
@@ -2096,24 +2096,32 @@ class SupervisorActor(xo.StatelessActor):
         else:
             # ``worker_ip`` may arrive as a comma-separated string (from the
             # REST API / web UI) or as a list (from the Python client). Normalize
-            # it to a list of IPs, then resolve each IP to the concrete worker
-            # address (``ip:port``) so the values match the keys used by
-            # ``_choose_worker`` and the ``n_worker`` count reflects real workers.
+            # it to a list of entries, then resolve each entry to the concrete
+            # worker address(es) (``ip:port``) so the values match the keys used
+            # by ``_choose_worker`` and the ``n_worker`` count reflects real
+            # workers. An entry may be a bare IP or an already-qualified
+            # ``ip:port`` worker address; both are accepted.
             if isinstance(worker_ip, list):
-                requested_ips = [
+                requested = [
                     str(item).strip() for item in worker_ip if str(item).strip()
                 ]
             else:
-                requested_ips = [
+                requested = [
                     item.strip() for item in str(worker_ip).split(",") if item.strip()
                 ]
             ip_to_addresses: Dict[str, List[str]] = {}
             for addr in self._worker_address_to_worker:
                 ip_to_addresses.setdefault(addr.split(":")[0], []).append(addr)
-            for ip in requested_ips:
-                matched = ip_to_addresses.get(ip)
+            for entry in requested:
+                if entry in self._worker_address_to_worker:
+                    # Already a concrete worker address (``ip:port``).
+                    available_workers.append(entry)
+                    continue
+                matched = ip_to_addresses.get(entry)
                 if not matched:
-                    raise ValueError(f"Worker ip address {ip} is not in the cluster.")
+                    raise ValueError(
+                        f"Worker ip address {entry} is not in the cluster."
+                    )
                 available_workers.extend(matched)
 
         async def _launch_model():

--- a/xinference/core/supervisor.py
+++ b/xinference/core/supervisor.py
@@ -2094,10 +2094,29 @@ class SupervisorActor(xo.StatelessActor):
                 # no registration, use all workers
                 available_workers = all_workers
         else:
+            # ``worker_ip`` may arrive as a comma-separated string (from the
+            # REST API / web UI) or as a list (from the Python client). Normalize
+            # it to a list of IPs, then resolve each IP to the concrete worker
+            # address (``ip:port``) so the values match the keys used by
+            # ``_choose_worker`` and the ``n_worker`` count reflects real workers.
             if isinstance(worker_ip, list):
-                available_workers.extend(worker_ip)
+                requested_ips = [
+                    str(item).strip() for item in worker_ip if str(item).strip()
+                ]
             else:
-                available_workers.append(worker_ip)
+                requested_ips = [
+                    item.strip() for item in str(worker_ip).split(",") if item.strip()
+                ]
+            ip_to_addresses: Dict[str, List[str]] = {}
+            for addr in self._worker_address_to_worker:
+                ip_to_addresses.setdefault(addr.split(":")[0], []).append(addr)
+            for ip in requested_ips:
+                matched = ip_to_addresses.get(ip)
+                if not matched:
+                    raise ValueError(
+                        f"Worker ip address {ip} is not in the cluster."
+                    )
+                available_workers.extend(matched)
 
         async def _launch_model():
             # Validation of n_worker, intercept if it is greater than the available workers.

--- a/xinference/core/tests/test_launch_strategy.py
+++ b/xinference/core/tests/test_launch_strategy.py
@@ -66,6 +66,28 @@ class DummyStatusGuard:
         return self.replica_counts[model_uid]
 
 
+class DummySupervisor:
+    def __init__(self, workers):
+        from xinference.core.supervisor import SupervisorActor
+
+        self._worker_address_to_worker = workers
+        self._model_uid_to_replica_info = {}
+        self._replica_model_uid_to_worker = {}
+        self._status_guard_ref = DummyStatusGuard()
+        self._unexpected_down_replicas = {}
+        self._build_replica_info = SupervisorActor._build_replica_info
+        self._choose_worker = SupervisorActor._choose_worker.__get__(self)
+        self._clear_unexpected_down_replicas = (
+            SupervisorActor._clear_unexpected_down_replicas.__get__(self)
+        )
+        self._launch_builtin_sharded_model = (
+            SupervisorActor._launch_builtin_sharded_model.__get__(self)
+        )
+
+    async def terminate_model(self, model_uid: str, suppress_exception: bool = False):
+        return None
+
+
 def test_assign_replica_gpu_single_slot_reused():
     # single gpu_idx with multiple replicas should be invalid
     with pytest.raises(ValueError):
@@ -243,31 +265,6 @@ def test_idle_first_multi_gpu_two_workers():
 
 @pytest.mark.asyncio
 async def test_distributed_launch_avoids_same_worker_for_shards():
-    from xinference.core.supervisor import SupervisorActor
-
-    class DummySupervisor:
-        _build_replica_info = staticmethod(SupervisorActor._build_replica_info)
-        _choose_worker = SupervisorActor._choose_worker
-        _launch_builtin_sharded_model = SupervisorActor._launch_builtin_sharded_model
-        _clear_unexpected_down_replicas = (
-            SupervisorActor._clear_unexpected_down_replicas
-        )
-
-        def __init__(self, workers):
-            self._worker_address_to_worker = workers
-            self._model_uid_to_replica_info = {}
-            self._replica_model_uid_to_worker = {}
-            self._status_guard_ref = DummyStatusGuard()
-            self._unexpected_down_replicas = {}
-
-        def _gen_model_uid(self, model_name: str) -> str:
-            return f"{model_name}-uid"
-
-        async def terminate_model(
-            self, model_uid: str, suppress_exception: bool = False
-        ):
-            return None
-
     launched = []
     worker1 = DummyWorkerRef("w1:1000", model_count=1, launched=launched)
     worker2 = DummyWorkerRef("w2:1000", model_count=0, launched=launched)
@@ -290,6 +287,62 @@ async def test_distributed_launch_avoids_same_worker_for_shards():
 
     assert set(launched) == {"w1:1000", "w2:1000"}
     assert len(launched) == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "worker_ip",
+    ["w1,w2", ["w1,w2"]],
+)
+async def test_distributed_launch_resolves_comma_separated_worker_ips(worker_ip):
+    launched = []
+    worker1 = DummyWorkerRef("w1:1000", model_count=1, launched=launched)
+    worker2 = DummyWorkerRef("w2:1000", model_count=0, launched=launched)
+    supervisor = DummySupervisor({"w1:1000": worker1, "w2:1000": worker2})
+
+    await supervisor._launch_builtin_sharded_model(
+        model_uid="demo-model",
+        model_name="demo",
+        model_size_in_billions=None,
+        model_format=None,
+        quantization=None,
+        model_engine=None,
+        model_type="LLM",
+        n_gpu=1,
+        n_worker=2,
+        worker_ip=worker_ip,
+        wait_ready=True,
+    )
+
+    assert set(launched) == {"w1:1000", "w2:1000"}
+    assert len(launched) == 2
+
+
+@pytest.mark.asyncio
+async def test_distributed_launch_deduplicates_worker_ips():
+    launched = []
+    worker = DummyWorkerRef("w1:1000", model_count=0, launched=launched)
+    supervisor = DummySupervisor({"w1:1000": worker})
+
+    with pytest.raises(
+        ValueError,
+        match="n_worker cannot be larger than the number of available workers",
+    ):
+        await supervisor._launch_builtin_sharded_model(
+            model_uid="demo-model",
+            model_name="demo",
+            model_size_in_billions=None,
+            model_format=None,
+            quantization=None,
+            model_engine=None,
+            model_type="LLM",
+            n_gpu=1,
+            n_worker=2,
+            worker_ip=["w1,w1:1000"],
+            wait_ready=True,
+        )
+
+    assert launched == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

Fixes #5138 — in a multi-worker cluster, launching a **distributed** model (`n_worker > 1`) with an explicit `worker_ip` fails with:

> `n_worker cannot be larger than the number of available workers`

even when enough workers are online.

## Why

The REST API / web UI passes the worker selection as a **comma-separated string** (e.g. `"192.168.100.1,192.168.100.2"`). In `_launch_builtin_sharded_model`, the `worker_ip` branch appended that raw string as a *single* list element:

```python
else:
    if isinstance(worker_ip, list):
        available_workers.extend(worker_ip)
    else:
        available_workers.append(worker_ip)   # "ip1,ip2" -> 1 element
```

So `len(available_workers) == 1` while `n_worker == 2`, tripping the validation. The path was in fact doubly broken: the bare IPs also never matched the `"ip:port"` keys that `_choose_worker` iterates over (`self._worker_address_to_worker`), so even past the count check no worker would be selected (`RuntimeError: No available worker found`).

Everywhere else in the supervisor, `worker_ip` is treated as a comma-separated list of IPs and resolved against worker addresses (see `_get_worker_refs_by_ip`, which does `ip.split(",")` and matches `addr.split(":")[0]`). The sharded path was the only place that didn't.

## Fix

Normalize `worker_ip` (list **or** comma-separated string) to a list of IPs, then resolve each IP to the concrete worker address(es), mirroring `_get_worker_refs_by_ip`. This makes the `n_worker` count reflect real workers and makes the resolved values match the keys used by `_choose_worker`. Unknown IPs now raise a clear `Worker ip address <ip> is not in the cluster.` error, consistent with the non-sharded path.

## Repro (from the issue)

Cluster with 2 workers (1 GPU each). Load an embedding on worker A, a rerank on worker B, then launch a distributed LLM with `Worker Count: 2`, `Worker IP: 192.168.100.1,192.168.100.2`. Before this change the launch is rejected; after it, the two IPs resolve to the two worker addresses and the shards are placed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
