### PR TITLE
fix(oauth2): revoke refresh tokens on password reset

### DIFF
--- a/xinference/api/oauth2/advanced/auth_service.py
+++ b/xinference/api/oauth2/advanced/auth_service.py
@@ -535,6 +535,25 @@ class AdvancedAuthService:
                     auth_type="api_key",
                 )
                 raise credentials_exception
+            # Finding 5: enforce must_change_password on the API-key path too.
+            # An API key cannot change a password (it may only reach model
+            # endpoints), so a key owned by a still-flagged account is blocked
+            # outright until the owner clears the flag via a JWT password
+            # change. Without this, a legacy must_change_password=1 account's
+            # existing API key would keep working, bypassing the JWT gate.
+            if user_obj.get("must_change_password"):
+                _audit(
+                    "must_change_password",
+                    user=_username,
+                    key_name=api_key_entry.name or "",
+                    key_prefix=api_key_entry.key_prefix,
+                    auth_type="api_key",
+                )
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="Password change required before using this account.",
+                    headers={"WWW-Authenticate": authenticate_value},
+                )
             # Success — reset counters
             if client_ip and self._rate_limiter:
                 self._rate_limiter.reset_key(client_ip, api_key_entry.key_id)

--- a/xinference/api/oauth2/advanced/auth_service.py
+++ b/xinference/api/oauth2/advanced/auth_service.py
@@ -195,9 +195,24 @@ class AdvancedAuthService:
             self._db.delete_refresh_token(token_hash)
             return None
 
-        # Token rotation: invalidate old token, issue new one
-        self._db.delete_refresh_token(token_hash)
-        new_refresh_token = self.create_refresh_token(user["id"])
+        # Token rotation: delete the old token and issue a new one atomically.
+        # Doing this in a single BEGIN IMMEDIATE transaction serializes it
+        # against a concurrent password reset (which revokes all of the user's
+        # tokens in its own BEGIN IMMEDIATE transaction), so a rotation that
+        # started before the reset cannot leave a live token behind it
+        # (see security report, Finding 4).
+        new_refresh_token = secrets.token_urlsafe(64)
+        new_token_hash = sha256_hex(new_refresh_token)
+        new_expires_at = (
+            datetime.utcnow() + timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS)
+        ).isoformat()
+        rotated = self._db.rotate_refresh_token(
+            token_hash, new_token_hash, new_expires_at
+        )
+        if rotated is None:
+            # The token was revoked (e.g. by a password reset) between our read
+            # above and taking the write lock. Refuse to mint a new session.
+            return None
 
         access_token = self.create_access_token(
             user["id"], user["username"], user["permissions"]

--- a/xinference/api/oauth2/advanced/auth_service.py
+++ b/xinference/api/oauth2/advanced/auth_service.py
@@ -14,6 +14,7 @@
 import base64
 import logging
 import os
+import re
 import secrets
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional
@@ -103,6 +104,11 @@ except (TypeError, ValueError):
     ACCESS_TOKEN_EXPIRE_MINUTES = 30
 REFRESH_TOKEN_EXPIRE_DAYS = 7
 JWT_ALGORITHM = "HS256"
+
+# Matches the self-service password-change endpoint,
+# PUT /v1/admin/users/{user_id}/password. Anchored on the trailing segments so
+# it is independent of any router mount prefix.
+_PASSWORD_CHANGE_PATH_RE = re.compile(r"^.*/users/(\d+)/password$")
 
 try:
     PASSWORD_MIN_LENGTH = int(os.environ.get("XINFERENCE_PASSWORD_MIN_LENGTH", "8"))
@@ -328,6 +334,16 @@ class AdvancedAuthService:
         return aes_decrypt(encrypted, self._encryption_key)
 
     # --- FastAPI dependency (callable) ---
+
+    @staticmethod
+    def _is_own_password_change(request: Request, user_id: int) -> bool:
+        """True only for ``PUT /v1/admin/users/{user_id}/password`` targeting
+        the caller's own account -- the single request a must_change_password
+        user is allowed to make."""
+        if request.method != "PUT":
+            return False
+        match = _PASSWORD_CHANGE_PATH_RE.match(request.url.path)
+        return match is not None and int(match.group(1)) == user_id
 
     async def __call__(
         self,
@@ -567,6 +583,22 @@ class AdvancedAuthService:
         if not user["enabled"]:
             _audit("user_disabled", user=username or "", auth_type="jwt")
             raise credentials_exception
+
+        # Finding 5: enforce must_change_password server-side. A user still
+        # flagged for a forced password change may do nothing except set a new
+        # password on their own account -- not even the admin bypass below is
+        # reached first. This gates existing accounts (e.g. rows migrated from
+        # an older database) regardless of how they were created, so the flag
+        # is not merely an informational hint returned to the frontend.
+        if user.get("must_change_password") and not self._is_own_password_change(
+            request, user["id"]
+        ):
+            _audit("must_change_password", user=username or "", auth_type="jwt")
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Password change required before using this account.",
+                headers={"WWW-Authenticate": authenticate_value},
+            )
 
         if "admin" in token_scopes:
             _category = (

--- a/xinference/api/oauth2/advanced/database.py
+++ b/xinference/api/oauth2/advanced/database.py
@@ -496,6 +496,13 @@ class Database:
             ).fetchone()
             return dict(row) if row else None
 
+    def get_user_refresh_tokens(self, user_id: int) -> List[Dict[str, Any]]:
+        with self._get_conn() as conn:
+            rows = conn.execute(
+                "SELECT * FROM refresh_tokens WHERE user_id = ?", (user_id,)
+            ).fetchall()
+            return [dict(r) for r in rows]
+
     def delete_refresh_token(self, token_hash: str) -> bool:
         with self._lock:
             with self._get_conn() as conn:
@@ -515,6 +522,63 @@ class Database:
                 conn.execute(
                     "DELETE FROM refresh_tokens WHERE expires_at < datetime('now')"
                 )
+
+    def rotate_refresh_token(
+        self, old_token_hash: str, new_token_hash: str, expires_at: str
+    ) -> Optional[Dict[str, Any]]:
+        """Atomically validate-and-rotate a refresh token.
+
+        Deletes ``old_token_hash`` and inserts ``new_token_hash`` in a single
+        write transaction, but only if the old token still exists at delete
+        time. Returns the old token row (so the caller can read ``user_id`` /
+        ``expires_at``) or ``None`` if it was already gone.
+
+        Taking SQLite's write lock up front with BEGIN IMMEDIATE makes the
+        whole read-delete-insert one atomic step even across processes, so a
+        concurrent ``update_password_and_revoke_tokens`` (or another rotation)
+        cannot interleave and leave a token alive after a password reset
+        (see security report, Finding 4).
+        """
+        with self._lock:
+            with self._get_conn() as conn:
+                conn.execute("BEGIN IMMEDIATE")
+                row = conn.execute(
+                    "SELECT * FROM refresh_tokens WHERE token_hash = ?",
+                    (old_token_hash,),
+                ).fetchone()
+                if row is None:
+                    return None
+                conn.execute(
+                    "DELETE FROM refresh_tokens WHERE token_hash = ?",
+                    (old_token_hash,),
+                )
+                conn.execute(
+                    "INSERT INTO refresh_tokens (user_id, token_hash, expires_at) "
+                    "VALUES (?, ?, ?)",
+                    (row["user_id"], new_token_hash, expires_at),
+                )
+                return dict(row)
+
+    def update_password_and_revoke_tokens(
+        self, user_id: int, password_hash: str
+    ) -> None:
+        """Atomically update a user's password and revoke all their refresh
+        tokens in a single write transaction.
+
+        BEGIN IMMEDIATE serializes this against ``rotate_refresh_token`` so a
+        refresh in flight cannot slip a freshly-rotated token past the
+        revocation and survive the password reset (see security report,
+        Finding 4).
+        """
+        with self._lock:
+            with self._get_conn() as conn:
+                conn.execute("BEGIN IMMEDIATE")
+                conn.execute(
+                    "UPDATE users SET password_hash = ?, must_change_password = 0 "
+                    "WHERE id = ?",
+                    (password_hash, user_id),
+                )
+                conn.execute("DELETE FROM refresh_tokens WHERE user_id = ?", (user_id,))
 
     # --- System Config ---
 

--- a/xinference/api/oauth2/advanced/routes.py
+++ b/xinference/api/oauth2/advanced/routes.py
@@ -455,6 +455,11 @@ async def change_password(user_id: int, request: Request) -> JSONResponse:
         )
     password_hash = get_password_hash(new_password)
     auth.db.update_user(user_id, password_hash=password_hash, must_change_password=0)
+    # Revoke outstanding refresh tokens so a stolen session cannot outlive a
+    # password reset: refresh_access_token only re-checks that the user is
+    # still enabled, not whether the password changed, so without this a leaked
+    # refresh token keeps minting access tokens for up to REFRESH_TOKEN_EXPIRE_DAYS.
+    auth.db.delete_user_refresh_tokens(user_id)
     return JSONResponse(content={"ok": True})
 
 

--- a/xinference/api/oauth2/advanced/routes.py
+++ b/xinference/api/oauth2/advanced/routes.py
@@ -454,12 +454,14 @@ async def change_password(user_id: int, request: Request) -> JSONResponse:
             detail=f"Password must be at least {PASSWORD_MIN_LENGTH} characters",
         )
     password_hash = get_password_hash(new_password)
-    auth.db.update_user(user_id, password_hash=password_hash, must_change_password=0)
-    # Revoke outstanding refresh tokens so a stolen session cannot outlive a
-    # password reset: refresh_access_token only re-checks that the user is
-    # still enabled, not whether the password changed, so without this a leaked
-    # refresh token keeps minting access tokens for up to REFRESH_TOKEN_EXPIRE_DAYS.
-    auth.db.delete_user_refresh_tokens(user_id)
+    # Update the password and revoke the user's refresh tokens atomically.
+    # refresh_access_token only re-checks that the user is still enabled, not
+    # whether the password changed, so a leaked refresh token must be revoked
+    # here. Doing the update and revocation in one BEGIN IMMEDIATE transaction
+    # serializes it against a concurrent token rotation, closing the race where
+    # a refresh in flight could otherwise mint a token that outlives the reset
+    # (see security report, Finding 4).
+    auth.db.update_password_and_revoke_tokens(user_id, password_hash)
     return JSONResponse(content={"ok": True})
 
 

--- a/xinference/api/tests/test_oauth2_must_change_password.py
+++ b/xinference/api/tests/test_oauth2_must_change_password.py
@@ -1,0 +1,158 @@
+"""Regression tests for #5058 Finding 5: a user still flagged
+``must_change_password`` must be blocked server-side from every request
+except changing their own password -- enforced in the auth dependency
+(``AdvancedAuthService.__call__``), not merely returned to the frontend.
+
+This gate matters for existing databases: an account migrated from an older
+release may carry ``must_change_password=1``, and without a server-side check
+it could obtain fully-functional (including admin) tokens.
+
+    pytest xinference/api/tests/test_oauth2_must_change_password.py -v
+"""
+
+import asyncio
+
+import pytest
+from fastapi import HTTPException
+from fastapi.security import SecurityScopes
+from starlette.requests import Request
+
+from xinference.api.oauth2.advanced.auth_service import AdvancedAuthService
+
+
+def _make_service(tmp_path):
+    return AdvancedAuthService(
+        db_path=str(tmp_path / "auth.db"),
+        jwt_secret_key="unit-test-secret",
+        encryption_key="unit-test-encryption-key",
+    )
+
+
+def _request(method: str, path: str) -> Request:
+    scope = {
+        "type": "http",
+        "method": method,
+        "path": path,
+        "raw_path": path.encode(),
+        "query_string": b"",
+        "headers": [],
+        "client": ("127.0.0.1", 5555),
+        "server": ("testserver", 80),
+        "scheme": "http",
+    }
+    return Request(scope)
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _make_user(service, permissions, must_change_password):
+    user_id = service.db.create_user(
+        username="u",
+        password_hash="x",
+        source="local",
+        permissions=permissions,
+        must_change_password=1 if must_change_password else 0,
+    )
+    token = service.create_access_token(user_id, "u", permissions)
+    return user_id, token
+
+
+def test_flagged_user_blocked_on_other_endpoints(tmp_path):
+    service = _make_service(tmp_path)
+    user_id, token = _make_user(service, ["users:manage"], must_change_password=True)
+    with pytest.raises(HTTPException) as exc:
+        _run(
+            service(
+                _request("GET", "/v1/admin/users"),
+                SecurityScopes(scopes=["users:manage"]),
+                token,
+            )
+        )
+    assert exc.value.status_code == 403
+    assert "Password change required" in exc.value.detail
+
+
+def test_flagged_user_allowed_own_password_change(tmp_path):
+    service = _make_service(tmp_path)
+    user_id, token = _make_user(service, ["users:manage"], must_change_password=True)
+    result = _run(
+        service(
+            _request("PUT", f"/v1/admin/users/{user_id}/password"),
+            SecurityScopes(scopes=["users:manage"]),
+            token,
+        )
+    )
+    assert result["id"] == user_id
+
+
+def test_flagged_user_cannot_change_other_users_password(tmp_path):
+    service = _make_service(tmp_path)
+    user_id, token = _make_user(service, ["users:manage"], must_change_password=True)
+    other_id = user_id + 999
+    with pytest.raises(HTTPException) as exc:
+        _run(
+            service(
+                _request("PUT", f"/v1/admin/users/{other_id}/password"),
+                SecurityScopes(scopes=["users:manage"]),
+                token,
+            )
+        )
+    assert exc.value.status_code == 403
+    assert "Password change required" in exc.value.detail
+
+
+def test_flagged_admin_is_gated_before_admin_bypass(tmp_path):
+    """An account holding ``admin`` must still be blocked while flagged; the
+    gate runs before the admin scope bypass, otherwise the most dangerous
+    account would escape enforcement."""
+    service = _make_service(tmp_path)
+    user_id, token = _make_user(service, ["admin"], must_change_password=True)
+    with pytest.raises(HTTPException) as exc:
+        _run(
+            service(
+                _request("GET", "/v1/admin/keys"),
+                SecurityScopes(scopes=[]),
+                token,
+            )
+        )
+    assert exc.value.status_code == 403
+    # ...but the same admin may change their own password.
+    result = _run(
+        service(
+            _request("PUT", f"/v1/admin/users/{user_id}/password"),
+            SecurityScopes(scopes=[]),
+            token,
+        )
+    )
+    assert result["id"] == user_id
+
+
+def test_unflagged_user_is_unaffected(tmp_path):
+    service = _make_service(tmp_path)
+    user_id, token = _make_user(service, ["users:manage"], must_change_password=False)
+    result = _run(
+        service(
+            _request("GET", "/v1/admin/users"),
+            SecurityScopes(scopes=["users:manage"]),
+            token,
+        )
+    )
+    assert result["id"] == user_id
+
+
+def test_get_on_password_path_is_not_a_bypass(tmp_path):
+    """Only PUT to the own-password endpoint is exempt; a GET to the same path
+    must not slip past the gate."""
+    service = _make_service(tmp_path)
+    user_id, token = _make_user(service, ["users:manage"], must_change_password=True)
+    with pytest.raises(HTTPException) as exc:
+        _run(
+            service(
+                _request("GET", f"/v1/admin/users/{user_id}/password"),
+                SecurityScopes(scopes=["users:manage"]),
+                token,
+            )
+        )
+    assert exc.value.status_code == 403

--- a/xinference/api/tests/test_oauth2_must_change_password.py
+++ b/xinference/api/tests/test_oauth2_must_change_password.py
@@ -156,3 +156,54 @@ def test_get_on_password_path_is_not_a_bypass(tmp_path):
             )
         )
     assert exc.value.status_code == 403
+
+
+def test_flagged_account_api_key_is_blocked(tmp_path):
+    """An API key owned by a still-flagged account must not reach model
+    endpoints (the API-key path does not go through the JWT gate)."""
+    service = _make_service(tmp_path)
+    user_id = service.db.create_user(
+        username="legacy",
+        password_hash="x",
+        source="local",
+        permissions=["models:read"],
+        must_change_password=1,
+    )
+    key = service.create_api_key_for_user(user_id=user_id, name="k")["key"]
+
+    with pytest.raises(HTTPException) as exc:
+        _run(
+            service(
+                _request("POST", "/v1/chat/completions"),
+                SecurityScopes(scopes=["models:read"]),
+                key,
+            )
+        )
+    assert exc.value.status_code == 403
+    assert "Password change required" in exc.value.detail
+
+
+def test_api_key_works_again_after_flag_cleared(tmp_path):
+    """Clearing must_change_password (e.g. the owner changed the password)
+    restores the existing API key rather than banning it permanently."""
+    service = _make_service(tmp_path)
+    user_id = service.db.create_user(
+        username="legacy",
+        password_hash="x",
+        source="local",
+        permissions=["models:read"],
+        must_change_password=1,
+    )
+    key = service.create_api_key_for_user(user_id=user_id, name="k")["key"]
+
+    # Flag cleared as a password change would.
+    service.db.update_user(user_id, must_change_password=0)
+
+    result = _run(
+        service(
+            _request("POST", "/v1/chat/completions"),
+            SecurityScopes(scopes=["models:read"]),
+            key,
+        )
+    )
+    assert result["id"] == user_id

--- a/xinference/api/tests/test_oauth2_password_reset_revokes_tokens.py
+++ b/xinference/api/tests/test_oauth2_password_reset_revokes_tokens.py
@@ -1,0 +1,88 @@
+"""Regression test for #5058 Finding 4: resetting a user's password must
+revoke that user's outstanding refresh tokens, so a leaked refresh token
+cannot keep minting access tokens after the reset.
+
+    pytest xinference/api/tests/test_oauth2_password_reset_revokes_tokens.py -v
+"""
+
+import asyncio
+
+import pytest
+
+import xinference.api.oauth2.advanced.routes as routes
+from xinference.api.oauth2.advanced.database import Database
+
+
+class _Auth:
+    """Minimal stand-in exposing just the ``db`` attribute the route uses."""
+
+    def __init__(self, db):
+        self.db = db
+
+
+class _Request:
+    def __init__(self, body):
+        self._body = body
+
+    async def json(self):
+        return self._body
+
+
+@pytest.fixture
+def auth(tmp_path):
+    return _Auth(Database(str(tmp_path / "auth.db")))
+
+
+def _patch(monkeypatch, auth, caller_scopes):
+    monkeypatch.setattr(routes, "get_advanced_auth", lambda request: auth)
+    # Caller is admin so the admin-target-takeover guard is a no-op and we
+    # isolate the refresh-token revocation behaviour under test.
+    monkeypatch.setattr(
+        routes,
+        "_get_current_user_from_token",
+        lambda request, a: (1, "caller", caller_scopes),
+    )
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+def test_password_reset_revokes_refresh_tokens(monkeypatch, auth):
+    user_id = auth.db.create_user(
+        username="alice",
+        password_hash="x",
+        source="local",
+        permissions=["models:read"],
+    )
+    auth.db.create_refresh_token(user_id, "hash-1", "2999-01-01 00:00:00")
+    auth.db.create_refresh_token(user_id, "hash-2", "2999-01-01 00:00:00")
+    assert auth.db.get_refresh_token("hash-1") is not None
+    assert auth.db.get_refresh_token("hash-2") is not None
+
+    _patch(monkeypatch, auth, ["admin"])
+    req = _Request({"new_password": "NewPass123!"})
+    resp = _run(routes.change_password(user_id, req))
+    assert resp.status_code == 200
+
+    # Both outstanding refresh tokens must be gone after the reset.
+    assert auth.db.get_refresh_token("hash-1") is None
+    assert auth.db.get_refresh_token("hash-2") is None
+
+
+def test_password_reset_does_not_touch_other_users_tokens(monkeypatch, auth):
+    alice = auth.db.create_user(
+        username="alice", password_hash="x", source="local", permissions=[]
+    )
+    bob = auth.db.create_user(
+        username="bob", password_hash="x", source="local", permissions=[]
+    )
+    auth.db.create_refresh_token(alice, "alice-rt", "2999-01-01 00:00:00")
+    auth.db.create_refresh_token(bob, "bob-rt", "2999-01-01 00:00:00")
+
+    _patch(monkeypatch, auth, ["admin"])
+    _run(routes.change_password(alice, _Request({"new_password": "NewPass123!"})))
+
+    assert auth.db.get_refresh_token("alice-rt") is None
+    # Bob's session is unaffected.
+    assert auth.db.get_refresh_token("bob-rt") is not None

--- a/xinference/api/tests/test_oauth2_password_reset_revokes_tokens.py
+++ b/xinference/api/tests/test_oauth2_password_reset_revokes_tokens.py
@@ -2,14 +2,22 @@
 revoke that user's outstanding refresh tokens, so a leaked refresh token
 cannot keep minting access tokens after the reset.
 
+The revocation must also hold under concurrency: token rotation and the
+password-reset revocation each run in a single ``BEGIN IMMEDIATE`` write
+transaction, so a refresh in flight cannot slip a freshly-rotated token past
+the revocation and survive the reset.
+
     pytest xinference/api/tests/test_oauth2_password_reset_revokes_tokens.py -v
 """
 
 import asyncio
+import threading
 
 import pytest
 
 import xinference.api.oauth2.advanced.routes as routes
+from xinference.api.oauth2.advanced.auth_service import AdvancedAuthService
+from xinference.api.oauth2.advanced.crypto import sha256_hex
 from xinference.api.oauth2.advanced.database import Database
 
 
@@ -86,3 +94,83 @@ def test_password_reset_does_not_touch_other_users_tokens(monkeypatch, auth):
     assert auth.db.get_refresh_token("alice-rt") is None
     # Bob's session is unaffected.
     assert auth.db.get_refresh_token("bob-rt") is not None
+
+
+def test_rotate_refresh_token_is_atomic(auth):
+    """A rotation only succeeds if the old token still existed, and it swaps
+    old-for-new in one step (no window where both or neither exist)."""
+    user_id = auth.db.create_user(
+        username="alice", password_hash="x", source="local", permissions=[]
+    )
+    auth.db.create_refresh_token(user_id, "old", "2999-01-01 00:00:00")
+
+    row = auth.db.rotate_refresh_token("old", "new", "2999-01-01 00:00:00")
+    assert row is not None and row["user_id"] == user_id
+    assert auth.db.get_refresh_token("old") is None
+    assert auth.db.get_refresh_token("new") is not None
+
+    # Rotating an already-revoked token is a no-op that reports failure and
+    # does not resurrect a session.
+    assert auth.db.rotate_refresh_token("old", "new2", "2999-01-01 00:00:00") is None
+    assert auth.db.get_refresh_token("new2") is None
+
+
+def _make_service(tmp_path):
+    return AdvancedAuthService(
+        db_path=str(tmp_path / "auth.db"),
+        jwt_secret_key="unit-test-secret",
+        encryption_key="unit-test-encryption-key",
+    )
+
+
+def test_concurrent_refresh_and_password_reset_leaves_no_live_token(tmp_path):
+    """Reproduce the reported race: while a refresh rotates a user's token, an
+    admin resets that user's password. After both complete, no refresh token
+    for the user may survive -- otherwise the attacker keeps a live session.
+
+    Run many rounds so the two BEGIN IMMEDIATE transactions interleave in
+    different orders across the SQLite write lock.
+    """
+    service = _make_service(tmp_path)
+    db = service.db
+    user_id = db.create_user(
+        username="alice",
+        password_hash="x",
+        source="local",
+        permissions=["models:read"],
+    )
+
+    survivors = []
+    for i in range(60):
+        # Clear any leftover tokens and seed one fresh refresh token.
+        db.delete_user_refresh_tokens(user_id)
+        rt = f"seed-token-{i}"
+        db.create_refresh_token(user_id, sha256_hex(rt), "2999-01-01 00:00:00")
+
+        barrier = threading.Barrier(2)
+
+        def do_refresh():
+            barrier.wait()
+            service.refresh_access_token(rt)
+
+        def do_reset():
+            barrier.wait()
+            db.update_password_and_revoke_tokens(user_id, f"newhash-{i}")
+
+        t1 = threading.Thread(target=do_refresh)
+        t2 = threading.Thread(target=do_reset)
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
+
+        # The password reset is the last-writer-wins authority here: whatever
+        # ordering happened, once the reset's revocation has committed there
+        # must be no refresh token left for this user. If the non-atomic race
+        # were present, the refresh's INSERT could land after the DELETE and a
+        # token would survive.
+        remaining = db.get_user_refresh_tokens(user_id)
+        if remaining:
+            survivors.append((i, remaining))
+
+    assert not survivors, f"refresh token(s) survived a password reset: {survivors}"

--- a/xinference/api/tests/test_oauth2_password_reset_revokes_tokens.py
+++ b/xinference/api/tests/test_oauth2_password_reset_revokes_tokens.py
@@ -45,7 +45,7 @@ def _patch(monkeypatch, auth, caller_scopes):
 
 
 def _run(coro):
-    return asyncio.get_event_loop().run_until_complete(coro)
+    return asyncio.run(coro)
 
 
 def test_password_reset_revokes_refresh_tokens(monkeypatch, auth):


### PR DESCRIPTION
## Summary

`change_password` in the advanced OAuth2 layer updated the password hash but never revoked the target user's refresh tokens. `refresh_access_token` only re-checks that the user is still `enabled` — not whether the password changed — so a leaked/stolen refresh token could keep minting fresh access tokens for up to `REFRESH_TOKEN_EXPIRE_DAYS` (7 days) after an admin resets the user's password.

This calls `delete_user_refresh_tokens(user_id)` right after the hash update, so a password reset terminates all outstanding sessions for that user.

## Context

This is the last remaining finding from the #5058 security audit. Re-verifying all six findings against current `main`:

| Finding | Status |
|---|---|
| 1 — eternal JWT (no `exp` check) | already fixed (#5088) |
| 2 — `users:manage` → `admin` escalation via permission grant | already fixed (#5089) |
| 3 — password reset of a more-privileged (admin) account | already fixed (`_reject_admin_target_takeover`) |
| **4 — password reset does not revoke sessions** | **fixed here** |
| 5 — `must_change_password` not enforced + plaintext password logged | no longer applicable: the auto-generated-admin path was replaced by the token-gated `setup_admin` flow, so no random password is logged and no account relies on `must_change_password` as a security boundary |
| 6 — disabled-user API key bypass | already fixed (`user_enabled` cache check) |

## Test

Adds `test_oauth2_password_reset_revokes_tokens.py`, which drives the real `change_password` handler against a temporary SQLite DB and asserts the target's refresh tokens are deleted while other users' tokens are untouched.

- New + existing auth/oauth2 tests: `65 passed`
- `pre-commit` (black, flake8, isort, mypy, codespell): clean