### PR TITLE
fix(llama.cpp): resolve mmproj against the model directory so image input works

### DIFF
--- a/xinference/model/llm/llama_cpp/core.py
+++ b/xinference/model/llm/llama_cpp/core.py
@@ -247,11 +247,16 @@ class XllamaCppModel(LLM, ChatModelMixin):
         multimodal_projector = self._llamacpp_model_config.get(
             "multimodal_projector", ""
         )
-        mmproj = (
-            os.path.join(self.model_path, multimodal_projector)
-            if multimodal_projector
-            else ""
-        )
+        if not multimodal_projector:
+            mmproj = ""
+        elif os.path.isabs(multimodal_projector):
+            mmproj = multimodal_projector
+        else:
+            # ``model_path`` resolves to the model *file*; the projector lives
+            # alongside it, so resolve it against the model's directory. Joining
+            # onto ``self.model_path`` directly would yield ".../model.gguf/mmproj"
+            # (a nonexistent path) whenever --model-path points at a single file.
+            mmproj = os.path.join(os.path.dirname(model_path), multimodal_projector)
 
         try:
             params = CommonParams()


### PR DESCRIPTION
### What
When launching a custom multimodal GGUF model with `--multimodal-projector`, the projector was never actually loaded, so llama.cpp rejected image input with:

> image input is not supported - hint: if this is unexpected, you may need to provide the mmproj

### Why
In `llama_cpp/core.py::load()`, when `--model-path` points at a single `.gguf` **file**, `self.model_path` is that file. The projector was then resolved with:

```python
mmproj = os.path.join(self.model_path, multimodal_projector)
```

which yields a nonexistent path such as `.../Qwen3.5-0.8B-BF16.gguf/mmproj-BF16.gguf`. `params.mmproj.path` is set to that bogus path, llama.cpp silently starts without a projector, and every image request fails.

### Fix
Resolve the projector against the model **directory** (`os.path.dirname(model_path)`) instead of the file path, and honor absolute projector paths as-is. This keeps the previous behavior for the directory/cache code paths (`os.path.dirname` of the joined model file equals the original model dir), so there is no regression for cached models.

Fixes #5169

🤖 Generated with [Claude Code](https://claude.com/claude-code)
