### PR TITLE
BUG: worker keeps stale model state after a launch fails during async engine load

### DIFF
--- a/xinference/core/tests/test_worker.py
+++ b/xinference/core/tests/test_worker.py
@@ -131,6 +131,18 @@ class MockWorkerActor(WorkerActor):
         self._model_uid_to_launch_args.pop(model_uid, None)
         del self._model_uid_to_addr[model_uid]
 
+    # --- test helpers for failed-launch cleanup ---
+    def set_model_ref_for_test(self, model_uid: str, model_ref):
+        self._model_uid_to_model[model_uid] = model_ref
+
+    def get_launch_state_presence_for_test(self, model_uid: str):
+        return {
+            "model": model_uid in self._model_uid_to_model,
+            "model_spec": model_uid in self._model_uid_to_model_spec,
+            "launch_args": model_uid in self._model_uid_to_launch_args,
+            "addr": model_uid in self._model_uid_to_addr,
+        }
+
     # --- test helpers for report_status GPU attribution ---
     def set_supervisor_ref_for_test(self, ref):
         self._supervisor_ref = ref
@@ -227,6 +239,58 @@ async def test_terminate_model_flag(setup_pool):
     gpu_to_model_id = await worker.get_gpu_to_model_uid()
     for dev in devices:
         assert dev not in gpu_to_model_id
+
+
+class _FailingLoadModelRef:
+    """Model ref whose engine loads asynchronously and fails, mirroring a
+    vLLM EngineCore init crash that only surfaces in wait_for_load."""
+
+    async def wait_for_load(self):
+        raise RuntimeError("EngineCore init failed")
+
+
+@pytest.mark.asyncio
+async def test_wait_for_load_failure_cleans_up_worker_state(setup_pool):
+    """A launch that fails after launch_builtin_model registered the model_uid
+    (e.g. the vLLM engine crashes during async load, surfacing in
+    wait_for_load) must roll back the worker state, otherwise relaunching the
+    same model_uid hits `assert model_uid not in self._model_uid_to_model`
+    until the whole service is restarted."""
+    pool = setup_pool
+    addr = pool.external_address
+
+    worker: xo.ActorRefType["MockWorkerActor"] = await xo.create_actor(  # type: ignore
+        MockWorkerActor,
+        address=addr,
+        uid=WorkerActor.default_uid(),
+        supervisor_address="test",
+        main_pool=pool,
+        cuda_devices=[0],
+    )
+
+    model_uid = "async_load_model-0"
+    await worker.launch_builtin_model(
+        model_uid, "mock_model_name", None, None, None, n_gpu=1
+    )
+    await worker.set_model_ref_for_test(model_uid, _FailingLoadModelRef())
+
+    with pytest.raises(RuntimeError, match="EngineCore init failed"):
+        await worker.wait_for_load(model_uid)
+
+    # all registration state must be rolled back
+    presence = await worker.get_launch_state_presence_for_test(model_uid)
+    assert not any(presence.values()), presence
+    gpu_to_model_uid = await worker.get_gpu_to_model_uid()
+    for model_uids in gpu_to_model_uid.values():
+        assert model_uid not in model_uids
+
+    # the same model_uid can be relaunched immediately
+    await worker.launch_builtin_model(
+        model_uid, "mock_model_name", None, None, None, n_gpu=1
+    )
+    presence = await worker.get_launch_state_presence_for_test(model_uid)
+    assert presence["model"] and presence["addr"]
+    await worker.terminate_model(model_uid)
 
 
 def test_merge_virtual_env_packages_override_and_append():

--- a/xinference/core/tests/test_worker.py
+++ b/xinference/core/tests/test_worker.py
@@ -24,7 +24,7 @@ from ...model.core import VirtualEnvSettings
 from ..status_guard import InstanceInfo, LaunchStatus, ReplicaStatus
 from ..supervisor import ReplicaInfo, SupervisorActor
 from ..utils import merge_virtual_env_packages
-from ..worker import WorkerActor
+from ..worker import ModelStatus, WorkerActor
 
 
 class MockWorkerActor(WorkerActor):
@@ -120,6 +120,7 @@ class MockWorkerActor(WorkerActor):
             **kwargs,
         }
         self._model_uid_to_addr[model_uid] = subpool_address
+        self._model_uid_to_model_status[model_uid] = ModelStatus(model_state="loading")
 
     async def terminate_model(self, model_uid: str, is_model_die: bool = False):
         self.release_devices(model_uid)
@@ -141,6 +142,7 @@ class MockWorkerActor(WorkerActor):
             "model_spec": model_uid in self._model_uid_to_model_spec,
             "launch_args": model_uid in self._model_uid_to_launch_args,
             "addr": model_uid in self._model_uid_to_addr,
+            "model_status": model_uid in self._model_uid_to_model_status,
         }
 
     # --- test helpers for report_status GPU attribution ---

--- a/xinference/core/tests/test_worker.py
+++ b/xinference/core/tests/test_worker.py
@@ -145,6 +145,9 @@ class MockWorkerActor(WorkerActor):
             "model_status": model_uid in self._model_uid_to_model_status,
         }
 
+    def set_status_guard_ref_for_test(self, ref):
+        self._status_guard_ref = ref
+
     # --- test helpers for report_status GPU attribution ---
     def set_supervisor_ref_for_test(self, ref):
         self._supervisor_ref = ref
@@ -154,6 +157,13 @@ class MockWorkerActor(WorkerActor):
         self._model_uid_to_pid = dict(pid)
         self._model_uid_to_subpool_pids = {k: set(v) for k, v in subpool.items()}
         self._total_gpu_devices = list(total_devices)
+
+
+class MockWorkerActorRealTerminate(MockWorkerActor):
+    """Variant that keeps the real ``WorkerActor.terminate_model`` so tests
+    cover the actual cleanup path instead of the simplified override above."""
+
+    terminate_model = WorkerActor.terminate_model
 
 
 @pytest_asyncio.fixture
@@ -293,6 +303,68 @@ async def test_wait_for_load_failure_cleans_up_worker_state(setup_pool):
     presence = await worker.get_launch_state_presence_for_test(model_uid)
     assert presence["model"] and presence["addr"]
     await worker.terminate_model(model_uid)
+
+
+class _UnavailableStatusGuardRef:
+    """StatusGuard stub whose reporting calls always fail, simulating a
+    status guard that became unreachable (e.g. supervisor outage)."""
+
+    async def update_instance_info(self, *args, **kwargs):
+        raise RuntimeError("status guard unavailable")
+
+    async def update_replica_status(self, *args, **kwargs):
+        raise RuntimeError("status guard unavailable")
+
+
+@pytest.mark.asyncio
+async def test_failed_launch_cleanup_survives_status_guard_outage(setup_pool):
+    """The failed-launch rollback goes through the real terminate_model,
+    whose status reporting must not block the local map/resource cleanup —
+    e.g. when the launch finalization failed precisely because the status
+    guard was unreachable. Uses the real WorkerActor.terminate_model so the
+    unprotected update_instance_info path is actually exercised."""
+    pool = setup_pool
+    addr = pool.external_address
+
+    worker: xo.ActorRefType["MockWorkerActorRealTerminate"] = await xo.create_actor(  # type: ignore
+        MockWorkerActorRealTerminate,
+        address=addr,
+        uid=WorkerActor.default_uid(),
+        supervisor_address="test",
+        main_pool=pool,
+        cuda_devices=[0],
+    )
+
+    model_uid = "async_load_model-0"
+    await worker.launch_builtin_model(
+        model_uid, "mock_model_name", None, None, None, n_gpu=1
+    )
+    await worker.set_model_ref_for_test(model_uid, _FailingLoadModelRef())
+    await worker.set_status_guard_ref_for_test(_UnavailableStatusGuardRef())
+
+    with pytest.raises(RuntimeError, match="EngineCore init failed"):
+        await worker.wait_for_load(model_uid)
+
+    # local maps and GPU allocations must be rolled back even though every
+    # status guard call raised
+    presence = await worker.get_launch_state_presence_for_test(model_uid)
+    assert not any(presence.values()), presence
+    gpu_to_model_uid = await worker.get_gpu_to_model_uid()
+    for model_uids in gpu_to_model_uid.values():
+        assert model_uid not in model_uids
+
+    # the same model_uid can be relaunched immediately
+    await worker.launch_builtin_model(
+        model_uid, "mock_model_name", None, None, None, n_gpu=1
+    )
+    presence = await worker.get_launch_state_presence_for_test(model_uid)
+    assert presence["model"] and presence["addr"]
+
+    # a normal terminate with the status guard still down must also clean up
+    # local state without raising
+    await worker.terminate_model(model_uid)
+    presence = await worker.get_launch_state_presence_for_test(model_uid)
+    assert not any(presence.values()), presence
 
 
 def test_merge_virtual_env_packages_override_and_append():

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -3287,26 +3287,54 @@ class WorkerActor(xo.StatelessActor):
             except Exception as e:
                 logger.warning(f"Failed to handle virtual environment info: {e}")
 
-        # update status to READY
-        abilities = await self._get_model_ability(model, model_type)
-        _ = await self.get_supervisor_ref(add_worker=False)
+        try:
+            # update status to READY
+            abilities = await self._get_model_ability(model, model_type)
+            _ = await self.get_supervisor_ref(add_worker=False)
 
-        if self._status_guard_ref is None:
-            _ = await self.get_supervisor_ref()
-        assert self._status_guard_ref is not None
-        await self._status_guard_ref.update_instance_info(
-            origin_uid,
-            {"model_ability": abilities, "status": LaunchStatus.READY.name},
-        )
-        if n_worker > 1 and shard == 0:  # type: ignore
-            return subpool_address, await model_ref.get_driver_info()
-        else:
-            return subpool_address
+            if self._status_guard_ref is None:
+                _ = await self.get_supervisor_ref()
+            assert self._status_guard_ref is not None
+            await self._status_guard_ref.update_instance_info(
+                origin_uid,
+                {"model_ability": abilities, "status": LaunchStatus.READY.name},
+            )
+            if n_worker > 1 and shard == 0:  # type: ignore
+                return subpool_address, await model_ref.get_driver_info()
+            else:
+                return subpool_address
+        except Exception:
+            logger.error(
+                f"Failed to finalize launch of model {model_uid}", exc_info=True
+            )
+            await self._clean_up_failed_launch(model_uid)
+            raise
+
+    async def _clean_up_failed_launch(self, model_uid: str):
+        """Roll back the state registered by ``launch_builtin_model`` when the
+        launch fails after registration (e.g. an engine that loads
+        asynchronously crashes at init and the error only surfaces in
+        ``wait_for_load``). Without this, the stale ``_model_uid_to_model``
+        entry makes relaunching the same model_uid fail on the registration
+        assert until the whole service is restarted."""
+        try:
+            await self.terminate_model(model_uid, is_model_die=True)
+        except Exception:
+            logger.error(
+                "Failed to clean up worker state after failed launch, model uid: %s",
+                model_uid,
+                exc_info=True,
+            )
 
     @log_async(logger=logger, level=logging.INFO)
     async def wait_for_load(self, model_uid: str):
         model_ref = self._model_uid_to_model[model_uid]
-        await model_ref.wait_for_load()
+        try:
+            await model_ref.wait_for_load()
+        except Exception:
+            logger.error(f"Failed to load model {model_uid}", exc_info=True)
+            await self._clean_up_failed_launch(model_uid)
+            raise
         await self._update_model_state(model_uid, "ready")
 
     @log_sync(logger=logger, level=logging.INFO)

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -3325,6 +3325,12 @@ class WorkerActor(xo.StatelessActor):
                 model_uid,
                 exc_info=True,
             )
+        finally:
+            # terminate_model(is_model_die=True) keeps _model_uid_to_model_status
+            # for the auto-recovery path, which relaunches the same model_uid;
+            # a failed launch has no relaunch, so drop it here to avoid leaking
+            # a stale "loading" entry.
+            self._model_uid_to_model_status.pop(model_uid, None)
 
     @log_async(logger=logger, level=logging.INFO)
     async def wait_for_load(self, model_uid: str):

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -3403,9 +3403,20 @@ class WorkerActor(xo.StatelessActor):
             logger.error("report_event error: %s" % (e))
 
         if self._status_guard_ref is not None:
-            await self._status_guard_ref.update_instance_info(
-                origin_uid, {"status": LaunchStatus.TERMINATING.name}
-            )
+            try:
+                await self._status_guard_ref.update_instance_info(
+                    origin_uid, {"status": LaunchStatus.TERMINATING.name}
+                )
+            except Exception:
+                # Status reporting must not block the local map/resource
+                # cleanup below, e.g. when terminating precisely because the
+                # status guard became unavailable during launch finalization.
+                logger.warning(
+                    "Failed to report TERMINATING status for %s, "
+                    "continuing with local cleanup",
+                    model_uid,
+                    exc_info=True,
+                )
         model_ref = self._model_uid_to_model.get(model_uid, None)
         if model_ref is None:
             logger.debug("Model not found, uid: %s", model_uid)
@@ -3500,12 +3511,22 @@ class WorkerActor(xo.StatelessActor):
                 await self._update_model_state(model_uid, "stopped")
                 self._model_uid_to_model_status.pop(model_uid, None)
 
-            if self._status_guard_ref is None:
-                _ = await self.get_supervisor_ref()
-            assert self._status_guard_ref is not None
-            await self._status_guard_ref.update_instance_info(
-                origin_uid, {"status": status}
-            )
+            try:
+                if self._status_guard_ref is None:
+                    _ = await self.get_supervisor_ref()
+                assert self._status_guard_ref is not None
+                await self._status_guard_ref.update_instance_info(
+                    origin_uid, {"status": status}
+                )
+            except Exception:
+                # Local cleanup already happened above; a status guard or
+                # supervisor outage must not fail the terminate itself.
+                logger.warning(
+                    "Failed to report %s status for %s after cleanup",
+                    status,
+                    model_uid,
+                    exc_info=True,
+                )
 
         # Per-uid persist state cleanup (prevent zombie entries on long-running workers)
         self._persist_launch_args_dirty_uids.discard(model_uid)


### PR DESCRIPTION
## What do these changes do?

Fixes a state-leak in `WorkerActor` that makes a failed model launch permanently block relaunching the same `model_uid` until the whole xinference service is restarted.

### Symptom

Launch a model with the vllm engine where the engine crashes at init (observed on a real deployment: qwen3 0.6b, EngineCore init crash due to missing `ninja`, after the virtualenv install succeeded). Then retry the same launch:

- The retry fails with `AssertionError` at `assert model_uid not in self._model_uid_to_model` in `launch_builtin_model`.
- The supervisor keeps logging `list_models: drop stale running model qwen3 without worker ref` every sync cycle.
- Only restarting the whole service clears it.

### Root cause

vLLM v1 creates its engine in a background thread: `VLLMModel.load()` returns after `join(1)`, and an EngineCore init crash only surfaces later in `wait_for_load()`. By that time `launch_builtin_model` has already registered the `model_uid` in `_model_uid_to_model` and its sibling maps and returned successfully.

The supervisor's `_launch_one_model` fails at `worker_ref.wait_for_load(...)` **before** it records `_replica_model_uid_to_worker`, so its rollback `terminate_model` cannot reach the worker ("Model not found in the model list", suppressed). The worker-side registration is never rolled back, leaving permanently stale state.

### Fix

- Add `WorkerActor._clean_up_failed_launch`, which rolls back the registration via `terminate_model(is_model_die=True)` — the same cleanup the auto-recovery path already uses for dead models.
- Call it from `wait_for_load` when the model's async load fails (the repro path), re-raising the original error so the supervisor still reports the launch failure.
- Call it from `launch_builtin_model` when the post-registration finalization (ability probe / status-guard update) fails, which leaks the same state.

A failed launch now fully cleans worker state and the same `model_uid` can be relaunched immediately.

### Test

Added `test_wait_for_load_failure_cleans_up_worker_state` in `xinference/core/tests/test_worker.py`: registers a model whose `wait_for_load` raises (mirroring an EngineCore init crash), asserts all worker maps and GPU allocations are rolled back, and that the same `model_uid` relaunches successfully. The test fails without the fix.

## Related issue number

N/A

## Check code requirements

- [x] tests added / passed (`pytest xinference/core/tests/test_worker.py` — 41 passed)
- [x] Ensure all linting tests pass (`pre-commit run` on changed files)