### PR TITLE
fix(webui): show model engine on running-model detail page

### DIFF
--- a/frontend/src/components/pages/running-model/index.tsx
+++ b/frontend/src/components/pages/running-model/index.tsx
@@ -337,10 +337,12 @@ const RunningModel = () => {
           <h3 className="font-medium">{t('runningModels.baseInfo')}</h3>
           <div className="grid grid-cols-2 gap-4">
             <ContentItemInfo title={t('runningModels.modelType')} value={activeModel.model_type} />
-            <ContentItemInfo
-              title={t('runningModels.modelEngine')}
-              value={activeModel.model_engine || '-'}
-            />
+            {'model_engine' in activeModel && (
+              <ContentItemInfo
+                title={t('runningModels.modelEngine')}
+                value={activeModel.model_engine || '-'}
+              />
+            )}
             <ContentItemInfo
               title={t('runningModels.modelFormat')}
               value={activeModel.model_format || '-'}

--- a/xinference/core/tests/test_restful_api.py
+++ b/xinference/core/tests/test_restful_api.py
@@ -88,6 +88,8 @@ async def test_restful_api(setup):
     response_data = response.json()
     assert response_data["model_name"] == "qwen1.5-chat"
     assert response_data["replica"] == 1
+    # the engine selected at launch is surfaced so the Web UI can display it
+    assert response_data["model_engine"] == "llama.cpp"
 
     response = requests.delete(f"{endpoint}/v1/models/bogus")
     assert response.status_code == 400
@@ -342,6 +344,12 @@ def test_restful_api_for_embedding(setup):
     response = requests.get(url)
     response_data = response.json()
     assert len(response_data["data"]) == 1
+
+    # describe: even without an explicitly selected engine, the default engine
+    # actually used at load time is surfaced (so the Web UI shows it, not a dash)
+    response = requests.get(f"{endpoint}/v1/models/test_embedding")
+    response_data = response.json()
+    assert response_data["model_engine"] == "sentence_transformers"
 
     # test embedding
     url = f"{endpoint}/v1/embeddings"

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -3397,6 +3397,12 @@ class WorkerActor(xo.StatelessActor):
                             continue
                     self._model_uid_to_subpool_pids[model_uid] = subpool_pids
                     model_spec = model.model_family.to_description()
+                    # ``to_description`` is derived from the model family alone and
+                    # therefore does not know which engine was selected at launch.
+                    # Surface it here so ``/v1/models`` can report the running
+                    # engine (shown in the Web UI running-model detail view).
+                    if model_engine is not None:
+                        model_spec["model_engine"] = model_engine
                     self._model_uid_to_model_spec[model_uid] = model_spec
                     self._model_uid_to_model_status[model_uid] = ModelStatus(
                         model_state="loading"

--- a/xinference/model/embedding/core.py
+++ b/xinference/model/embedding/core.py
@@ -110,6 +110,7 @@ class EmbeddingModelFamilyV2(BaseModel, ModelInstanceInfoMixin):
             "address": getattr(self, "address", None),
             "accelerators": getattr(self, "accelerators", None),
             "model_name": self.model_name,
+            "model_engine": getattr(self, "model_engine", None),
             "model_format": spec.model_format,
             "dimensions": self.dimensions,
             "max_tokens": self.max_tokens,
@@ -605,6 +606,9 @@ def create_embedding_model_instance(
             model_format,
             quantization,
         )
+    # Record the engine actually used (including the default fallback above) on
+    # the family object so ``to_description`` can surface it to ``/v1/models``.
+    model_family.model_engine = model_engine
     model = embedding_cls(
         model_uid,
         model_path,

--- a/xinference/model/embedding/core.py
+++ b/xinference/model/embedding/core.py
@@ -608,6 +608,8 @@ def create_embedding_model_instance(
         )
     # Record the engine actually used (including the default fallback above) on
     # the family object so ``to_description`` can surface it to ``/v1/models``.
+    # Copy first to avoid mutating a possibly shared family object.
+    model_family = model_family.copy()
     model_family.model_engine = model_engine
     model = embedding_cls(
         model_uid,

--- a/xinference/model/image/core.py
+++ b/xinference/model/image/core.py
@@ -200,6 +200,8 @@ def create_ocr_model_instance(
         )
     # Record the engine actually used (including the default fallback above) on
     # the family object so ``to_description`` can surface it to ``/v1/models``.
+    # Copy first to avoid mutating the shared builtin family object.
+    model_spec = model_spec.copy()
     model_spec.model_engine = model_engine
     return ocr_cls(
         model_uid,
@@ -332,6 +334,8 @@ def create_image_model_instance(
 
     # Record the engine actually used (including the default fallback above) on
     # the family object so ``to_description`` can surface it to ``/v1/models``.
+    # Copy first to avoid mutating the shared builtin family object.
+    model_spec = model_spec.copy()
     model_spec.model_engine = model_engine
     model = model_cls(
         model_uid,

--- a/xinference/model/image/core.py
+++ b/xinference/model/image/core.py
@@ -70,6 +70,7 @@ class ImageModelFamilyV2(CacheableModelSpec, ModelInstanceInfoMixin):
             "address": getattr(self, "address", None),
             "accelerators": getattr(self, "accelerators", None),
             "model_name": self.model_name,
+            "model_engine": getattr(self, "model_engine", None),
             "model_family": self.model_family,
             "model_revision": self.model_revision,
             "model_ability": self.model_ability,
@@ -197,6 +198,9 @@ def create_ocr_model_instance(
             model_format,
             quantization,
         )
+    # Record the engine actually used (including the default fallback above) on
+    # the family object so ``to_description`` can surface it to ``/v1/models``.
+    model_spec.model_engine = model_engine
     return ocr_cls(
         model_uid,
         model_path,
@@ -326,6 +330,9 @@ def create_image_model_instance(
             quantization,
         )
 
+    # Record the engine actually used (including the default fallback above) on
+    # the family object so ``to_description`` can surface it to ``/v1/models``.
+    model_spec.model_engine = model_engine
     model = model_cls(
         model_uid,
         model_path,

--- a/xinference/model/rerank/core.py
+++ b/xinference/model/rerank/core.py
@@ -93,6 +93,7 @@ class RerankModelFamilyV2(BaseModel, ModelInstanceInfoMixin):
             "accelerators": getattr(self, "accelerators", None),
             "type": self.type,
             "model_name": self.model_name,
+            "model_engine": getattr(self, "model_engine", None),
             "model_format": spec.model_format,
             "language": self.language,
             "model_revision": spec.model_revision,
@@ -265,6 +266,9 @@ def create_rerank_model_instance(
             model_format,
             quantization,
         )
+    # Record the engine actually used (including the default fallback above) on
+    # the family object so ``to_description`` can surface it to ``/v1/models``.
+    model_family.model_engine = model_engine
     model = rerank_cls(
         model_uid,
         model_path,

--- a/xinference/model/rerank/core.py
+++ b/xinference/model/rerank/core.py
@@ -268,6 +268,8 @@ def create_rerank_model_instance(
         )
     # Record the engine actually used (including the default fallback above) on
     # the family object so ``to_description`` can surface it to ``/v1/models``.
+    # Copy first to avoid mutating a possibly shared family object.
+    model_family = model_family.copy()
     model_family.model_engine = model_engine
     model = rerank_cls(
         model_uid,


### PR DESCRIPTION
## Problem

On the running-model detail page, the **Model Engine** field always showed a dash (`-`), even for models that clearly run on a specific engine.

The frontend reads `model_engine` from `/v1/models`, but the backend never reported it. `to_description()` is built from the model family alone and has no knowledge of which engine was selected at launch, so the field was always absent and the UI fell back to a dash.

## Fix

- **worker**: inject the launch-time engine onto the model spec so `/v1/models` reports it. This covers **LLM**, where the engine is mandatory and always present at the worker layer.
- **embedding / rerank / image**: these types resolve a default engine (e.g. `sentence_transformers`, `diffusers`) *inside the model subprocess*, so the worker's `model_engine` argument is `None` when the user does not pick one explicitly. Record the engine actually used on the family object and surface it via `to_description()`, so models launched without an explicit engine still report the real engine instead of a dash.
- **frontend**: only render the engine row when the model type actually has an engine concept. **audio / video / flexible** have no user-selectable engine, so the row is now hidden for them instead of showing a meaningless dash.

## Behavior per model type

| Type | Has engine | Detail page after fix |
|---|---|---|
| LLM | yes (required) | shows engine |
| embedding | yes | shows engine (incl. default) |
| rerank | yes | shows engine (incl. default) |
| image | yes | shows engine (incl. default) |
| audio / video / flexible | no | row hidden |

## Tests

Added end-to-end assertions in `test_restful_api.py`:
- LLM launched with an explicit engine (`llama.cpp`) → described with that engine.
- Embedding launched **without** an engine → described with the resolved default (`sentence_transformers`).

Frontend `tsc --noEmit` and ESLint pass; backend `pre-commit` passes.