### PR TITLE
fix: mirror dependencies declared by wheels built from sdists

### DIFF
--- a/xinference/deploy/docker/pypiserver/download_packages.py
+++ b/xinference/deploy/docker/pypiserver/download_packages.py
@@ -411,31 +411,78 @@ def main() -> None:
     # 4. Build wheels for sdist-only downloads so the runtime never
     #    compiles. Failures keep the sdist (the runtime image has a
     #    toolchain) and are recorded in the report.
+    #
+    #    A built wheel can declare dependencies that the sdist's static
+    #    metadata omitted (e.g. GPTQModel publishes an sdist whose
+    #    PKG-INFO lists no runtime requirements, while the wheel its
+    #    setup.py builds does). The locks above only saw the sdist
+    #    metadata, so fetch each built wheel's dependencies explicitly
+    #    and repeat until no new sdists arrive.
     # ------------------------------------------------------------------
-    for sdist in sorted(dest.iterdir()):
-        if sdist.suffix not in (".gz", ".zip", ".bz2") and not sdist.name.endswith(
-            ".tar.gz"
-        ):
-            continue
-        proc = run(
-            [
-                sys.executable,
-                "-m",
-                "pip",
-                "wheel",
-                "--quiet",
-                "--no-deps",
-                "--wheel-dir",
-                str(dest),
-                str(sdist),
-            ],
-            env=package_build_env,
-        )
-        if proc.returncode == 0:
-            sdist.unlink()
-        else:
-            print(f"WARN: keeping sdist {sdist.name}", flush=True)
-            sdist_left.append(sdist.name)
+    failed_sdists: Set[str] = set()
+    while True:
+        built_wheels: List[Path] = []
+        for sdist in sorted(dest.iterdir()):
+            if sdist.suffix not in (".gz", ".zip", ".bz2") and not sdist.name.endswith(
+                ".tar.gz"
+            ):
+                continue
+            if sdist.name in failed_sdists:
+                continue
+            wheels_before = {p.name for p in dest.glob("*.whl")}
+            proc = run(
+                [
+                    sys.executable,
+                    "-m",
+                    "pip",
+                    "wheel",
+                    "--quiet",
+                    "--no-deps",
+                    "--wheel-dir",
+                    str(dest),
+                    str(sdist),
+                ],
+                env=package_build_env,
+            )
+            if proc.returncode == 0:
+                sdist.unlink()
+                built_wheels.extend(
+                    p for p in dest.glob("*.whl") if p.name not in wheels_before
+                )
+            else:
+                print(f"WARN: keeping sdist {sdist.name}", flush=True)
+                failed_sdists.add(sdist.name)
+        if not built_wheels:
+            break
+        for wheel in built_wheels:
+            proc = pip_download(
+                [str(wheel)],
+                dest,
+                index_url=args.index_url,
+                extra_index_urls=[args.pytorch_index],
+                constraints=master_constraints,
+                env=package_build_env,
+            )
+            if proc.returncode != 0:
+                print(
+                    f"WARN: retrying dependencies of '{wheel.name}' "
+                    "without constraints",
+                    flush=True,
+                )
+                proc = pip_download(
+                    [str(wheel)],
+                    dest,
+                    index_url=args.index_url,
+                    extra_index_urls=[args.pytorch_index],
+                    env=package_build_env,
+                )
+                if proc.returncode != 0:
+                    sys.exit(
+                        f"FATAL: failed to fetch dependencies of built "
+                        f"wheel '{wheel.name}'"
+                    )
+                unconstrained_fallbacks.append(wheel.name)
+    sdist_left.extend(sorted(failed_sdists))
 
     # ------------------------------------------------------------------
     # Report.

--- a/xinference/deploy/docker/pypiserver/tests/test_scripts.py
+++ b/xinference/deploy/docker/pypiserver/tests/test_scripts.py
@@ -417,10 +417,18 @@ def test_download_packages_main_orchestration_skips_git(monkeypatch, tmp_path):
         download_calls.append((list(args), kwargs))
         if args == ["model-pin==1.0"]:
             (target / "source-1.0.tar.gz").write_text("sdist")
+        # The wheel built from the sdist declares a dependency that the
+        # sdist metadata omitted; it only exists as an sdist itself.
+        if args == [str(dest / "source-1.0-py3-none-any.whl")]:
+            (target / "hiddendep-1.0.tar.gz").write_text("sdist")
         return subprocess.CompletedProcess([], 0)
 
     def fake_run(cmd, **kwargs):
         run_calls.append((list(cmd), kwargs))
+        if "wheel" in cmd:
+            sdist_name = Path(cmd[-1]).name
+            wheel_name = sdist_name.replace(".tar.gz", "-py3-none-any.whl")
+            (dest / wheel_name).write_text("wheel")
         return subprocess.CompletedProcess(cmd, 0)
 
     monkeypatch.setattr(downloader, "uv_compile", fake_uv_compile)
@@ -458,6 +466,15 @@ def test_download_packages_main_orchestration_skips_git(monkeypatch, tmp_path):
     assert all(call[1]["env"]["TORCH_VERSION"] == "2.12.3" for call in download_calls)
     assert all(call[1]["env"]["TORCH_VERSION"] == "2.12.3" for call in run_calls)
     assert not (dest / "source-1.0.tar.gz").exists()
+    # Dependencies of wheels built from sdists are fetched from the built
+    # wheel's own metadata, transitively until no new sdists arrive.
+    assert [str(dest / "source-1.0-py3-none-any.whl")] in [
+        call[0] for call in download_calls
+    ]
+    assert [str(dest / "hiddendep-1.0-py3-none-any.whl")] in [
+        call[0] for call in download_calls
+    ]
+    assert not (dest / "hiddendep-1.0.tar.gz").exists()
     report = json.loads((manifest / "report.json").read_text())
     assert "transformers==5.13.1" in report["runtime_constraints"]
     assert report["unconstrained_fallbacks"] == []


### PR DESCRIPTION
## Summary

- after building wheels from sdist-only downloads, fetch each built wheel's declared dependencies into the mirror, repeating until no new sdists arrive
- extend the download orchestration test to cover the new closure pass, including a dependency that itself only exists as an sdist

## Root cause

The `v3.0.0` pypiserver release rebuild (after #5200) got past the GPTQModel wheel build, but then failed selfcheck on both architectures:

```
FAIL engine:transformers
× Because device-smi was not found in the package registry and all
  versions of gptqmodel depend on device-smi==0.4.1 ...
```

Failed run: https://github.com/xorbitsai/inference/actions/runs/29656911852 (pypiserver image run 29656911825)

`gptqmodel==4.2.5` is published only as an sdist, and its static PKG-INFO metadata declares **no** base requirements — its setup.py skips `requirements.txt` when the `CI` environment variable is set, which it is on the publisher's release CI. The lock phase (`uv pip compile`) trusts that static metadata, so gptqmodel's real dependencies never entered the engine locks and were never mirrored.

The mirror then builds the wheel itself in step 4 (`pip wheel`, no `CI` in the Docker build), where setup.py *does* read `requirements.txt`, so the built wheel declares the full dependency list (`device-smi==0.4.1`, `random_word`, `tokenicer`, `logbar`, `maturin`, ...). Selfcheck resolves against that wheel's metadata and fails on the first dependency missing from the mirror.

## Fix

Close the mirror over the metadata of wheels it builds: after each round of sdist wheel builds, run `pip download` on every newly built wheel (constrained by the master constraints, with the usual unconstrained fallback) so its declared dependencies land in the mirror, and loop until a round produces no new sdists. This is generic — any package whose sdist static metadata disagrees with what its build backend actually produces is handled, not just GPTQModel.

Setting `CI=1` during the wheel build was rejected as an alternative: it would reproduce the empty-dependency metadata, so the runtime venv would install gptqmodel without `device-smi` and friends and break at import time.

## Validation

- `pytest -q xinference/deploy/docker/pypiserver/tests/test_scripts.py` (12 passed)
- `pre-commit run --files ...` on both modified files (all hooks passed)
- verified the mechanism empirically: `pip download <local wheel> --dest <dir containing that wheel>` reports "File was already downloaded" for the wheel itself and fetches its dependencies into the same directory