### PR TITLE
feat(audio): batch Qwen3-ASR transcriptions

### DIFF
--- a/xinference/model/audio/qwen3_asr.py
+++ b/xinference/model/audio/qwen3_asr.py
@@ -34,6 +34,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+QWEN3_ASR_DEFAULT_BATCH_INTERVAL = 0.1
+
 
 class Qwen3ASRModel(BatchMixin):
     def __init__(
@@ -51,7 +53,7 @@ class Qwen3ASRModel(BatchMixin):
         self._device = device
         self._model = None
         batch_size = kwargs.pop("batch_size", None)
-        batch_interval = kwargs.pop("batch_interval", None)
+        batch_interval = kwargs.pop("batch_interval", QWEN3_ASR_DEFAULT_BATCH_INTERVAL)
         self._kwargs = kwargs
 
         batching_kwargs = {}

--- a/xinference/model/audio/qwen3_asr.py
+++ b/xinference/model/audio/qwen3_asr.py
@@ -12,16 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
 import logging
 import os
 import tempfile
+from collections import defaultdict
 from typing import TYPE_CHECKING, List, Optional, Tuple
+
+from xoscar import extensible
 
 from ...device_utils import (
     get_available_device,
     get_device_preferred_dtype,
     is_device_available,
 )
+from ...utils import make_hashable
+from ..batch import BatchMixin
 
 if TYPE_CHECKING:
     from .core import AudioModelFamilyV2
@@ -29,7 +35,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class Qwen3ASRModel:
+class Qwen3ASRModel(BatchMixin):
     def __init__(
         self,
         model_uid: str,
@@ -44,7 +50,19 @@ class Qwen3ASRModel:
         self._model_spec = model_spec
         self._device = device
         self._model = None
+        batch_size = kwargs.pop("batch_size", None)
+        batch_interval = kwargs.pop("batch_interval", None)
         self._kwargs = kwargs
+
+        batching_kwargs = {}
+        max_inference_batch_size = kwargs.get("max_inference_batch_size")
+        if batch_size is not None:
+            batching_kwargs["batch_size"] = batch_size
+        elif max_inference_batch_size is not None and int(max_inference_batch_size) > 0:
+            batching_kwargs["batch_size"] = max_inference_batch_size
+        if batch_interval is not None:
+            batching_kwargs["batch_interval"] = batch_interval
+        BatchMixin.__init__(self, self._batch_transcribe, **batching_kwargs)
 
     @property
     def model_ability(self):
@@ -139,7 +157,108 @@ class Qwen3ASRModel:
 
         return str(result), None
 
-    def transcriptions(
+    def _format_transcription_result(self, result, response_format: str):
+        text, detected_language = self._extract_text_and_language(result)
+        if response_format == "json":
+            return {"text": text}
+        if response_format == "verbose_json":
+            return {
+                "task": "transcribe",
+                "language": detected_language,
+                "text": text,
+            }
+        raise ValueError(f"Unsupported response format: {response_format}")
+
+    def _run_transcription_batch(
+        self,
+        audios: List[bytes],
+        languages: List[Optional[str]],
+        response_formats: List[str],
+        transcription_kwargs: dict,
+    ) -> List[dict]:
+        assert self._model is not None
+        with tempfile.TemporaryDirectory() as temp_dir:
+            audio_paths = []
+            for i, audio in enumerate(audios):
+                audio_path = os.path.join(temp_dir, f"audio-{i}")
+                with open(audio_path, "wb") as f:
+                    f.write(audio)
+                audio_paths.append(audio_path)
+
+            results = self._model.transcribe(
+                audio=audio_paths,
+                language=languages,
+                **transcription_kwargs,
+            )
+
+        if not isinstance(results, list):
+            raise RuntimeError(
+                f"Qwen3-ASR returned an invalid batch result: {type(results)}"
+            )
+        if len(results) != len(audios):
+            raise RuntimeError(
+                "Qwen3-ASR returned a different number of results than inputs: "
+                f"{len(results)} != {len(audios)}"
+            )
+        return [
+            self._format_transcription_result(result, response_format)
+            for result, response_format in zip(results, response_formats)
+        ]
+
+    @extensible
+    def _batch_transcribe(
+        self,
+        audio: bytes,
+        language: Optional[str],
+        response_format: str,
+        transcription_kwargs: dict,
+    ) -> dict:
+        return self._run_transcription_batch(
+            [audio], [language], [response_format], transcription_kwargs
+        )[0]
+
+    @_batch_transcribe.batch  # type: ignore
+    async def _batch_transcribe(self, args_list, kwargs_list):
+        grouped = defaultdict(
+            lambda: {
+                "audios": [],
+                "languages": [],
+                "response_formats": [],
+                "transcription_kwargs": None,
+                "indices": [],
+            }
+        )
+
+        for index, (args, kwargs) in enumerate(zip(args_list, kwargs_list)):
+            if kwargs:
+                raise TypeError("Qwen3-ASR internal batch call expects positional args")
+            audio, language, response_format, transcription_kwargs = args
+            key = make_hashable(transcription_kwargs)
+            group = grouped[key]
+            group["audios"].append(audio)
+            group["languages"].append(language)
+            group["response_formats"].append(response_format)
+            group["transcription_kwargs"] = transcription_kwargs
+            group["indices"].append(index)
+
+        results_with_indices = []
+        for group in grouped.values():
+            results = await asyncio.to_thread(
+                self._run_transcription_batch,
+                group["audios"],
+                group["languages"],
+                group["response_formats"],
+                group["transcription_kwargs"],
+            )
+            results_with_indices.extend(zip(group["indices"], results))
+
+        results_with_indices.sort(key=lambda item: item[0])
+        return [result for _, result in results_with_indices]
+
+    def _get_batch_size(self, *args, **kwargs) -> int:
+        return 1
+
+    async def transcriptions(
         self,
         audio: bytes,
         language: Optional[str] = None,
@@ -163,25 +282,12 @@ class Qwen3ASRModel:
             logger.warning(
                 "Prompt for Qwen3-ASR transcriptions will be ignored: %s", prompt
             )
+        if response_format not in ("json", "verbose_json"):
+            raise ValueError(f"Unsupported response format: {response_format}")
 
         kw = dict(getattr(self._model_spec, "default_transcription_config", None) or {})
         kw.update(kwargs)
-
-        with tempfile.NamedTemporaryFile(buffering=0) as f:
-            f.write(audio)
-            assert self._model is not None
-            result = self._model.transcribe(audio=f.name, language=language, **kw)
-            text, detected_language = self._extract_text_and_language(result)
-
-        if response_format == "json":
-            return {"text": text}
-        if response_format == "verbose_json":
-            return {
-                "task": "transcribe",
-                "language": detected_language,
-                "text": text,
-            }
-        raise ValueError(f"Unsupported response format: {response_format}")
+        return await self._batch_transcribe(audio, language, response_format, kw)
 
     def translations(
         self,

--- a/xinference/model/audio/qwen3_asr.py
+++ b/xinference/model/audio/qwen3_asr.py
@@ -61,6 +61,8 @@ class Qwen3ASRModel(BatchMixin):
         if batch_size is not None:
             batching_kwargs["batch_size"] = batch_size
         elif max_inference_batch_size is not None and int(max_inference_batch_size) > 0:
+            # qwen_asr consumes this as a native from_pretrained argument;
+            # reuse it as Xinference's request-batch limit when no override is set.
             batching_kwargs["batch_size"] = max_inference_batch_size
         if batch_interval is not None:
             batching_kwargs["batch_interval"] = batch_interval

--- a/xinference/model/audio/tests/test_qwen3_asr.py
+++ b/xinference/model/audio/tests/test_qwen3_asr.py
@@ -1,0 +1,155 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+from contextlib import suppress
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from ..qwen3_asr import Qwen3ASRModel
+
+
+class _FakeQwenASR:
+    def __init__(self):
+        self.calls = []
+
+    def transcribe(self, audio, language, **kwargs):
+        payloads = [Path(path).read_bytes().decode() for path in audio]
+        self.calls.append(
+            {"payloads": payloads, "language": list(language), "kwargs": kwargs}
+        )
+        return [
+            SimpleNamespace(text=payload, language=lang or "Detected")
+            for payload, lang in zip(payloads, language)
+        ]
+
+
+def _new_model(batch_size=8, batch_interval=0.01, **kwargs):
+    model_spec = SimpleNamespace(
+        model_name="Qwen3-ASR-0.6B",
+        model_ability=["audio2text"],
+        default_transcription_config={},
+    )
+    model = Qwen3ASRModel(
+        "qwen3-asr",
+        "/unused",
+        model_spec,
+        batch_size=batch_size,
+        batch_interval=batch_interval,
+        **kwargs,
+    )
+    model._model = _FakeQwenASR()
+    return model
+
+
+async def _shutdown_batch_processor(model):
+    task = model._process_batch_task
+    if task is not None:
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
+
+
+@pytest.mark.asyncio
+async def test_qwen3_asr_batches_requests_and_preserves_order():
+    model = _new_model()
+    try:
+        results = await asyncio.gather(
+            model.transcriptions(b"first", language="Chinese"),
+            model.transcriptions(
+                b"second", language="English", response_format="verbose_json"
+            ),
+            model.transcriptions(b"third"),
+        )
+
+        assert results == [
+            {"text": "first"},
+            {"task": "transcribe", "language": "English", "text": "second"},
+            {"text": "third"},
+        ]
+        assert model._model.calls == [
+            {
+                "payloads": ["first", "second", "third"],
+                "language": ["Chinese", "English", None],
+                "kwargs": {},
+            }
+        ]
+    finally:
+        await _shutdown_batch_processor(model)
+
+
+@pytest.mark.asyncio
+async def test_qwen3_asr_respects_batch_size():
+    model = _new_model(batch_size=2)
+    try:
+        results = await asyncio.gather(
+            model.transcriptions(b"first"),
+            model.transcriptions(b"second"),
+            model.transcriptions(b"third"),
+        )
+
+        assert results == [
+            {"text": "first"},
+            {"text": "second"},
+            {"text": "third"},
+        ]
+        assert [call["payloads"] for call in model._model.calls] == [
+            ["first", "second"],
+            ["third"],
+        ]
+    finally:
+        await _shutdown_batch_processor(model)
+
+
+@pytest.mark.asyncio
+async def test_qwen3_asr_groups_model_kwargs_and_survives_cancellation():
+    model = _new_model()
+    try:
+        cancelled = asyncio.create_task(
+            model.transcriptions(b"cancelled", language="Chinese", beam_size=1)
+        )
+        kept = asyncio.create_task(
+            model.transcriptions(b"kept", language="English", beam_size=1)
+        )
+        other_group = asyncio.create_task(
+            model.transcriptions(b"other", language="Japanese", beam_size=2)
+        )
+        await asyncio.sleep(0)
+        cancelled.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await cancelled
+        assert await kept == {"text": "kept"}
+        assert await other_group == {"text": "other"}
+
+        # A cancelled waiter must not stop the long-lived batch processor.
+        assert await model.transcriptions(b"after") == {"text": "after"}
+
+        assert model._model.calls[:2] == [
+            {
+                "payloads": ["kept"],
+                "language": ["English"],
+                "kwargs": {"beam_size": 1},
+            },
+            {
+                "payloads": ["other"],
+                "language": ["Japanese"],
+                "kwargs": {"beam_size": 2},
+            },
+        ]
+        assert model._model.calls[2]["payloads"] == ["after"]
+    finally:
+        await _shutdown_batch_processor(model)

--- a/xinference/model/audio/tests/test_qwen3_asr.py
+++ b/xinference/model/audio/tests/test_qwen3_asr.py
@@ -55,6 +55,20 @@ def _new_model(batch_size=8, batch_interval=0.01, **kwargs):
     return model
 
 
+def test_qwen3_asr_uses_audio_batch_interval_default():
+    model_spec = SimpleNamespace(
+        model_name="Qwen3-ASR-0.6B",
+        model_ability=["audio2text"],
+        default_transcription_config={},
+    )
+
+    model = Qwen3ASRModel("default", "/unused", model_spec)
+    overridden = Qwen3ASRModel("overridden", "/unused", model_spec, batch_interval=0.02)
+
+    assert model.batch_interval == pytest.approx(0.1)
+    assert overridden.batch_interval == pytest.approx(0.02)
+
+
 async def _shutdown_batch_processor(model):
     task = model._process_batch_task
     if task is not None:

--- a/xinference/model/batch.py
+++ b/xinference/model/batch.py
@@ -35,7 +35,7 @@ class BatchMixin:
         self._func_name = func.func.__name__
         setattr(self, self._func_name, types.MethodType(self._wrap_method(), self))
 
-        self._is_process_batch_running = False
+        self._process_batch_task = None
 
         if "batch_size" in kwargs:
             self.batch_size = int(kwargs.pop("batch_size") or XINFERENCE_BATCH_SIZE)
@@ -51,12 +51,11 @@ class BatchMixin:
         return self._queue
 
     def _ensure_process_batch_running(self):
-        if self._is_process_batch_running:
+        if self._process_batch_task is not None and not self._process_batch_task.done():
             return
 
         # create asyncio task to process batch
-        asyncio.create_task(self._process_batch())
-        self._is_process_batch_running = True
+        self._process_batch_task = asyncio.create_task(self._process_batch())
 
     def _get_batch_size(self, *args, **kwargs) -> int:
         raise NotImplementedError
@@ -71,7 +70,7 @@ class BatchMixin:
             futures = [first_future]
 
             # Try to gather more items into the same batch within a short timeout window
-            while size <= self.batch_size:
+            while size < self.batch_size:
                 try:
                     # Wait for a new request for a short time window (e.g. 3ms)
                     # This allows batching multiple requests that arrive close in time.
@@ -88,21 +87,33 @@ class BatchMixin:
 
             logger.debug("Calling batch %s with %d size", self._func_name, size)
 
+            active = [
+                (delay, future)
+                for delay, future in zip(delays, futures)
+                if not future.done()
+            ]
+            if not active:
+                continue
+            delays, futures = map(list, zip(*active))
+
             try:
                 results = self._func.batch(*delays)
                 if inspect.isawaitable(results):
                     results = await results
+                if len(results) != len(futures):
+                    raise RuntimeError(
+                        "#results should be equal to #futures, "
+                        f"got {len(results)} and {len(futures)}"
+                    )
             except Exception as e:  # Handle errors for the entire batch
                 for fut in futures:
-                    fut.set_exception(e)
+                    if not fut.done():
+                        fut.set_exception(e)
             else:
-                # Ensure the number of results matches the number of input futures
-                assert len(results) == len(
-                    futures
-                ), f"#results should be equal to #futures, got {len(results)} and {len(futures)}"
                 # Deliver the results to the corresponding waiting callers
                 for fut, result in zip(futures, results):
-                    fut.set_result(result)
+                    if not fut.done():
+                        fut.set_result(result)
 
     def _wrap_method(self):
 

--- a/xinference/model/batch.py
+++ b/xinference/model/batch.py
@@ -61,9 +61,17 @@ class BatchMixin:
         raise NotImplementedError
 
     async def _process_batch(self):
+        pending = None
         while True:
             # Wait until at least one item is available
-            (first_args, first_kwargs), first_future = await self._queue.get()
+            if pending is None:
+                (first_args, first_kwargs), first_future = await self._queue.get()
+            else:
+                (first_args, first_kwargs), first_future = pending
+                pending = None
+
+            if first_future.done():
+                continue
 
             delays = [self._func.delay(*first_args, **first_kwargs)]
             size = self._get_batch_size(*first_args, **first_kwargs)
@@ -77,7 +85,15 @@ class BatchMixin:
                     (args, kwargs), future = await asyncio.wait_for(
                         self._queue.get(), timeout=self.batch_interval
                     )
-                    size += self._get_batch_size(*args, **kwargs)
+                    if future.done():
+                        continue
+                    next_size = self._get_batch_size(*args, **kwargs)
+                    if size + next_size > self.batch_size:
+                        # Preserve FIFO order without putting the request back
+                        # behind newer queue entries.
+                        pending = ((args, kwargs), future)
+                        break
+                    size += next_size
                     delays.append(self._func.delay(*args, **kwargs))
                     futures.append(future)
                 except asyncio.TimeoutError:

--- a/xinference/model/tests/test_batch.py
+++ b/xinference/model/tests/test_batch.py
@@ -1,0 +1,82 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+from contextlib import suppress
+
+import pytest
+from xoscar import extensible
+
+from ..batch import BatchMixin
+
+
+class _BatchProbe(BatchMixin):
+    def __init__(self, batch_size):
+        self.calls = []
+        BatchMixin.__init__(self, self.run, batch_size=batch_size, batch_interval=0.001)
+
+    @extensible
+    def run(self, values):
+        return values
+
+    @run.batch  # type: ignore
+    async def run(self, args_list, kwargs_list):
+        assert not any(kwargs_list)
+        values = [args[0] for args in args_list]
+        self.calls.append(values)
+        return values
+
+    def _get_batch_size(self, values):
+        return len(values)
+
+
+async def _shutdown_batch_processor(probe):
+    task = probe._process_batch_task
+    if task is not None:
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("request_sizes", "expected_batch_sizes"),
+    [
+        ([3, 2], [[3], [2]]),
+        ([2, 2, 1], [[2, 2], [1]]),
+        ([3, 2, 2], [[3], [2, 2]]),
+        ([5, 1], [[5], [1]]),
+    ],
+)
+async def test_batch_mixin_respects_batch_size_and_order(
+    request_sizes, expected_batch_sizes
+):
+    probe = _BatchProbe(batch_size=4)
+    requests = [
+        [f"request-{request_index}-item-{item_index}" for item_index in range(size)]
+        for request_index, size in enumerate(request_sizes)
+    ]
+
+    try:
+        results = await asyncio.gather(*(probe.run(request) for request in requests))
+
+        assert results == requests
+        assert [
+            [len(request) for request in batch] for batch in probe.calls
+        ] == expected_batch_sizes
+        assert [
+            request[0].split("-item-")[0] for batch in probe.calls for request in batch
+        ] == [f"request-{i}" for i in range(len(requests))]
+    finally:
+        await _shutdown_batch_processor(probe)


### PR DESCRIPTION
## Summary

- batch concurrent Qwen3-ASR transcription requests through the model's native list inference
- preserve per-request language and response formatting while grouping compatible inference kwargs
- use a Qwen3-ASR-specific 100 ms aggregation window by default while keeping `batch_interval` configurable
- harden the shared batch worker against cancellation and result-count mismatches
- enforce the shared `BatchMixin` size limit while preserving FIFO order for requests deferred to the next batch

## Why

Qwen3-ASR supports batched transcription, but Xinference currently invokes each concurrent audio request separately. This change lets compatible requests share one model call while preserving the existing API response behavior.

The shared 3 ms batching interval is too short for differently sized audio uploads to reach the model actor together. Qwen3-ASR therefore uses a 100 ms default without changing the global `BatchMixin` default.

`BatchMixin` is shared by embedding, rerank, and Qwen3-ASR models. Because one queued request can contain multiple inputs, checking only the current accumulated size is insufficient: the next request can push a batch past its configured limit. The worker now retains such a request as a FIFO-preserving pending item for the next batch. A single request that already exceeds the limit still runs alone because the mixin cannot split one request.

## Validation

- `pytest -q xinference/model/tests/test_batch.py xinference/model/audio/tests/test_qwen3_asr.py` — 8 passed
- `pre-commit run --files xinference/model/batch.py xinference/model/tests/test_batch.py xinference/model/audio/qwen3_asr.py` — passed
- `git diff --check` — passed

The shared batch tests cover a request that would overflow the remaining capacity, exact-capacity batches, FIFO preservation across deferred requests, and a single oversized request.

### GPU end-to-end results

Tested through a real Xinference service on an NVIDIA GeForce RTX 3090 Ti with `Qwen3-ASR-1.7B`, `batch_size=2`, and the default `batch_interval=0.1`.

Method:

- excluded one warm-up run
- ran three measured rounds and alternated sequential/batch order
- sequential time is the sum of the two individual request times
- batch time is wall-clock time until both concurrent requests complete
- compared the returned text for every input across every sequential and batch run

| Inputs | Sequential sum, median | Batch wall time, median | Result |
| --- | ---: | ---: | ---: |
| `蝶恋花·春景.mp3` ×2 (180.024 s each) | 3.232 s | 2.033 s | 37.1% lower wall time |
| `synthesized_speech_92345053.mp3` ×2 (106.606 s each) | 8.362 s | 4.409 s | 47.3% lower wall time |
| Mixed 180.024 s + 106.606 s inputs | 5.877 s | 6.649 s | 13.1% higher wall time |

Debug logs confirmed that sequential runs invoked native batch sizes `[1, 1]`, while concurrent runs invoked `[2]`.

Sequential and batched outputs matched exactly for both files in every measured round. This validates output parity, not transcript ground-truth accuracy.

The mixed-duration pair is slower because native batching pads work toward the longest item: the two inputs contain 286.630 seconds of audio in total, while a two-item batch can process approximately 360.048 seconds of padded frames. The throughput gain is therefore strongest when requests have similar lengths.
