### PR TITLE
fix(image/ocr): import torchvision lazily in deepseek_ocr (#5189)

### DIFF
--- a/xinference/model/image/ocr/deepseek_ocr.py
+++ b/xinference/model/image/ocr/deepseek_ocr.py
@@ -23,7 +23,6 @@ import numpy as np
 import PIL.Image
 import torch
 import torch.nn as nn
-from torchvision import transforms
 
 if TYPE_CHECKING:
     from ..core import ImageModelFamilyV2
@@ -170,6 +169,8 @@ def normalize_transform(
     std: Optional[Union[Tuple[float, float, float], List[float]]],
 ):
     """Create normalization transform."""
+    from torchvision import transforms
+
     if mean is None and std is None:
         return None
     elif mean is None and std is not None:
@@ -191,6 +192,8 @@ class BasicImageTransform:
         std: Optional[Tuple[float, float, float]] = (0.5, 0.5, 0.5),
         normalize: bool = True,
     ):
+        from torchvision import transforms
+
         self.mean = mean
         self.std = std
 


### PR DESCRIPTION
## Problem

`xinference/model/__init__._install()` imports every model family at actor-creation
time. That chain reaches `model/image/__init__.py` → `.ocr` → `ocr/__init__.py` →
`deepseek_ocr.py`, which does a **module-level** `from torchvision import transforms`.

Net effect: torchvision is imported into **every** model subprocess — audio models,
LLMs, anything — regardless of whether the model has anything to do with OCR.

## Why this is the odd one out

Every other torchvision consumer in the tree already imports it lazily, inside the
function that needs it:

| file | import site |
|---|---|
| `model/llm/transformers/multimodal/intern_vl.py` | inside method (line ~113) |
| `model/llm/transformers/multimodal/ovis2.py` | inside method (line ~99) |
| `model/video/diffusers.py` | inside method (line ~393) |
| `model/image/ocr/deepseek_ocr.py` | **module level** ← this PR |

So this looks like a plain oversight rather than a deliberate choice.

## Change

Move the import into the only two scopes that use `transforms`:

- `normalize_transform()`
- `BasicImageTransform.__init__()`

That is the whole diff — 5 lines, no behavior change for OCR users (the import
just happens on first use instead of at module import).

## Relation to #5189

This is the "additionally" item called out at the end of #5189, filed as its own
minimal change. It does **not** claim to fix the root cause of #5189 (the
`_create_subpool` / `_prepare_virtual_env` ordering — that reorder touches the
launch flow and deserves a separate, maintainer-directed discussion).

What it does do is remove one eager **host** torchvision import from subprocesses
whose virtualenv installs its own pinned torchvision, which the issue identifies as
what aggravates the `operator torchvision::nms does not exist` failure variant for
audio models that never use torchvision at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
