### PR TITLE
fix(audio): add WeTextProcessing virtualenv dependency for MegaTTS3

### DIFF
--- a/xinference/model/audio/model_spec.json
+++ b/xinference/model/audio/model_spec.json
@@ -1541,6 +1541,11 @@
       "text2audio_zero_shot"
     ],
     "multilingual": true,
+    "virtualenv": {
+      "packages": [
+        "WeTextProcessing==1.0.4.1"
+      ]
+    },
     "model_src": {
       "huggingface": {
         "model_id": "ByteDance/MegaTTS3",


### PR DESCRIPTION
MegaTTS3 requires WeTextProcessing for Chinese/English text normalization during speech synthesis. This was verified locally — without this dependency, the model fails at inference time when processing input text.

This change adds the dependency as a `virtualenv` block in `model_spec.json`, matching the pattern used by other audio models (CosyVoice2, Qwen3-TTS, VoxCPM2, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)