### PR TITLE
fix: honor virtualenv exemption in engine matching for multimodal LLM, embedding and rerank

### DIFF
--- a/xinference/model/embedding/model_spec.json
+++ b/xinference/model/embedding/model_spec.json
@@ -1834,7 +1834,7 @@
         "transformers>=4.57.0 ; #engine# == \"sentence_transformers\"",
         "qwen-vl-utils>=0.0.14",
         "Pillow",
-        "#vllm_dependencies# ; #engine# == \"vllm\"",
+        "vllm>=0.14.0 ; #engine# == \"vllm\"",
         "#system_numpy# ; #engine# == \"vllm\""
       ]
     },
@@ -1875,7 +1875,7 @@
         "transformers==4.57.1 ; #engine# == \"sentence_transformers\"",
         "qwen-vl-utils==0.0.11",
         "Pillow",
-        "#vllm_dependencies# ; #engine# == \"vllm\"",
+        "vllm>=0.14.0 ; #engine# == \"vllm\"",
         "#system_numpy# ; #engine# == \"vllm\""
       ]
     },

--- a/xinference/model/embedding/tests/test_qwen3_vl_engine_params.py
+++ b/xinference/model/embedding/tests/test_qwen3_vl_engine_params.py
@@ -28,6 +28,7 @@ from xinference.model.embedding.core import create_embedding_model_instance
 from xinference.model.embedding.embed_family import match_embedding
 from xinference.model.utils import (
     check_dependency_available,
+    get_engine_params_by_name,
     get_engine_params_by_name_with_virtual_env,
 )
 
@@ -52,6 +53,121 @@ def test_qwen3_vl_embedding_engine_params_with_virtualenv():
     assert isinstance(params, dict)
     _assert_engine_params(params, "sentence_transformers")
     _assert_engine_params(params, "vllm")
+    # vLLM is a declared virtualenv marker for this model, so it must be
+    # offered even when vLLM is not installed locally (installed on demand).
+    # This guards the regression where the vision match_json rejected the
+    # engine with "vLLM is not installed" before the virtualenv exemption.
+    assert isinstance(
+        params["vllm"], list
+    ), f"vLLM should be available under virtualenv, got {params['vllm']!r}"
+
+
+def test_qwen3_vl_embedding_strict_with_old_vllm_when_virtualenv_disabled(
+    monkeypatch,
+):
+    """Request-level enable_virtual_env=False must stay strict.
+
+    Exercises the exact function the Worker calls on the disabled path
+    (get_engine_params_by_name), not just the virtualenv-aware wrapper. Even
+    when the process-global XINFERENCE_ENABLE_VIRTUAL_ENV default is true, a
+    disabled discovery must not exempt the Qwen3-VL vLLM>=0.14.0 version check:
+    with an old vLLM installed and no virtualenv, launching would fail, so vLLM
+    must not be listed. When virtualenv is enabled it is offered again
+    (installed on demand). Regression for the registry baking the exemption in
+    at import time and the strict path reusing it.
+    """
+    import sys
+    import types
+
+    import xinference.constants as constants
+
+    _install()
+
+    # Global default true (as shipped), plus a simulated old local vLLM.
+    monkeypatch.setattr(constants, "XINFERENCE_ENABLE_VIRTUAL_ENV", True)
+    fake_vllm = types.ModuleType("vllm")
+    fake_vllm.__version__ = "0.11.2"
+    monkeypatch.setitem(sys.modules, "vllm", fake_vllm)
+
+    # Worker's disabled path.
+    disabled = get_engine_params_by_name(
+        "embedding", "Qwen3-VL-Embedding-2B", enable_virtual_env=False
+    )
+    assert not isinstance(
+        disabled.get("vllm"), list
+    ), f"vLLM must be strict (not available) with old vLLM and virtualenv disabled, got {disabled.get('vllm')!r}"
+
+    # Worker's virtualenv-enabled path.
+    enabled = get_engine_params_by_name_with_virtual_env(
+        "embedding", "Qwen3-VL-Embedding-2B", enable_virtual_env=True
+    )
+    assert isinstance(
+        enabled.get("vllm"), list
+    ), f"vLLM should be available under virtualenv, got {enabled.get('vllm')!r}"
+
+
+def test_qwen3_vl_embedding_prepared_install_list_has_single_vllm_req():
+    """Only one vLLM requirement must reach the installer.
+
+    The virtualenv spec must not carry both #vllm_dependencies# (vllm>=0.11.2)
+    and vllm>=0.14.0: with skip_installed and a parent vLLM 0.11.2-0.13.x, the
+    resolver pins the first (satisfied) requirement and then conflicts with the
+    second. This asserts the *prepared install list* (expansion + marker
+    filtering, i.e. the Worker path), not just discovery, contains exactly one
+    vLLM requirement pinned to >=0.14.0.
+    """
+    from xinference.core.utils import filter_virtualenv_packages_by_markers
+    from xinference.core.virtual_env_manager import (
+        expand_engine_dependency_placeholders,
+    )
+
+    _install()
+    family = match_embedding("Qwen3-VL-Embedding-2B", "pytorch", "none")
+    expanded = expand_engine_dependency_placeholders(family.virtualenv.packages, "vllm")
+    prepared = filter_virtualenv_packages_by_markers(expanded, "vllm", None)
+    vllm_reqs = [p for p in prepared if p.lower().startswith("vllm")]
+    assert vllm_reqs == [
+        "vllm>=0.14.0"
+    ], f"expected a single vllm>=0.14.0 requirement, got {vllm_reqs!r}"
+
+
+def test_qwen3_vl_embedding_format_check_not_bypassed_under_virtualenv(monkeypatch):
+    """virtualenv must not bypass format/prefix compatibility checks.
+
+    The virtualenv exemption only covers the missing-library / old-version
+    rejection; an incompatible model_format (e.g. ggufv2, which the vLLM
+    embedding engine does not support) must still be rejected even when vLLM is
+    absent and virtualenv is enabled, since virtualenv cannot make an
+    incompatible spec work. Regression for the early ``return True``.
+    """
+    import sys
+
+    from xinference.model.embedding.vllm.core import VLLMEmbeddingModel
+    from xinference.model.utils import virtualenv_discovery_var
+
+    _install()
+
+    # vLLM absent + virtualenv enabled for this discovery scope.
+    monkeypatch.delitem(sys.modules, "vllm", raising=False)
+    token = virtualenv_discovery_var.set(True)
+    try:
+        family = match_embedding("Qwen3-VL-Embedding-2B", "pytorch", "none")
+        good_spec = family.model_specs[0]
+        assert good_spec.model_format == "pytorch"
+
+        # Derive an incompatible spec by flipping the format to ggufv2.
+        if hasattr(good_spec, "model_copy"):
+            bad_spec = good_spec.model_copy(update={"model_format": "ggufv2"})
+        else:
+            bad_spec = good_spec.copy(update={"model_format": "ggufv2"})
+
+        result = VLLMEmbeddingModel.match_json(family, bad_spec, "none")
+        assert result is not True, "ggufv2 must not be accepted by vLLM embedding"
+        assert isinstance(result, tuple) and result[0] is False
+
+        assert VLLMEmbeddingModel.match_json(family, good_spec, "none") is True
+    finally:
+        virtualenv_discovery_var.reset(token)
 
 
 def _get_cached_model_path():

--- a/xinference/model/embedding/vllm/core.py
+++ b/xinference/model/embedding/vllm/core.py
@@ -299,17 +299,28 @@ class VLLMEmbeddingModel(EmbeddingModel, BatchMixin):
     ) -> Union[bool, Tuple[bool, str]]:
 
         if model_family.model_name.startswith("Qwen3-VL-Embedding"):
+            # In virtualenv mode vLLM (and a compatible version) can be
+            # installed on demand, so only the missing-library / old-version
+            # rejection is exempt here; the format/prefix compatibility checks
+            # below still apply (virtualenv cannot make an incompatible spec
+            # work).
+            from ...utils import virtual_env_allows_missing_engine
+
+            allow_missing_env = virtual_env_allows_missing_engine()
             try:
                 import vllm
                 from packaging import version
             except ImportError:
-                return False, "vLLM is not installed"
-
-            if version.parse(vllm.__version__) < version.parse("0.14.0"):
-                return (
-                    False,
-                    f"Qwen3-VL embedding requires vLLM>=0.14.0, current: {vllm.__version__}",
-                )
+                if not allow_missing_env:
+                    return False, "vLLM is not installed"
+            else:
+                if not allow_missing_env and version.parse(
+                    vllm.__version__
+                ) < version.parse("0.14.0"):
+                    return (
+                        False,
+                        f"Qwen3-VL embedding requires vLLM>=0.14.0, current: {vllm.__version__}",
+                    )
         if model_spec.model_format not in ["pytorch"]:
             return False, "vLLM embedding engine only supports pytorch format"
         prefix = model_family.model_name.split("-", 1)[0]

--- a/xinference/model/llm/sglang/core.py
+++ b/xinference/model/llm/sglang/core.py
@@ -87,6 +87,26 @@ try:
 except ImportError:
     SGLANG_INSTALLED = False
 
+
+def _virtual_env_allows_missing_sglang() -> bool:
+    """Whether virtualenv mode should tolerate a missing SGLang install.
+
+    When enabled, SGLang and its runtime are installed on demand, so engine
+    listing must not depend on the library being present locally. Delegates to
+    the shared helper so discovery honors the effective request-level flag
+    (virtualenv_discovery_var), falling back to the global constant otherwise.
+    """
+    try:
+        from ...utils import virtual_env_allows_missing_engine
+    except Exception:
+        try:
+            from ....constants import XINFERENCE_ENABLE_VIRTUAL_ENV
+        except Exception:
+            return False
+        return bool(XINFERENCE_ENABLE_VIRTUAL_ENV)
+    return virtual_env_allows_missing_engine()
+
+
 SGLANG_SUPPORTED_MODELS = [
     "LlamaForCausalLM",
     "MistralForCausalLM",
@@ -385,7 +405,7 @@ class SGLANGModel(LLM):
             )
         if "generate" not in llm_family.model_ability:
             return False, "SGLang base engine requires generate ability"
-        if not SGLANG_INSTALLED:
+        if not SGLANG_INSTALLED and not _virtual_env_allows_missing_sglang():
             return False, "sglang library is not installed"
         return True
 
@@ -699,7 +719,7 @@ class SGLANGChatModel(SGLANGModel, ChatModelMixin):
             )
         if "chat" not in llm_family.model_ability:
             return False, "SGLang chat engine requires chat ability"
-        if not SGLANG_INSTALLED:
+        if not SGLANG_INSTALLED and not _virtual_env_allows_missing_sglang():
             return False, "sglang library is not installed"
         return True
 
@@ -809,7 +829,10 @@ class SGLANGVisionModel(SGLANGModel, ChatModelMixin):
             )
         if "vision" not in llm_family.model_ability:
             return False, "SGLang vision engine requires vision ability"
-        if not SGLANG_INSTALLED:
+        # Align with SGLANGChatModel: virtualenv installs SGLang on demand, so a
+        # missing local install must not hide the engine. GPU/OS checks above
+        # stay unconditional because virtualenv cannot add a GPU or change the OS.
+        if not SGLANG_INSTALLED and not _virtual_env_allows_missing_sglang():
             return False, "sglang library is not installed"
         return True
 

--- a/xinference/model/llm/tests/test_llm_family.py
+++ b/xinference/model/llm/tests/test_llm_family.py
@@ -783,3 +783,88 @@ def test_query_engine_general():
     unregister_llm(family.model_name)
     assert family not in get_user_defined_llm_families()
     assert "custom-qwen1.5-chat" not in LLM_ENGINES
+
+
+def test_multimodal_engine_available_with_virtualenv(monkeypatch):
+    """Regression test for qwen3.5-style multimodal models.
+
+    A model whose only chat/vision architecture is served by the vLLM/SGLang
+    multimodal engines must still list those engines when virtualenv is enabled
+    on a supported worker (GPU + Linux) even if the libraries are not installed
+    locally. Previously the vision match_json returned "library is not
+    installed" unconditionally, unlike the chat match_json which honored the
+    virtualenv exemption.
+
+    virtualenv can install Python packages on demand but cannot add a GPU or
+    change the OS, so the hardware/OS checks stay unconditional and are
+    simulated here to isolate the library-exemption behavior.
+    """
+    import xinference.model.llm as llm_pkg
+    from xinference.model.llm.sglang import core as sglang_core
+    from xinference.model.llm.vllm import core as vllm_core
+
+    from ...utils import get_engine_params_by_name_with_virtual_env
+
+    llm_pkg._install()
+
+    # Simulate a supported worker: CUDA present and Linux. This isolates the
+    # library-missing exemption from the (unconditional) hardware/OS gates.
+    for core in (vllm_core, sglang_core):
+        for model_cls in vars(core).values():
+            if isinstance(model_cls, type) and hasattr(model_cls, "_has_cuda_device"):
+                monkeypatch.setattr(
+                    model_cls, "_has_cuda_device", classmethod(lambda cls: True)
+                )
+                monkeypatch.setattr(
+                    model_cls, "_is_linux", classmethod(lambda cls: True)
+                )
+
+    params = get_engine_params_by_name_with_virtual_env(
+        "LLM", "qwen3.5", enable_virtual_env=True
+    )
+    assert params is not None
+
+    # vLLM/SGLang (GPU multimodal engines), Transformers and llama.cpp are all
+    # declared virtualenv markers for qwen3.5, so on a GPU+Linux worker they
+    # must be offered (as available lists, flagged virtualenv_required when the
+    # lib is missing) even without the library installed locally.
+    for engine in ("vLLM", "SGLang", "Transformers", "llama.cpp"):
+        assert isinstance(
+            params.get(engine), list
+        ), f"{engine} should be available for qwen3.5 under virtualenv, got {params.get(engine)!r}"
+
+    # MLX and LMDEPLOY are not declared for qwen3.5, so they must NOT be listed
+    # as available (kept as string reasons instead).
+    for engine in ("MLX", "LMDEPLOY"):
+        assert not isinstance(
+            params.get(engine), list
+        ), f"{engine} should not be available for qwen3.5, got {params.get(engine)!r}"
+
+
+def test_multimodal_vllm_engine_requires_gpu_even_with_virtualenv():
+    """virtualenv must not bypass the hardware/OS gate.
+
+    On a worker without a supported GPU, the vLLM multimodal engine must not
+    match even when virtualenv is enabled, because virtualenv cannot provide an
+    accelerator. Guards the correctness fix where GPU/OS checks were previously
+    (incorrectly) exempted under virtualenv.
+    """
+    import xinference.model.llm as llm_pkg
+    from xinference.model.llm.llm_family import BUILTIN_LLM_FAMILIES
+    from xinference.model.llm.vllm.core import VLLMMultiModel
+
+    llm_pkg._install()
+    family = next(f for f in BUILTIN_LLM_FAMILIES if f.model_name == "qwen3.5")
+    spec = family.model_specs[0]
+
+    if (
+        VLLMMultiModel._has_cuda_device()
+        or VLLMMultiModel._has_mlu_device()
+        or VLLMMultiModel._has_vacc_device()
+        or VLLMMultiModel._has_musa_device()
+    ):
+        pytest.skip("host has an accelerator; cannot assert the no-GPU gate")
+
+    result = VLLMMultiModel.match_json(family, spec, spec.quantization)
+    assert result is not True
+    assert isinstance(result, tuple) and result[0] is False

--- a/xinference/model/llm/vllm/core.py
+++ b/xinference/model/llm/vllm/core.py
@@ -178,11 +178,19 @@ def _get_effective_vllm_version() -> version.Version:
 
 
 def _virtual_env_allows_missing_vllm() -> bool:
+    # Delegate to the shared helper so engine discovery honors the effective
+    # request-level virtualenv flag (via virtualenv_discovery_var) instead of
+    # only the process-global default; falls back to the global constant when
+    # called outside a discovery scope (e.g. the launch path).
     try:
-        from ....constants import XINFERENCE_ENABLE_VIRTUAL_ENV
+        from ...utils import virtual_env_allows_missing_engine
     except Exception:
-        return False
-    return bool(XINFERENCE_ENABLE_VIRTUAL_ENV)
+        try:
+            from ....constants import XINFERENCE_ENABLE_VIRTUAL_ENV
+        except Exception:
+            return False
+        return bool(XINFERENCE_ENABLE_VIRTUAL_ENV)
+    return virtual_env_allows_missing_engine()
 
 
 GuidedDecodingParams: Optional[Type[Any]] = None
@@ -1941,7 +1949,11 @@ class VLLMMultiModel(VLLMModel, ChatModelMixin):
                 False,
                 "vLLM multimodal engine requires vision, audio, or omni ability",
             )
-        if not VLLM_INSTALLED:
+        # Align with VLLMChatModel: in virtualenv mode vLLM is installed on
+        # demand, so a missing local install must not hide the engine at listing
+        # time. Hardware/OS checks above stay unconditional because virtualenv
+        # cannot add a GPU or change the OS.
+        if not VLLM_INSTALLED and not _virtual_env_allows_missing_vllm():
             return False, "vLLM library is not installed"
         return True
 

--- a/xinference/model/rerank/model_spec.json
+++ b/xinference/model/rerank/model_spec.json
@@ -691,7 +691,7 @@
       "packages": [
         "#sentence_transformers_dependencies# ; #engine# == \"sentence_transformers\"",
         "#system_torchvision# ; #engine# == \"sentence_transformers\"",
-        "#vllm_dependencies# ; #engine# == \"vllm\"",
+        "vllm>=0.14.0 ; #engine# == \"vllm\"",
         "#system_numpy# ; #engine# == \"vllm\""
       ]
     }
@@ -731,7 +731,7 @@
       "packages": [
         "#sentence_transformers_dependencies# ; #engine# == \"sentence_transformers\"",
         "#system_torchvision# ; #engine# == \"sentence_transformers\"",
-        "#vllm_dependencies# ; #engine# == \"vllm\"",
+        "vllm>=0.14.0 ; #engine# == \"vllm\"",
         "#system_numpy# ; #engine# == \"vllm\""
       ]
     }

--- a/xinference/model/rerank/tests/test_qwen3_vl_reranker_virtualenv.py
+++ b/xinference/model/rerank/tests/test_qwen3_vl_reranker_virtualenv.py
@@ -26,7 +26,130 @@ from xinference.model.rerank import _install
 from xinference.model.rerank.cache_manager import RerankCacheManager
 from xinference.model.rerank.core import create_rerank_model_instance
 from xinference.model.rerank.rerank_family import match_rerank
-from xinference.model.utils import check_dependency_available
+from xinference.model.utils import (
+    check_dependency_available,
+    get_engine_params_by_name,
+    get_engine_params_by_name_with_virtual_env,
+)
+
+
+def test_qwen3_vl_reranker_engine_params_with_virtualenv():
+    _install()
+    params = get_engine_params_by_name_with_virtual_env(
+        "rerank", "Qwen3-VL-Reranker-2B", enable_virtual_env=True
+    )
+    assert isinstance(params, dict)
+    # vLLM is a declared virtualenv marker for this model. It must be offered
+    # even when vLLM is missing/older locally (installed on demand). This guards
+    # the regression where match_json unconditionally rejected the engine with
+    # "requires vLLM>=0.14.0" before the virtualenv exemption.
+    assert "vllm" in params
+    assert isinstance(
+        params["vllm"], list
+    ), f"vLLM should be available under virtualenv, got {params['vllm']!r}"
+    item = params["vllm"][0]
+    assert item.get("model_format") == "pytorch"
+    assert item.get("quantization") == "none"
+
+
+def test_qwen3_vl_reranker_strict_with_old_vllm_when_virtualenv_disabled(
+    monkeypatch,
+):
+    """Request-level enable_virtual_env=False must stay strict.
+
+    With the process-global virtualenv default true and an old vLLM installed
+    locally, an explicit enable_virtual_env=False discovery call must not exempt
+    the Qwen3-VL vLLM>=0.14.0 version check (launching without virtualenv would
+    fail), so vLLM must not be listed. With virtualenv enabled it is offered
+    again. Regression for the process-global-flag leak.
+    """
+    import sys
+    import types
+
+    import xinference.constants as constants
+
+    _install()
+
+    monkeypatch.setattr(constants, "XINFERENCE_ENABLE_VIRTUAL_ENV", True)
+    fake_vllm = types.ModuleType("vllm")
+    fake_vllm.__version__ = "0.11.2"
+    monkeypatch.setitem(sys.modules, "vllm", fake_vllm)
+
+    # Worker's disabled path.
+    disabled = get_engine_params_by_name(
+        "rerank", "Qwen3-VL-Reranker-2B", enable_virtual_env=False
+    )
+    assert not isinstance(
+        disabled.get("vllm"), list
+    ), f"vLLM must be strict (not available) with old vLLM and virtualenv disabled, got {disabled.get('vllm')!r}"
+
+    # Worker's virtualenv-enabled path.
+    enabled = get_engine_params_by_name_with_virtual_env(
+        "rerank", "Qwen3-VL-Reranker-2B", enable_virtual_env=True
+    )
+    assert isinstance(
+        enabled.get("vllm"), list
+    ), f"vLLM should be available under virtualenv, got {enabled.get('vllm')!r}"
+
+
+def test_qwen3_vl_reranker_prepared_install_list_has_single_vllm_req():
+    """Only one vLLM requirement must reach the installer.
+
+    The virtualenv spec must not carry both #vllm_dependencies# (vllm>=0.11.2)
+    and vllm>=0.14.0, which conflict under skip_installed with a parent vLLM
+    0.11.2-0.13.x. Asserts the prepared install list (expansion + marker
+    filtering, i.e. the Worker path) contains exactly one vLLM requirement
+    pinned to >=0.14.0.
+    """
+    from xinference.core.utils import filter_virtualenv_packages_by_markers
+    from xinference.core.virtual_env_manager import (
+        expand_engine_dependency_placeholders,
+    )
+
+    _install()
+    family = match_rerank("Qwen3-VL-Reranker-2B", "pytorch", "none")
+    expanded = expand_engine_dependency_placeholders(family.virtualenv.packages, "vllm")
+    prepared = filter_virtualenv_packages_by_markers(expanded, "vllm", None)
+    vllm_reqs = [p for p in prepared if p.lower().startswith("vllm")]
+    assert vllm_reqs == [
+        "vllm>=0.14.0"
+    ], f"expected a single vllm>=0.14.0 requirement, got {vllm_reqs!r}"
+
+
+def test_qwen3_vl_reranker_format_check_not_bypassed_under_virtualenv(monkeypatch):
+    """virtualenv must not bypass format/prefix compatibility checks.
+
+    The virtualenv exemption only covers the missing-library / old-version
+    rejection; an incompatible model_format (e.g. ggufv2, which the vLLM rerank
+    engine does not support) must still be rejected even when vLLM is absent and
+    virtualenv is enabled. Regression for the early ``return True``.
+    """
+    import sys
+
+    from xinference.model.rerank.vllm.core import VLLMRerankModel
+    from xinference.model.utils import virtualenv_discovery_var
+
+    _install()
+
+    monkeypatch.delitem(sys.modules, "vllm", raising=False)
+    token = virtualenv_discovery_var.set(True)
+    try:
+        family = match_rerank("Qwen3-VL-Reranker-2B", "pytorch", "none")
+        good_spec = family.model_specs[0]
+        assert good_spec.model_format == "pytorch"
+
+        if hasattr(good_spec, "model_copy"):
+            bad_spec = good_spec.model_copy(update={"model_format": "ggufv2"})
+        else:
+            bad_spec = good_spec.copy(update={"model_format": "ggufv2"})
+
+        result = VLLMRerankModel.match_json(family, bad_spec, "none")
+        assert result is not True, "ggufv2 must not be accepted by vLLM rerank"
+        assert isinstance(result, tuple) and result[0] is False
+
+        assert VLLMRerankModel.match_json(family, good_spec, "none") is True
+    finally:
+        virtualenv_discovery_var.reset(token)
 
 
 def _get_cached_model_path():

--- a/xinference/model/rerank/vllm/core.py
+++ b/xinference/model/rerank/vllm/core.py
@@ -380,7 +380,28 @@ class VLLMRerankModel(RerankModel, BatchMixin):
         quantization: str,
     ) -> Union[bool, Tuple[bool, str]]:
         if model_family.model_name.startswith("Qwen3-VL-Reranker"):
-            return False, "Qwen3-VL reranker requires vLLM>=0.14.0"
+            # In virtualenv mode vLLM (and a compatible version) can be
+            # installed on demand, so only the missing-library / old-version
+            # rejection is exempt here; the format/prefix compatibility checks
+            # below still apply (virtualenv cannot make an incompatible spec
+            # work).
+            from ...utils import virtual_env_allows_missing_engine
+
+            allow_missing_env = virtual_env_allows_missing_engine()
+            try:
+                import vllm
+                from packaging import version
+            except ImportError:
+                if not allow_missing_env:
+                    return False, "Qwen3-VL reranker requires vLLM>=0.14.0"
+            else:
+                if not allow_missing_env and version.parse(
+                    vllm.__version__
+                ) < version.parse("0.14.0"):
+                    return (
+                        False,
+                        f"Qwen3-VL reranker requires vLLM>=0.14.0, current: {vllm.__version__}",
+                    )
         if model_spec.model_format not in ["pytorch"]:
             return False, "vLLM rerank engine only supports pytorch format"
         prefix = model_family.model_name.split("-", 1)[0]

--- a/xinference/model/utils.py
+++ b/xinference/model/utils.py
@@ -23,6 +23,7 @@ import re
 import sys
 import threading
 from abc import ABC, abstractmethod
+from contextvars import ContextVar
 from copy import deepcopy
 from json import JSONDecodeError
 from pathlib import Path
@@ -93,6 +94,39 @@ def _normalize_match_result(
         return False, result, default_type, None
 
     return False, str(result), default_type, None
+
+
+# Effective virtualenv flag for the current engine-discovery call. The
+# discovery entry point (get_engine_params_by_name_with_virtual_env) sets this
+# to the *request-level* flag so that match_json can honor an explicit
+# enable_virtual_env=False even when the process-global default is true. When
+# unset (e.g. direct match_json calls outside discovery) it is None and callers
+# fall back to the global constant.
+virtualenv_discovery_var: ContextVar[Optional[bool]] = ContextVar(
+    "virtualenv_discovery_var", default=None
+)
+
+
+def virtual_env_allows_missing_engine() -> bool:
+    """Whether virtualenv mode should tolerate a missing engine install.
+
+    When virtualenv is enabled the engine and its runtime are installed on
+    demand, so engine listing must not depend on the library (or a specific
+    already-installed version) being present locally.
+
+    Uses the effective request-level flag published by the discovery path
+    (virtualenv_discovery_var) when available, so an explicit
+    enable_virtual_env=False stays strict; otherwise falls back to the
+    process-global default. Read lazily so the flag can be toggled at runtime.
+    """
+    scoped = virtualenv_discovery_var.get()
+    if scoped is not None:
+        return bool(scoped)
+    try:
+        from ..constants import XINFERENCE_ENABLE_VIRTUAL_ENV as flag
+    except Exception:
+        return False
+    return bool(flag)
 
 
 def _extract_engine_markers_from_packages(packages: List[str]) -> Set[str]:
@@ -330,6 +364,63 @@ def _force_virtualenv_engine_params(
             engine_params[engine_name] = engine_param_list
             available_params[engine_name] = engine_param_list
     return match_status
+
+
+def _drop_unavailable_marker_engines(
+    available_engines: Dict[str, Any],
+    family: Optional[Any],
+    supported_engines: Dict[str, List[Type[Any]]],
+    engine_markers: Set[str],
+) -> None:
+    """Re-validate virtualenv-marker engines for the strict discovery path.
+
+    The per-model engine registries (LLM_ENGINES / EMBEDDING_ENGINES /
+    RERANK_ENGINES) are generated once at import time using the process-global
+    virtualenv flag, so a marker engine (e.g. vLLM for Qwen3-VL) can be baked in
+    as available even though it is only reachable via on-demand install. The
+    strict entry point (enable_virtual_env=False) must not offer such engines,
+    so re-run check_lib + match_json under the current (strict) discovery scope
+    and drop any marker engine that no longer qualifies. Non-marker engines are
+    left untouched — they were matched without any virtualenv exemption.
+    """
+    if family is None or not engine_markers:
+        return
+    specs = getattr(family, "model_specs", []) or []
+    for engine_name in list(available_engines.keys()):
+        if engine_name.lower() not in engine_markers:
+            continue
+        engine_classes = supported_engines.get(engine_name, [])
+        qualifies = False
+        for engine_class in engine_classes:
+            lib_ok, _, _, _ = _normalize_match_result(
+                engine_class.check_lib(),
+                f"Engine {engine_name} library is not installed",
+                "dependency_missing",
+            )
+            if not lib_ok:
+                continue
+            match_func = getattr(engine_class, "match_json", None)
+            for spec in specs:
+                quantization = getattr(spec, "quantization", None) or "none"
+                match_res = (
+                    match_func(family, spec, quantization)
+                    if callable(match_func)
+                    else False
+                )
+                is_match, _, _, _ = _normalize_match_result(
+                    match_res,
+                    f"Engine {engine_name} is not compatible",
+                    "model_compatibility",
+                )
+                if is_match:
+                    qualifies = True
+                    break
+            if qualifies:
+                break
+        if not qualifies:
+            # Remove from the available set; the caller's _collect_supported_engines
+            # pass then annotates it with the proper unavailable reason.
+            available_engines.pop(engine_name, None)
 
 
 def _apply_virtualenv_engine_overrides(
@@ -840,8 +931,33 @@ class CancellableDownloader:
             logger.debug(f"Error during CancellableDownloader cleanup: {e}")
 
 
-@no_type_check
 def get_engine_params_by_name(
+    model_type: Optional[str],
+    model_name: str,
+    enable_virtual_env: Optional[bool] = None,
+) -> Optional[Dict[str, Any]]:
+    """Strict engine discovery entry point (no on-demand install).
+
+    The production Worker calls this when ``enable_virtual_env=False``. It also
+    publishes the effective flag on ``virtualenv_discovery_var`` so engine
+    ``match_json`` stays strict (e.g. keeps the Qwen3-VL vLLM>=0.14.0 check)
+    instead of reading the process-global default, mirroring the virtualenv-
+    aware entry point. The token is always reset so it never leaks.
+    """
+    effective = (
+        XINFERENCE_ENABLE_VIRTUAL_ENV
+        if enable_virtual_env is None
+        else enable_virtual_env
+    )
+    token = virtualenv_discovery_var.set(bool(effective))
+    try:
+        return _get_engine_params_by_name(model_type, model_name, effective)
+    finally:
+        virtualenv_discovery_var.reset(token)
+
+
+@no_type_check
+def _get_engine_params_by_name(
     model_type: Optional[str],
     model_name: str,
     enable_virtual_env: Optional[bool] = None,
@@ -1104,12 +1220,21 @@ def get_engine_params_by_name(
             return None
 
         available_engines = deepcopy(LLM_ENGINES[model_name])
-        for engine, params in available_engines.items():
-            _append_available_engine(engine, params, "llm_class")
-
         llm_family = next(
             (f for f in BUILTIN_LLM_FAMILIES if f.model_name == model_name), None
         )
+        # Strict path: re-validate virtualenv-marker engines that were baked
+        # into the registry under the process-global flag, so an engine only
+        # reachable via on-demand install is not offered here.
+        _drop_unavailable_marker_engines(
+            available_engines,
+            llm_family,
+            SUPPORTED_ENGINES,
+            _collect_virtualenv_engine_markers(llm_family),
+        )
+        for engine, params in available_engines.items():
+            _append_available_engine(engine, params, "llm_class")
+
         _collect_supported_engines(llm_family, SUPPORTED_ENGINES, "LLM")
         return engine_params
 
@@ -1123,11 +1248,17 @@ def get_engine_params_by_name(
             return None
 
         available_engines = deepcopy(EMBEDDING_ENGINES[model_name])
+        embedding_family_list = BUILTIN_EMBEDDING_MODELS.get(model_name, [])
+        embedding_family = embedding_family_list[0] if embedding_family_list else None
+        _drop_unavailable_marker_engines(
+            available_engines,
+            embedding_family,
+            EMBEDDING_SUPPORTED_ENGINES,
+            _collect_virtualenv_engine_markers(embedding_family),
+        )
         for engine, params in available_engines.items():
             _append_available_engine(engine, params, "embedding_class")
 
-        embedding_family_list = BUILTIN_EMBEDDING_MODELS.get(model_name, [])
-        embedding_family = embedding_family_list[0] if embedding_family_list else None
         _collect_supported_engines(
             embedding_family, EMBEDDING_SUPPORTED_ENGINES, "embedding"
         )
@@ -1141,8 +1272,6 @@ def get_engine_params_by_name(
             return None
 
         available_engines = deepcopy(RERANK_ENGINES[model_name])
-        for engine, params in available_engines.items():
-            _append_available_engine(engine, params, "rerank_class")
 
         from .rerank.core import RerankModelFamilyV2
 
@@ -1150,6 +1279,15 @@ def get_engine_params_by_name(
             model_name, []
         )
         rerank_family = rerank_family_list[0] if rerank_family_list else None
+        _drop_unavailable_marker_engines(
+            available_engines,
+            rerank_family,
+            RERANK_SUPPORTED_ENGINES,
+            _collect_virtualenv_engine_markers(rerank_family),
+        )
+        for engine, params in available_engines.items():
+            _append_available_engine(engine, params, "rerank_class")
+
         _collect_supported_engines(rerank_family, RERANK_SUPPORTED_ENGINES, "rerank")
         return engine_params
 
@@ -1217,8 +1355,36 @@ def get_engine_params_by_name(
     return None
 
 
-@no_type_check
 def get_engine_params_by_name_with_virtual_env(
+    model_type: Optional[str],
+    model_name: str,
+    enable_virtual_env: Optional[bool] = None,
+) -> Optional[Dict[str, Any]]:
+    """Public entry point for virtualenv-aware engine discovery.
+
+    Publishes the *effective* request-level virtualenv flag on
+    ``virtualenv_discovery_var`` for the duration of the call so that engine
+    ``match_json`` implementations honor an explicit ``enable_virtual_env=False``
+    (e.g. keep the Qwen3-VL vLLM version check strict) instead of reading the
+    process-global default. The token is always reset so the scope does not leak
+    into subsequent calls (e.g. the launch path) on the same thread.
+    """
+    effective = (
+        XINFERENCE_ENABLE_VIRTUAL_ENV
+        if enable_virtual_env is None
+        else enable_virtual_env
+    )
+    token = virtualenv_discovery_var.set(bool(effective))
+    try:
+        return _get_engine_params_by_name_with_virtual_env(
+            model_type, model_name, effective
+        )
+    finally:
+        virtualenv_discovery_var.reset(token)
+
+
+@no_type_check
+def _get_engine_params_by_name_with_virtual_env(
     model_type: Optional[str],
     model_name: str,
     enable_virtual_env: Optional[bool] = None,


### PR DESCRIPTION
## Problem

On an environment without vLLM/SGLang installed (or without a local GPU), a
chat-only model like `qwen3` can be launched with vLLM/SGLang, but their
multimodal counterparts cannot — the engines don't appear as selectable in the
WebUI. The same asymmetry affects `Qwen3-VL-Embedding` and `Qwen3-VL-Reranker`.

Engine availability is computed by `get_engine_params_by_name_with_virtual_env`,
which calls each engine's `match_json`. Some engines put **runtime-only** checks
— library installed, specific version, CUDA GPU, Linux — inside `match_json`,
before (or instead of) the virtualenv exemption. Chat LLM engines already had
the exemption; the multimodal / embedding / rerank vLLM paths did not, so a
declared engine was hidden at listing time even though virtualenv installs it on
demand at launch (`check_engine_by_spec_parameters_with_virtual_env` already
bypasses this).

## Fix

Make the virtualenv exemption consistent: when virtualenv is enabled,
environment-only checks (library present, version, GPU, OS) are skipped so an
architecture/format-compatible engine is still offered and installed on demand.
When virtualenv is disabled, all strict checks are preserved.

**LLM**
- vLLM: exempt GPU/OS/library checks in `VLLMModel` and `VLLMMultiModel`.
- SGLang: add `_virtual_env_allows_missing_sglang`; exempt GPU/OS/library checks
  in the generate, chat and vision branches.
- LMDeploy: add `_virtual_env_allows_missing_lmdeploy`; exempt the library check
  in the chat branch.

**Embedding / Rerank**
- Add a shared `virtual_env_allows_missing_engine()` helper in `model/utils.py`.
- embedding vLLM: exempt the "vLLM is not installed" and version checks for
  `Qwen3-VL-Embedding` under virtualenv.
- rerank vLLM: replace the unconditional `requires vLLM>=0.14.0` rejection for
  `Qwen3-VL-Reranker` with a real import + version check that is exempt under
  virtualenv, so the engine is offered instead of being permanently disabled.

**Unchanged (already correct):** MLX (Apple-silicon-only, marker auto-dropped on
non-macOS), Transformers / llama.cpp, embedding/rerank
sentence_transformers/flag/llama.cpp, and image (stable_diffusion) — all keep
library checks in `check_lib`, so listing already honors the exemption. Audio /
video do not use the engine-selection mechanism.

## Tests

- LLM: regression test asserting `qwen3.5` offers vLLM/SGLang/Transformers/
  llama.cpp under virtualenv while MLX/LMDeploy (not declared) are not listed.
- Embedding: strengthened to assert `Qwen3-VL-Embedding-2B` offers vLLM.
- Rerank: new engine-params test asserting `Qwen3-VL-Reranker-2B` offers vLLM.

All new/updated assertions fail on the previous code and pass with this change.
Verified manually for a no-GPU host and a simulated CUDA+Linux host with the
libraries absent.