### PR TITLE
fix(audio/indextts2): return waveform in memory to avoid TorchCodec save failure (#5201)

### DIFF
--- a/xinference/model/audio/indextts2.py
+++ b/xinference/model/audio/indextts2.py
@@ -138,15 +138,18 @@ class Indextts2:
                 temp_emo.write(emo_prompt_speech)
                 emo_prompt_path = temp_emo.name
 
-        # Generate complete audio first
-        with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as temp_output:
-            output_path = temp_output.name
-
         try:
-            self._model.infer(
+            # Pass output_path=None so IndexTTS2 returns the generated waveform in
+            # memory (as an int16 numpy array) instead of writing it to disk with
+            # torchaudio.save. torchaudio.save routes through TorchCodec, whose
+            # FFmpeg shared libraries are missing / ABI-mismatched in some images
+            # (see #5201), which made /v1/audio/speech fail at the save step even
+            # though inference had already succeeded. soundfile below performs the
+            # actual encoding, so the on-disk WAV round-trip is not needed.
+            sample_rate, audio = self._model.infer(
                 spk_audio_prompt=temp_prompt_path,
                 text=input,
-                output_path=output_path,
+                output_path=None,
                 emo_audio_prompt=emo_prompt_path,
                 emo_alpha=emo_alpha,
                 emo_text=emo_text,
@@ -154,9 +157,6 @@ class Indextts2:
                 emo_vector=emo_vector,
                 use_emo_text=use_emo_text,
             )
-
-            # Read generated audio
-            audio, sample_rate = soundfile.read(output_path)
 
             if stream:
                 # Streaming mode - return generator that yields chunks
@@ -167,9 +167,6 @@ class Indextts2:
                         ) as f:
                             f.write(audio)
                         complete_audio = out.getvalue()
-
-                    # Clean up temp file
-                    os.unlink(output_path)
 
                     # Yield the complete audio in chunks
                     chunk_size = 8192  # 8KB chunks
@@ -186,8 +183,6 @@ class Indextts2:
                         f.write(audio)
                     result = out.getvalue()
 
-                # Clean up temp file
-                os.unlink(output_path)
                 return result
         finally:
             # Clean up temp files


### PR DESCRIPTION
## Summary

Fixes #5201.

`IndexTTS2` inference completes, but `/v1/audio/speech` returns **500 at the WAV save step**: the model's `infer()` writes the intermediate WAV via `torchaudio.save`, which routes through **TorchCodec**. In several images TorchCodec's FFmpeg shared libraries are missing or ABI-mismatched against `torch==2.11.0+cu130`:

```
RuntimeError: Could not load libtorchcodec
OSError: libavutil.so.58: cannot open shared object file
```

The generated waveform already exists in memory before this failure — only the on-disk serialization breaks.

## Fix

`IndexTTS2.infer()` already supports `output_path=None`, in which case it **returns `(sampling_rate, wav)`** (int16 numpy, `samples × channels`) and skips `torchaudio.save` completely. `speech()` in `xinference/model/audio/indextts2.py` then re-encodes the response with `soundfile` anyway, after reading the temp WAV back.

So this change:

- passes `output_path=None` and consumes the returned waveform directly,
- drops the temp-file creation, the `soundfile.read()` round-trip, and the two `os.unlink(output_path)` cleanups.

Net effect: the TorchCodec/FFmpeg dependency is removed from this code path; encoding is done solely by `soundfile` (already used here and already a dependency). No inference logic changes, and no other model's TorchCodec usage is touched. The int16 array returned by `infer()` is losslessly equivalent to reading back the int16 PCM WAV that `torchaudio.save` previously wrote, so the emitted audio is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
