### PR TITLE
fix(embedding/rerank): fix sentence_transformers load failures from torch-ecosystem package mismatches

### DIFF
--- a/xinference/core/tests/test_utils.py
+++ b/xinference/core/tests/test_utils.py
@@ -225,3 +225,51 @@ def test_build_subpool_envs_for_virtual_env_enabled():
     assert result["VIRTUAL_ENV"] == "/venv"
     assert result["FLASHINFER_NINJA_PATH"] == "/custom/ninja"
     assert result is not base_envs
+
+
+def test_model_specs_pin_system_torch_with_torchvision():
+    """Every model that pins torchvision to the system version must also pin
+    torch to the system version under the same environment markers/conditions.
+
+    Otherwise torch is pulled fresh from PyPI into the sub venv while
+    torchvision stays on the (older) system version, producing an ABI
+    mismatch such as ``operator torchvision::nms does not exist`` (see #5208).
+    """
+    import json
+    import os
+
+    here = os.path.dirname(__file__)
+    spec_files = [
+        os.path.join(here, "..", "..", "model", "embedding", "model_spec.json"),
+        os.path.join(here, "..", "..", "model", "rerank", "model_spec.json"),
+    ]
+
+    offenders = []
+    for spec_file in spec_files:
+        with open(spec_file) as f:
+            data = json.load(f)
+        for m in data:
+            pkgs = (m.get("virtualenv") or {}).get("packages") or []
+            parsed_pkgs = []
+            for p in pkgs:
+                parts = p.split(";", 1)
+                name = parts[0].strip()
+                marker = parts[1].strip() if len(parts) > 1 else ""
+                parsed_pkgs.append((name, marker))
+
+            torchvision_markers = {
+                marker for name, marker in parsed_pkgs if name == "#system_torchvision#"
+            }
+            torch_markers = {
+                marker for name, marker in parsed_pkgs if name == "#system_torch#"
+            }
+
+            if torchvision_markers - torch_markers:
+                family = os.path.basename(os.path.dirname(spec_file))
+                offenders.append("{}/{}".format(family, m.get("model_name")))
+
+    assert not offenders, (
+        "Models declare #system_torchvision# but not #system_torch# under the "
+        "same environment markers (torch/torchvision would be mixed-source): "
+        + ", ".join(offenders)
+    )

--- a/xinference/model/embedding/model_spec.json
+++ b/xinference/model/embedding/model_spec.json
@@ -34,6 +34,7 @@
       "packages": [
         "#sentence_transformers_dependencies# ; #engine# == \"sentence_transformers\"",
         "#system_torchvision# ; #engine# == \"sentence_transformers\"",
+        "#system_torch# ; #engine# == \"sentence_transformers\"",
         "FlagEmbedding ; #engine# == \"flag\"",
         "#vllm_dependencies# ; #engine# == \"vllm\"",
         "#system_numpy# ; #engine# == \"vllm\""
@@ -75,6 +76,7 @@
       "packages": [
         "#sentence_transformers_dependencies# ; #engine# == \"sentence_transformers\"",
         "#system_torchvision# ; #engine# == \"sentence_transformers\"",
+        "#system_torch# ; #engine# == \"sentence_transformers\"",
         "FlagEmbedding ; #engine# == \"flag\"",
         "#vllm_dependencies# ; #engine# == \"vllm\"",
         "#system_numpy# ; #engine# == \"vllm\""
@@ -116,6 +118,7 @@
       "packages": [
         "#sentence_transformers_dependencies# ; #engine# == \"sentence_transformers\"",
         "#system_torchvision# ; #engine# == \"sentence_transformers\"",
+        "#system_torch# ; #engine# == \"sentence_transformers\"",
         "#vllm_dependencies# ; #engine# == \"vllm\"",
         "#system_numpy# ; #engine# == \"vllm\""
       ]
@@ -156,6 +159,7 @@
       "packages": [
         "#sentence_transformers_dependencies# ; #engine# == \"sentence_transformers\"",
         "#system_torchvision# ; #engine# == \"sentence_transformers\"",
+        "#system_torch# ; #engine# == \"sentence_transformers\"",
         "#vllm_dependencies# ; #engine# == \"vllm\"",
         "#system_numpy# ; #engine# == \"vllm\""
       ]
@@ -195,7 +199,8 @@
     "virtualenv": {
       "packages": [
         "#sentence_transformers_dependencies# ; #engine# == \"sentence_transformers\"",
-        "#system_torchvision# ; #engine# == \"sentence_transformers\""
+        "#system_torchvision# ; #engine# == \"sentence_transformers\"",
+        "#system_torch# ; #engine# == \"sentence_transformers\""
       ]
     }
   },
@@ -234,6 +239,7 @@
       "packages": [
         "#sentence_transformers_dependencies# ; #engine# == \"sentence_transformers\"",
         "#system_torchvision# ; #engine# == \"sentence_transformers\"",
+        "#system_torch# ; #engine# == \"sentence_transformers\"",
         "FlagEmbedding ; #engine# == \"flag\"",
         "#vllm_dependencies# ; #engine# == \"vllm\"",
         "#system_numpy# ; #engine# == \"vllm\""
@@ -275,6 +281,7 @@
       "packages": [
         "#sentence_transformers_dependencies# ; #engine# == \"sentence_transformers\"",
         "#system_torchvision# ; #engine# == \"sentence_transformers\"",
+        "#system_torch# ; #engine# == \"sentence_transformers\"",
         "#vllm_dependencies# ; #engine# == \"vllm\"",
         "#system_numpy# ; #engine# == \"vllm\""
       ]
@@ -315,6 +322,7 @@
       "packages": [
         "#sentence_transformers_dependencies# ; #engine# == \"sentence_transformers\"",
         "#system_torchvision# ; #engine# == \"sentence_transformers\"",
+        "#system_torch# ; #engine# == \"sentence_transformers\"",
         "FlagEmbedding ; #engine# == \"flag\"",
         "#vllm_dependencies# ; #engine# == \"vllm\"",
         "#system_numpy# ; #engine# == \"vllm\""
@@ -355,7 +363,8 @@
     "virtualenv": {
       "packages": [
         "#sentence_transformers_dependencies# ; #engine# == \"sentence_transformers\"",
-        "#system_torchvision# ; #engine# == \"sentence_transformers\""
+        "#system_torchvision# ; #engine# == \"sentence_transformers\"",
+        "#system_torch# ; #engine# == \"sentence_transformers\""
       ]
     }
   },
@@ -394,6 +403,7 @@
       "packages": [
         "#sentence_transformers_dependencies# ; #engine# == \"sentence_transformers\"",
         "#system_torchvision# ; #engine# == \"sentence_transformers\"",
+        "#system_torch# ; #engine# == \"sentence_transformers\"",
         "FlagEmbedding ; #engine# == \"flag\"",
         "#vllm_dependencies# ; #engine# == \"vllm\"",
         "#system_numpy# ; #engine# == \"vllm\""
@@ -435,6 +445,7 @@
       "packages": [
         "#sentence_transformers_dependencies# ; #engine# == \"sentence_transformers\"",
         "#system_torchvision# ; #engine# == \"sentence_transformers\"",
+        "#system_torch# ; #engine# == \"sentence_transformers\"",
         "FlagEmbedding ; #engine# == \"flag\"",
         "#vllm_dependencies# ; #engine# == \"vllm\"",
         "#system_numpy# ; #engine# == \"vllm\""
@@ -476,6 +487,7 @@
       "packages": [
         "#sentence_transformers_dependencies# ; #engine# == \"sentence_transformers\"",
         "#system_torchvision# ; #engine# == \"sentence_transformers\"",
+        "#system_torch# ; #engine# == \"sentence_transformers\"",
         "FlagEmbedding ; #engine# == \"flag\"",
         "#vllm_dependencies# ; #engine# == \"vllm\"",
         "#system_numpy# ; #engine# == \"vllm\""
@@ -517,6 +529,7 @@
       "packages": [
         "#sentence_transformers_dependencies# ; #engine# == \"sentence_transformers\"",
         "#system_torchvision# ; #engine# == \"sentence_transformers\"",
+        "#system_torch# ; #engine# == \"sentence_transformers\"",
         "FlagEmbedding ; #engine# == \"flag\"",
         "#vllm_dependencies# ; #engine# == \"vllm\"",
         "#system_numpy# ; #engine# == \"vllm\""
@@ -558,6 +571,7 @@
       "packages": [
         "#sentence_transformers_dependencies# ; #engine# == \"sentence_transformers\"",
         "#system_torchvision# ; #engine# == \"sentence_transformers\"",
+        "#system_torch# ; #engine# == \"sentence_transformers\"",
         "FlagEmbedding ; #engine# == \"flag\"",
         "#vllm_dependencies# ; #engine# == \"vllm\"",
         "#system_numpy# ; #engine# == \"vllm\""
@@ -599,6 +613,7 @@
       "packages": [
         "#sentence_transformers_dependencies# ; #engine# == \"sentence_transformers\"",
         "#system_torchvision# ; #engine# == \"sentence_transformers\"",
+        "#system_torch# ; #engine# == \"sentence_transformers\"",
         "FlagEmbedding ; #engine# == \"flag\"",
         "#vllm_dependencies# ; #engine# == \"vllm\"",
         "#system_numpy# ; #engine# == \"vllm\""
@@ -640,6 +655,7 @@
       "packages": [
         "#sentence_transformers_dependencies# ; #engine# == \"sentence_transformers\"",
         "#system_torchvision# ; #engine# == \"sentence_transformers\"",
+        "#system_torch# ; #engine# == \"sentence_transformers\"",
         "FlagEmbedding ; #engine# == \"flag\"",
         "#vllm_dependencies# ; #engine# == \"vllm\"",
         "#system_numpy# ; #engine# == \"vllm\""
@@ -680,7 +696,8 @@
     "virtualenv": {
       "packages": [
         "#sentence_transformers_dependencies# ; #engine# == \"sentence_transformers\"",
-        "#system_torchvision# ; #engine# == \"sentence_transformers\""
+        "#system_torchvision# ; #engine# == \"sentence_transformers\"",
+        "#system_torch# ; #engine# == \"sentence_transformers\""
       ]
     }
   },
@@ -718,7 +735,8 @@
     "virtualenv": {
       "packages": [
         "#sentence_transformers_dependencies# ; #engine# == \"sentence_transformers\"",
-        "#system_torchvision# ; #engine# == \"sentence_transformers\""
+        "#system_torchvision# ; #engine# == \"sentence_transformers\"",
+        "#system_torch# ; #engine# == \"sentence_transformers\""
       ]
     }
   },
@@ -798,6 +816,7 @@
       "packages": [
         "#sentence_transformers_dependencies# ; #engine# == \"sentence_transformers\"",
         "#system_torchvision# ; #engine# == \"sentence_transformers\"",
+        "#system_torch# ; #engine# == \"sentence_transformers\"",
         "#vllm_dependencies# ; #engine# == \"vllm\"",
         "#system_numpy# ; #engine# == \"vllm\""
       ]
@@ -837,6 +856,7 @@
       "packages": [
         "#sentence_transformers_dependencies# ; #engine# == \"sentence_transformers\"",
         "#system_torchvision# ; #engine# == \"sentence_transformers\"",
+        "#system_torch# ; #engine# == \"sentence_transformers\"",
         "#vllm_dependencies# ; #engine# == \"vllm\"",
         "#system_numpy# ; #engine# == \"vllm\""
       ]
@@ -876,6 +896,7 @@
       "packages": [
         "#sentence_transformers_dependencies# ; #engine# == \"sentence_transformers\"",
         "#system_torchvision# ; #engine# == \"sentence_transformers\"",
+        "#system_torch# ; #engine# == \"sentence_transformers\"",
         "#vllm_dependencies# ; #engine# == \"vllm\"",
         "#system_numpy# ; #engine# == \"vllm\""
       ]
@@ -909,6 +930,7 @@
       "packages": [
         "#sentence_transformers_dependencies# ; #engine# == \"sentence_transformers\"",
         "#system_torchvision# ; #engine# == \"sentence_transformers\"",
+        "#system_torch# ; #engine# == \"sentence_transformers\"",
         "#vllm_dependencies# ; #engine# == \"vllm\"",
         "#system_numpy# ; #engine# == \"vllm\""
       ]
@@ -942,6 +964,7 @@
       "packages": [
         "#sentence_transformers_dependencies# ; #engine# == \"sentence_transformers\"",
         "#system_torchvision# ; #engine# == \"sentence_transformers\"",
+        "#system_torch# ; #engine# == \"sentence_transformers\"",
         "#vllm_dependencies# ; #engine# == \"vllm\"",
         "#system_numpy# ; #engine# == \"vllm\""
       ]
@@ -1022,6 +1045,7 @@
       "packages": [
         "#sentence_transformers_dependencies# ; #engine# == \"sentence_transformers\"",
         "#system_torchvision# ; #engine# == \"sentence_transformers\"",
+        "#system_torch# ; #engine# == \"sentence_transformers\"",
         "#llama_cpp_dependencies# ; #engine# == \"llama.cpp\"",
         "FlagEmbedding ; #engine# == \"flag\"",
         "#vllm_dependencies# ; #engine# == \"vllm\"",
@@ -1064,6 +1088,7 @@
       "packages": [
         "#sentence_transformers_dependencies# ; #engine# == \"sentence_transformers\"",
         "#system_torchvision# ; #engine# == \"sentence_transformers\"",
+        "#system_torch# ; #engine# == \"sentence_transformers\"",
         "#vllm_dependencies# ; #engine# == \"vllm\"",
         "#system_numpy# ; #engine# == \"vllm\""
       ]
@@ -1104,6 +1129,7 @@
       "packages": [
         "#sentence_transformers_dependencies# ; #engine# == \"sentence_transformers\"",
         "#system_torchvision# ; #engine# == \"sentence_transformers\"",
+        "#system_torch# ; #engine# == \"sentence_transformers\"",
         "#vllm_dependencies# ; #engine# == \"vllm\"",
         "#system_numpy# ; #engine# == \"vllm\""
       ]
@@ -1144,6 +1170,7 @@
       "packages": [
         "#sentence_transformers_dependencies# ; #engine# == \"sentence_transformers\"",
         "#system_torchvision# ; #engine# == \"sentence_transformers\"",
+        "#system_torch# ; #engine# == \"sentence_transformers\"",
         "#vllm_dependencies# ; #engine# == \"vllm\"",
         "#system_numpy# ; #engine# == \"vllm\""
       ]
@@ -1184,6 +1211,7 @@
       "packages": [
         "#sentence_transformers_dependencies# ; #engine# == \"sentence_transformers\"",
         "#system_torchvision# ; #engine# == \"sentence_transformers\"",
+        "#system_torch# ; #engine# == \"sentence_transformers\"",
         "#vllm_dependencies# ; #engine# == \"vllm\"",
         "#system_numpy# ; #engine# == \"vllm\""
       ]
@@ -1224,6 +1252,7 @@
       "packages": [
         "#sentence_transformers_dependencies# ; #engine# == \"sentence_transformers\"",
         "#system_torchvision# ; #engine# == \"sentence_transformers\"",
+        "#system_torch# ; #engine# == \"sentence_transformers\"",
         "#vllm_dependencies# ; #engine# == \"vllm\"",
         "#system_numpy# ; #engine# == \"vllm\""
       ]
@@ -1284,6 +1313,7 @@
       "packages": [
         "#sentence_transformers_dependencies# ; #engine# == \"sentence_transformers\"",
         "#system_torchvision# ; #engine# == \"sentence_transformers\"",
+        "#system_torch# ; #engine# == \"sentence_transformers\"",
         "#llama_cpp_dependencies# ; #engine# == \"llama.cpp\"",
         "#vllm_dependencies# ; #engine# == \"vllm\"",
         "#system_numpy# ; #engine# == \"vllm\""
@@ -1353,6 +1383,7 @@
       "packages": [
         "#sentence_transformers_dependencies# ; #engine# == \"sentence_transformers\"",
         "#system_torchvision# ; #engine# == \"sentence_transformers\"",
+        "#system_torch# ; #engine# == \"sentence_transformers\"",
         "#llama_cpp_dependencies# ; #engine# == \"llama.cpp\"",
         "#vllm_dependencies# ; #engine# == \"vllm\"",
         "#system_numpy# ; #engine# == \"vllm\""
@@ -1422,6 +1453,7 @@
       "packages": [
         "#sentence_transformers_dependencies# ; #engine# == \"sentence_transformers\"",
         "#system_torchvision# ; #engine# == \"sentence_transformers\"",
+        "#system_torch# ; #engine# == \"sentence_transformers\"",
         "#llama_cpp_dependencies# ; #engine# == \"llama.cpp\"",
         "#vllm_dependencies# ; #engine# == \"vllm\"",
         "#system_numpy# ; #engine# == \"vllm\""
@@ -1500,6 +1532,7 @@
       "packages": [
         "#sentence_transformers_dependencies# ; #engine# == \"sentence_transformers\"",
         "#system_torchvision# ; #engine# == \"sentence_transformers\"",
+        "#system_torch# ; #engine# == \"sentence_transformers\"",
         "transformers==4.52.0",
         "xformers"
       ],

--- a/xinference/model/embedding/sentence_transformers/core.py
+++ b/xinference/model/embedding/sentence_transformers/core.py
@@ -188,13 +188,19 @@ class SentenceTransformerEmbeddingModel(EmbeddingModel, BatchMixin):
                     "Please upgrade your version via `pip install -U sentence_transformers` or refer to "
                     "https://github.com/UKPLab/sentence-transformers"
                 )
-        except ImportError:
+        except ImportError as e:
             error_message = "Failed to import module 'SentenceTransformer'"
             installation_guide = [
                 "Please make sure 'sentence-transformers' is installed. ",
                 "You can install it by `pip install sentence-transformers`\n",
             ]
-            raise ImportError(f"{error_message}\n\n{''.join(installation_guide)}")
+            # Preserve the original exception so that the real root cause is not
+            # swallowed. A common case is a torch/torchvision version mismatch
+            # (e.g. "operator torchvision::nms does not exist"), where the actual
+            # error has nothing to do with sentence-transformers being missing.
+            raise ImportError(
+                f"{error_message}: {e}\n\n{''.join(installation_guide)}"
+            ) from e
 
         class XSentenceTransformer(SentenceTransformer):
             def to(self, *args, **kwargs):

--- a/xinference/model/embedding/sentence_transformers/core.py
+++ b/xinference/model/embedding/sentence_transformers/core.py
@@ -178,6 +178,16 @@ class SentenceTransformerEmbeddingModel(EmbeddingModel, BatchMixin):
                 model_name_or_path=self._model_path, **self._kwargs
             )
             return
+        # sentence-transformers >= 5.4 imports torchcodec at import time and only
+        # tolerates ImportError/OSError; a broken (version-mismatched) torchcodec
+        # raises RuntimeError and would abort loading of a text-only model. Defuse
+        # it before importing sentence_transformers (see #5208). Kept outside the
+        # try/except below so a mistake here surfaces instead of being reported as
+        # a missing sentence-transformers.
+        from ...utils import neutralize_broken_torchcodec
+
+        neutralize_broken_torchcodec()
+
         try:
             import sentence_transformers
             from sentence_transformers import SentenceTransformer

--- a/xinference/model/rerank/model_spec.json
+++ b/xinference/model/rerank/model_spec.json
@@ -35,6 +35,7 @@
       "packages": [
         "#sentence_transformers_dependencies# ; #engine# == \"sentence_transformers\"",
         "#system_torchvision# ; #engine# == \"sentence_transformers\"",
+        "#system_torch# ; #engine# == \"sentence_transformers\"",
         "#vllm_dependencies# ; #engine# == \"vllm\"",
         "#system_numpy# ; #engine# == \"vllm\""
       ]
@@ -76,6 +77,7 @@
       "packages": [
         "#sentence_transformers_dependencies# ; #engine# == \"sentence_transformers\"",
         "#system_torchvision# ; #engine# == \"sentence_transformers\"",
+        "#system_torch# ; #engine# == \"sentence_transformers\"",
         "#vllm_dependencies# ; #engine# == \"vllm\"",
         "#system_numpy# ; #engine# == \"vllm\""
       ]
@@ -116,7 +118,8 @@
     "virtualenv": {
       "packages": [
         "#sentence_transformers_dependencies# ; #engine# == \"sentence_transformers\"",
-        "#system_torchvision# ; #engine# == \"sentence_transformers\""
+        "#system_torchvision# ; #engine# == \"sentence_transformers\"",
+        "#system_torch# ; #engine# == \"sentence_transformers\""
       ]
     }
   },
@@ -189,6 +192,7 @@
       "packages": [
         "#sentence_transformers_dependencies# ; #engine# == \"sentence_transformers\"",
         "#system_torchvision# ; #engine# == \"sentence_transformers\"",
+        "#system_torch# ; #engine# == \"sentence_transformers\"",
         "#llama_cpp_dependencies# ; #engine# == \"llama.cpp\"",
         "#vllm_dependencies# ; #engine# == \"vllm\"",
         "#system_numpy# ; #engine# == \"vllm\""
@@ -231,6 +235,7 @@
       "packages": [
         "#sentence_transformers_dependencies# ; #engine# == \"sentence_transformers\"",
         "#system_torchvision# ; #engine# == \"sentence_transformers\"",
+        "#system_torch# ; #engine# == \"sentence_transformers\"",
         "#vllm_dependencies# ; #engine# == \"vllm\"",
         "#system_numpy# ; #engine# == \"vllm\""
       ]
@@ -272,6 +277,7 @@
       "packages": [
         "#sentence_transformers_dependencies# ; #engine# == \"sentence_transformers\"",
         "#system_torchvision# ; #engine# == \"sentence_transformers\"",
+        "#system_torch# ; #engine# == \"sentence_transformers\"",
         "#vllm_dependencies# ; #engine# == \"vllm\"",
         "#system_numpy# ; #engine# == \"vllm\""
       ]
@@ -313,6 +319,7 @@
       "packages": [
         "#sentence_transformers_dependencies# ; #engine# == \"sentence_transformers\"",
         "#system_torchvision# ; #engine# == \"sentence_transformers\"",
+        "#system_torch# ; #engine# == \"sentence_transformers\"",
         "#vllm_dependencies# ; #engine# == \"vllm\"",
         "#system_numpy# ; #engine# == \"vllm\""
       ]
@@ -352,7 +359,8 @@
     "virtualenv": {
       "packages": [
         "#sentence_transformers_dependencies# ; #engine# == \"sentence_transformers\"",
-        "#system_torchvision# ; #engine# == \"sentence_transformers\""
+        "#system_torchvision# ; #engine# == \"sentence_transformers\"",
+        "#system_torch# ; #engine# == \"sentence_transformers\""
       ]
     }
   },
@@ -436,6 +444,7 @@
       "packages": [
         "#sentence_transformers_dependencies# ; #engine# == \"sentence_transformers\"",
         "#system_torchvision# ; #engine# == \"sentence_transformers\"",
+        "#system_torch# ; #engine# == \"sentence_transformers\"",
         "#llama_cpp_dependencies# ; #engine# == \"llama.cpp\"",
         "#vllm_dependencies# ; #engine# == \"vllm\"",
         "#system_numpy# ; #engine# == \"vllm\""
@@ -522,6 +531,7 @@
       "packages": [
         "#sentence_transformers_dependencies# ; #engine# == \"sentence_transformers\"",
         "#system_torchvision# ; #engine# == \"sentence_transformers\"",
+        "#system_torch# ; #engine# == \"sentence_transformers\"",
         "#llama_cpp_dependencies# ; #engine# == \"llama.cpp\"",
         "#vllm_dependencies# ; #engine# == \"vllm\"",
         "#system_numpy# ; #engine# == \"vllm\""
@@ -608,6 +618,7 @@
       "packages": [
         "#sentence_transformers_dependencies# ; #engine# == \"sentence_transformers\"",
         "#system_torchvision# ; #engine# == \"sentence_transformers\"",
+        "#system_torch# ; #engine# == \"sentence_transformers\"",
         "#llama_cpp_dependencies# ; #engine# == \"llama.cpp\"",
         "#vllm_dependencies# ; #engine# == \"vllm\"",
         "#system_numpy# ; #engine# == \"vllm\""
@@ -691,6 +702,7 @@
       "packages": [
         "#sentence_transformers_dependencies# ; #engine# == \"sentence_transformers\"",
         "#system_torchvision# ; #engine# == \"sentence_transformers\"",
+        "#system_torch# ; #engine# == \"sentence_transformers\"",
         "vllm>=0.14.0 ; #engine# == \"vllm\"",
         "#system_numpy# ; #engine# == \"vllm\""
       ]
@@ -731,6 +743,7 @@
       "packages": [
         "#sentence_transformers_dependencies# ; #engine# == \"sentence_transformers\"",
         "#system_torchvision# ; #engine# == \"sentence_transformers\"",
+        "#system_torch# ; #engine# == \"sentence_transformers\"",
         "vllm>=0.14.0 ; #engine# == \"vllm\"",
         "#system_numpy# ; #engine# == \"vllm\""
       ]

--- a/xinference/model/rerank/sentence_transformers/core.py
+++ b/xinference/model/rerank/sentence_transformers/core.py
@@ -109,14 +109,20 @@ class SentenceTransformerRerankModel(RerankModel, BatchMixin):
                         "Please upgrade your version via `pip install -U sentence_transformers` or refer to "
                         "https://github.com/UKPLab/sentence-transformers"
                     )
-            except ImportError:
+            except ImportError as e:
                 error_message = "Failed to import module 'sentence-transformers'"
                 installation_guide = [
                     "Please make sure 'sentence-transformers' is installed. ",
                     "You can install it by `pip install sentence-transformers`\n",
                 ]
 
-                raise ImportError(f"{error_message}\n\n{''.join(installation_guide)}")
+                # Preserve the original exception so that the real root cause is
+                # not swallowed. A common case is a torch/torchvision version
+                # mismatch (e.g. "operator torchvision::nms does not exist"),
+                # which is unrelated to sentence-transformers being missing.
+                raise ImportError(
+                    f"{error_message}: {e}\n\n{''.join(installation_guide)}"
+                ) from e
             self._model = CrossEncoder(
                 self._model_path,
                 device=self._device,

--- a/xinference/model/rerank/sentence_transformers/core.py
+++ b/xinference/model/rerank/sentence_transformers/core.py
@@ -99,6 +99,16 @@ class SentenceTransformerRerankModel(RerankModel, BatchMixin):
             and "qwen3" not in self.model_family.model_name.lower()
             and "jina-reranker-v3" not in self.model_family.model_name.lower()
         ):
+            # sentence-transformers >= 5.4 imports torchcodec at import time and
+            # only tolerates ImportError/OSError; a broken (version-mismatched)
+            # torchcodec raises RuntimeError and would abort loading of a
+            # text-only model. Defuse it before importing sentence_transformers
+            # (see #5208). Kept outside the try/except below so a mistake here
+            # surfaces instead of being reported as a missing sentence-transformers.
+            from ...utils import neutralize_broken_torchcodec
+
+            neutralize_broken_torchcodec()
+
             try:
                 import sentence_transformers
                 from sentence_transformers.cross_encoder import CrossEncoder

--- a/xinference/model/tests/test_utils.py
+++ b/xinference/model/tests/test_utils.py
@@ -26,6 +26,7 @@ from ..utils import (
     _collect_virtualenv_engine_markers,
     _extract_engine_markers_from_packages,
     _force_virtualenv_engine_params,
+    neutralize_broken_torchcodec,
     parse_uri,
 )
 
@@ -298,3 +299,136 @@ async def test_cancel():
         with pytest.raises(asyncio.CancelledError):
             await cache_task
         assert downloader.get_progress() == 1.0
+
+
+def _clear_torchcodec_from_sys_modules():
+    for name in [
+        n for n in list(sys.modules) if n == "torchcodec" or n.startswith("torchcodec.")
+    ]:
+        del sys.modules[name]
+
+
+def test_neutralize_broken_torchcodec_runtime_error(monkeypatch):
+    """A torchcodec that raises RuntimeError on import (e.g. version-mismatched
+    shared libs) is poisoned so importers see ImportError and can degrade."""
+    _clear_torchcodec_from_sys_modules()
+    import importlib as _importlib
+
+    def fake_import(name, *args, **kwargs):
+        if name == "torchcodec":
+            raise RuntimeError("Could not load libtorchcodec")
+        return _importlib.import_module(name, *args, **kwargs)
+
+    monkeypatch.setattr("xinference.model.utils.importlib.import_module", fake_import)
+    try:
+        neutralize_broken_torchcodec()
+        # torchcodec is now poisoned -> importing it raises ImportError, which is
+        # exactly what sentence-transformers' guard tolerates.
+        assert sys.modules.get("torchcodec", "missing") is None
+        with pytest.raises(ImportError):
+            import torchcodec  # noqa: F401
+    finally:
+        _clear_torchcodec_from_sys_modules()
+
+
+def test_neutralize_broken_torchcodec_missing(monkeypatch):
+    """A genuinely absent torchcodec is left as-is (its own ImportError stands)."""
+    _clear_torchcodec_from_sys_modules()
+    import importlib as _importlib
+
+    def fake_import(name, *args, **kwargs):
+        if name == "torchcodec":
+            raise ModuleNotFoundError("No module named 'torchcodec'")
+        return _importlib.import_module(name, *args, **kwargs)
+
+    monkeypatch.setattr("xinference.model.utils.importlib.import_module", fake_import)
+    neutralize_broken_torchcodec()
+    # Not poisoned: absence is handled by the caller's own guard.
+    assert "torchcodec" not in sys.modules
+
+
+def test_neutralize_broken_torchcodec_healthy(monkeypatch):
+    """A healthy torchcodec is left untouched."""
+    _clear_torchcodec_from_sys_modules()
+    import types
+
+    fake_mod = types.ModuleType("torchcodec")
+    sys.modules["torchcodec"] = fake_mod
+    try:
+        neutralize_broken_torchcodec()
+        assert sys.modules["torchcodec"] is fake_mod
+    finally:
+        _clear_torchcodec_from_sys_modules()
+
+
+def test_sentence_transformers_loaders_resolve_neutralizer():
+    """The embedding and rerank loaders reference neutralize_broken_torchcodec
+    via a relative import; verify that import path actually resolves (a wrong
+    relative-import depth previously pointed at xinference.utils and broke load
+    at runtime, see #5208)."""
+    import ast
+    import importlib
+    import os
+
+    here = os.path.dirname(__file__)
+    core_files = {
+        "xinference.model.embedding.sentence_transformers.core": os.path.join(
+            here, "..", "embedding", "sentence_transformers", "core.py"
+        ),
+        "xinference.model.rerank.sentence_transformers.core": os.path.join(
+            here, "..", "rerank", "sentence_transformers", "core.py"
+        ),
+    }
+
+    for module_name, path in core_files.items():
+        with open(path) as f:
+            tree = ast.parse(f.read())
+        found = False
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and any(
+                alias.name == "neutralize_broken_torchcodec" for alias in node.names
+            ):
+                found = True
+                # Resolve the relative import against the core module's package.
+                pkg = module_name.rsplit(".", 1)[0]
+                base = pkg
+                for _ in range(node.level - 1):
+                    base = base.rsplit(".", 1)[0]
+                target = f"{base}.{node.module}" if node.module else base
+                mod = importlib.import_module(target)
+                assert hasattr(mod, "neutralize_broken_torchcodec"), (
+                    f"{module_name} imports neutralize_broken_torchcodec from "
+                    f"{target!r}, which has no such symbol"
+                )
+        assert found, f"{module_name} no longer imports neutralize_broken_torchcodec"
+
+
+def test_neutralize_broken_torchcodec_idempotent(monkeypatch):
+    """After poisoning, a second call must be a no-op and must NOT re-import
+    torchcodec (a stale re-import would raise+swallow ModuleNotFoundError on
+    every subsequent model load)."""
+    _clear_torchcodec_from_sys_modules()
+    import importlib as _importlib
+
+    calls = {"n": 0}
+    real_import = _importlib.import_module
+
+    def counting_import(name, *args, **kwargs):
+        if name == "torchcodec":
+            calls["n"] += 1
+            raise RuntimeError("Could not load libtorchcodec")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(
+        "xinference.model.utils.importlib.import_module", counting_import
+    )
+    try:
+        neutralize_broken_torchcodec()
+        neutralize_broken_torchcodec()
+        neutralize_broken_torchcodec()
+        # torchcodec import is attempted only on the first call; later calls
+        # short-circuit on the sys.modules guard.
+        assert calls["n"] == 1
+        assert sys.modules.get("torchcodec", "missing") is None
+    finally:
+        _clear_torchcodec_from_sys_modules()

--- a/xinference/model/utils.py
+++ b/xinference/model/utils.py
@@ -129,6 +129,55 @@ def virtual_env_allows_missing_engine() -> bool:
     return bool(flag)
 
 
+def neutralize_broken_torchcodec() -> None:
+    """Make an unusable ``torchcodec`` install look absent to importers.
+
+    ``sentence-transformers`` >= 5.4 imports ``torchcodec`` at module import
+    time (``base/modality_types.py``) for optional audio/video decoding, and
+    guards it with ``except (ImportError, OSError)`` so a *missing* torchcodec
+    degrades gracefully (``AudioDecoder = None``). However, when torchcodec is
+    *present but fails to load its shared libraries* — e.g. a copy leaked from
+    the parent/system environment whose version does not match the venv's torch
+    (torch 2.9.x needs torchcodec 0.9) — its import raises ``RuntimeError``,
+    which escapes that guard and aborts loading of an otherwise text-only model
+    (see #5208).
+
+    We probe torchcodec first. If importing it raises anything other than the
+    ``ImportError``/``OSError`` that sentence-transformers already tolerates, we
+    poison ``sys.modules`` so the subsequent ``from torchcodec.decoders import
+    ...`` raises ``ImportError`` and hits the graceful-degradation branch. A
+    healthy torchcodec is left untouched; a genuinely absent one already works.
+    """
+    if "torchcodec" in sys.modules:
+        # Already processed in this process (imported successfully, or poisoned
+        # to None by a prior call); nothing to do. Returning here also avoids a
+        # needless re-import + swallowed ModuleNotFoundError on later model loads.
+        return
+    try:
+        importlib.import_module("torchcodec")
+    except (ImportError, OSError):
+        # sentence-transformers already handles these; leave as-is so its own
+        # guard runs (and a real "not installed" state stays truthful).
+        return
+    except Exception as e:  # typically RuntimeError from libtorchcodec loading
+        logger.warning(
+            "torchcodec is installed but failed to load (%s: %s); disabling it "
+            "so text-only models can still load. Audio/video features that rely "
+            "on torchcodec will be unavailable. Install a torchcodec build that "
+            "matches your torch version to enable them.",
+            type(e).__name__,
+            e,
+        )
+        # Poison torchcodec and any submodules so importers see ImportError.
+        for name in [
+            name
+            for name in sys.modules
+            if name == "torchcodec" or name.startswith("torchcodec.")
+        ]:
+            sys.modules[name] = None  # type: ignore[assignment]
+        sys.modules.setdefault("torchcodec", None)  # type: ignore[arg-type]
+
+
 def _extract_engine_markers_from_packages(packages: List[str]) -> Set[str]:
     engines: Set[str] = set()
     for pkg in packages:


### PR DESCRIPTION
## Problem

Deploying `bge-m3` (and other sentence_transformers-based embedding/rerank models) into a per-model virtual env fails with a misleading `Failed to import module 'SentenceTransformer'` error. The real cause is a torch-ecosystem package leaking in from the parent/system environment with a version that does not match the sub venv's torch. Two distinct manifestations of the same class of problem are addressed here.

Fixes #5208.

## Part 1 — pin system torch alongside torchvision

For the `sentence_transformers` engine, `torchvision` is pinned to the **system** version via `#system_torchvision#` in `model_spec.json`, while `torch` is pulled **fresh from PyPI** into the sub venv by the bare `sentence_transformers` dependency. The two end up mismatched, so torchvision's C++ op fails to register:

```
RuntimeError: operator torchvision::nms does not exist
```

The design intent (single-source torch/torchvision) was only half-applied: models declared `#system_torchvision#` without the matching `#system_torch#`. 33 embedding + 13 rerank models were affected; the ~10 models added more recently already declared both and serve as the correct template.

**Change:** add `#system_torch#` next to `#system_torchvision#` for the models missing it, and a regression test asserting every model pinning system torchvision also pins system torch under the same environment markers.

## Part 2 — tolerate a broken torchcodec

With torch/torchvision resolved, the next failure is `torchcodec`:

```
RuntimeError: Could not load libtorchcodec ...
```

`sentence-transformers` >= 5.4 imports `torchcodec` at import time for optional audio/video decoding, guarded by `except (ImportError, OSError)` so a *missing* torchcodec degrades gracefully (`AudioDecoder = None`). But a *present-but-unloadable* torchcodec (version-mismatched copy leaking from the parent/system env; torch 2.9.x needs torchcodec 0.9) raises `RuntimeError`, which escapes that guard and aborts loading of an otherwise text-only model.

**Change:** add `neutralize_broken_torchcodec()` — probe torchcodec before importing sentence_transformers; if it raises anything other than the `ImportError`/`OSError` that sentence-transformers already tolerates, poison it in `sys.modules` so the subsequent `from torchcodec.decoders import ...` raises `ImportError` and hits the graceful-degradation branch. A healthy torchcodec is untouched; a genuinely absent one already worked. Called from both the embedding and rerank loaders, with unit tests for the healthy / missing / broken paths.

## Verification

- `pre-commit` (black/flake8/isort/mypy/codespell) passes.
- Part 1: 0 models declare `#system_torchvision#` without `#system_torch#` after the change; specs round-trip as valid JSON.
- Part 2: unit tests cover healthy/missing/broken torchcodec; an end-to-end simulation confirms a `RuntimeError`-on-import torchcodec is neutralized so the sentence-transformers guard degrades to `AudioDecoder = None`.

Not verified: end-to-end launch on the reporter's GPU host (no equivalent environment available locally); awaiting the reporter's confirmation.