### PR TITLE
FIX: mitigate Slow HTTP DoS (Slowloris) by enforcing a request receipt deadline

### DIFF
--- a/doc/source/getting_started/environments.rst
+++ b/doc/source/getting_started/environments.rst
@@ -72,6 +72,24 @@ XINFERENCE_ALLOWED_IPS
 ~~~~~~~~~~~~~~~~~~~~~~
 Restrict access to specified IPs or CIDR blocks. Default is unset (no restriction).
 
+XINFERENCE_HTTP_REQUEST_TIMEOUT
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Maximum seconds allowed to receive a complete HTTP request (headers and body).
+Connections that fail to deliver a full request in time are closed, protecting
+against slow-request denial-of-service attacks such as Slowloris. Streaming
+responses and websockets are not affected. Set to 0 to disable.
+Default value is 120.
+
+XINFERENCE_HTTP_TIMEOUT_KEEP_ALIVE
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Idle timeout (seconds) for keep-alive connections between requests.
+Default value is 5.
+
+XINFERENCE_HTTP_LIMIT_CONCURRENCY
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Maximum number of concurrent connections or tasks the HTTP server allows
+before returning 503 responses. Default is unset (unlimited).
+
 XINFERENCE_BATCH_SIZE
 ~~~~~~~~~~~~~~~~~~~~~
 Default batch size used by the server when batching is enabled.

--- a/xinference/api/restful_api.py
+++ b/xinference/api/restful_api.py
@@ -53,6 +53,9 @@ from ..constants import (
     XINFERENCE_DEFAULT_CANCEL_BLOCK_DURATION,
     XINFERENCE_DEFAULT_ENDPOINT_PORT,
     XINFERENCE_ENABLE_OTEL,
+    XINFERENCE_HTTP_LIMIT_CONCURRENCY,
+    XINFERENCE_HTTP_REQUEST_TIMEOUT,
+    XINFERENCE_HTTP_TIMEOUT_KEEP_ALIVE,
     XINFERENCE_LAUNCH_HISTORY_DB_PATH,
     XINFERENCE_MONITOR_CONFIG_DB_PATH,
     XINFERENCE_SSE_PING_ATTEMPTS_SECONDS,
@@ -63,6 +66,7 @@ from ..constants import (
 )
 from ..core.event import Event, EventCollectorActor, EventType
 from ..core.exceptions import ModelNotReadyError
+from ..core.http_protocol import create_hardened_http_protocol
 from ..core.supervisor import SupervisorActor
 from ..core.utils import CancelMixin
 from ..types import (
@@ -601,6 +605,10 @@ class RESTfulAPI(CancelMixin):
             log_config=logging_conf,
             proxy_headers=True,
             forwarded_allow_ips="*",
+            # Slow HTTP DoS (Slowloris) protection, see xinference/core/http_protocol.py
+            http=create_hardened_http_protocol(XINFERENCE_HTTP_REQUEST_TIMEOUT),
+            timeout_keep_alive=XINFERENCE_HTTP_TIMEOUT_KEEP_ALIVE,
+            limit_concurrency=XINFERENCE_HTTP_LIMIT_CONCURRENCY,
         )
         server = Server(config)
         server.run()

--- a/xinference/api/tests/test_http_request_timeout.py
+++ b/xinference/api/tests/test_http_request_timeout.py
@@ -1,0 +1,180 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the Slow HTTP DoS (Slowloris, CVE-2007-6750) protection."""
+
+import asyncio
+import socket
+import threading
+import time
+
+import pytest
+import uvicorn
+from fastapi import FastAPI
+
+from ...core.http_protocol import RequestDeadlineMixin, create_hardened_http_protocol
+
+REQUEST_TIMEOUT = 2.0
+# Generous upper bound for CI machines under load.
+CLOSE_SLACK = 4.0
+
+
+@pytest.fixture
+def server_port():
+    app = FastAPI()
+
+    @app.get("/")
+    async def ok():
+        return {"ok": True}
+
+    @app.get("/slow")
+    async def slow():
+        # Response takes much longer than the request deadline.
+        await asyncio.sleep(REQUEST_TIMEOUT * 2.5)
+        return {"ok": True}
+
+    protocol = create_hardened_http_protocol(REQUEST_TIMEOUT)
+    assert isinstance(protocol, type)
+    config = uvicorn.Config(
+        app, host="127.0.0.1", port=0, http=protocol, log_level="error"
+    )
+    server = uvicorn.Server(config)
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+    deadline = time.time() + 30
+    while not server.started:
+        assert time.time() < deadline, "test server failed to start"
+        time.sleep(0.05)
+    port = server.servers[0].sockets[0].getsockname()[1]
+    yield port
+    server.should_exit = True
+    thread.join(timeout=10)
+
+
+def _connect(port: int) -> socket.socket:
+    sock = socket.create_connection(("127.0.0.1", port), timeout=5)
+    sock.settimeout(REQUEST_TIMEOUT + CLOSE_SLACK + 5)
+    return sock
+
+
+def _wait_for_close(sock: socket.socket) -> float:
+    """Read until the peer closes; return the elapsed time since call."""
+    start = time.time()
+    while True:
+        data = sock.recv(4096)
+        if not data:
+            return time.time() - start
+
+
+def _read_http_response(sock: socket.socket) -> bytes:
+    """Read one non-chunked HTTP response based on Content-Length."""
+    buf = b""
+    while b"\r\n\r\n" not in buf:
+        chunk = sock.recv(4096)
+        assert chunk, f"connection closed before response completed: {buf!r}"
+        buf += chunk
+    header, _, body = buf.partition(b"\r\n\r\n")
+    content_length = 0
+    for line in header.split(b"\r\n"):
+        if line.lower().startswith(b"content-length:"):
+            content_length = int(line.split(b":", 1)[1])
+    while len(body) < content_length:
+        chunk = sock.recv(4096)
+        assert chunk, "connection closed before body completed"
+        body += chunk
+    return header + b"\r\n\r\n" + body
+
+
+def test_slow_headers_closed(server_port):
+    """An incomplete request must be dropped around the deadline."""
+    sock = _connect(server_port)
+    try:
+        sock.sendall(b"GET / HTTP/1.1\r\nHost: localhost\r\n")  # no final CRLF
+        elapsed = _wait_for_close(sock)
+    finally:
+        sock.close()
+    assert REQUEST_TIMEOUT - 0.5 <= elapsed <= REQUEST_TIMEOUT + CLOSE_SLACK
+
+
+def test_dripping_bytes_closed(server_port):
+    """The deadline is absolute: trickling bytes must not reset it."""
+    sock = _connect(server_port)
+    start = time.time()
+    try:
+        payload = b"GET / HTTP/1.1\r\nHost: localhost\r\nX-A: "
+        closed = False
+        for byte in payload:
+            try:
+                sock.sendall(bytes([byte]))
+            except OSError:
+                closed = True
+                break
+            time.sleep(0.3)
+        if not closed:
+            _wait_for_close(sock)
+        elapsed = time.time() - start
+    finally:
+        sock.close()
+    assert REQUEST_TIMEOUT - 0.5 <= elapsed <= REQUEST_TIMEOUT + CLOSE_SLACK
+
+
+def test_normal_request_ok(server_port):
+    sock = _connect(server_port)
+    try:
+        sock.sendall(b"GET / HTTP/1.1\r\nHost: localhost\r\n\r\n")
+        response = _read_http_response(sock)
+    finally:
+        sock.close()
+    assert response.startswith(b"HTTP/1.1 200")
+
+
+def test_slow_response_not_killed(server_port):
+    """The deadline covers request receipt only, never response duration."""
+    sock = _connect(server_port)
+    try:
+        sock.sendall(b"GET /slow HTTP/1.1\r\nHost: localhost\r\n\r\n")
+        start = time.time()
+        response = _read_http_response(sock)
+        elapsed = time.time() - start
+    finally:
+        sock.close()
+    assert response.startswith(b"HTTP/1.1 200")
+    assert elapsed >= REQUEST_TIMEOUT * 2
+
+
+def test_keep_alive_second_slow_request_closed(server_port):
+    """A slow request on a reused keep-alive connection is also dropped."""
+    sock = _connect(server_port)
+    try:
+        sock.sendall(b"GET / HTTP/1.1\r\nHost: localhost\r\n\r\n")
+        response = _read_http_response(sock)
+        assert response.startswith(b"HTTP/1.1 200")
+        # Second request: incomplete headers.
+        sock.sendall(b"GET / HTTP/1.1\r\nHost: localhost\r\n")
+        elapsed = _wait_for_close(sock)
+    finally:
+        sock.close()
+    assert elapsed <= REQUEST_TIMEOUT + CLOSE_SLACK
+
+
+def test_factory_disabled_returns_auto():
+    assert create_hardened_http_protocol(0) == "auto"
+    assert create_hardened_http_protocol(-1) == "auto"
+
+
+def test_factory_returns_hardened_class():
+    protocol = create_hardened_http_protocol(30)
+    assert isinstance(protocol, type)
+    assert issubclass(protocol, RequestDeadlineMixin)
+    assert protocol.request_timeout == 30.0

--- a/xinference/constants.py
+++ b/xinference/constants.py
@@ -466,3 +466,19 @@ XINFERENCE_RATE_LIMIT_KEY_BAN_SECONDS = int(
 
 # Trusted proxy IPs — only honor X-Forwarded-For/X-Real-IP from these peers
 XINFERENCE_TRUSTED_PROXIES = os.environ.get("XINFERENCE_TRUSTED_PROXIES", "")
+
+# Slow HTTP DoS (Slowloris, CVE-2007-6750) protection: max seconds allowed to
+# receive a complete HTTP request (headers + body). 0 disables the protection.
+XINFERENCE_HTTP_REQUEST_TIMEOUT = float(
+    os.environ.get("XINFERENCE_HTTP_REQUEST_TIMEOUT", "120")
+)
+# Idle keep-alive timeout between requests (passed to uvicorn).
+XINFERENCE_HTTP_TIMEOUT_KEEP_ALIVE = int(
+    os.environ.get("XINFERENCE_HTTP_TIMEOUT_KEEP_ALIVE", "5")
+)
+# Optional cap on concurrent connections/tasks (uvicorn limit_concurrency,
+# requests above the cap get a 503 response). 0 means unlimited.
+_http_limit_concurrency = int(os.environ.get("XINFERENCE_HTTP_LIMIT_CONCURRENCY", "0"))
+XINFERENCE_HTTP_LIMIT_CONCURRENCY = (
+    _http_limit_concurrency if _http_limit_concurrency > 0 else None
+)

--- a/xinference/core/http_protocol.py
+++ b/xinference/core/http_protocol.py
@@ -1,0 +1,160 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import logging
+from typing import Any, Optional, Union
+
+logger = logging.getLogger(__name__)
+
+
+class RequestDeadlineMixin:
+    """Close connections whose HTTP request is not fully received in time.
+
+    Mitigates Slow HTTP DoS attacks (Slowloris, CVE-2007-6750): uvicorn's
+    ``timeout_keep_alive`` only covers idle time *between* requests and is
+    reset on every received byte, so a client trickling one byte at a time
+    can hold a connection open indefinitely. This mixin enforces an absolute
+    deadline of ``request_timeout`` seconds for receiving a complete request
+    (headers and body).
+
+    The deadline only covers request receipt — it is disarmed as soon as the
+    request is fully received, so long-running or streaming responses (e.g.
+    chat completions) and websocket connections are never affected.
+    """
+
+    request_timeout: float = 120.0  # overridden by the factory below
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._deadline_handle: Optional[asyncio.TimerHandle] = None
+        # Snapshot of self.cycle at arm time, used to distinguish a stale
+        # completed cycle from the request currently being received.
+        self._deadline_cycle: Any = None
+        self._deadline_mid_request: bool = False
+
+    def connection_made(self, transport: Any) -> None:
+        super().connection_made(transport)  # type: ignore[misc]
+        self._arm_deadline()
+
+    def data_received(self, data: bytes) -> None:
+        if self._deadline_handle is None:
+            # First bytes of a new request on a keep-alive connection, or
+            # remaining body bytes of a pipelined request.
+            self._arm_deadline()
+        super().data_received(data)  # type: ignore[misc]
+        self._maybe_disarm()
+
+    def connection_lost(self, exc: Optional[Exception]) -> None:
+        self._disarm_deadline()
+        super().connection_lost(exc)  # type: ignore[misc]
+
+    def handle_websocket_upgrade(self, *args: Any) -> None:
+        # The transport is handed over to the websocket protocol class and
+        # this protocol receives no further callbacks, so a live timer here
+        # would later kill the websocket connection. Signature differs
+        # between h11 (event arg) and httptools (no args), hence *args.
+        self._disarm_deadline()
+        return super().handle_websocket_upgrade(*args)  # type: ignore[misc]
+
+    def _arm_deadline(self) -> None:
+        if self.request_timeout <= 0 or self._deadline_handle is not None:
+            return
+        cycle = self.cycle  # type: ignore[attr-defined]
+        self._deadline_cycle = cycle
+        # True when arming while a request body is already in flight
+        # (pipelined request resumed after the previous response finished).
+        self._deadline_mid_request = cycle is not None and cycle.more_body
+        self._deadline_handle = self.loop.call_later(  # type: ignore[attr-defined]
+            self.request_timeout, self._deadline_expired
+        )
+
+    def _disarm_deadline(self) -> None:
+        if self._deadline_handle is not None:
+            self._deadline_handle.cancel()
+            self._deadline_handle = None
+        self._deadline_cycle = None
+        self._deadline_mid_request = False
+
+    def _maybe_disarm(self) -> None:
+        if self._deadline_handle is None:
+            return
+        cycle = self.cycle  # type: ignore[attr-defined]
+        if cycle is None or cycle.more_body:
+            return  # still receiving (or headers not parsed yet)
+        # cycle.more_body is False, which means "request complete" only if
+        # it is a new cycle since arming, or we armed mid-request. A stale
+        # completed cycle (next request's partial headers trickling in on a
+        # keep-alive connection) must NOT disarm the deadline.
+        if self._deadline_mid_request or cycle is not self._deadline_cycle:
+            self._disarm_deadline()
+
+    def _deadline_expired(self) -> None:
+        self._deadline_handle = None
+        transport = self.transport  # type: ignore[attr-defined]
+        if transport is None or transport.is_closing():
+            return
+        client = self.client  # type: ignore[attr-defined]
+        prefix = "%s:%d - " % client if client else ""
+        self.logger.warning(  # type: ignore[attr-defined]
+            "%sClosing connection: HTTP request not received within %.0f "
+            "seconds (slow-request protection).",
+            prefix,
+            self.request_timeout,
+        )
+        transport.close()
+
+
+def create_hardened_http_protocol(request_timeout: float) -> Union[type, str]:
+    """Return a Slowloris-hardened uvicorn HTTP protocol class.
+
+    Returns the string ``"auto"`` (uvicorn's default protocol selection) when
+    ``request_timeout`` is non-positive or the installed uvicorn does not
+    expose the expected protocol internals.
+    """
+    if request_timeout <= 0:
+        return "auto"
+    try:
+        # Mirror uvicorn's "auto" selection: httptools if available, else h11.
+        try:
+            import httptools  # noqa: F401
+            from uvicorn.protocols.http.httptools_impl import HttpToolsProtocol as _Base
+        except ImportError:
+            from uvicorn.protocols.http.h11_impl import (
+                H11Protocol as _Base,  # type: ignore[assignment]
+            )
+
+        # Guard against future uvicorn refactors of internal attributes.
+        for attr in (
+            "connection_made",
+            "data_received",
+            "connection_lost",
+            "on_response_complete",
+            "handle_websocket_upgrade",
+        ):
+            if not hasattr(_Base, attr):
+                raise AttributeError(attr)
+    except Exception as e:  # pragma: no cover - defensive
+        logger.warning(
+            "Cannot enable slow-request protection with the installed "
+            "uvicorn (%s); falling back to the default HTTP protocol.",
+            e,
+        )
+        return "auto"
+
+    class HardenedHTTPProtocol(RequestDeadlineMixin, _Base):  # type: ignore[valid-type, misc]
+        pass
+
+    HardenedHTTPProtocol.request_timeout = float(request_timeout)
+    return HardenedHTTPProtocol

--- a/xinference/core/http_protocol.py
+++ b/xinference/core/http_protocol.py
@@ -140,7 +140,6 @@ def create_hardened_http_protocol(request_timeout: float) -> Union[type, str]:
             "connection_made",
             "data_received",
             "connection_lost",
-            "on_response_complete",
             "handle_websocket_upgrade",
         ):
             if not hasattr(_Base, attr):

--- a/xinference/core/metrics.py
+++ b/xinference/core/metrics.py
@@ -24,6 +24,12 @@ from aioprometheus.asgi.starlette import metrics
 from fastapi import FastAPI
 from fastapi.responses import RedirectResponse
 
+from ..constants import (
+    XINFERENCE_HTTP_REQUEST_TIMEOUT,
+    XINFERENCE_HTTP_TIMEOUT_KEEP_ALIVE,
+)
+from .http_protocol import create_hardened_http_protocol
+
 logger = logging.getLogger(__name__)
 
 DEFAULT_METRICS_SERVER_LOG_LEVEL = "warning"
@@ -679,20 +685,18 @@ def launch_metrics_export_server(q, host=None, port=None):
         return response
 
     async def main():
-        if host is not None and port is not None:
-            config = uvicorn.Config(
-                app, host=host, port=port, log_level=DEFAULT_METRICS_SERVER_LOG_LEVEL
-            )
-        elif host is not None:
-            config = uvicorn.Config(
-                app, host=host, port=0, log_level=DEFAULT_METRICS_SERVER_LOG_LEVEL
-            )
+        kwargs: Dict[str, Any] = {
+            "log_level": DEFAULT_METRICS_SERVER_LOG_LEVEL,
+            # Slow HTTP DoS (Slowloris) protection, see http_protocol.py
+            "http": create_hardened_http_protocol(XINFERENCE_HTTP_REQUEST_TIMEOUT),
+            "timeout_keep_alive": XINFERENCE_HTTP_TIMEOUT_KEEP_ALIVE,
+        }
+        if host is not None:
+            kwargs["host"] = host
+            kwargs["port"] = port if port is not None else 0
         elif port is not None:
-            config = uvicorn.Config(
-                app, port=port, log_level=DEFAULT_METRICS_SERVER_LOG_LEVEL
-            )
-        else:
-            config = uvicorn.Config(app, log_level=DEFAULT_METRICS_SERVER_LOG_LEVEL)
+            kwargs["port"] = port
+        config = uvicorn.Config(app, **kwargs)
 
         server = uvicorn.Server(config)
         task = asyncio.create_task(server.serve())


### PR DESCRIPTION
## What does this PR do?

A security scan flagged the API server (default port 9997) as vulnerable to Slow HTTP DoS (Slowloris, CVE-2007-6750): a single connection sending an incomplete request could be held open for ~290 seconds, allowing an attacker to exhaust server connections cheaply.

Root cause: uvicorn has no timeout covering request transmission. `timeout_keep_alive` only applies to idle time *between* requests and is reset on every received byte (`_unset_keepalive_if_required()` is the first line of `data_received` in both the h11 and httptools implementations), so a client trickling one byte at a time holds the connection indefinitely. ASGI middleware cannot help because it runs only after the request is fully parsed.

### Changes

- **New `xinference/core/http_protocol.py`**: a `RequestDeadlineMixin` and factory that wrap uvicorn's HTTP protocol class (httptools when available, h11 otherwise) to enforce an absolute deadline for receiving a complete request (headers + body). On expiry the connection is closed and a warning is logged.
  - The deadline covers request receipt only — it is disarmed as soon as the request is fully received, so long-running/streaming responses (chat completions) are never affected, and it is disarmed on websocket upgrade.
  - Keep-alive reuse is handled: the deadline re-arms on the first bytes of each subsequent request, with cycle-identity tracking so a completed previous request cannot disarm protection for the next one.
  - If a future uvicorn refactor removes the internals we rely on, the factory logs a warning and falls back to the default protocol instead of failing startup.
- **Wired into both first-party servers**: the main API server (`restful_api.py`) and the worker metrics exporter (`core/metrics.py`).
- **New env vars** (documented in `environments.rst`):
  - `XINFERENCE_HTTP_REQUEST_TIMEOUT` — max seconds to receive a complete request; default 120 (comfortably above legitimate large uploads, well below the scanner's 290s hold); `0` disables.
  - `XINFERENCE_HTTP_TIMEOUT_KEEP_ALIVE` — idle keep-alive timeout, default 5.
  - `XINFERENCE_HTTP_LIMIT_CONCURRENCY` — optional connection/task cap (503 above the cap), unlimited by default.

### Tests

New `xinference/api/tests/test_http_request_timeout.py` (7 tests, raw-socket integration against an in-process uvicorn server with the hardened protocol):

- incomplete headers are dropped at the deadline;
- trickling bytes do not reset the deadline (absolute cutoff);
- normal requests succeed;
- a response taking 2.5x the deadline is delivered in full (deadline never covers responses);
- a slow second request on a reused keep-alive connection is also dropped;
- factory returns `"auto"` when disabled and a hardened class otherwise.

All 7 pass locally; `pre-commit` (black/flake8/isort/mypy/codespell) passes on the changed files. Note: `doc/source/locale/zh_CN` translations for the new env var entries are not included; untranslated strings fall back to English.

### Verification against the original finding

With the server running, an incomplete request (`GET / HTTP/1.1\r\nHost: x\r\n` with no terminating blank line) is now disconnected by the server after ~120s instead of being held indefinitely, so a rescan of the 290s POC fails.
