### PR TITLE
fix(worker): use os.replace for atomic launch_args persist on Windows (#5161)

### DIFF
--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -1041,7 +1041,7 @@ class WorkerActor(xo.StatelessActor):
             tmp_path = filepath + ".tmp"
             with open(tmp_path, "w") as f:
                 json.dump(data, f, ensure_ascii=False)
-            os.rename(tmp_path, filepath)
+            os.replace(tmp_path, filepath)
             logger.debug(
                 "Persisted launch_args for %d models to %s", len(data), filepath
             )
@@ -1064,7 +1064,7 @@ class WorkerActor(xo.StatelessActor):
                 tmp_path = filepath + ".tmp"
                 with open(tmp_path, "w") as f:
                     json.dump(data, f, ensure_ascii=False)
-                os.rename(tmp_path, filepath)
+                os.replace(tmp_path, filepath)
         except Exception:
             logger.warning("Failed to update persisted launch_args", exc_info=True)
 


### PR DESCRIPTION
## Summary

On Windows, `os.rename(src, dst)` raises `FileExistsError: [WinError 183]` when `dst` already exists — unlike POSIX, it is **not** an atomic overwrite. Both `_persist_launch_args` and `_remove_persisted_launch_args` in `xinference/core/worker.py` rely on the temp-file + rename pattern to atomically update `worker_recovery/<worker>/models.json`.

As a result, on Windows every persist **after the first** silently fails:
- `models.json` keeps reflecting only the first launched model,
- `models.json.tmp` is left holding the newer (uncommitted) content,
- the failure is swallowed by the surrounding `except Exception` (only a debug/warning log), so it is silent,
- auto-recovery on the next worker restart only restores the first model.

## Fix

Replace `os.rename(tmp_path, filepath)` with `os.replace(tmp_path, filepath)` at both call sites. `os.replace` overwrites the destination atomically on **all** platforms (Windows and POSIX), which is exactly the intended semantics — the docstring already says *"Atomically persist current launch_args to disk."*

This also matches the existing atomic-write in the same file (the `.pth` write already uses `os.replace(str(tmp_file), str(pth_file))`), so the fix is consistent with established style in the codebase.

No behavior change on Linux/macOS; fixes the silent breakage on Windows.

Fixes #5161

🤖 Generated with [Claude Code](https://claude.com/claude-code)
