### PR TITLE
fix(core): free GPU memory when stopping pytorch rerank models

### DIFF
--- a/xinference/core/model.py
+++ b/xinference/core/model.py
@@ -209,6 +209,7 @@ class ModelActor(xo.StatelessActor, CancelMixin):
         from ..model.llm.sglang.core import SGLANGModel
         from ..model.llm.transformers.core import PytorchModel as LLMPytorchModel
         from ..model.llm.vllm.core import VLLMModel as LLMVLLMModel
+        from ..model.rerank.core import RerankModel
 
         if hasattr(self._model, "stop") and callable(self._model.stop):
             await asyncio.to_thread(self._model.stop)
@@ -223,10 +224,21 @@ class ModelActor(xo.StatelessActor, CancelMixin):
                         f"Destroy transfer actor failed, address: {self.address}, error: {e}"
                     )
 
+        # Free GPU memory on teardown for pytorch-backed models. Pytorch
+        # embedding/rerank models are included here: they hold CUDA tensors
+        # but define no stop()/close(), so without an explicit del +
+        # empty_cache their VRAM is not released until the subpool process
+        # exits. That leak leaves the GPU busy and can crash the next model's
+        # subpool during CUDA init on relaunch (see issue #5156). The pytorch
+        # format guard keeps the torch-free llama.cpp embedding/rerank paths
+        # out of the torch-dependent branch below.
         if (
             isinstance(self._model, (LLMPytorchModel, LLMVLLMModel, SGLANGModel))
             and self._model.model_spec.model_format == "pytorch"
-        ) or isinstance(self._model, EmbeddingModel):
+        ) or (
+            isinstance(self._model, (EmbeddingModel, RerankModel))
+            and self._model._model_spec.model_format == "pytorch"
+        ):
             try:
                 import gc
 

--- a/xinference/core/tests/test_model.py
+++ b/xinference/core/tests/test_model.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import asyncio
+import types
 
 import pytest
 import pytest_asyncio
@@ -125,3 +126,148 @@ async def test_concurrent_call(setup_pool):
     await check_task
     pending_count = await worker.get_pending_requests_count()
     assert pending_count == 0
+
+
+def _gguf_spec_fields():
+    return {
+        "quantization": "Q8_0",
+        "model_file_name_template": "m.gguf",
+        "model_file_name_split_template": None,
+        "quantization_parts": None,
+        "model_id": None,
+        "model_uri": None,
+        "model_revision": None,
+    }
+
+
+def _make_rerank_model(model_format: str):
+    """Build an unloaded RerankModel with the given spec format (issue #5156)."""
+    from typing import Any, Dict
+
+    from ...model.rerank.core import RerankModel, RerankModelFamilyV2
+
+    spec: Dict[str, Any] = {
+        "model_format": model_format,
+        "model_hub": "huggingface",
+        "quantization": "none",
+    }
+    if model_format == "ggufv2":
+        spec.update(_gguf_spec_fields())
+    family = RerankModelFamilyV2(
+        version=2,
+        model_name="fake-reranker",
+        model_specs=[spec],
+        language=["en"],
+        # non-"unknown" type avoids _auto_detect_type reading a real model path
+        type="normal",
+        max_tokens=512,
+        virtualenv=None,
+    )
+
+    class _FakeRerankModel(RerankModel):
+        @classmethod
+        def check_lib(cls):
+            return True
+
+        @classmethod
+        def match_json(cls, model_family, model_spec, quantization):
+            return True
+
+        def load(self):
+            pass
+
+        def rerank(self, *args, **kwargs):
+            raise NotImplementedError
+
+    model = _FakeRerankModel("fake-reranker-0", "/tmp/fake", family, "none")
+    # emulate a loaded model holding GPU tensors
+    model._model = object()  # type: ignore[assignment]
+    return model
+
+
+def _make_embedding_model(model_format: str):
+    """Build an unloaded EmbeddingModel with the given spec format (issue #5156)."""
+    from typing import Any, Dict
+
+    from ...model.embedding.core import EmbeddingModel, EmbeddingModelFamilyV2
+
+    spec: Dict[str, Any] = {
+        "model_format": model_format,
+        "model_hub": "huggingface",
+        "model_id": None,
+        "model_uri": None,
+        "model_revision": None,
+        "quantization": "none",
+    }
+    if model_format == "ggufv2":
+        spec.update(_gguf_spec_fields())
+    family = EmbeddingModelFamilyV2(
+        version=2,
+        model_name="fake-embedding",
+        dimensions=8,
+        max_tokens=512,
+        language=["en"],
+        model_specs=[spec],
+        cache_config=None,
+        virtualenv=None,
+    )
+
+    class _FakeEmbeddingModel(EmbeddingModel):
+        @classmethod
+        def check_lib(cls):
+            return True
+
+        @classmethod
+        def match_json(cls, model_family, model_spec, quantization):
+            return True
+
+        def load(self):
+            pass
+
+        def _create_embedding(self, *args, **kwargs):
+            raise NotImplementedError
+
+    model = _FakeEmbeddingModel("fake-embedding-0", "/tmp/fake", family)
+    # emulate a loaded model holding GPU tensors
+    model._model = object()  # type: ignore[assignment]
+    return model
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "make_model, model_format, expect_freed",
+    [
+        (_make_rerank_model, "pytorch", True),
+        (_make_rerank_model, "ggufv2", False),
+        (_make_embedding_model, "pytorch", True),
+        (_make_embedding_model, "ggufv2", False),
+    ],
+)
+async def test_pre_destroy_frees_gpu_memory(
+    monkeypatch, make_model, model_format, expect_freed
+):
+    # Regression test for issue #5156: stopping a pytorch (sentence_transformers)
+    # rerank/embedding model must run del + empty_cache so its VRAM is
+    # released; the torch-free llama.cpp (ggufv2) path must be skipped.
+    calls = []
+    monkeypatch.setattr(
+        "xinference.core.model.empty_cache",
+        lambda: calls.append(1),
+    )
+
+    # __pre_destroy__ only touches self._model and (vLLM-only) self._transfer_ref,
+    # so exercise it on a lightweight stand-in to avoid the xoscar actor context.
+    stub = types.SimpleNamespace(
+        _model=make_model(model_format),
+        _transfer_ref=None,
+        address="test:0",
+    )
+
+    await ModelActor.__pre_destroy__(stub)
+
+    if expect_freed:
+        assert len(calls) == 1
+        assert not hasattr(stub, "_model")
+    else:
+        assert len(calls) == 0
+        assert stub._model is not None


### PR DESCRIPTION
## Summary
- `RerankModel` has no `stop()`/`close()`, and `ModelActor.__pre_destroy__`'s GPU-cleanup branch only covered LLM pytorch/vllm/sglang and `EmbeddingModel`, so stopping a pytorch-format rerank model (e.g. sentence_transformers) never released its CUDA tensors/VRAM.
- The leaked VRAM/CUDA context then crashed the next model's subpool during CUDA init on relaunch, surfacing as `xoscar.errors.ServerClosed: ... 0 bytes read` at `create_actor` — reproducing the second-launch failure of Qwen3-Reranker-0.6B.
- Extended `__pre_destroy__` to also run the existing `del self._model; gc.collect(); empty_cache()` cleanup for pytorch-format `RerankModel` instances, guarded by `model_format == "pytorch"` so the torch-free llama.cpp (ggufv2) rerank path is unaffected.

## Test plan
- [x] Added `test_pre_destroy_frees_rerank_gpu_memory` in `xinference/core/tests/test_model.py`, parametrized over pytorch (expects cleanup) and ggufv2 (expects skip).
- [x] `pytest xinference/core/tests/test_model.py` — 3 passed
- [x] `pre-commit run --files xinference/core/model.py xinference/core/tests/test_model.py` — black/isort/mypy/codespell pass (one pre-existing flake8 E231 false positive on an unrelated line is unchanged)