### PR TITLE
fix(venv): pin torch to system version to prevent torchvision ABI crash on relaunch

### DIFF
--- a/xinference/core/tests/test_utils.py
+++ b/xinference/core/tests/test_utils.py
@@ -21,6 +21,7 @@ from ..utils import (
 from ..virtual_env_manager import (
     ENGINE_VIRTUALENV_PACKAGES,
     XLLAMACPP_CUDA_INDEX_URLS,
+    ensure_system_torch_pin,
     get_xllamacpp_cuda_index_url,
 )
 
@@ -86,7 +87,12 @@ def test_get_xllamacpp_cuda_index_url():
 
 
 def _run_prepare_virtual_env(
-    cuda_version, inherited_index_url, skip_installed=True, cuda_available=True
+    cuda_version,
+    inherited_index_url,
+    skip_installed=True,
+    cuda_available=True,
+    model_engine="llama.cpp",
+    packages=("xllamacpp>=0.2.6",),
 ):
     """
     Drive WorkerActor._prepare_virtual_env for the llama.cpp engine and report
@@ -138,9 +144,9 @@ def _run_prepare_virtual_env(
     ):
         WorkerActor._prepare_virtual_env(
             virtual_env_manager=_FakeVEM(),
-            settings=VirtualEnvSettings(packages=["xllamacpp>=0.2.6"]),
+            settings=VirtualEnvSettings(packages=list(packages)),
             virtual_env_packages=None,
-            model_engine="llama.cpp",
+            model_engine=model_engine,
             model_name="qwen3",
             architectures=None,
         )
@@ -203,6 +209,150 @@ def test_prepare_virtual_env_llama_cpp_no_gpu_device_keeps_cpu_index():
         result["conf"]["index_url"] == "https://mirrors.cloud.tencent.com/pypi/simple/"
     )
     assert result["uninstalled"] == []
+
+
+def _run_prepare_with_torchvision_version(model_engine, tv_version="0.20.0+cu130"):
+    # Built-in embedding/rerank specs share this engine-guarded companion entry
+    # across engines. Pin the reported torchvision version so the PyTorch CUDA
+    # index decision is deterministic regardless of the test host.
+    import importlib.metadata
+    from unittest import mock
+
+    real_version = importlib.metadata.version
+
+    def _fake_version(name):
+        if name.lower() == "torchvision":
+            return tv_version
+        return real_version(name)
+
+    with mock.patch("importlib.metadata.version", side_effect=_fake_version):
+        return _run_prepare_virtual_env(
+            cuda_version="13.0",
+            inherited_index_url=None,
+            model_engine=model_engine,
+            packages=(
+                'sentence_transformers ; #engine# == "sentence_transformers"',
+                '#system_torchvision# ; #engine# == "sentence_transformers"',
+            ),
+        )
+
+
+def test_prepare_virtual_env_pytorch_index_skipped_for_nonmatching_engine():
+    # A flag launch must NOT auto-configure the PyTorch CUDA index from the
+    # sentence_transformers-guarded #system_torchvision# marker, and the
+    # inactive companion is filtered out entirely (issue #5156 review).
+    result = _run_prepare_with_torchvision_version("flag")
+    extra = result["conf"].get("extra_index_url")
+    assert not extra or "download.pytorch.org" not in str(extra)
+    assert result["packages"] == []
+
+
+def test_prepare_virtual_env_pytorch_index_used_for_matching_engine():
+    # The sentence_transformers launch keeps the companion (guard stripped) and
+    # does auto-configure the matching PyTorch CUDA index.
+    result = _run_prepare_with_torchvision_version("sentence_transformers")
+    extra = result["conf"].get("extra_index_url")
+    assert extra and "https://download.pytorch.org/whl/cu130" in extra
+    # #system_torchvision# survives (guard stripped) and #system_torch# is added.
+    assert "#system_torchvision#" in result["packages"]
+    assert "#system_torch#" in result["packages"]
+
+
+def test_ensure_system_torch_pin_injects_when_missing():
+    # #system_torchvision# present but torch unpinned -> #system_torch# added,
+    # inheriting the companion's environment marker (issue #5156).
+    packages = [
+        "sentence_transformers",
+        '#system_torchvision# ; #engine# == "sentence_transformers"',
+    ]
+    result = ensure_system_torch_pin(packages)
+    assert '#system_torch# ; #engine# == "sentence_transformers"' in result
+    # original entries preserved, torch pin appended once
+    assert result[: len(packages)] == packages
+    assert sum(1 for p in result if p.split(";", 1)[0].strip() == "#system_torch#") == 1
+
+
+def test_ensure_system_torch_pin_no_marker_when_companion_unmarked():
+    packages = ["sentence_transformers", "#system_torchvision#"]
+    result = ensure_system_torch_pin(packages)
+    assert "#system_torch#" in result
+
+
+def test_ensure_system_torch_pin_noop_when_torch_already_pinned_marker():
+    packages = [
+        '#system_torchvision# ; #engine# == "sentence_transformers"',
+        '#system_torch# ; #engine# == "sentence_transformers"',
+    ]
+    result = ensure_system_torch_pin(packages)
+    assert result == packages
+
+
+def test_ensure_system_torch_pin_noop_when_torch_already_pinned_plain():
+    # A plain torch pin (e.g. user-registered model) also counts as pinned.
+    packages = ["torch==2.11.0", "#system_torchvision#"]
+    result = ensure_system_torch_pin(packages)
+    assert result == packages
+
+
+def test_ensure_system_torch_pin_noop_without_companion():
+    packages = ["sentence_transformers", "einops", "#system_numpy#"]
+    result = ensure_system_torch_pin(packages)
+    assert result == packages
+    assert not any("torch" in p for p in result)
+
+
+def test_ensure_system_torch_pin_empty():
+    assert ensure_system_torch_pin([]) == []
+
+
+def test_ensure_system_torch_pin_multiple_companions_different_markers():
+    # Two companions guarded by different engine markers each get a matching
+    # torch pin under the same condition (issue #5156 review follow-up).
+    packages = [
+        '#system_torchvision# ; #engine# == "sentence_transformers"',
+        '#system_torchaudio# ; #engine# == "audio"',
+    ]
+    result = ensure_system_torch_pin(packages)
+    assert '#system_torch# ; #engine# == "sentence_transformers"' in result
+    assert '#system_torch# ; #engine# == "audio"' in result
+    assert result[: len(packages)] == packages
+    assert len(result) == 4
+
+
+def test_ensure_system_torch_pin_only_fills_missing_marker():
+    # A conditional torch pin already covers one companion; the other companion
+    # (different marker) still gets its own torch pin, and the existing one is
+    # left untouched.
+    packages = [
+        '#system_torchvision# ; #engine# == "sentence_transformers"',
+        '#system_torch# ; #engine# == "sentence_transformers"',
+        '#system_torchaudio# ; #engine# == "audio"',
+    ]
+    result = ensure_system_torch_pin(packages)
+    assert result[: len(packages)] == packages
+    assert result[len(packages) :] == ['#system_torch# ; #engine# == "audio"']
+
+
+def test_ensure_system_torch_pin_unconditional_torch_covers_all():
+    # An unconditional torch pin satisfies every companion regardless of marker.
+    packages = [
+        "torch==2.11.0",
+        '#system_torchvision# ; #engine# == "sentence_transformers"',
+        "#system_torchaudio#",
+    ]
+    result = ensure_system_torch_pin(packages)
+    assert result == packages
+
+
+def test_ensure_system_torch_pin_deduplicates_same_marker():
+    # Two companions sharing one marker yield a single torch pin.
+    packages = [
+        '#system_torchvision# ; #engine# == "x"',
+        '#system_torchaudio# ; #engine# == "x"',
+    ]
+    result = ensure_system_torch_pin(packages)
+    assert result.count('#system_torch# ; #engine# == "x"') == 1
+    assert len(result) == 3
 
 
 def test_build_subpool_envs_for_virtual_env_disabled():

--- a/xinference/core/virtual_env_manager.py
+++ b/xinference/core/virtual_env_manager.py
@@ -175,6 +175,106 @@ def get_xllamacpp_cuda_index_url(
     return None
 
 
+# torch companion packages whose binaries are compiled against a specific torch
+# ABI. When any of these is pinned to the system version (via #system_<pkg>#) the
+# environment MUST also keep torch at the system version, otherwise the resolver
+# is free to upgrade torch (e.g. sentence_transformers pulling the latest wheel)
+# while these stay at the system version, producing a broken pair that fails at
+# import time with errors like "operator torchvision::nms does not exist".
+TORCH_COMPANION_PACKAGES = {"torchvision", "torchaudio", "torchcodec"}
+
+
+def ensure_system_torch_pin(packages: List[str]) -> List[str]:
+    """
+    Pin torch to the system version whenever a torch companion package
+    (torchvision/torchaudio/torchcodec) is pinned to the system version but torch
+    itself is left unpinned.
+
+    Model specs pin the companion via ``#system_torchvision#`` yet sometimes omit a
+    torch pin. Without it the resolver is free to upgrade torch in the child venv
+    (e.g. ``sentence_transformers`` pulling the latest wheel) while the companion
+    stays at the older system version inherited through ``--system-site-packages``.
+    The resulting ABI mismatch crashes the model subprocess at import time with
+    errors like ``operator torchvision::nms does not exist`` — reproducibly on the
+    second launch of a model, once the venv has been populated (issue #5156).
+
+    A ``#system_torch#`` marker is appended (matching the convention of the specs
+    that already carry it); xoscar's ``process_packages`` later resolves it to the
+    installed ``torch==<version>``. Each companion's environment marker (e.g. the
+    engine guard) is preserved so the injected torch pin applies under exactly the
+    same conditions. When several companions carry different markers (e.g.
+    ``#system_torchvision# ; #engine# == "sentence_transformers"`` alongside
+    ``#system_torchaudio# ; #engine# == "audio"``), a matching torch pin is added
+    for each distinct marker that does not already have one. This covers built-in
+    specs and user-registered models alike, and is a no-op when torch is already
+    pinned under the relevant condition or no companion is pinned.
+    """
+    if not packages:
+        return packages
+
+    def _marker_name(pkg: str) -> Optional[str]:
+        # Split off any PEP 508 environment marker (";" onwards) before matching
+        # the "#system_<name>#" placeholder.
+        head = pkg.split(";", 1)[0].strip()
+        if head.startswith("#system_") and head.endswith("#"):
+            return head[len("#system_") : -1].lower()
+        return None
+
+    def _requirement_name(pkg: str) -> Optional[str]:
+        # Best-effort package name for a plain requirement string like
+        # "torch==2.11.0" or "torch ; marker".
+        head = pkg.split(";", 1)[0].strip()
+        if not head or head.startswith("#"):
+            return None
+        for sep in ("==", ">=", "<=", "~=", "!=", ">", "<", "[", " "):
+            if sep in head:
+                head = head.split(sep, 1)[0]
+                break
+        return head.strip().lower() or None
+
+    def _env_marker(pkg: str) -> Optional[str]:
+        # The PEP 508 environment marker (text after ";"), or None if unconditional.
+        return pkg.split(";", 1)[1].strip() if ";" in pkg else None
+
+    # Collect the conditions under which torch is already pinned. ``None`` means an
+    # unconditional pin (which satisfies every companion), so we can stop early.
+    existing_torch_markers: set = set()
+    for pkg in packages:
+        if _marker_name(pkg) == "torch" or _requirement_name(pkg) == "torch":
+            marker = _env_marker(pkg)
+            if marker is None:
+                return packages
+            existing_torch_markers.add(marker)
+
+    # Inject one torch pin per distinct companion condition that lacks one,
+    # preserving that companion's environment marker so the pin applies under
+    # exactly the same conditions.
+    to_inject: List[str] = []
+    seen_markers = set(existing_torch_markers)
+    for pkg in packages:
+        if _marker_name(pkg) not in TORCH_COMPANION_PACKAGES:
+            continue
+        marker = _env_marker(pkg)
+        if marker in seen_markers:
+            continue
+        seen_markers.add(marker)
+        to_inject.append(
+            f"#system_torch# ; {marker}" if marker is not None else "#system_torch#"
+        )
+
+    if not to_inject:
+        return packages
+
+    for torch_entry in to_inject:
+        logger.info(
+            "Pinning torch to the system version (%s) to match the system torch "
+            "companion package pinned in the virtual env; avoids a torch/torchvision "
+            "ABI mismatch on relaunch (issue #5156).",
+            torch_entry,
+        )
+    return packages + to_inject
+
+
 def extract_cuda_version_from_url(url: str) -> Optional[str]:
     """Extract CUDA version suffix (e.g. 'cu130') from a wheel index URL."""
     if not url:

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -105,6 +105,7 @@ from .utils import (
 )
 from .virtual_env_manager import VirtualEnvManager as XinferenceVirtualEnvManager
 from .virtual_env_manager import (
+    ensure_system_torch_pin,
     expand_engine_dependency_placeholders,
     get_engine_critical_dependency_specs,
     get_engine_model_format_virtualenv_packages,
@@ -2688,17 +2689,36 @@ class WorkerActor(xo.StatelessActor):
         )
         packages = merge_virtual_env_packages(base_packages, virtual_env_packages)
 
+        try:
+            from xoscar.virtualenv.platform import get_cuda_version
+
+            cuda_version = get_cuda_version()
+        except Exception:
+            cuda_version = None
+
         # Auto-configure PyTorch wheel URL based on system packages
         # Check if packages contain PyTorch system markers (#system_torch#, etc.)
         # If so, detect CUDA version from system and configure wheel URL
         # Note: markers are kept as-is and resolved later by xoscar's process_packages
         from .virtual_env_manager import PYTORCH_CUDA_WHEEL_URLS, PYTORCH_PACKAGES
 
+        # Only consider markers that actually apply to the current engine/CUDA/
+        # platform. Built-in embedding/rerank specs carry an engine-guarded entry
+        # such as '#system_torchvision# ; #engine# == "sentence_transformers"';
+        # evaluating it for a non-matching engine (e.g. flag/vllm) would otherwise
+        # auto-configure the PyTorch CUDA index from an inactive marker (issue
+        # #5156). filter_virtualenv_packages_by_markers drops non-applicable
+        # entries and strips the guard from the ones that remain.
+        active_packages = filter_virtualenv_packages_by_markers(
+            packages, model_engine, cuda_version
+        )
+
         system_cuda_urls = None
-        for pkg in packages:
-            if pkg.startswith("#system_") and pkg.endswith("#"):
+        for pkg in active_packages:
+            marker_head = pkg.split(";", 1)[0].strip()
+            if marker_head.startswith("#system_") and marker_head.endswith("#"):
                 # Extract package name from marker
-                marker_pkg = pkg[len("#system_") : -1].lower()
+                marker_pkg = marker_head[len("#system_") : -1].lower()
                 if marker_pkg in PYTORCH_PACKAGES:
                     try:
                         import importlib.metadata
@@ -2746,13 +2766,6 @@ class WorkerActor(xo.StatelessActor):
                 settings.extra_index_url = system_cuda_urls + [
                     u for u in existing_urls if u not in system_cuda_urls
                 ]
-
-        try:
-            from xoscar.virtualenv.platform import get_cuda_version
-
-            cuda_version = get_cuda_version()
-        except Exception:
-            cuda_version = None
 
         if not is_cuda_compatible(settings.extra_index_url, cuda_version):
             logger.debug(
@@ -2824,9 +2837,9 @@ class WorkerActor(xo.StatelessActor):
                 # force this install so the GPU wheel actually replaces it.
                 force_reinstall_xllamacpp = True
 
-        packages = filter_virtualenv_packages_by_markers(
-            packages, model_engine, cuda_version
-        )
+        # Reuse the engine/CUDA/platform-filtered list computed above for the
+        # PyTorch index decision — same inputs, so the result is identical.
+        packages = active_packages
 
         critical_specs = get_engine_critical_dependency_specs(model_engine, packages)
         if critical_specs:
@@ -2857,6 +2870,13 @@ class WorkerActor(xo.StatelessActor):
                     "non-wheel direct references; preinstall or replace these "
                     f"requirements: {direct_references}"
                 )
+
+        # Keep torch aligned with any system-pinned torch companion package
+        # (torchvision/torchaudio/torchcodec). Without this, the resolver may
+        # upgrade torch in the child venv while the companion stays at the system
+        # version, and the ABI mismatch crashes the model subprocess on relaunch
+        # (issue #5156).
+        packages = ensure_system_torch_pin(packages)
 
         conf = dict(settings)
         conf.pop("packages", None)


### PR DESCRIPTION
### Summary

Fixes #5156. Reranker/embedding models on the `sentence_transformers` engine crash on the **second** launch with:

```
xoscar.errors.ServerClosed: Remote server unixsocket:///... closed: 0 bytes read on a total of 11 expected bytes
```

The first launch succeeds; after stopping the model, every subsequent launch fails. Reproduced reliably with `Qwen3-Reranker-0.6B` (`sentence_transformers` engine, pytorch format).

### Root cause

The per-model virtualenv pins `torchvision` to the system version via `#system_torchvision#` but leaves `torch` unpinned.

- On the **first** launch the model subpool is spawned *before* the venv is populated, so it imports the system `torch`/`torchvision` pair (a matched build). During that launch the venv install pulls the **latest** `torch` (e.g. `2.13.0`) as a transitive dependency of `sentence_transformers`, while `torchvision` stays at the system version (e.g. `0.26.0`, built against `torch 2.11.0`) inherited through `--system-site-packages`.
- On the **next** launch the subpool imports the venv's newer `torch`, now ABI-incompatible with the system `torchvision`. The C++ operator registration fails with `RuntimeError: operator torchvision::nms does not exist` while loading the model, killing the subprocess — surfaced as `ServerClosed`.

### Fix

1. **`ensure_system_torch_pin`** (`virtual_env_manager.py`) appends `#system_torch#` whenever a torch companion package (`torchvision`/`torchaudio`/`torchcodec`) is pinned to the system version but `torch` is not. This keeps `torch` aligned with the companion so the pair stays ABI-compatible. Applies to built-in specs and user-registered models; no-op when `torch` is already pinned or no companion is pinned.
2. **PyTorch CUDA wheel-index auto-config** (`worker.py`) now strips a package's environment marker before matching the `#system_<pkg>#` placeholder. Spec entries carry an engine guard (`#system_torchvision# ; #engine# == "sentence_transformers"`), and the previous `endswith("#")` check skipped them — so the CUDA wheel index was never configured and the new system-version torch pin could not resolve.

### Verification

Tested on a CUDA 13.1 / RTX 3090 box with the `xprobe/xinference:latest` image:

- **Before:** launch → stop → launch reproduces `ServerClosed` every time; the venv ends up with `torch 2.13.0` + system `torchvision 0.26.0`, and importing the model raises `operator torchvision::nms does not exist`.
- **After:** the venv keeps `torch 2.11.0` matched with `torchvision 0.26.0`; launch → stop → launch (and a third cycle) all succeed, and `/v1/rerank` returns correct scores.
- Added unit tests for `ensure_system_torch_pin`; full `test_utils.py` passes and pre-commit is clean.
