### PR TITLE
FEAT: production-ready Docker Compose deployment with offline private PyPI profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,11 @@ parts/
 sdist/
 var/
 wheels/
+# Keep the offline-wheels mount point for the Docker Compose deployment,
+# but not the wheels themselves.
+!xinference/deploy/docker/wheels/
+xinference/deploy/docker/wheels/*
+!xinference/deploy/docker/wheels/.gitkeep
 pip-wheel-metadata/
 share/python-wheels/
 *.egg-info/
@@ -102,6 +107,7 @@ celerybeat.pid
 
 # Environments
 .env
+offline.env
 .venv
 .inference_home
 env/

--- a/doc/source/getting_started/index.rst
+++ b/doc/source/getting_started/index.rst
@@ -12,6 +12,7 @@ Getting Started
    using_xinference
    logging
    using_docker_image
+   using_docker_compose
    using_kubernetes
    troubleshooting
    environments

--- a/doc/source/getting_started/using_docker_compose.rst
+++ b/doc/source/getting_started/using_docker_compose.rst
@@ -1,0 +1,183 @@
+.. _using_docker_compose:
+
+=========================
+Docker Compose Deployment
+=========================
+
+Xinference ships an official Docker Compose setup for standalone deployment, located at
+`xinference/deploy/docker <https://github.com/xorbitsai/inference/tree/main/xinference/deploy/docker>`_.
+It supports online hosts as well as fully offline / air-gapped environments, where an optional
+private PyPI server is started alongside Xinference to serve the packages installed at
+model-launch time.
+
+Prerequisites
+=============
+* Docker Compose **v2.24.4 or above** (required by the ``env_file: required: false`` and ``!reset`` features used in the compose files).
+* For GPU deployment: a host with NVIDIA GPUs, CUDA installed, and `NVIDIA Container Toolkit <https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html>`_. See :ref:`using_docker_image` for image requirements.
+* Get the whole ``xinference/deploy/docker`` directory. The compose file bind-mounts ``pip.conf`` and ``./wheels`` from the same directory, so downloading ``docker-compose.yml`` alone is not sufficient:
+
+.. code-block:: bash
+
+   git clone https://github.com/xorbitsai/inference.git
+   cd inference/xinference/deploy/docker
+
+
+Quick Start (GPU)
+=================
+Start Xinference with all GPUs of the host:
+
+.. code-block:: bash
+
+   docker compose up -d
+
+Wait until the service is healthy, then verify:
+
+.. code-block:: bash
+
+   docker compose ps
+   curl http://localhost:9997/status
+
+The Web UI is served at ``http://localhost:9997``.
+
+
+Configuration
+=============
+All settings are exposed as variables with sensible defaults and can be overridden through a
+``.env`` file next to ``docker-compose.yml``. Copy the template and edit as needed:
+
+.. code-block:: bash
+
+   cp .env.example .env
+
+Available variables:
+
+* ``XINFERENCE_IMAGE``: image to run, defaults to ``xprobe/xinference:latest``. Pin a release tag such as ``xprobe/xinference:v<version>`` for production.
+* ``XINFERENCE_PORT``: host port of the RESTful API / Web UI, defaults to ``9997``.
+* ``XINFERENCE_MODEL_SRC``: model download source, ``huggingface`` (default) or ``modelscope``.
+* ``XINFERENCE_SHM_SIZE``: shared memory size, defaults to ``8gb``. Increase for multi-GPU inference.
+* ``XINFERENCE_LOG_LEVEL``: log level, defaults to ``info``.
+* ``XINFERENCE_HOME_DIR`` / ``XINFERENCE_HF_CACHE_DIR`` / ``XINFERENCE_MODELSCOPE_CACHE_DIR``: persistence locations. They default to named Docker volumes; point them at absolute host paths to reuse existing model caches, in the same way as described in :ref:`using_docker_image`.
+* ``XINFERENCE_WHEELS_DIR`` / ``XINFERENCE_PYPISERVER_PORT`` / ``XINFERENCE_PYPISERVER_IMAGE``: offline profile settings, see below.
+
+For other runtime options (authentication, OpenTelemetry, health-check tuning, ...), add the
+corresponding variables under the ``environment:`` section of ``docker-compose.yml``.
+See :ref:`environments` for the full list.
+
+
+CPU-only Deployment
+===================
+On hosts without NVIDIA GPUs, apply the CPU override file, which switches the image to the
+``-cpu`` variant and removes the GPU reservation:
+
+.. code-block:: bash
+
+   docker compose -f docker-compose.yml -f docker-compose.cpu.yml up -d
+
+
+Health Check and Restart Policy
+===============================
+The ``xinference`` service reports health through the ``/status`` endpoint and restarts
+automatically unless explicitly stopped (``restart: unless-stopped``). ``docker compose ps``
+shows the health state; orchestration on top of compose can rely on it.
+
+
+Offline / Air-gapped Deployment
+===============================
+By default Xinference installs the extra Python packages declared by a model at launch time
+into a per-model virtual environment (controlled by ``XINFERENCE_ENABLE_VIRTUAL_ENV``,
+see :ref:`environments`). On a host without Internet access these installs would fail.
+
+The ``offline`` compose profile solves this by starting a private PyPI server
+(`pypiserver <https://github.com/pypiserver/pypiserver>`_) next to Xinference. It serves wheels
+from the local ``./wheels`` directory, and the offline configuration points every runtime
+``pip`` / ``uv`` invocation inside the Xinference container at it.
+
+Step 1: Prepare wheels on an Internet-connected machine
+-------------------------------------------------------
+Download the wheels of every package your models declare in their ``virtualenv`` section
+(shown on each model card in the Web UI, or in the built-in model JSON specs). The GPU image
+runs Python 3.12 on ``x86_64``:
+
+.. code-block:: bash
+
+   python3 -m pip download \
+      --dest ./wheels \
+      --only-binary=:all: \
+      --python-version 312 \
+      --platform manylinux2014_x86_64 \
+      'transformers>=4.53.3' accelerate
+
+Copy the resulting ``wheels`` directory into ``xinference/deploy/docker/wheels`` on the offline
+host. Also transfer the Docker images (``docker save`` / ``docker load``): the Xinference image
+and ``pypiserver/pypiserver:v2.3.2``.
+
+Step 2: Enable the offline configuration
+----------------------------------------
+.. code-block:: bash
+
+   cp offline.env.example offline.env
+
+Then open ``pip.conf`` and uncomment the three lines of the offline block:
+
+.. code-block:: ini
+
+   [global]
+   index-url = http://xinference-pypiserver:8080/simple
+   extra-index-url = http://xinference-pypiserver:8080/simple
+   trusted-host = xinference-pypiserver
+
+.. note::
+
+   Both pieces are required because they cover different code paths. ``pip.conf`` feeds
+   Xinference's pip-config inheritance, which passes the private index explicitly to the
+   per-model virtual-env installer; the ``UV_*`` variables in ``offline.env`` cover ``uv``
+   invocations that do not carry index flags (such as the dependency-resolution dry-run).
+   Removing either half breaks the offline install chain.
+
+Step 3: Start with the offline profile
+--------------------------------------
+.. code-block:: bash
+
+   docker compose --profile offline up -d
+
+Or set ``COMPOSE_PROFILES=offline`` in ``.env`` to omit the ``--profile`` flag. Combine with the
+CPU override if needed:
+
+.. code-block:: bash
+
+   docker compose --profile offline -f docker-compose.yml -f docker-compose.cpu.yml up -d
+
+The private index is also published on the host (default port ``8080``), so other machines on
+the same network can reuse it with ``pip install -i http://<host>:8080/simple ...``.
+
+.. warning::
+
+   When launching models with the **vLLM** or **SGLang** engines, Xinference by default resolves
+   some dependencies from hardcoded public indexes (``wheels.vllm.ai``,
+   ``download.pytorch.org``). The offline ``pip.conf`` above overrides them with the private
+   index, which means those wheels must be present in ``./wheels`` — mirror the required
+   ``vllm`` / ``torch`` CUDA wheels when preparing Step 1. Alternatively, set
+   ``XINFERENCE_ENABLE_VIRTUAL_ENV=0`` in ``offline.env`` to skip runtime installs entirely and
+   rely on the packages baked into the image.
+
+Offline model weights
+---------------------
+The offline configuration sets ``HF_HUB_OFFLINE=1`` and ``TRANSFORMERS_OFFLINE=1``, so model
+weights are read from the local cache only. Populate the cache before going offline, either by
+pointing the cache variables in ``.env`` at host directories that already contain the models,
+or by launching each model once on a connected host and copying the volumes. Models can also be
+loaded from arbitrary local paths by registering custom models or passing ``--model-path``.
+
+Smoke test
+----------
+.. code-block:: bash
+
+   # The private index serves your wheels:
+   curl http://localhost:8080/simple/
+
+   # Inside the container, installs resolve against the private index only:
+   docker compose exec xinference python3 -m pip config list
+   docker compose exec xinference uv pip install --dry-run --python /usr/bin/python3 <some-package-in-wheels>
+
+Then launch a model and watch ``docker compose logs -f xinference`` — package installation logs
+should reference ``http://xinference-pypiserver:8080/simple``.

--- a/doc/source/getting_started/using_docker_compose.rst
+++ b/doc/source/getting_started/using_docker_compose.rst
@@ -111,6 +111,14 @@ Copy the resulting ``wheels`` directory into ``xinference/deploy/docker/wheels``
 host. Also transfer the Docker images (``docker save`` / ``docker load``): the Xinference image
 and ``pypiserver/pypiserver:v2.3.2``.
 
+On Linux hosts, grant the pypiserver container user (UID 9898) access to the directory —
+its entrypoint requires read/write/execute permission bits, although the volume itself is
+mounted read-only:
+
+.. code-block:: bash
+
+   chmod -R a+rwX ./wheels
+
 Step 2: Enable the offline configuration
 ----------------------------------------
 .. code-block:: bash

--- a/doc/source/getting_started/using_docker_compose.rst
+++ b/doc/source/getting_started/using_docker_compose.rst
@@ -176,6 +176,37 @@ pointing the cache variables in ``.env`` at host directories that already contai
 or by launching each model once on a connected host and copying the volumes. Models can also be
 loaded from arbitrary local paths by registering custom models or passing ``--model-path``.
 
+Enforced network isolation (optional)
+-------------------------------------
+The offline configuration redirects every download to local sources, but by itself it does not
+prevent the containers from reaching the Internet if the host happens to have connectivity. To
+*guarantee* isolation at the network level, add the air-gap override, which moves Xinference and
+the private PyPI server onto an ``internal`` Docker network with no external routing:
+
+.. code-block:: bash
+
+   docker compose --profile offline \
+      -f docker-compose.yml -f docker-compose.airgap.yml up -d
+
+Because Docker does not publish ports of internal-only networks, the override adds a minimal
+TCP gateway (``alpine/socat``) that forwards the API port from the host into the isolated
+network. The gateway only relays inbound traffic to ``xinference:9997``; the containers cannot
+use it as an egress path. Remember to transfer the ``alpine/socat`` image to the offline host
+along with the others.
+
+.. note::
+
+   In this mode the private PyPI server is not published on the host; it is only reachable
+   from containers inside the isolated network. Verify the isolation from within the
+   container — external requests must fail while the private index stays reachable:
+
+   .. code-block:: bash
+
+      docker compose -f docker-compose.yml -f docker-compose.airgap.yml exec xinference \
+         curl -s -m 5 https://pypi.org -o /dev/null || echo "external access blocked"
+      docker compose -f docker-compose.yml -f docker-compose.airgap.yml exec xinference \
+         curl -s http://xinference-pypiserver:8080/health
+
 Smoke test
 ----------
 .. code-block:: bash

--- a/doc/source/locale/zh_CN/LC_MESSAGES/getting_started/using_docker_compose.po
+++ b/doc/source/locale/zh_CN/LC_MESSAGES/getting_started/using_docker_compose.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Xinference \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-14 12:08+0800\n"
+"POT-Creation-Date: 2026-07-14 12:37+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: zh_CN\n"
@@ -255,8 +255,8 @@ msgid ""
 "the directory — its entrypoint requires read/write/execute permission "
 "bits, although the volume itself is mounted read-only:"
 msgstr ""
-"在 Linux 主机上，需要让 pypiserver 容器用户（UID 9898）能访问该目录——"
-"其 entrypoint 强制要求读/写/执行权限位，尽管卷本身是以只读方式挂载的："
+"在 Linux 主机上，需要让 pypiserver 容器用户（UID 9898）能访问该目录——其 "
+"entrypoint 强制要求读/写/执行权限位，尽管卷本身是以只读方式挂载的："
 
 #: ../../source/getting_started/using_docker_compose.rst:123
 msgid "Step 2: Enable the offline configuration"
@@ -340,10 +340,51 @@ msgstr ""
 "路径加载模型。"
 
 #: ../../source/getting_started/using_docker_compose.rst:180
+msgid "Enforced network isolation (optional)"
+msgstr "强制网络隔离（可选）"
+
+#: ../../source/getting_started/using_docker_compose.rst:181
+msgid ""
+"The offline configuration redirects every download to local sources, but "
+"by itself it does not prevent the containers from reaching the Internet "
+"if the host happens to have connectivity. To *guarantee* isolation at the"
+" network level, add the air-gap override, which moves Xinference and the "
+"private PyPI server onto an ``internal`` Docker network with no external "
+"routing:"
+msgstr ""
+"离线配置只是把所有下载重定向到本地源，其本身并不能阻止容器在宿主机联网时"
+"访问互联网。若要在网络层面 *保证* 隔离，可叠加 air-gap override：它会把 "
+"Xinference 和私有 PyPI 服务移入一个没有外部路由的 ``internal`` Docker 网络："
+
+#: ../../source/getting_started/using_docker_compose.rst:191
+msgid ""
+"Because Docker does not publish ports of internal-only networks, the "
+"override adds a minimal TCP gateway (``alpine/socat``) that forwards the "
+"API port from the host into the isolated network. The gateway only relays"
+" inbound traffic to ``xinference:9997``; the containers cannot use it as "
+"an egress path. Remember to transfer the ``alpine/socat`` image to the "
+"offline host along with the others."
+msgstr ""
+"由于 Docker 不会发布纯 internal 网络上的端口，该 override 增加了一个极简 "
+"TCP 网关（``alpine/socat``），把 API 端口从宿主机转发进隔离网络。网关只会"
+"把入站流量转发到 ``xinference:9997``，容器无法把它当作出网通道。记得把 "
+"``alpine/socat`` 镜像与其他镜像一起传输到离线主机。"
+
+#: ../../source/getting_started/using_docker_compose.rst:199
+msgid ""
+"In this mode the private PyPI server is not published on the host; it is "
+"only reachable from containers inside the isolated network. Verify the "
+"isolation from within the container — external requests must fail while "
+"the private index stays reachable:"
+msgstr ""
+"该模式下私有 PyPI 服务不再发布到宿主机，只有隔离网络内的容器可以访问。"
+"可在容器内验证隔离效果——外网请求必须失败，而私有源保持可达："
+
+#: ../../source/getting_started/using_docker_compose.rst:211
 msgid "Smoke test"
 msgstr "冒烟验证"
 
-#: ../../source/getting_started/using_docker_compose.rst:190
+#: ../../source/getting_started/using_docker_compose.rst:221
 msgid ""
 "Then launch a model and watch ``docker compose logs -f xinference`` — "
 "package installation logs should reference ``http://xinference-pypiserver"

--- a/doc/source/locale/zh_CN/LC_MESSAGES/getting_started/using_docker_compose.po
+++ b/doc/source/locale/zh_CN/LC_MESSAGES/getting_started/using_docker_compose.po
@@ -1,0 +1,345 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2025, Xorbits Inc.
+# This file is distributed under the same license as the Xinference package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Xinference \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-13 16:05+0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: zh_CN\n"
+"Language-Team: zh_CN <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.18.0\n"
+
+#: ../../source/getting_started/using_docker_compose.rst:5
+msgid "Docker Compose Deployment"
+msgstr "Docker Compose 部署"
+
+#: ../../source/getting_started/using_docker_compose.rst:7
+msgid ""
+"Xinference ships an official Docker Compose setup for standalone "
+"deployment, located at `xinference/deploy/docker "
+"<https://github.com/xorbitsai/inference/tree/main/xinference/deploy/docker>`_."
+" It supports online hosts as well as fully offline / air-gapped "
+"environments, where an optional private PyPI server is started alongside "
+"Xinference to serve the packages installed at model-launch time."
+msgstr ""
+"Xinference 提供官方的单机 Docker Compose 部署方案，位于 `xinference/"
+"deploy/docker <https://github.com/xorbitsai/inference/tree/main/"
+"xinference/deploy/docker>`_。它同时支持联网主机和完全离线（air-gapped）"
+"环境：离线场景下会随 Xinference 一起启动一个可选的私有 PyPI 服务，为模型"
+"启动时安装的依赖包提供内网源。"
+
+#: ../../source/getting_started/using_docker_compose.rst:14
+msgid "Prerequisites"
+msgstr "准备工作"
+
+#: ../../source/getting_started/using_docker_compose.rst:15
+msgid ""
+"Docker Compose **v2.24.4 or above** (required by the ``env_file: "
+"required: false`` and ``!reset`` features used in the compose files)."
+msgstr ""
+"Docker Compose **v2.24.4 及以上版本** ，compose 文件用到了 ``env_file: "
+"required: false`` 与 ``!reset`` 特性。"
+
+#: ../../source/getting_started/using_docker_compose.rst:16
+msgid ""
+"For GPU deployment: a host with NVIDIA GPUs, CUDA installed, and `NVIDIA "
+"Container Toolkit <https://docs.nvidia.com/datacenter/cloud-native"
+"/container-toolkit/latest/install-guide.html>`_. See "
+":ref:`using_docker_image` for image requirements."
+msgstr ""
+"GPU 部署需要：配备 NVIDIA GPU 且安装了 CUDA 与 `NVIDIA Container Toolkit "
+"<https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest"
+"/install-guide.html>`_ 的主机。镜像要求参见 :ref:`using_docker_image`。"
+
+#: ../../source/getting_started/using_docker_compose.rst:17
+msgid ""
+"Get the whole ``xinference/deploy/docker`` directory. The compose file "
+"bind-mounts ``pip.conf`` and ``./wheels`` from the same directory, so "
+"downloading ``docker-compose.yml`` alone is not sufficient:"
+msgstr ""
+"获取完整的 ``xinference/deploy/docker`` 目录。compose 文件会以 bind mount"
+" 方式挂载同目录下的 ``pip.conf`` 和 ``./wheels``，因此只下载 ``docker-"
+"compose.yml`` 是不够的："
+
+#: ../../source/getting_started/using_docker_compose.rst:26
+msgid "Quick Start (GPU)"
+msgstr "快速开始（GPU）"
+
+#: ../../source/getting_started/using_docker_compose.rst:27
+msgid "Start Xinference with all GPUs of the host:"
+msgstr "使用主机全部 GPU 启动 Xinference："
+
+#: ../../source/getting_started/using_docker_compose.rst:33
+msgid "Wait until the service is healthy, then verify:"
+msgstr "等服务进入 healthy 状态后验证："
+
+#: ../../source/getting_started/using_docker_compose.rst:40
+msgid "The Web UI is served at ``http://localhost:9997``."
+msgstr "Web UI 地址为 ``http://localhost:9997``。"
+
+#: ../../source/getting_started/using_docker_compose.rst:44
+msgid "Configuration"
+msgstr "配置"
+
+#: ../../source/getting_started/using_docker_compose.rst:45
+msgid ""
+"All settings are exposed as variables with sensible defaults and can be "
+"overridden through a ``.env`` file next to ``docker-compose.yml``. Copy "
+"the template and edit as needed:"
+msgstr ""
+"所有配置项都以带默认值的变量形式暴露，可以通过与 ``docker-compose.yml`` "
+"同目录的 ``.env`` 文件覆盖。复制模板后按需修改："
+
+#: ../../source/getting_started/using_docker_compose.rst:52
+msgid "Available variables:"
+msgstr "可用变量："
+
+#: ../../source/getting_started/using_docker_compose.rst:54
+msgid ""
+"``XINFERENCE_IMAGE``: image to run, defaults to "
+"``xprobe/xinference:latest``. Pin a release tag such as "
+"``xprobe/xinference:v<version>`` for production."
+msgstr ""
+"``XINFERENCE_IMAGE``：运行的镜像，默认 ``xprobe/xinference:latest``。生产"
+"环境建议固定为发布版本，如 ``xprobe/xinference:v<version>``。"
+
+#: ../../source/getting_started/using_docker_compose.rst:55
+msgid ""
+"``XINFERENCE_PORT``: host port of the RESTful API / Web UI, defaults to "
+"``9997``."
+msgstr "``XINFERENCE_PORT``：RESTful API / Web UI 的主机端口，默认 ``9997``。"
+
+#: ../../source/getting_started/using_docker_compose.rst:56
+msgid ""
+"``XINFERENCE_MODEL_SRC``: model download source, ``huggingface`` "
+"(default) or ``modelscope``."
+msgstr ""
+"``XINFERENCE_MODEL_SRC``：模型下载源，``huggingface``（默认）或 ``"
+"modelscope``。"
+
+#: ../../source/getting_started/using_docker_compose.rst:57
+msgid ""
+"``XINFERENCE_SHM_SIZE``: shared memory size, defaults to ``8gb``. "
+"Increase for multi-GPU inference."
+msgstr "``XINFERENCE_SHM_SIZE``：共享内存大小，默认 ``8gb``。多卡推理时建议调大。"
+
+#: ../../source/getting_started/using_docker_compose.rst:58
+msgid "``XINFERENCE_LOG_LEVEL``: log level, defaults to ``info``."
+msgstr "``XINFERENCE_LOG_LEVEL``：日志级别，默认 ``info``。"
+
+#: ../../source/getting_started/using_docker_compose.rst:59
+msgid ""
+"``XINFERENCE_HOME_DIR`` / ``XINFERENCE_HF_CACHE_DIR`` / "
+"``XINFERENCE_MODELSCOPE_CACHE_DIR``: persistence locations. They default "
+"to named Docker volumes; point them at absolute host paths to reuse "
+"existing model caches, in the same way as described in "
+":ref:`using_docker_image`."
+msgstr ""
+"``XINFERENCE_HOME_DIR`` / ``XINFERENCE_HF_CACHE_DIR`` / ``XINFERENCE_"
+"MODELSCOPE_CACHE_DIR``：持久化位置。默认使用 Docker 命名卷；指向主机上的"
+"绝对路径即可复用已有的模型缓存，方式与 :ref:`using_docker_image` 中的说明"
+"相同。"
+
+#: ../../source/getting_started/using_docker_compose.rst:60
+msgid ""
+"``XINFERENCE_WHEELS_DIR`` / ``XINFERENCE_PYPISERVER_PORT`` / "
+"``XINFERENCE_PYPISERVER_IMAGE``: offline profile settings, see below."
+msgstr ""
+"``XINFERENCE_WHEELS_DIR`` / ``XINFERENCE_PYPISERVER_PORT`` / ``XINFERENCE"
+"_PYPISERVER_IMAGE``：离线 profile 相关配置，见下文。"
+
+#: ../../source/getting_started/using_docker_compose.rst:62
+msgid ""
+"For other runtime options (authentication, OpenTelemetry, health-check "
+"tuning, ...), add the corresponding variables under the ``environment:`` "
+"section of ``docker-compose.yml``. See :ref:`environments` for the full "
+"list."
+msgstr ""
+"其他运行时选项（认证、OpenTelemetry、健康检查调优等）可在 ``docker-"
+"compose.yml`` 的 ``environment:`` 段落中添加对应变量，完整列表见 :ref:`"
+"environments`。"
+
+#: ../../source/getting_started/using_docker_compose.rst:68
+msgid "CPU-only Deployment"
+msgstr "纯 CPU 部署"
+
+#: ../../source/getting_started/using_docker_compose.rst:69
+msgid ""
+"On hosts without NVIDIA GPUs, apply the CPU override file, which switches"
+" the image to the ``-cpu`` variant and removes the GPU reservation:"
+msgstr ""
+"在没有 NVIDIA GPU 的主机上，叠加 CPU override 文件即可：它会把镜像切换为 "
+"``-cpu`` 变体并移除 GPU 预留配置："
+
+#: ../../source/getting_started/using_docker_compose.rst:78
+msgid "Health Check and Restart Policy"
+msgstr "健康检查与重启策略"
+
+#: ../../source/getting_started/using_docker_compose.rst:79
+msgid ""
+"The ``xinference`` service reports health through the ``/status`` "
+"endpoint and restarts automatically unless explicitly stopped (``restart:"
+" unless-stopped``). ``docker compose ps`` shows the health state; "
+"orchestration on top of compose can rely on it."
+msgstr ""
+"``xinference`` 服务通过 ``/status`` 接口上报健康状态，且除非显式停止否则"
+"会自动重启（``restart: unless-stopped``）。``docker compose ps`` 可查看"
+"健康状态；基于 compose 的上层编排可以依赖该状态。"
+
+#: ../../source/getting_started/using_docker_compose.rst:85
+msgid "Offline / Air-gapped Deployment"
+msgstr "离线 / 内网（Air-gapped）部署"
+
+#: ../../source/getting_started/using_docker_compose.rst:86
+msgid ""
+"By default Xinference installs the extra Python packages declared by a "
+"model at launch time into a per-model virtual environment (controlled by "
+"``XINFERENCE_ENABLE_VIRTUAL_ENV``, see :ref:`environments`). On a host "
+"without Internet access these installs would fail."
+msgstr ""
+"默认情况下，Xinference 会在模型启动时把模型声明的额外 Python 依赖安装到"
+"独立的虚拟环境中（由 ``XINFERENCE_ENABLE_VIRTUAL_ENV`` 控制，见 :ref:`"
+"environments`）。在无法访问互联网的主机上，这些安装会失败。"
+
+#: ../../source/getting_started/using_docker_compose.rst:90
+msgid ""
+"The ``offline`` compose profile solves this by starting a private PyPI "
+"server (`pypiserver <https://github.com/pypiserver/pypiserver>`_) next to"
+" Xinference. It serves wheels from the local ``./wheels`` directory, and "
+"the offline configuration points every runtime ``pip`` / ``uv`` "
+"invocation inside the Xinference container at it."
+msgstr ""
+"``offline`` profile 通过在 Xinference 旁边启动一个私有 PyPI 服务（`"
+"pypiserver <https://github.com/pypiserver/pypiserver>`_）来解决这个问题。"
+"它对外提供本地 ``./wheels`` 目录中的 wheel 包，离线配置会让 Xinference "
+"容器内所有运行时的 ``pip`` / ``uv`` 调用都指向它。"
+
+#: ../../source/getting_started/using_docker_compose.rst:96
+msgid "Step 1: Prepare wheels on an Internet-connected machine"
+msgstr "第一步：在联网机器上准备 wheels"
+
+#: ../../source/getting_started/using_docker_compose.rst:97
+msgid ""
+"Download the wheels of every package your models declare in their "
+"``virtualenv`` section (shown on each model card in the Web UI, or in the"
+" built-in model JSON specs). The GPU image runs Python 3.12 on "
+"``x86_64``:"
+msgstr ""
+"下载你要部署的模型在 ``virtualenv`` 配置段中声明的所有依赖包的 wheel（可"
+"在 Web UI 的模型卡片或内置模型 JSON 配置中查看）。GPU 镜像运行的是 ``x86_"
+"64`` 上的 Python 3.12："
+
+#: ../../source/getting_started/using_docker_compose.rst:110
+msgid ""
+"Copy the resulting ``wheels`` directory into "
+"``xinference/deploy/docker/wheels`` on the offline host. Also transfer "
+"the Docker images (``docker save`` / ``docker load``): the Xinference "
+"image and ``pypiserver/pypiserver:v2.3.2``."
+msgstr ""
+"把得到的 ``wheels`` 目录拷贝到离线主机的 ``xinference/deploy/docker/"
+"wheels`` 下。同时用 ``docker save`` / ``docker load`` 传输 Docker 镜像："
+"Xinference 镜像与 ``pypiserver/pypiserver:v2.3.2``。"
+
+#: ../../source/getting_started/using_docker_compose.rst:115
+msgid "Step 2: Enable the offline configuration"
+msgstr "第二步：启用离线配置"
+
+#: ../../source/getting_started/using_docker_compose.rst:120
+msgid "Then open ``pip.conf`` and uncomment the three lines of the offline block:"
+msgstr "然后打开 ``pip.conf``，取消离线配置块三行的注释："
+
+#: ../../source/getting_started/using_docker_compose.rst:131
+msgid ""
+"Both pieces are required because they cover different code paths. "
+"``pip.conf`` feeds Xinference's pip-config inheritance, which passes the "
+"private index explicitly to the per-model virtual-env installer; the "
+"``UV_*`` variables in ``offline.env`` cover ``uv`` invocations that do "
+"not carry index flags (such as the dependency-resolution dry-run). "
+"Removing either half breaks the offline install chain."
+msgstr ""
+"两部分配置都是必需的，因为它们覆盖不同的代码路径：``pip.conf`` 供 "
+"Xinference 的 pip 配置继承机制读取，把私有源显式传给每个模型虚拟环境的"
+"安装器；``offline.env`` 中的 ``UV_*`` 变量则覆盖不带源参数的 ``uv`` 调用"
+"（例如依赖解析的 dry-run）。缺少任何一半都会破坏离线安装链路。"
+
+#: ../../source/getting_started/using_docker_compose.rst:138
+msgid "Step 3: Start with the offline profile"
+msgstr "第三步：以离线 profile 启动"
+
+#: ../../source/getting_started/using_docker_compose.rst:143
+msgid ""
+"Or set ``COMPOSE_PROFILES=offline`` in ``.env`` to omit the ``--profile``"
+" flag. Combine with the CPU override if needed:"
+msgstr ""
+"也可以在 ``.env`` 中设置 ``COMPOSE_PROFILES=offline`` 以省略 ``--profile`"
+"` 参数。如有需要可与 CPU override 组合使用："
+
+#: ../../source/getting_started/using_docker_compose.rst:150
+msgid ""
+"The private index is also published on the host (default port ``8080``), "
+"so other machines on the same network can reuse it with ``pip install -i "
+"http://<host>:8080/simple ...``."
+msgstr ""
+"私有源同时发布在主机上（默认端口 ``8080``），同一网络内的其他机器可通过 `"
+"`pip install -i http://<host>:8080/simple ...`` 复用它。"
+
+#: ../../source/getting_started/using_docker_compose.rst:155
+msgid ""
+"When launching models with the **vLLM** or **SGLang** engines, Xinference"
+" by default resolves some dependencies from hardcoded public indexes (``"
+"wheels.vllm.ai``, ``download.pytorch.org``). The offline ``pip.conf`` "
+"above overrides them with the private index, which means those wheels "
+"must be present in ``./wheels`` — mirror the required ``vllm`` / ``torch`"
+"` CUDA wheels when preparing Step 1. Alternatively, set ``XINFERENCE_"
+"ENABLE_VIRTUAL_ENV=0`` in ``offline.env`` to skip runtime installs "
+"entirely and rely on the packages baked into the image."
+msgstr ""
+"使用 **vLLM** 或 **SGLang** 引擎启动模型时，Xinference 默认会从硬编码的"
+"公网源（``wheels.vllm.ai``、``download.pytorch.org``）解析部分依赖。上面"
+"的离线 ``pip.conf`` 会用私有源覆盖它们，这意味着相应的 wheel 必须存在于 `"
+"`./wheels`` 中——在第一步准备时请一并镜像所需的 ``vllm`` / ``torch`` CUDA "
+"wheel。或者，在 ``offline.env`` 中设置 ``XINFERENCE_ENABLE_VIRTUAL_ENV=0`"
+"` 完全跳过运行时安装，仅依赖镜像内置的包。"
+
+#: ../../source/getting_started/using_docker_compose.rst:164
+msgid "Offline model weights"
+msgstr "离线模型权重"
+
+#: ../../source/getting_started/using_docker_compose.rst:165
+msgid ""
+"The offline configuration sets ``HF_HUB_OFFLINE=1`` and "
+"``TRANSFORMERS_OFFLINE=1``, so model weights are read from the local "
+"cache only. Populate the cache before going offline, either by pointing "
+"the cache variables in ``.env`` at host directories that already contain "
+"the models, or by launching each model once on a connected host and "
+"copying the volumes. Models can also be loaded from arbitrary local paths"
+" by registering custom models or passing ``--model-path``."
+msgstr ""
+"离线配置设置了 ``HF_HUB_OFFLINE=1`` 和 ``TRANSFORMERS_OFFLINE=1``，模型"
+"权重只会从本地缓存读取。请在离线前准备好缓存：既可以把 ``.env`` 中的缓存"
+"变量指向已包含模型的主机目录，也可以在联网主机上把每个模型启动一次后拷贝"
+"数据卷。此外，也可以通过注册自定义模型或传入 ``--model-path`` 从任意本地"
+"路径加载模型。"
+
+#: ../../source/getting_started/using_docker_compose.rst:172
+msgid "Smoke test"
+msgstr "冒烟验证"
+
+#: ../../source/getting_started/using_docker_compose.rst:182
+msgid ""
+"Then launch a model and watch ``docker compose logs -f xinference`` — "
+"package installation logs should reference ``http://xinference-pypiserver"
+":8080/simple``."
+msgstr ""
+"然后启动一个模型并观察 ``docker compose logs -f xinference``——依赖安装"
+"日志中应出现 ``http://xinference-pypiserver:8080/simple``。"
+

--- a/doc/source/locale/zh_CN/LC_MESSAGES/getting_started/using_docker_compose.po
+++ b/doc/source/locale/zh_CN/LC_MESSAGES/getting_started/using_docker_compose.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Xinference \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-13 16:05+0800\n"
+"POT-Creation-Date: 2026-07-14 12:08+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: zh_CN\n"
@@ -249,15 +249,24 @@ msgstr ""
 "wheels`` 下。同时用 ``docker save`` / ``docker load`` 传输 Docker 镜像："
 "Xinference 镜像与 ``pypiserver/pypiserver:v2.3.2``。"
 
-#: ../../source/getting_started/using_docker_compose.rst:115
+#: ../../source/getting_started/using_docker_compose.rst:114
+msgid ""
+"On Linux hosts, grant the pypiserver container user (UID 9898) access to "
+"the directory — its entrypoint requires read/write/execute permission "
+"bits, although the volume itself is mounted read-only:"
+msgstr ""
+"在 Linux 主机上，需要让 pypiserver 容器用户（UID 9898）能访问该目录——"
+"其 entrypoint 强制要求读/写/执行权限位，尽管卷本身是以只读方式挂载的："
+
+#: ../../source/getting_started/using_docker_compose.rst:123
 msgid "Step 2: Enable the offline configuration"
 msgstr "第二步：启用离线配置"
 
-#: ../../source/getting_started/using_docker_compose.rst:120
+#: ../../source/getting_started/using_docker_compose.rst:128
 msgid "Then open ``pip.conf`` and uncomment the three lines of the offline block:"
 msgstr "然后打开 ``pip.conf``，取消离线配置块三行的注释："
 
-#: ../../source/getting_started/using_docker_compose.rst:131
+#: ../../source/getting_started/using_docker_compose.rst:139
 msgid ""
 "Both pieces are required because they cover different code paths. "
 "``pip.conf`` feeds Xinference's pip-config inheritance, which passes the "
@@ -271,11 +280,11 @@ msgstr ""
 "安装器；``offline.env`` 中的 ``UV_*`` 变量则覆盖不带源参数的 ``uv`` 调用"
 "（例如依赖解析的 dry-run）。缺少任何一半都会破坏离线安装链路。"
 
-#: ../../source/getting_started/using_docker_compose.rst:138
+#: ../../source/getting_started/using_docker_compose.rst:146
 msgid "Step 3: Start with the offline profile"
 msgstr "第三步：以离线 profile 启动"
 
-#: ../../source/getting_started/using_docker_compose.rst:143
+#: ../../source/getting_started/using_docker_compose.rst:151
 msgid ""
 "Or set ``COMPOSE_PROFILES=offline`` in ``.env`` to omit the ``--profile``"
 " flag. Combine with the CPU override if needed:"
@@ -283,7 +292,7 @@ msgstr ""
 "也可以在 ``.env`` 中设置 ``COMPOSE_PROFILES=offline`` 以省略 ``--profile`"
 "` 参数。如有需要可与 CPU override 组合使用："
 
-#: ../../source/getting_started/using_docker_compose.rst:150
+#: ../../source/getting_started/using_docker_compose.rst:158
 msgid ""
 "The private index is also published on the host (default port ``8080``), "
 "so other machines on the same network can reuse it with ``pip install -i "
@@ -292,7 +301,7 @@ msgstr ""
 "私有源同时发布在主机上（默认端口 ``8080``），同一网络内的其他机器可通过 `"
 "`pip install -i http://<host>:8080/simple ...`` 复用它。"
 
-#: ../../source/getting_started/using_docker_compose.rst:155
+#: ../../source/getting_started/using_docker_compose.rst:163
 msgid ""
 "When launching models with the **vLLM** or **SGLang** engines, Xinference"
 " by default resolves some dependencies from hardcoded public indexes (``"
@@ -310,11 +319,11 @@ msgstr ""
 "wheel。或者，在 ``offline.env`` 中设置 ``XINFERENCE_ENABLE_VIRTUAL_ENV=0`"
 "` 完全跳过运行时安装，仅依赖镜像内置的包。"
 
-#: ../../source/getting_started/using_docker_compose.rst:164
+#: ../../source/getting_started/using_docker_compose.rst:172
 msgid "Offline model weights"
 msgstr "离线模型权重"
 
-#: ../../source/getting_started/using_docker_compose.rst:165
+#: ../../source/getting_started/using_docker_compose.rst:173
 msgid ""
 "The offline configuration sets ``HF_HUB_OFFLINE=1`` and "
 "``TRANSFORMERS_OFFLINE=1``, so model weights are read from the local "
@@ -330,11 +339,11 @@ msgstr ""
 "数据卷。此外，也可以通过注册自定义模型或传入 ``--model-path`` 从任意本地"
 "路径加载模型。"
 
-#: ../../source/getting_started/using_docker_compose.rst:172
+#: ../../source/getting_started/using_docker_compose.rst:180
 msgid "Smoke test"
 msgstr "冒烟验证"
 
-#: ../../source/getting_started/using_docker_compose.rst:182
+#: ../../source/getting_started/using_docker_compose.rst:190
 msgid ""
 "Then launch a model and watch ``docker compose logs -f xinference`` — "
 "package installation logs should reference ``http://xinference-pypiserver"

--- a/xinference/core/tests/test_worker.py
+++ b/xinference/core/tests/test_worker.py
@@ -875,6 +875,80 @@ def test_prepare_virtual_env_keeps_system_markers():
     ]
 
 
+def test_prepare_virtual_env_system_torch_respects_configured_extra_index(monkeypatch):
+    # Regression test: an explicitly configured extra index (e.g. an
+    # offline/private mirror inherited from pip config) must not be overridden
+    # by the auto-configured public CUDA wheel index when the package list
+    # contains a #system_torch# marker — uv treats an unreachable extra index
+    # as fatal, breaking air-gapped deployments.
+    import importlib.metadata
+
+    from ..virtual_env_manager import PYTORCH_PACKAGES
+
+    manager = DummyVirtualEnvManager()
+    settings = VirtualEnvSettings(
+        packages=["#system_torch#"],
+        inherit_pip_config=True,
+    )
+
+    private_index = "http://pypiserver:8080/simple"
+    monkeypatch.setattr(
+        "xinference.core.worker.get_pip_config_args",
+        lambda: {"index_url": private_index, "extra_index_url": private_index},
+    )
+    real_version = importlib.metadata.version
+    monkeypatch.setattr(
+        "importlib.metadata.version",
+        lambda name: "2.9.0+cu130" if name in PYTORCH_PACKAGES else real_version(name),
+    )
+    monkeypatch.setattr("xoscar.virtualenv.platform.get_cuda_version", lambda: "13.0")
+
+    WorkerActor._prepare_virtual_env(
+        manager,
+        settings,
+        None,
+        model_engine="vllm",
+    )
+
+    assert len(manager.calls) == 1
+    _, kwargs = manager.calls[0]
+    assert kwargs["index_url"] == private_index
+    assert "download.pytorch.org" not in str(kwargs["extra_index_url"])
+    assert kwargs["extra_index_url"] == private_index
+
+
+def test_prepare_virtual_env_system_torch_injects_cuda_index_by_default(monkeypatch):
+    # Without any explicitly configured index, the auto-configured CUDA wheel
+    # index keeps being injected for #system_torch# (default online behavior).
+    import importlib.metadata
+
+    from ..virtual_env_manager import PYTORCH_CUDA_WHEEL_URLS, PYTORCH_PACKAGES
+
+    manager = DummyVirtualEnvManager()
+    settings = VirtualEnvSettings(
+        packages=["#system_torch#"],
+        inherit_pip_config=False,
+    )
+
+    real_version = importlib.metadata.version
+    monkeypatch.setattr(
+        "importlib.metadata.version",
+        lambda name: "2.9.0+cu130" if name in PYTORCH_PACKAGES else real_version(name),
+    )
+    monkeypatch.setattr("xoscar.virtualenv.platform.get_cuda_version", lambda: "13.0")
+
+    WorkerActor._prepare_virtual_env(
+        manager,
+        settings,
+        None,
+        model_engine=None,
+    )
+
+    assert len(manager.calls) == 1
+    _, kwargs = manager.calls[0]
+    assert kwargs["extra_index_url"] == [PYTORCH_CUDA_WHEEL_URLS["cu130"]]
+
+
 def test_prepare_virtual_env_expands_engine_dependencies_before_user_override():
     manager = DummyVirtualEnvManager()
     settings = VirtualEnvSettings(

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -2551,6 +2551,11 @@ class WorkerActor(xo.StatelessActor):
                 if hasattr(settings, k) and not getattr(settings, k):
                     setattr(settings, k, v)
 
+        # An extra index present at this point was configured explicitly — by
+        # the model spec or inherited pip config (e.g. an offline/private
+        # mirror) — as opposed to the engine defaults applied below.
+        user_configured_extra_index = settings.extra_index_url is not None
+
         apply_engine_virtualenv_settings(settings, model_engine)
 
         base_packages = engine_defaults
@@ -2596,6 +2601,19 @@ class WorkerActor(xo.StatelessActor):
         if system_cuda_urls:
             if settings.extra_index_url is None:
                 settings.extra_index_url = system_cuda_urls
+            elif user_configured_extra_index:
+                # An explicitly configured extra index (model spec or inherited
+                # pip config, e.g. an offline/private mirror) stays
+                # authoritative: uv treats an unreachable extra index as fatal
+                # instead of falling back, so forcing the public CUDA wheel
+                # index here would break air-gapped deployments even when the
+                # wheels exist on the private index.
+                logger.info(
+                    "Skipping auto-configured PyTorch wheel URL %s: explicitly "
+                    "configured extra index takes precedence: %s",
+                    system_cuda_urls,
+                    settings.extra_index_url,
+                )
             else:
                 # Merge with existing extra_index_url, system URLs first for priority
                 existing_urls = (

--- a/xinference/deploy/docker/.env.example
+++ b/xinference/deploy/docker/.env.example
@@ -1,0 +1,42 @@
+# Copy to .env and uncomment values to override the compose defaults.
+#   cp .env.example .env
+
+# Xinference image. Use xprobe/xinference:latest-cpu together with
+# docker-compose.cpu.yml on CPU-only hosts, or pin a release tag,
+# e.g. xprobe/xinference:v1.6.0.
+# XINFERENCE_IMAGE=xprobe/xinference:latest
+
+# Host port for the RESTful API / Web UI.
+# XINFERENCE_PORT=9997
+
+# Model download source: huggingface or modelscope.
+# XINFERENCE_MODEL_SRC=huggingface
+
+# Shared memory size; increase for multi-GPU inference.
+# XINFERENCE_SHM_SIZE=8gb
+
+# Log level: debug, info, warning, error.
+# XINFERENCE_LOG_LEVEL=info
+
+# Persistence. Defaults are named Docker volumes. Point these at host
+# directories (absolute paths) to reuse existing model caches.
+# XINFERENCE_HOME_DIR=/path/on/host/.xinference
+# XINFERENCE_HF_CACHE_DIR=/path/on/host/.cache/huggingface
+# XINFERENCE_MODELSCOPE_CACHE_DIR=/path/on/host/.cache/modelscope
+
+# ── Offline profile (docker compose --profile offline) ──────────────────────
+# Directory of pre-downloaded wheels served by the private PyPI server.
+# XINFERENCE_WHEELS_DIR=./wheels
+
+# Host port of the private PyPI server (for debugging or other LAN hosts).
+# XINFERENCE_PYPISERVER_PORT=8080
+
+# pypiserver image; pin or mirror it into your registry for offline hosts.
+# XINFERENCE_PYPISERVER_IMAGE=pypiserver/pypiserver:v2.3.2
+
+# Set to always enable the offline profile without passing --profile.
+# COMPOSE_PROFILES=offline
+
+# For other XINFERENCE_* runtime options (auth, OTEL, health checks, ...) see
+# https://inference.readthedocs.io/en/latest/getting_started/environments.html
+# and add them under the `environment:` section of docker-compose.yml.

--- a/xinference/deploy/docker/docker-compose.airgap.yml
+++ b/xinference/deploy/docker/docker-compose.airgap.yml
@@ -1,0 +1,40 @@
+# Air-gap enforcement override: moves xinference and the private PyPI server
+# onto an internal Docker network with NO external routing, so offline is
+# guaranteed at the network level rather than by configuration alone.
+# A minimal TCP gateway (socat) publishes the API port, since Docker does not
+# publish ports of internal-only networks. The gateway only forwards inbound
+# traffic to xinference:9997 — it cannot be used by the containers as an
+# egress path.
+#
+# Use together with the offline profile:
+#   docker compose --profile offline \
+#     -f docker-compose.yml -f docker-compose.airgap.yml up -d
+#
+# Note: in this mode the private PyPI server is NOT published on the host;
+# it is only reachable from containers on the isolated network.
+# Requires Docker Compose >= v2.24.4 (for the !reset tag).
+
+networks:
+  isolated:
+    internal: true
+
+services:
+  xinference:
+    networks:
+      - isolated
+    ports: !reset []
+
+  xinference-pypiserver:
+    networks:
+      - isolated
+    ports: !reset []
+
+  xinference-gateway:
+    image: ${XINFERENCE_GATEWAY_IMAGE:-alpine/socat:latest}
+    restart: unless-stopped
+    command: TCP-LISTEN:9997,fork,reuseaddr TCP:xinference:9997
+    ports:
+      - "${XINFERENCE_PORT:-9997}:9997"
+    networks:
+      - default
+      - isolated

--- a/xinference/deploy/docker/docker-compose.cpu.yml
+++ b/xinference/deploy/docker/docker-compose.cpu.yml
@@ -1,0 +1,7 @@
+# CPU-only override. Use together with the base file:
+#   docker compose -f docker-compose.yml -f docker-compose.cpu.yml up -d
+# Requires Docker Compose >= v2.24.4 (for the !reset tag).
+services:
+  xinference:
+    image: ${XINFERENCE_IMAGE:-xprobe/xinference:latest-cpu}
+    deploy: !reset null

--- a/xinference/deploy/docker/docker-compose.yml
+++ b/xinference/deploy/docker/docker-compose.yml
@@ -66,6 +66,9 @@ services:
     # Unauthenticated read/download access.
     command: run -a . -P . /data/packages
     volumes:
+      # On Linux hosts run `chmod -R a+rwX ./wheels` first: the image's
+      # entrypoint requires these permission bits for its internal user
+      # (UID 9898), even though the mount is read-only.
       - ${XINFERENCE_WHEELS_DIR:-./wheels}:/data/packages:ro
     ports:
       - "${XINFERENCE_PYPISERVER_PORT:-8080}:8080"

--- a/xinference/deploy/docker/docker-compose.yml
+++ b/xinference/deploy/docker/docker-compose.yml
@@ -1,39 +1,52 @@
-version: '3.8'
+# Xinference standalone Docker Compose deployment.
+#
+# Online (default):
+#   docker compose up -d
+#
+# Offline / air-gapped (starts a private PyPI server backed by ./wheels):
+#   cp offline.env.example offline.env
+#   # uncomment the offline block in pip.conf
+#   docker compose --profile offline up -d
+#
+# CPU-only host:
+#   docker compose -f docker-compose.yml -f docker-compose.cpu.yml up -d
+#
+# All ${VAR:-default} values below can be overridden via a .env file,
+# see .env.example. Requires Docker Compose >= v2.24.4.
 
 services:
   xinference:
-    image: xprobe/xinference:latest
+    image: ${XINFERENCE_IMAGE:-xprobe/xinference:latest}
+    restart: unless-stopped
+    # Multi-GPU inference needs a larger shared memory segment.
+    shm_size: ${XINFERENCE_SHM_SIZE:-8gb}
     ports:
-      - "9997:9997"
-#    volumes:
-#      # Replace <xinference_home> with your xinference home path on the host machine
-#      - <xinference_home>:/root/.xinference
-#      # Replace <huggingface_cache_dir> with your huggingface cache path, default is
-#      # <home_path>/.cache/huggingface
-#      - <huggingface_cache_dir>:/root/.cache/huggingface
-#      # If models are downloaded from modelscope, replace <huggingface_cache_dir> with
-#      # your modelscope cache path, default is <home_path>/.cache/modelscope
-#      - <modelscope_cache_dir>:/root/.cache/modelscope
-#    environment:
-#      # add envs here. Here's an example, if you want to download model from modelscope
-#      - XINFERENCE_MODEL_SRC=modelscope
-#      # ── OpenTelemetry (OTEL) ──────────────────────────────────────────────
-#      # Set XINFERENCE_ENABLE_OTEL=true and install xinference[otel] to enable OTEL.
-#      - XINFERENCE_ENABLE_OTEL=false
-#      - XINFERENCE_OTLP_BASE_ENDPOINT=http://localhost:4318
-#      - XINFERENCE_OTLP_TRACE_ENDPOINT=
-#      - XINFERENCE_OTLP_METRIC_ENDPOINT=
-#      - XINFERENCE_OTLP_API_KEY=
-#      - XINFERENCE_OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
-#      - XINFERENCE_OTEL_EXPORTER_TYPE=otlp
-#      - XINFERENCE_OTEL_SAMPLING_RATE=0.1
-#      - XINFERENCE_OTEL_BATCH_EXPORT_SCHEDULE_DELAY=5000
-#      - XINFERENCE_OTEL_MAX_QUEUE_SIZE=2048
-#      - XINFERENCE_OTEL_MAX_EXPORT_BATCH_SIZE=512
-#      - XINFERENCE_OTEL_METRIC_EXPORT_INTERVAL=60000
-#      - XINFERENCE_OTEL_BATCH_EXPORT_TIMEOUT=10000
-#      - XINFERENCE_OTEL_METRIC_EXPORT_TIMEOUT=30000
-    command: xinference-local --host 0.0.0.0 --port 9997
+      - "${XINFERENCE_PORT:-9997}:9997"
+    command: xinference-local -H 0.0.0.0 --port 9997 --log-level ${XINFERENCE_LOG_LEVEL:-info}
+    environment:
+      # Model download source: huggingface (default) or modelscope.
+      XINFERENCE_MODEL_SRC: ${XINFERENCE_MODEL_SRC:-huggingface}
+    env_file:
+      # Only present in offline deployments (cp offline.env.example offline.env).
+      # Silently skipped when the file does not exist.
+      - path: ./offline.env
+        required: false
+    volumes:
+      # Defaults are named volumes; point the variables at host directories
+      # in .env to reuse existing model caches (see .env.example).
+      - ${XINFERENCE_HOME_DIR:-xinference_home}:/root/.xinference
+      - ${XINFERENCE_HF_CACHE_DIR:-huggingface_cache}:/root/.cache/huggingface
+      - ${XINFERENCE_MODELSCOPE_CACHE_DIR:-modelscope_cache}:/root/.cache/modelscope
+      # No-op by default; holds the private index configuration for the
+      # offline profile. Must be a file next to this compose file.
+      - ./pip.conf:/etc/pip.conf:ro
+    healthcheck:
+      # python3 is guaranteed in every xinference image (curl is not).
+      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:9997/status')"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 60s
     deploy:
       resources:
         reservations:
@@ -41,3 +54,28 @@ services:
             - capabilities: [gpu]
               driver: nvidia
               count: all
+
+  # Private PyPI server for offline / air-gapped deployments. Serves wheels
+  # from ./wheels to the runtime virtual-env installer of xinference
+  # (and to any other host on the LAN via the published port).
+  # Only started with: docker compose --profile offline up -d
+  xinference-pypiserver:
+    image: ${XINFERENCE_PYPISERVER_IMAGE:-pypiserver/pypiserver:v2.3.2}
+    profiles: ["offline"]
+    restart: unless-stopped
+    # Unauthenticated read/download access.
+    command: run -a . -P . /data/packages
+    volumes:
+      - ${XINFERENCE_WHEELS_DIR:-./wheels}:/data/packages:ro
+    ports:
+      - "${XINFERENCE_PYPISERVER_PORT:-8080}:8080"
+    healthcheck:
+      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8080/health')"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+volumes:
+  xinference_home:
+  huggingface_cache:
+  modelscope_cache:

--- a/xinference/deploy/docker/offline.env.example
+++ b/xinference/deploy/docker/offline.env.example
@@ -1,0 +1,35 @@
+# Offline / air-gapped environment for the xinference service.
+# Enable with:
+#   cp offline.env.example offline.env
+#   docker compose --profile offline up -d
+#
+# Both the UV_* variables below AND the pip.conf mounted into the container
+# are required — they cover different code paths:
+#   * pip.conf feeds xinference's `inherit_pip_config` mechanism, which turns
+#     the values into explicit `uv pip install` flags for the per-model
+#     virtual environments. Setting extra-index-url there also prevents
+#     xinference from injecting hardcoded public indexes for the
+#     vLLM / SGLang engines.
+#   * The UV_* environment variables cover uv invocations that do not carry
+#     index flags (e.g. the dependency-resolution dry-run used by
+#     XINFERENCE_VIRTUAL_ENV_SKIP_INSTALLED).
+# Remember to also uncomment the offline block in pip.conf.
+
+# Runtime pip/uv installs go through the private PyPI server.
+UV_DEFAULT_INDEX=http://xinference-pypiserver:8080/simple
+# Kept for compatibility with older uv versions (deprecated alias).
+UV_INDEX_URL=http://xinference-pypiserver:8080/simple
+# The private index is plain http.
+UV_INSECURE_HOST=xinference-pypiserver:8080
+# For manual `pip install` inside the container.
+PIP_INDEX_URL=http://xinference-pypiserver:8080/simple
+PIP_TRUSTED_HOST=xinference-pypiserver
+
+# Model weights are read from the local cache volumes only.
+HF_HUB_OFFLINE=1
+TRANSFORMERS_OFFLINE=1
+
+# Alternative: skip runtime package installs entirely and rely on the
+# packages baked into the image. With this set, the private PyPI server
+# is not needed at model-launch time.
+# XINFERENCE_ENABLE_VIRTUAL_ENV=0

--- a/xinference/deploy/docker/pip.conf
+++ b/xinference/deploy/docker/pip.conf
@@ -1,0 +1,13 @@
+# Mounted read-only at /etc/pip.conf inside the xinference container.
+# No-op by default. For offline / air-gapped deployments, uncomment the
+# three lines below (see offline.env.example for the full setup).
+#
+# xinference forwards these values to the per-model virtual-env installer
+# (`inherit_pip_config`). extra-index-url intentionally repeats the private
+# index: a non-empty value prevents xinference from injecting hardcoded
+# public extra indexes for the vLLM / SGLang engines.
+
+[global]
+# index-url = http://xinference-pypiserver:8080/simple
+# extra-index-url = http://xinference-pypiserver:8080/simple
+# trusted-host = xinference-pypiserver


### PR DESCRIPTION
## What do these changes do?

The existing `docker-compose.yml` / `docker-compose-distributed.yml` were added as bare examples and are not referenced anywhere in the documentation. This PR turns the standalone compose file into a first-class, documented deployment option, with built-in support for offline / air-gapped environments.

### Reworked `docker-compose.yml`
- All settings parameterized with `${VAR:-default}` and an `.env.example` template (image tag, port, model source, shm size, log level, cache locations).
- `/status` healthcheck (via `python3` + `urllib`, since not every image variant ships `curl`) and `restart: unless-stopped`.
- Model caches persisted in named volumes by default, overridable to host paths.
- Removed the deprecated `version` field and the stale commented-out blocks.

### New: `offline` profile with a private PyPI server
`docker compose --profile offline up -d` additionally starts a [pypiserver](https://github.com/pypiserver/pypiserver) service backed by a local `./wheels` directory. The offline configuration (`offline.env` + mounted `pip.conf`) routes every runtime package install of the model virtual-env machinery to the private index through two complementary channels:

- **`pip.conf`** feeds the `inherit_pip_config` mechanism (`get_pip_config_args()` only reads `global.*` keys from `pip config list`, so env vars alone are not picked up). A non-empty `extra-index-url` also prevents the hardcoded public vLLM/SGLang extra indexes from being injected (`apply_engine_virtualenv_settings` only fills them when unset).
- **`UV_DEFAULT_INDEX` / `UV_INDEX_URL` / `UV_INSECURE_HOST`** cover `uv` invocations that do not carry index flags, e.g. the dependency-resolution dry-run used by `XINFERENCE_VIRTUAL_ENV_SKIP_INSTALLED`.

Model weights are handled by `HF_HUB_OFFLINE=1` / `TRANSFORMERS_OFFLINE=1` plus the mounted cache volumes. Users who prefer fully pre-provisioned images can set `XINFERENCE_ENABLE_VIRTUAL_ENV=0` instead.

### Other additions
- `docker-compose.cpu.yml`: 4-line override for CPU-only hosts (`-cpu` image + `deploy: !reset null`).
- New documentation page `getting_started/using_docker_compose.rst` (added to the toctree) covering quick start, configuration, CPU-only, and a step-by-step offline guide, with zh_CN translation.
- `.gitignore`: keep the `wheels/` mount point (`.gitkeep`), ignore user-local `offline.env`.

Online users are unaffected: `docker compose up -d` works with zero configuration, and the pypiserver service only starts when the `offline` profile is enabled.

## Verification
- `docker compose config` validated for all three views (default / `--profile offline` / CPU override).
- Real smoke test on Docker Desktop (macOS, CPU): stack becomes healthy; inside the container `pip config list` exposes the `global.*` keys; requesting a version absent from the local index fails without falling back to pypi.org, proving `uv` resolves against the private index only.
- End-to-end: launched `qwen3` 0.6B (transformers engine) through the compose stack on a slim image without torch/transformers — the runtime virtual-env installed 34 packages and the model came up successfully.
- Docs: `make html` and `make html_zh_cn` build without new warnings.

## Notes
- Requires Docker Compose >= v2.24.4 (`env_file: required: false`, `!reset`); stated in the docs and file comments.
- The distributed compose file is intentionally left untouched in this PR.