### PR TITLE
fix: pass torch version to offline package builds

### DIFF
--- a/xinference/deploy/docker/pypiserver/download_packages.py
+++ b/xinference/deploy/docker/pypiserver/download_packages.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import subprocess
 import sys
 from collections import defaultdict
@@ -175,6 +176,7 @@ def pip_download(
     extra_index_urls: List[str],
     no_deps: bool = False,
     constraints: Optional[Path] = None,
+    env: Optional[Dict[str, str]] = None,
 ) -> subprocess.CompletedProcess:
     cmd = [
         sys.executable,
@@ -194,7 +196,7 @@ def pip_download(
         cmd.append("--no-deps")
     if constraints is not None:
         cmd += ["-c", str(constraints)]
-    return run(cmd + args)
+    return run(cmd + args, env=env)
 
 
 def main() -> None:
@@ -225,6 +227,13 @@ def main() -> None:
         runtime_pins = load_runtime_constraints(args.runtime_constraints)
     except ValueError as exc:
         sys.exit(f"FATAL: {exc}")
+
+    package_build_env = dict(os.environ)
+    torch_specifier = next(iter(Requirement(runtime_pins["torch"]).specifier))
+    # Some sdist-only packages inspect torch while preparing metadata or
+    # building a wheel. The mirror downloads torch instead of installing it,
+    # so expose the exact runtime version through their supported build hook.
+    package_build_env["TORCH_VERSION"] = torch_specifier.version
 
     machine = {"amd64": "x86_64", "arm64": "aarch64"}[args.platform]
     # The runtime image's glibc supports manylinux_2_34 wheels; the default
@@ -329,6 +338,7 @@ def main() -> None:
             extra_index_urls=(meta.get("extra_index_urls") or [])
             + [args.pytorch_index],
             no_deps=True,
+            env=package_build_env,
         )
         if proc.returncode != 0:
             sys.exit(f"FATAL: failed to fetch locked engine set '{engine}'")
@@ -350,6 +360,7 @@ def main() -> None:
             index_url=args.index_url,
             extra_index_urls=[args.pytorch_index],
             constraints=pruned,
+            env=package_build_env,
         )
         if proc.returncode != 0:
             print(f"WARN: retrying '{spec}' without constraints", flush=True)
@@ -358,6 +369,7 @@ def main() -> None:
                 dest,
                 index_url=args.index_url,
                 extra_index_urls=[args.pytorch_index],
+                env=package_build_env,
             )
             if proc.returncode != 0:
                 sys.exit(f"FATAL: pin '{spec}' cannot be downloaded")
@@ -380,6 +392,7 @@ def main() -> None:
             index_url=args.index_url,
             extra_index_urls=[args.pytorch_index],
             constraints=master_constraints,
+            env=package_build_env,
         )
         if proc.returncode != 0:
             print(f"WARN: retrying '{url}' without constraints", flush=True)
@@ -388,6 +401,7 @@ def main() -> None:
                 dest,
                 index_url=args.index_url,
                 extra_index_urls=[args.pytorch_index],
+                env=package_build_env,
             )
             if proc.returncode != 0:
                 sys.exit(f"FATAL: failed to download '{url}'")
@@ -414,7 +428,8 @@ def main() -> None:
                 "--wheel-dir",
                 str(dest),
                 str(sdist),
-            ]
+            ],
+            env=package_build_env,
         )
         if proc.returncode == 0:
             sdist.unlink()

--- a/xinference/deploy/docker/pypiserver/tests/test_scripts.py
+++ b/xinference/deploy/docker/pypiserver/tests/test_scripts.py
@@ -141,6 +141,29 @@ def test_download_report_wheel_filename_parsing():
     assert downloader.wheel_name_version("invalid.whl") is None
 
 
+def test_pip_download_forwards_package_build_environment(monkeypatch, tmp_path):
+    downloader = _load_script("download_packages")
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(downloader, "run", fake_run)
+    build_env = {"TORCH_VERSION": "2.12.3"}
+
+    downloader.pip_download(
+        ["gptqmodel==4.2.5"],
+        tmp_path,
+        index_url="https://example.invalid/simple",
+        extra_index_urls=[],
+        no_deps=True,
+        env=build_env,
+    )
+
+    assert calls[0][1]["env"] is build_env
+
+
 def test_runtime_constraints_require_exact_pins(tmp_path):
     downloader = _load_script("download_packages")
     constraints = tmp_path / "runtime.txt"
@@ -375,6 +398,9 @@ def test_download_packages_main_orchestration_skips_git(monkeypatch, tmp_path):
     dest = tmp_path / "packages"
     runtime_constraints = tmp_path / "runtime.txt"
     _write_runtime_constraints(runtime_constraints)
+    runtime_constraints.write_text(
+        runtime_constraints.read_text().replace("torch==2.11.0", "torch==2.12.3")
+    )
     compile_calls = []
     download_calls = []
     run_calls = []
@@ -393,8 +419,8 @@ def test_download_packages_main_orchestration_skips_git(monkeypatch, tmp_path):
             (target / "source-1.0.tar.gz").write_text("sdist")
         return subprocess.CompletedProcess([], 0)
 
-    def fake_run(cmd, **_kwargs):
-        run_calls.append(list(cmd))
+    def fake_run(cmd, **kwargs):
+        run_calls.append((list(cmd), kwargs))
         return subprocess.CompletedProcess(cmd, 0)
 
     monkeypatch.setattr(downloader, "uv_compile", fake_uv_compile)
@@ -428,7 +454,9 @@ def test_download_packages_main_orchestration_skips_git(monkeypatch, tmp_path):
         call[0] for call in download_calls
     ]
     assert all(git_source not in " ".join(call[0]) for call in download_calls)
-    assert all(git_source not in " ".join(call) for call in run_calls)
+    assert all(git_source not in " ".join(call[0]) for call in run_calls)
+    assert all(call[1]["env"]["TORCH_VERSION"] == "2.12.3" for call in download_calls)
+    assert all(call[1]["env"]["TORCH_VERSION"] == "2.12.3" for call in run_calls)
     assert not (dest / "source-1.0.tar.gz").exists()
     report = json.loads((manifest / "report.json").read_text())
     assert "transformers==5.13.1" in report["runtime_constraints"]


### PR DESCRIPTION
## Summary

- derive `TORCH_VERSION` from the exact torch pin in the shared runtime constraints
- pass the package-build environment to both `pip download` and `pip wheel`
- cover environment propagation through the download orchestration tests

## Root cause

The `v3.0.0` pypiserver release build resolves `gptqmodel==4.2.5`, which is only published as an sdist. Its build metadata inspects the installed torch version. The mirror downloads the torch wheel without installing it, so both amd64 and arm64 builds failed while preparing GPTQModel metadata with `No package metadata was found for torch`.

Supplying the version through GPTQModel's supported `TORCH_VERSION` build hook avoids installing the large torch wheel into the downloader while keeping the value aligned with `requirements-runtime.txt`.

Failed release run: https://github.com/xorbitsai/inference/actions/runs/29653510204

## Validation

- `pytest -q xinference/deploy/docker/pypiserver/tests/test_scripts.py` (12 passed)
- `pre-commit run --files xinference/deploy/docker/pypiserver/download_packages.py xinference/deploy/docker/pypiserver/tests/test_scripts.py`
- in an isolated Python 3.12 environment with no torch installed, successfully downloaded the `gptqmodel==4.2.5` sdist and built `gptqmodel-4.2.5-py3-none-any.whl` with `TORCH_VERSION=2.11.0`
