### PR TITLE
BUG: sglang venv inherits incompatible parent transformers under skip_installed

### DIFF
--- a/xinference/core/tests/test_virtual_env_manager.py
+++ b/xinference/core/tests/test_virtual_env_manager.py
@@ -17,6 +17,7 @@
 See optimize/20260702/2026070209.md for root cause analysis.
 """
 
+import importlib.metadata
 import os
 from unittest import mock
 
@@ -27,6 +28,7 @@ from ..virtual_env_manager import (
     FLASHINFER_AOT_PACKAGES,
     FLASHINFER_AOT_WHEEL_URL,
     apply_flashinfer_aot_post_install,
+    get_engine_critical_dependency_specs,
     needs_flashinfer_aot,
 )
 
@@ -247,3 +249,113 @@ class TestApplyFlashinferAotPostInstall:
                 "12.0",
             )
             run_mock.assert_not_called()
+
+
+class TestGetEngineCriticalDependencySpecs:
+    """Tests for get_engine_critical_dependency_specs().
+
+    Covers the skip_installed inheritance hole: when the parent env's engine
+    copy satisfies the requested spec, the venv skips installing the engine,
+    so nothing enforces the engine's own declared dependency requirements
+    (e.g. sglang declares transformers==4.57.1 while the Docker image ships
+    transformers 5.x, which breaks sglang.srt at import).
+    """
+
+    def _patch_metadata(self, versions, requires_map=None):
+        requires_map = requires_map or {}
+
+        def fake_version(name):
+            try:
+                return versions[name.lower()]
+            except KeyError:
+                raise importlib.metadata.PackageNotFoundError(name)
+
+        def fake_requires(name):
+            if name.lower() not in versions:
+                raise importlib.metadata.PackageNotFoundError(name)
+            return requires_map.get(name.lower(), [])
+
+        return mock.patch.multiple(
+            "importlib.metadata", version=fake_version, requires=fake_requires
+        )
+
+    def test_incompatible_parent_dependency_adds_declared_spec(self):
+        with self._patch_metadata(
+            {"sglang": "0.5.6", "transformers": "5.5.0"},
+            {"sglang": ["transformers==4.57.1"]},
+        ):
+            specs = get_engine_critical_dependency_specs("sglang", ["sglang>=0.5.6"])
+        assert specs == ["transformers==4.57.1"]
+
+    def test_compatible_parent_dependency_is_noop(self):
+        with self._patch_metadata(
+            {"sglang": "0.5.6", "transformers": "4.57.1"},
+            {"sglang": ["transformers==4.57.1"]},
+        ):
+            specs = get_engine_critical_dependency_specs("sglang", ["sglang>=0.5.6"])
+        assert specs == []
+
+    def test_engine_absent_from_parent_is_noop(self):
+        """Without a parent copy the venv resolves the engine and its full
+        dependency closure itself; nothing to compensate for."""
+        with self._patch_metadata({"transformers": "5.5.0"}):
+            specs = get_engine_critical_dependency_specs("sglang", ["sglang>=0.5.6"])
+        assert specs == []
+
+    def test_requested_spec_forcing_fresh_engine_install_is_noop(self):
+        """A parent copy not satisfying the requested spec means the venv
+        installs its own engine with full dependency resolution."""
+        with self._patch_metadata(
+            {"sglang": "0.5.6", "transformers": "5.5.0"},
+            {"sglang": ["transformers==4.57.1"]},
+        ):
+            specs = get_engine_critical_dependency_specs("sglang", ["sglang>=0.5.7"])
+        assert specs == []
+
+    def test_explicit_dependency_spec_wins(self):
+        with self._patch_metadata(
+            {"sglang": "0.5.6", "transformers": "5.5.0"},
+            {"sglang": ["transformers==4.57.1"]},
+        ):
+            specs = get_engine_critical_dependency_specs(
+                "sglang", ["sglang>=0.5.6", "transformers==4.55.0"]
+            )
+        assert specs == []
+
+    def test_missing_dependency_is_added(self):
+        with self._patch_metadata(
+            {"sglang": "0.5.6"},
+            {"sglang": ["transformers==4.57.1"]},
+        ):
+            specs = get_engine_critical_dependency_specs("sglang", ["sglang>=0.5.6"])
+        assert specs == ["transformers==4.57.1"]
+
+    def test_extra_marker_requirements_ignored(self):
+        with self._patch_metadata(
+            {"sglang": "0.5.6", "transformers": "5.5.0"},
+            {"sglang": ['transformers==4.57.1 ; extra == "srt"']},
+        ):
+            specs = get_engine_critical_dependency_specs("sglang", ["sglang>=0.5.6"])
+        assert specs == []
+
+    def test_non_critical_engine_is_noop(self):
+        specs = get_engine_critical_dependency_specs("vllm", ["vllm>=0.11.2"])
+        assert specs == []
+
+    def test_no_engine_is_noop(self):
+        assert get_engine_critical_dependency_specs(None, []) == []
+
+    def test_unparseable_package_entries_are_skipped(self):
+        with self._patch_metadata(
+            {"sglang": "0.5.6", "transformers": "5.5.0"},
+            {"sglang": ["transformers==4.57.1"]},
+        ):
+            specs = get_engine_critical_dependency_specs(
+                "sglang",
+                [
+                    "#system_torch#",
+                    'https://example.com/sgl_kernel-0.3.21+cu130-cp310-abi3-manylinux2014_x86_64.whl ; cuda_version == "13.0"',
+                    "sglang>=0.5.6",
+                ],
+            )
+        assert specs == ["transformers==4.57.1"]

--- a/xinference/core/virtual_env_manager.py
+++ b/xinference/core/virtual_env_manager.py
@@ -33,11 +33,6 @@ ENGINE_VIRTUALENV_PACKAGES: Dict[str, List[str]] = {
         "ninja",
         "numpy>=2.4.1",
         "sglang>=0.5.6",
-        # sglang 0.5.x requires exactly transformers 4.57.1; pin it here so the
-        # venv gets a compatible copy even when skip_installed inherits sglang
-        # from a parent env that ships transformers 5.x (e.g. the Docker image),
-        # where importing sglang.srt crashes at DeepseekVL2Config.
-        "transformers==4.57.1",
         'https://github.com/sgl-project/whl/releases/download/v0.3.21/sgl_kernel-0.3.21+cu130-cp310-abi3-manylinux2014_x86_64.whl ; cuda_version == "13.0" and platform_machine == "x86_64"',
         'https://github.com/sgl-project/whl/releases/download/v0.3.21/sgl_kernel-0.3.21+cu130-cp310-abi3-manylinux2014_aarch64.whl ; cuda_version == "13.0" and platform_machine == "aarch64"',
         'sgl_kernel ; cuda_version < "13.0"',
@@ -67,6 +62,22 @@ ENGINE_VIRTUALENV_PACKAGES: Dict[str, List[str]] = {
     "llama.cpp": [
         "xllamacpp>=0.2.6",
     ],
+}
+
+# Critical dependencies of engine packages that may be inherited from the
+# parent environment instead of installed into the venv: with skip_installed
+# enabled (the default), an engine spec satisfied by the parent copy is not
+# installed, so nothing pulls the engine's own dependency requirements into
+# the venv. If the parent copy of such a dependency violates the engine's
+# declared requirement (e.g. sglang declares transformers==4.57.1 while the
+# Docker image ships transformers 5.x, which breaks sglang.srt at import),
+# the engine's declared spec is added to the venv install list so the venv
+# gets a compatible copy that shadows the parent's. The specs are read from
+# the installed engine's metadata at launch time, so they follow whatever
+# the installed engine version declares. Structure: engine name ->
+# {distribution name -> [critical dependency names]}.
+ENGINE_CRITICAL_DEPENDENCIES: Dict[str, Dict[str, List[str]]] = {
+    "sglang": {"sglang": ["transformers"]},
 }
 
 ENGINE_VIRTUALENV_EXTRA_INDEX_URLS: Dict[str, List[str]] = {
@@ -139,6 +150,86 @@ def get_engine_virtualenv_packages(model_engine: Optional[str]) -> List[str]:
     if not model_engine:
         return []
     return ENGINE_VIRTUALENV_PACKAGES.get(model_engine.lower(), []).copy()
+
+
+def get_engine_critical_dependency_specs(
+    model_engine: Optional[str], packages: Optional[List[str]] = None
+) -> List[str]:
+    """
+    Return dependency specs that must be installed into the venv because the
+    engine package will be inherited from the parent environment while the
+    parent copies of its critical dependencies (see
+    ``ENGINE_CRITICAL_DEPENDENCIES``) do not satisfy the engine's own declared
+    requirements.
+
+    Returns an empty list when the engine is absent from the parent
+    environment or the requested spec forces a fresh engine install — in both
+    cases the resolver installs the engine together with its dependencies and
+    there is nothing to compensate for. Dependencies explicitly listed in
+    ``packages`` are also left untouched so user-provided specs win.
+    """
+    if not model_engine:
+        return []
+    critical = ENGINE_CRITICAL_DEPENDENCIES.get(model_engine.lower())
+    if not critical:
+        return []
+
+    import importlib.metadata
+
+    from packaging.requirements import Requirement
+
+    requested: Dict[str, Requirement] = {}
+    for pkg in packages or []:
+        try:
+            req = Requirement(pkg.split(";", 1)[0].strip())
+        except Exception:
+            # placeholders (#system_torch#) and direct wheel URLs
+            continue
+        requested[req.name.lower()] = req
+
+    specs: List[str] = []
+    for dist_name, dep_names in critical.items():
+        try:
+            parent_version = importlib.metadata.version(dist_name)
+        except importlib.metadata.PackageNotFoundError:
+            continue
+
+        engine_req = requested.get(dist_name.lower())
+        if engine_req is not None and engine_req.specifier:
+            try:
+                if not engine_req.specifier.contains(parent_version, prereleases=True):
+                    # parent copy doesn't satisfy the requested spec, the venv
+                    # installs its own engine with full dependency resolution
+                    continue
+            except Exception:
+                continue
+
+        try:
+            declared = importlib.metadata.requires(dist_name) or []
+        except importlib.metadata.PackageNotFoundError:
+            continue
+
+        wanted = {name.lower() for name in dep_names}
+        for req_str in declared:
+            try:
+                req = Requirement(req_str)
+            except Exception:
+                continue
+            name = req.name.lower()
+            if name not in wanted or name in requested:
+                continue
+            if req.marker is not None and not req.marker.evaluate({"extra": ""}):
+                continue
+            try:
+                dep_version: Optional[str] = importlib.metadata.version(req.name)
+            except importlib.metadata.PackageNotFoundError:
+                dep_version = None
+            if dep_version is not None and req.specifier.contains(
+                dep_version, prereleases=True
+            ):
+                continue
+            specs.append(f"{req.name}{req.specifier}" if req.specifier else req.name)
+    return specs
 
 
 def get_engine_virtualenv_extra_index_urls(

--- a/xinference/core/virtual_env_manager.py
+++ b/xinference/core/virtual_env_manager.py
@@ -33,6 +33,11 @@ ENGINE_VIRTUALENV_PACKAGES: Dict[str, List[str]] = {
         "ninja",
         "numpy>=2.4.1",
         "sglang>=0.5.6",
+        # sglang 0.5.x requires exactly transformers 4.57.1; pin it here so the
+        # venv gets a compatible copy even when skip_installed inherits sglang
+        # from a parent env that ships transformers 5.x (e.g. the Docker image),
+        # where importing sglang.srt crashes at DeepseekVL2Config.
+        "transformers==4.57.1",
         'https://github.com/sgl-project/whl/releases/download/v0.3.21/sgl_kernel-0.3.21+cu130-cp310-abi3-manylinux2014_x86_64.whl ; cuda_version == "13.0" and platform_machine == "x86_64"',
         'https://github.com/sgl-project/whl/releases/download/v0.3.21/sgl_kernel-0.3.21+cu130-cp310-abi3-manylinux2014_aarch64.whl ; cuda_version == "13.0" and platform_machine == "aarch64"',
         'sgl_kernel ; cuda_version < "13.0"',

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -103,6 +103,7 @@ from .utils import (
 from .virtual_env_manager import VirtualEnvManager as XinferenceVirtualEnvManager
 from .virtual_env_manager import (
     expand_engine_dependency_placeholders,
+    get_engine_critical_dependency_specs,
     is_cuda_compatible,
     resolve_virtualenv_python_path,
 )
@@ -2646,6 +2647,17 @@ class WorkerActor(xo.StatelessActor):
         packages = filter_virtualenv_packages_by_markers(
             packages, model_engine, cuda_version
         )
+
+        critical_specs = get_engine_critical_dependency_specs(model_engine, packages)
+        if critical_specs:
+            logger.info(
+                "Engine %s will be inherited from the parent environment whose "
+                "copies of its critical dependencies do not satisfy the "
+                "engine's declared requirements; installing %s into the venv",
+                model_engine,
+                critical_specs,
+            )
+            packages = packages + critical_specs
 
         conf = dict(settings)
         conf.pop("packages", None)


### PR DESCRIPTION
## What do these changes do?

Fixes sglang engine launches failing inside `xprobe/xinference:nightly-main` (and any environment whose parent site-packages ship transformers 5.x next to sglang 0.5.x).

### Root cause

- The Docker image installs `transformers==5.5.0` and `--no-deps sglang==0.5.6` into the same environment. All sglang 0.5.x releases (0.5.6 through 0.5.9) declare `transformers==4.57.1`.
- Under transformers 5.x, importing `sglang.srt.entrypoints.engine` crashes while defining `DeepseekVL2Config(PretrainedConfig)`: transformers 5's `PretrainedConfig.__init_subclass__` wraps subclasses with `dataclass(...)`, which raises `TypeError: non-default argument 'vision_config' follows default argument` (sglang `srt/configs/deepseekvl2.py`).
- With `XINFERENCE_VIRTUAL_ENV_SKIP_INSTALLED=1` (the default), the parent's sglang 0.5.6 satisfies the `sglang>=0.5.6` spec in `ENGINE_VIRTUALENV_PACKAGES`, so per-model venvs skip installing sglang entirely — and nothing pulls a compatible transformers into the venv. Every sglang model launch then fails at engine import (reproduced with qwen3 0.6B, `--model-engine sglang`, 2×RTX 3090 Ti, CUDA 13).

### Fix

Rather than hard-pinning a transformers version (which would go stale as sglang evolves), derive the required spec from the inherited engine's own dependency metadata at launch time:

- New `ENGINE_CRITICAL_DEPENDENCIES` map and `get_engine_critical_dependency_specs()` in `virtual_env_manager.py`: when the parent env's engine copy will be inherited by the venv (its version satisfies the requested spec) and the parent copy of a critical dependency (transformers, for sglang) violates the engine's declared requirement (`Requires-Dist`), the engine's declared spec is added to the venv install list. The venv-installed copy shadows the parent's because child site-packages precede the parent `.pth` entry.
- Wired into `WorkerActor._prepare_virtual_env` after marker filtering.

The check is a no-op when:
- the parent environment is consistent (dependency satisfies the engine's requirement),
- the engine is absent from the parent (the resolver then installs the engine with its full dependency closure),
- the requested spec forces a fresh engine install into the venv,
- the user supplies an explicit spec for the dependency (user specs win).

Because the spec is read from the installed engine's metadata, it automatically follows whatever the installed sglang version declares — no maintenance needed when sglang bumps its transformers requirement.

### Verification

- Reproduced the incompatibility in an isolated venv with sglang 0.5.6: under `transformers==5.5.0`, importing `sglang/srt/configs/deepseekvl2.py` raises the exact `TypeError` seen in the nightly image; under `transformers==4.57.1` the same import succeeds.
- Added `TestGetEngineCriticalDependencySpecs` (10 cases) to `xinference/core/tests/test_virtual_env_manager.py`; the full file passes (30 passed).

Not run: an end-to-end sglang model launch on GPU (requires the CUDA Docker environment).