### PR TITLE
fix: disambiguate replica model UIDs with -rep{n} suffix

### DIFF
--- a/xinference/core/autostart.py
+++ b/xinference/core/autostart.py
@@ -46,7 +46,9 @@ def normalize_launch_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
     model_uid = launch.get("model_uid") or model_name
     if not isinstance(model_uid, str) or not is_valid_model_uid(model_uid):
         raise ValueError(
-            "Autostart launch config requires a non-empty model_uid up to 100 characters."
+            "Autostart launch config requires a non-empty model_uid up to 100 "
+            "characters, not ending with the reserved replica suffix "
+            "'-rep<number>'."
         )
 
     launch["model_name"] = model_name.strip()

--- a/xinference/core/supervisor.py
+++ b/xinference/core/supervisor.py
@@ -1143,7 +1143,9 @@ class SupervisorActor(xo.StatelessActor):
     async def remove_autostart_model(self, model_uid: str) -> Dict[str, Any]:
         if not isinstance(model_uid, str) or not is_valid_model_uid(model_uid):
             raise ValueError(
-                "The model UID is invalid. Please specify the model UID by 0 < length <= 100."
+                "The model UID is invalid. Please specify the model UID by "
+                "0 < length <= 100, not ending with the reserved replica "
+                "suffix '-rep<number>'."
             )
 
         async with self._autostart_store_lock:
@@ -2358,7 +2360,9 @@ class SupervisorActor(xo.StatelessActor):
 
         if not is_valid_model_uid(model_uid):
             raise ValueError(
-                "The model UID is invalid. Please specify the model UID by 0 < length <= 100."
+                "The model UID is invalid. Please specify the model UID by "
+                "0 < length <= 100, not ending with the reserved replica "
+                "suffix '-rep<number>'."
             )
 
         if request_limits is not None and request_limits < 0:
@@ -2550,7 +2554,9 @@ class SupervisorActor(xo.StatelessActor):
 
         if not is_valid_model_uid(model_uid):
             raise ValueError(
-                "The model UID is invalid. Please specify the model UID by 0 < length <= 100."
+                "The model UID is invalid. Please specify the model UID by "
+                "0 < length <= 100, not ending with the reserved replica "
+                "suffix '-rep<number>'."
             )
 
         if request_limits is not None and request_limits < 0:

--- a/xinference/core/supervisor.py
+++ b/xinference/core/supervisor.py
@@ -1366,7 +1366,7 @@ class SupervisorActor(xo.StatelessActor):
             worker_replica_count: Dict[str, int] = defaultdict(int)
             replica_gpu_details: list = []
             for _rep_idx, ref_list in replica_info.replica_to_worker_refs.items():
-                replica_uid = f"{model_uid}-{_rep_idx}"
+                replica_uid = build_replica_model_uid(model_uid, _rep_idx)
                 gpu_indices = self._replica_gpu_cache.get(replica_uid, [])
                 for ref in ref_list:
                     worker_replica_count[ref.address] += 1

--- a/xinference/core/tests/test_launch_strategy.py
+++ b/xinference/core/tests/test_launch_strategy.py
@@ -18,7 +18,7 @@ import random
 import pytest
 
 from xinference.core.launch_strategy import IdleFirstLaunchStrategy
-from xinference.core.utils import assign_replica_gpu
+from xinference.core.utils import assign_replica_gpu, build_replica_model_uid
 
 
 class DummyRef:
@@ -91,14 +91,20 @@ class DummySupervisor:
 def test_assign_replica_gpu_single_slot_reused():
     # single gpu_idx with multiple replicas should be invalid
     with pytest.raises(ValueError):
-        assign_replica_gpu("foo-0", replica=6, gpu_idx=[1])
+        assign_replica_gpu(build_replica_model_uid("foo", 0), replica=6, gpu_idx=[1])
 
 
 def test_assign_replica_gpu_slicing():
     # multiple gpu_idx are sliced by replica id
-    assert assign_replica_gpu("foo-0", replica=3, gpu_idx=[0, 1, 2]) == [0]
-    assert assign_replica_gpu("foo-1", replica=3, gpu_idx=[0, 1, 2]) == [1]
-    assert assign_replica_gpu("foo-2", replica=3, gpu_idx=[0, 1, 2]) == [2]
+    assert assign_replica_gpu(
+        build_replica_model_uid("foo", 0), replica=3, gpu_idx=[0, 1, 2]
+    ) == [0]
+    assert assign_replica_gpu(
+        build_replica_model_uid("foo", 1), replica=3, gpu_idx=[0, 1, 2]
+    ) == [1]
+    assert assign_replica_gpu(
+        build_replica_model_uid("foo", 2), replica=3, gpu_idx=[0, 1, 2]
+    ) == [2]
 
 
 def test_idle_first_prefers_empty_gpu(monkeypatch):
@@ -375,9 +381,10 @@ async def test_terminate_model_replica_updates_active_replica_set():
                 )
             }
             self._replica_model_uid_to_worker = {
-                "demo-model-0": DummyReplicaWorkerRef("w0:1000"),
-                "demo-model-1": DummyReplicaWorkerRef("w1:1000"),
-                "demo-model-2": DummyReplicaWorkerRef("w2:1000"),
+                build_replica_model_uid(
+                    "demo-model", replica_id
+                ): DummyReplicaWorkerRef(f"w{replica_id}:1000")
+                for replica_id in range(3)
             }
             self._status_guard_ref = DummyStatusGuard()
             self._status_guard_ref.replica_counts["demo-model"] = 3
@@ -394,7 +401,10 @@ async def test_terminate_model_replica_updates_active_replica_set():
         0,
         2,
     ]
-    assert "demo-model-1" not in supervisor._replica_model_uid_to_worker
+    assert (
+        build_replica_model_uid("demo-model", 1)
+        not in supervisor._replica_model_uid_to_worker
+    )
     assert next(supervisor._model_uid_to_replica_info["demo-model"].scheduler) == 0
     assert next(supervisor._model_uid_to_replica_info["demo-model"].scheduler) == 2
     assert supervisor._status_guard_ref.updates[-1] == (

--- a/xinference/core/tests/test_utils.py
+++ b/xinference/core/tests/test_utils.py
@@ -17,6 +17,7 @@ from ..utils import (
     build_subpool_envs_for_virtual_env,
     is_valid_model_uid,
     iter_replica_model_uid,
+    parse_legacy_replica_model_uid,
     parse_replica_model_uid,
 )
 from ..virtual_env_manager import (
@@ -59,6 +60,17 @@ def test_is_valid_model_uid_rejects_replica_shaped_names():
     assert is_valid_model_uid("my-model")
     assert not is_valid_model_uid("llama-2-rep0")
     assert not is_valid_model_uid("")
+
+
+def test_parse_legacy_replica_model_uid():
+    """Migration helper for pre--rep{n} recovery files."""
+    assert parse_legacy_replica_model_uid("myllm-0") == ("myllm", 0)
+    assert parse_legacy_replica_model_uid("llama-2-1") == ("llama-2", 1)
+    # Ambiguous by design: bare names ending in digits also match; callers
+    # must verify the base uid against known models.
+    assert parse_legacy_replica_model_uid("llama-2") == ("llama", 2)
+    assert parse_legacy_replica_model_uid("mymodel") is None
+    assert parse_legacy_replica_model_uid("myllm-rep0") is None
 
 
 class DummyVirtualEnvManager:

--- a/xinference/core/tests/test_utils.py
+++ b/xinference/core/tests/test_utils.py
@@ -15,6 +15,7 @@
 from ..utils import (
     build_replica_model_uid,
     build_subpool_envs_for_virtual_env,
+    is_valid_model_uid,
     iter_replica_model_uid,
     parse_replica_model_uid,
 )
@@ -35,6 +36,29 @@ def test_replica_model_uid():
         all_gen_ids.append(replica_model_uid)
     assert len(all_gen_ids) == 5
     assert len(set(all_gen_ids)) == 5
+
+
+def test_parse_replica_model_uid_bare_names_ending_in_digits():
+    """Bare model uids like llama-2 must not be treated as replicas (#5198)."""
+    assert parse_replica_model_uid("llama-2") == ("llama-2", -1)
+    assert parse_replica_model_uid("phi-2") == ("phi-2", -1)
+    assert parse_replica_model_uid("gpt-4") == ("gpt-4", -1)
+    assert parse_replica_model_uid("mymodel") == ("mymodel", -1)
+
+    built = build_replica_model_uid("llama-2", 0)
+    assert built == "llama-2-rep0"
+    assert parse_replica_model_uid(built) == ("llama-2", 0)
+
+    built2 = build_replica_model_uid("gpt-4", 3)
+    assert parse_replica_model_uid(built2) == ("gpt-4", 3)
+    assert build_replica_model_uid(*parse_replica_model_uid(built2)) == built2
+
+
+def test_is_valid_model_uid_rejects_replica_shaped_names():
+    assert is_valid_model_uid("llama-2")
+    assert is_valid_model_uid("my-model")
+    assert not is_valid_model_uid("llama-2-rep0")
+    assert not is_valid_model_uid("")
 
 
 class DummyVirtualEnvManager:

--- a/xinference/core/tests/test_worker.py
+++ b/xinference/core/tests/test_worker.py
@@ -24,7 +24,7 @@ from xoscar import MainActorPoolType, create_actor_pool, get_pool_config
 from ...model.core import VirtualEnvSettings
 from ..status_guard import InstanceInfo, LaunchStatus, ReplicaStatus
 from ..supervisor import ReplicaInfo, SupervisorActor
-from ..utils import build_replica_model_uid, merge_virtual_env_packages
+from ..utils import merge_virtual_env_packages
 from ..worker import WorkerActor
 
 
@@ -390,8 +390,8 @@ async def test_worker_report_status_reconnects_and_replays_running_models(
         cuda_devices=[0],
     )
 
-    model_a_replica_uid = build_replica_model_uid("model-a", 0)
-    model_b_replica_uid = build_replica_model_uid("model-b", 1)
+    model_a_replica_uid = "model-a-rep0"
+    model_b_replica_uid = "model-b-rep1"
     await worker.launch_builtin_model(
         model_a_replica_uid, "mock_model_name", None, None, None, n_gpu=1
     )
@@ -474,7 +474,7 @@ async def test_worker_report_status_refreshes_supervisor_internal_address_on_rec
         cuda_devices=[0],
     )
 
-    replica_model_uid = build_replica_model_uid("model-a", 0)
+    replica_model_uid = "model-a-rep0"
     await worker.launch_builtin_model(
         replica_model_uid, "mock_model_name", None, None, None, n_gpu=1
     )
@@ -576,7 +576,7 @@ async def test_worker_report_status_does_not_refresh_address_when_connection_is_
 async def test_supervisor_add_worker_idempotent_rebuilds_replica_state(monkeypatch):
     supervisor = SupervisorActor()
     supervisor._status_guard_ref = DummyStatusGuardRef()
-    replica_uids = [build_replica_model_uid("model-a", i) for i in range(2)]
+    replica_uids = ["model-a-rep0", "model-a-rep1"]
     worker_ref = DummyReplicaWorkerRef(
         "worker-1",
         models={
@@ -644,7 +644,7 @@ async def test_supervisor_report_worker_status_accepts_registered_worker():
 async def test_supervisor_add_worker_preserves_sharded_replicas_on_replay(monkeypatch):
     supervisor = SupervisorActor()
     supervisor._status_guard_ref = DummyStatusGuardRef()
-    replica_model_uid = build_replica_model_uid("model-s", 0)
+    replica_model_uid = "model-s-rep0"
     shard0 = DummyReplicaWorkerRef(
         "worker-0",
         models={
@@ -710,7 +710,7 @@ async def test_supervisor_add_worker_preserves_sharded_replicas_on_replay(monkey
 async def test_supervisor_add_worker_rebuilds_sharded_replica_order(monkeypatch):
     supervisor = SupervisorActor()
     supervisor._status_guard_ref = DummyStatusGuardRef()
-    replica_model_uid = build_replica_model_uid("model-s", 0)
+    replica_model_uid = "model-s-rep0"
     shard0 = DummyReplicaWorkerRef(
         "worker-0",
         models={
@@ -772,7 +772,7 @@ async def test_supervisor_add_worker_rebuilds_replica_details_after_reconnect(
 ):
     supervisor = SupervisorActor()
     supervisor._status_guard_ref = DummyStatusGuardRef()
-    replica_uids = [build_replica_model_uid("model-a", i) for i in range(2)]
+    replica_uids = ["model-a-rep0", "model-a-rep1"]
     worker_ref = DummyReplicaWorkerRef(
         "worker-1",
         models={
@@ -1684,7 +1684,7 @@ async def test_mark_replica_dead_last_replica_terminates_rank0():
     replica_info.active_replica_ids.append(0)
     replica_info.replica_to_worker_refs[0].append(replica_ref)
     supervisor._model_uid_to_replica_info = {"model-x": replica_info}
-    replica_model_uid = build_replica_model_uid("model-x", 0)
+    replica_model_uid = "model-x-rep0"
     supervisor._replica_model_uid_to_worker = {
         replica_model_uid: replica_ref,
         "model-x-rank0": rank0_ref,
@@ -2005,7 +2005,7 @@ async def test_try_recover_models_marks_ready_via_wait_for_load(monkeypatch):
     import xinference.core.worker as worker_module
 
     monkeypatch.setattr(worker_module, "_strip_test_envs", lambda args: (args, set()))
-    replica_model_uid = build_replica_model_uid("test-model", 0)
+    replica_model_uid = "test-model-rep0"
 
     class _SupervisorRef:
         async def describe_model(self, origin_uid):
@@ -2048,7 +2048,7 @@ async def test_try_recover_models_migrates_legacy_replica_uid(monkeypatch):
 
     monkeypatch.setattr(worker_module, "_strip_test_envs", lambda args: (args, set()))
     legacy_replica_uid = "test-model-0"
-    replica_model_uid = build_replica_model_uid("test-model", 0)
+    replica_model_uid = "test-model-rep0"
 
     class _SupervisorRef:
         def __init__(self):

--- a/xinference/core/tests/test_worker.py
+++ b/xinference/core/tests/test_worker.py
@@ -24,7 +24,7 @@ from xoscar import MainActorPoolType, create_actor_pool, get_pool_config
 from ...model.core import VirtualEnvSettings
 from ..status_guard import InstanceInfo, LaunchStatus, ReplicaStatus
 from ..supervisor import ReplicaInfo, SupervisorActor
-from ..utils import merge_virtual_env_packages
+from ..utils import build_replica_model_uid, merge_virtual_env_packages
 from ..worker import WorkerActor
 
 
@@ -390,11 +390,13 @@ async def test_worker_report_status_reconnects_and_replays_running_models(
         cuda_devices=[0],
     )
 
+    model_a_replica_uid = build_replica_model_uid("model-a", 0)
+    model_b_replica_uid = build_replica_model_uid("model-b", 1)
     await worker.launch_builtin_model(
-        "model-a-0", "mock_model_name", None, None, None, n_gpu=1
+        model_a_replica_uid, "mock_model_name", None, None, None, n_gpu=1
     )
     await worker.launch_builtin_model(
-        "model-b-1", "mock_model_name", None, None, None, n_gpu=None
+        model_b_replica_uid, "mock_model_name", None, None, None, n_gpu=None
     )
 
     first_supervisor = DummySupervisorRef(fail_report_status_times=1)
@@ -425,7 +427,7 @@ async def test_worker_report_status_reconnects_and_replays_running_models(
             addr,
             [
                 {
-                    "replica_model_uid": "model-a-0",
+                    "replica_model_uid": model_a_replica_uid,
                     "n_worker": 1,
                     "shard": 0,
                     "model_uid": "model-a",
@@ -437,7 +439,7 @@ async def test_worker_report_status_reconnects_and_replays_running_models(
                     "instance_created_ts": 1710000000,
                 },
                 {
-                    "replica_model_uid": "model-b-1",
+                    "replica_model_uid": model_b_replica_uid,
                     "n_worker": 1,
                     "shard": 0,
                     "model_uid": "model-b",
@@ -472,8 +474,9 @@ async def test_worker_report_status_refreshes_supervisor_internal_address_on_rec
         cuda_devices=[0],
     )
 
+    replica_model_uid = build_replica_model_uid("model-a", 0)
     await worker.launch_builtin_model(
-        "model-a-0", "mock_model_name", None, None, None, n_gpu=1
+        replica_model_uid, "mock_model_name", None, None, None, n_gpu=1
     )
 
     refreshed_supervisor = DummySupervisorRef()
@@ -514,7 +517,7 @@ async def test_worker_report_status_refreshes_supervisor_internal_address_on_rec
     assert worker_address == addr
     assert replica_model_uids == []
     assert len(replica_states) == 1
-    assert replica_states[0]["replica_model_uid"] == "model-a-0"
+    assert replica_states[0]["replica_model_uid"] == replica_model_uid
     assert replica_states[0]["n_worker"] == 1
     assert replica_states[0]["shard"] == 0
     assert refreshed_supervisor.report_worker_status_calls == [(addr, {"cpu": "ok"})]
@@ -573,11 +576,12 @@ async def test_worker_report_status_does_not_refresh_address_when_connection_is_
 async def test_supervisor_add_worker_idempotent_rebuilds_replica_state(monkeypatch):
     supervisor = SupervisorActor()
     supervisor._status_guard_ref = DummyStatusGuardRef()
+    replica_uids = [build_replica_model_uid("model-a", i) for i in range(2)]
     worker_ref = DummyReplicaWorkerRef(
         "worker-1",
         models={
-            "model-a-0": {"model_uid": "model-a-0", "address": "worker-1"},
-            "model-a-1": {"model_uid": "model-a-1", "address": "worker-1"},
+            replica_uid: {"model_uid": replica_uid, "address": "worker-1"}
+            for replica_uid in replica_uids
         },
     )
 
@@ -588,8 +592,8 @@ async def test_supervisor_add_worker_idempotent_rebuilds_replica_state(monkeypat
     monkeypatch.setattr(xo, "actor_ref", fake_actor_ref)
 
     replica_states = [
-        {"replica_model_uid": "model-a-0", "n_worker": 1, "shard": 0},
-        {"replica_model_uid": "model-a-1", "n_worker": 1, "shard": 0},
+        {"replica_model_uid": replica_uids[0], "n_worker": 1, "shard": 0},
+        {"replica_model_uid": replica_uids[1], "n_worker": 1, "shard": 0},
         {"replica_model_uid": "model-a-rank0", "n_worker": 1, "shard": 0},
     ]
 
@@ -598,8 +602,8 @@ async def test_supervisor_add_worker_idempotent_rebuilds_replica_state(monkeypat
 
     replica_info = supervisor._model_uid_to_replica_info["model-a"]
     assert replica_info.replica == 2
-    assert supervisor._replica_model_uid_to_worker["model-a-0"] is worker_ref
-    assert supervisor._replica_model_uid_to_worker["model-a-1"] is worker_ref
+    assert supervisor._replica_model_uid_to_worker[replica_uids[0]] is worker_ref
+    assert supervisor._replica_model_uid_to_worker[replica_uids[1]] is worker_ref
     assert "model-a-rank0" not in supervisor._replica_model_uid_to_worker
     assert replica_info.replica_to_worker_refs[0] == [worker_ref]
     assert replica_info.replica_to_worker_refs[1] == [worker_ref]
@@ -640,20 +644,31 @@ async def test_supervisor_report_worker_status_accepts_registered_worker():
 async def test_supervisor_add_worker_preserves_sharded_replicas_on_replay(monkeypatch):
     supervisor = SupervisorActor()
     supervisor._status_guard_ref = DummyStatusGuardRef()
+    replica_model_uid = build_replica_model_uid("model-s", 0)
     shard0 = DummyReplicaWorkerRef(
         "worker-0",
-        models={"model-s-0": {"model_uid": "model-s-0", "address": "worker-0"}},
+        models={
+            replica_model_uid: {
+                "model_uid": replica_model_uid,
+                "address": "worker-0",
+            }
+        },
     )
     shard1 = DummyReplicaWorkerRef(
         "worker-1",
-        models={"model-s-0": {"model_uid": "model-s-0", "address": "worker-1"}},
+        models={
+            replica_model_uid: {
+                "model_uid": replica_model_uid,
+                "address": "worker-1",
+            }
+        },
     )
 
     supervisor._worker_address_to_worker = {
         "worker-0": shard0,
         "worker-1": shard1,
     }
-    supervisor._replica_model_uid_to_worker = {"model-s-0": (shard0, shard1)}
+    supervisor._replica_model_uid_to_worker = {replica_model_uid: (shard0, shard1)}
     supervisor._model_uid_to_replica_info = {
         "model-s": ReplicaInfo(replica=1, scheduler=itertools.cycle(range(1)))
     }
@@ -672,10 +687,12 @@ async def test_supervisor_add_worker_preserves_sharded_replicas_on_replay(monkey
 
     await supervisor.add_worker(
         "worker-1",
-        replica_states=[{"replica_model_uid": "model-s-0", "n_worker": 2, "shard": 1}],
+        replica_states=[
+            {"replica_model_uid": replica_model_uid, "n_worker": 2, "shard": 1}
+        ],
     )
 
-    worker_refs = supervisor._replica_model_uid_to_worker["model-s-0"]
+    worker_refs = supervisor._replica_model_uid_to_worker[replica_model_uid]
     assert isinstance(worker_refs, tuple)
     assert worker_refs == (shard0, shard1)
     assert supervisor._model_uid_to_replica_info["model-s"].replica_to_worker_refs[
@@ -693,13 +710,24 @@ async def test_supervisor_add_worker_preserves_sharded_replicas_on_replay(monkey
 async def test_supervisor_add_worker_rebuilds_sharded_replica_order(monkeypatch):
     supervisor = SupervisorActor()
     supervisor._status_guard_ref = DummyStatusGuardRef()
+    replica_model_uid = build_replica_model_uid("model-s", 0)
     shard0 = DummyReplicaWorkerRef(
         "worker-0",
-        models={"model-s-0": {"model_uid": "model-s-0", "address": "worker-0"}},
+        models={
+            replica_model_uid: {
+                "model_uid": replica_model_uid,
+                "address": "worker-0",
+            }
+        },
     )
     shard1 = DummyReplicaWorkerRef(
         "worker-1",
-        models={"model-s-0": {"model_uid": "model-s-0", "address": "worker-1"}},
+        models={
+            replica_model_uid: {
+                "model_uid": replica_model_uid,
+                "address": "worker-1",
+            }
+        },
     )
 
     async def fake_actor_ref(address, uid):
@@ -713,14 +741,18 @@ async def test_supervisor_add_worker_rebuilds_sharded_replica_order(monkeypatch)
 
     await supervisor.add_worker(
         "worker-1",
-        replica_states=[{"replica_model_uid": "model-s-0", "n_worker": 2, "shard": 1}],
+        replica_states=[
+            {"replica_model_uid": replica_model_uid, "n_worker": 2, "shard": 1}
+        ],
     )
     await supervisor.add_worker(
         "worker-0",
-        replica_states=[{"replica_model_uid": "model-s-0", "n_worker": 2, "shard": 0}],
+        replica_states=[
+            {"replica_model_uid": replica_model_uid, "n_worker": 2, "shard": 0}
+        ],
     )
 
-    worker_refs = supervisor._replica_model_uid_to_worker["model-s-0"]
+    worker_refs = supervisor._replica_model_uid_to_worker[replica_model_uid]
     assert isinstance(worker_refs, tuple)
     assert worker_refs == (shard0, shard1)
     assert supervisor._model_uid_to_replica_info["model-s"].replica_to_worker_refs[
@@ -740,11 +772,12 @@ async def test_supervisor_add_worker_rebuilds_replica_details_after_reconnect(
 ):
     supervisor = SupervisorActor()
     supervisor._status_guard_ref = DummyStatusGuardRef()
+    replica_uids = [build_replica_model_uid("model-a", i) for i in range(2)]
     worker_ref = DummyReplicaWorkerRef(
         "worker-1",
         models={
-            "model-a-0": {"model_uid": "model-a-0", "address": "worker-1"},
-            "model-a-1": {"model_uid": "model-a-1", "address": "worker-1"},
+            replica_uid: {"model_uid": replica_uid, "address": "worker-1"}
+            for replica_uid in replica_uids
         },
     )
 
@@ -756,7 +789,7 @@ async def test_supervisor_add_worker_rebuilds_replica_details_after_reconnect(
 
     replica_states = [
         {
-            "replica_model_uid": "model-a-0",
+            "replica_model_uid": replica_uids[0],
             "n_worker": 1,
             "shard": 0,
             "model_uid": "model-a",
@@ -768,7 +801,7 @@ async def test_supervisor_add_worker_rebuilds_replica_details_after_reconnect(
             "instance_created_ts": 1710000001,
         },
         {
-            "replica_model_uid": "model-a-1",
+            "replica_model_uid": replica_uids[1],
             "n_worker": 1,
             "shard": 0,
             "model_uid": "model-a",
@@ -800,10 +833,7 @@ async def test_supervisor_add_worker_rebuilds_replica_details_after_reconnect(
     )
     assert len(replica_statuses) == 2
     assert [status.replica_id for status in replica_statuses] == [0, 1]
-    assert [status.replica_model_uid for status in replica_statuses] == [
-        "model-a-0",
-        "model-a-1",
-    ]
+    assert [status.replica_model_uid for status in replica_statuses] == replica_uids
     assert [status.worker_address for status in replica_statuses] == [
         "worker-1",
         "worker-1",
@@ -1654,19 +1684,20 @@ async def test_mark_replica_dead_last_replica_terminates_rank0():
     replica_info.active_replica_ids.append(0)
     replica_info.replica_to_worker_refs[0].append(replica_ref)
     supervisor._model_uid_to_replica_info = {"model-x": replica_info}
+    replica_model_uid = build_replica_model_uid("model-x", 0)
     supervisor._replica_model_uid_to_worker = {
-        "model-x-0": replica_ref,
+        replica_model_uid: replica_ref,
         "model-x-rank0": rank0_ref,
     }
 
-    await supervisor.mark_replica_dead("model-x-0")
+    await supervisor.mark_replica_dead(replica_model_uid)
 
     # rank0 terminated on the worker and supervisor mapping dropped.
     assert rank0_ref.terminated == ["model-x-rank0"]
     assert "model-x-rank0" not in supervisor._replica_model_uid_to_worker
     # Dead replica evicted and model taken offline.
     assert "model-x" not in supervisor._model_uid_to_replica_info
-    assert "model-x-0" not in supervisor._replica_model_uid_to_worker
+    assert replica_model_uid not in supervisor._replica_model_uid_to_worker
     # Failure gauge marker stays lit (mark_replica_dead must not clear it).
     assert ("model-x", 0) in supervisor._unexpected_down_replicas
 
@@ -1974,9 +2005,7 @@ async def test_try_recover_models_marks_ready_via_wait_for_load(monkeypatch):
     import xinference.core.worker as worker_module
 
     monkeypatch.setattr(worker_module, "_strip_test_envs", lambda args: (args, set()))
-    monkeypatch.setattr(
-        worker_module, "parse_replica_model_uid", lambda uid: ("test-model", 0)
-    )
+    replica_model_uid = build_replica_model_uid("test-model", 0)
 
     class _SupervisorRef:
         async def describe_model(self, origin_uid):
@@ -1990,8 +2019,8 @@ async def test_try_recover_models_marks_ready_via_wait_for_load(monkeypatch):
 
         def _load_persisted_launch_args(self):
             return {
-                "test-model-0": {
-                    "model_uid": "test-model-0",
+                replica_model_uid: {
+                    "model_uid": replica_model_uid,
                     "model_name": "test-model",
                 }
             }
@@ -2010,4 +2039,57 @@ async def test_try_recover_models_marks_ready_via_wait_for_load(monkeypatch):
     await WorkerActor._try_recover_models(worker)
 
     assert worker.launch_called
-    assert worker.wait_for_load_called_with == "test-model-0"
+    assert worker.wait_for_load_called_with == replica_model_uid
+
+
+@pytest.mark.asyncio
+async def test_try_recover_models_migrates_legacy_replica_uid(monkeypatch):
+    import xinference.core.worker as worker_module
+
+    monkeypatch.setattr(worker_module, "_strip_test_envs", lambda args: (args, set()))
+    legacy_replica_uid = "test-model-0"
+    replica_model_uid = build_replica_model_uid("test-model", 0)
+
+    class _SupervisorRef:
+        def __init__(self):
+            self.describe_model_calls = []
+
+        async def describe_model(self, model_uid):
+            self.describe_model_calls.append(model_uid)
+            if model_uid == "test-model":
+                return {"some": "info"}
+            return None
+
+    class _MockWorker:
+        def __init__(self):
+            self._supervisor_ref = _SupervisorRef()
+            self.launch_model_uid = None
+            self.wait_for_load_called_with = None
+
+        def _load_persisted_launch_args(self):
+            return {
+                legacy_replica_uid: {
+                    "model_uid": legacy_replica_uid,
+                    "model_name": "test-model",
+                }
+            }
+
+        async def launch_builtin_model(self, **kwargs):
+            self.launch_model_uid = kwargs["model_uid"]
+            return "mock-subpool-address"
+
+        async def wait_for_load(self, model_uid):
+            self.wait_for_load_called_with = model_uid
+
+        def _persist_launch_args(self):
+            pass
+
+    worker = _MockWorker()
+    await WorkerActor._try_recover_models(worker)
+
+    assert worker._supervisor_ref.describe_model_calls == [
+        legacy_replica_uid,
+        "test-model",
+    ]
+    assert worker.launch_model_uid == replica_model_uid
+    assert worker.wait_for_load_called_with == replica_model_uid

--- a/xinference/core/utils.py
+++ b/xinference/core/utils.py
@@ -163,7 +163,9 @@ def log_sync(logger, level=logging.DEBUG, log_exception=True):
 # Replica suffix must not collide with bare model names that end in
 # "-<digits>" (llama-2, phi-2, gpt-2, ...). See #5198.
 _REPLICA_MODEL_UID_SEP = "-rep"
-_REPLICA_MODEL_UID_RE = re.compile(rf"^(?P<uid>.+){_REPLICA_MODEL_UID_SEP}(?P<rep>\d+)$")
+_REPLICA_MODEL_UID_RE = re.compile(
+    rf"^(?P<uid>.+){_REPLICA_MODEL_UID_SEP}(?P<rep>\d+)$"
+)
 
 
 def iter_replica_model_uid(model_uid: str, replica: int) -> Generator[str, None, None]:
@@ -197,12 +199,34 @@ def parse_replica_model_uid(replica_model_uid: str) -> Tuple[str, int]:
         return match.group("uid"), int(match.group("rep"))
     # No reserved suffix: treat as bare model uid. Do NOT fall back to the
     # legacy "-{n}" split here — that mis-parses real model names like
-    # "llama-2" as ("llama", 2). Legacy in-memory uids built before this
-    # change still round-trip via the pattern only when callers pass a
-    # value that was produced by the old builder AND the base uid itself
-    # never ended in digits; those are rare enough that we prefer correct
-    # bare-name handling.
+    # "llama-2" as ("llama", 2). UIDs built by the old builder therefore no
+    # longer parse as replicas; migration paths that may still see them
+    # (e.g. worker recovery files written by an older version) must handle
+    # the legacy format explicitly via parse_legacy_replica_model_uid.
     return replica_model_uid, -1
+
+
+_LEGACY_REPLICA_MODEL_UID_RE = re.compile(r"^(?P<uid>.+)-(?P<rep>\d+)$")
+
+
+def parse_legacy_replica_model_uid(
+    replica_model_uid: str,
+) -> Optional[Tuple[str, int]]:
+    """
+    Parse the legacy ``{model_uid}-{n}`` replica format used before the
+    reserved ``-rep{n}`` suffix was introduced.
+
+    Only intended for migration paths (e.g. worker recovery files written
+    by an older version). The legacy format is ambiguous by design — a bare
+    model name like ``llama-2`` also matches — so callers must verify that
+    the returned base uid actually refers to a known model before trusting
+    the result. Returns ``None`` when the input does not match the legacy
+    pattern.
+    """
+    match = _LEGACY_REPLICA_MODEL_UID_RE.match(replica_model_uid)
+    if match:
+        return match.group("uid"), int(match.group("rep"))
+    return None
 
 
 def is_valid_model_uid(model_uid: str) -> bool:

--- a/xinference/core/utils.py
+++ b/xinference/core/utils.py
@@ -160,37 +160,58 @@ def log_sync(logger, level=logging.DEBUG, log_exception=True):
     return decorator
 
 
+# Replica suffix must not collide with bare model names that end in
+# "-<digits>" (llama-2, phi-2, gpt-2, ...). See #5198.
+_REPLICA_MODEL_UID_SEP = "-rep"
+_REPLICA_MODEL_UID_RE = re.compile(rf"^(?P<uid>.+){_REPLICA_MODEL_UID_SEP}(?P<rep>\d+)$")
+
+
 def iter_replica_model_uid(model_uid: str, replica: int) -> Generator[str, None, None]:
     """
     Generates all the replica model uids.
     """
     replica = int(replica)
     for rep_id in range(replica):
-        yield f"{model_uid}-{rep_id}"
+        yield build_replica_model_uid(model_uid, rep_id)
 
 
 def build_replica_model_uid(model_uid: str, rep_id: int) -> str:
     """
     Build a replica model uid.
+
+    Uses a reserved ``-rep{n}`` suffix so bare model names that themselves
+    end in ``-<digits>`` (e.g. ``llama-2``) are not ambiguous with a replica
+    index.
     """
-    return f"{model_uid}-{rep_id}"
+    return f"{model_uid}{_REPLICA_MODEL_UID_SEP}{int(rep_id)}"
 
 
 def parse_replica_model_uid(replica_model_uid: str) -> Tuple[str, int]:
     """
     Parse replica model uid to model uid and rep id.
+
+    Returns ``(model_uid, -1)`` when the input has no replica suffix.
     """
-    parts = replica_model_uid.split("-")
-    if len(parts) == 1:
-        return replica_model_uid, -1
-    rep_id = int(parts.pop())
-    model_uid = "-".join(parts)
-    return model_uid, rep_id
+    match = _REPLICA_MODEL_UID_RE.match(replica_model_uid)
+    if match:
+        return match.group("uid"), int(match.group("rep"))
+    # No reserved suffix: treat as bare model uid. Do NOT fall back to the
+    # legacy "-{n}" split here — that mis-parses real model names like
+    # "llama-2" as ("llama", 2). Legacy in-memory uids built before this
+    # change still round-trip via the pattern only when callers pass a
+    # value that was produced by the old builder AND the base uid itself
+    # never ended in digits; those are rare enough that we prefer correct
+    # bare-name handling.
+    return replica_model_uid, -1
 
 
 def is_valid_model_uid(model_uid: str) -> bool:
     model_uid = model_uid.strip()
     if not model_uid or len(model_uid) > 100:
+        return False
+    # Forbid user-supplied uids that look like a replica suffix so they
+    # cannot collide with build_replica_model_uid output.
+    if _REPLICA_MODEL_UID_RE.match(model_uid):
         return False
     return True
 

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -93,12 +93,14 @@ from .resource import gather_node_info
 from .status_guard import StatusGuardActor
 from .utils import (
     apply_engine_virtualenv_settings,
+    build_replica_model_uid,
     build_subpool_envs_for_virtual_env,
     filter_virtualenv_packages_by_markers,
     find_direct_reference_packages,
     log_async,
     log_sync,
     merge_virtual_env_packages,
+    parse_legacy_replica_model_uid,
     parse_replica_model_uid,
     purge_dir,
     rewrite_direct_url_packages_for_index,
@@ -1390,11 +1392,33 @@ class WorkerActor(xo.StatelessActor):
         for model_uid, launch_args in persisted.items():
             try:
                 # Cross-validate: check if supervisor still knows about this model
-                origin_uid, _ = parse_replica_model_uid(model_uid)
+                origin_uid, rep_id = parse_replica_model_uid(model_uid)
                 try:
                     model_info = await supervisor_ref.describe_model(origin_uid)
                 except Exception:
                     model_info = None
+                if model_info is None and rep_id == -1:
+                    # The recovery file may have been written by a version
+                    # that built replica uids as "{uid}-{n}" instead of the
+                    # reserved "-rep{n}" suffix. That format is ambiguous
+                    # (a bare "llama-2" also matches), so only migrate when
+                    # the stripped base uid is a model the supervisor knows.
+                    legacy = parse_legacy_replica_model_uid(model_uid)
+                    if legacy is not None:
+                        try:
+                            model_info = await supervisor_ref.describe_model(legacy[0])
+                        except Exception:
+                            model_info = None
+                        if model_info is not None:
+                            new_uid = build_replica_model_uid(*legacy)
+                            logger.info(
+                                "Migrating legacy replica model uid %s -> %s "
+                                "for recovery",
+                                model_uid,
+                                new_uid,
+                            )
+                            model_uid = new_uid
+                            launch_args["model_uid"] = new_uid
                 if model_info is None:
                     logger.info(
                         "Model %s no longer registered in supervisor, skipping recovery",


### PR DESCRIPTION
## Summary
`parse_replica_model_uid` split on `-` and treated the last segment as a replica index whenever it was numeric. Bare model UIDs that themselves end in `-<digits>` (built-in names such as `llama-2`, `phi-2`, `gpt-2`, `glm-5`, …) were therefore rewritten, e.g. `llama-2` → `("llama", 2)` instead of `("llama-2", -1)`.

That breaks any call site that may receive a bare `model_uid` (worker backend checks, metrics keys, …) even though the `len(parts) == 1` branch was clearly intended to accept non-replica UIDs.

## Change
- Encode replica UIDs as `{model_uid}-rep{n}` via `build_replica_model_uid` / `iter_replica_model_uid`
- Parse only the reserved `-rep{n}` suffix; anything else is a bare UID (`rep_id = -1`)
- Reject user-supplied UIDs that already look like a replica suffix in `is_valid_model_uid`
- Replace the one hardcoded `f"{model_uid}-{_rep_idx}"` in supervisor metrics with the helper
- Unit tests for bare digit-suffixed names + round-trip + validation

## Test plan
- [x] Pure logic assertions for `llama-2` / `phi-2` / `gpt-4` bare parse + `llama-2-rep0` round-trip
- [x] Extended `xinference/core/tests/test_utils.py`
- [ ] CI: `pytest xinference/core/tests/test_utils.py -q`

Fixes #5198


## Upgrade notes (added by maintainer)

Replica UIDs change format from `{uid}-{n}` to `{uid}-rep{n}`, which has two operational consequences:

- **Worker recovery files** written by older versions are migrated automatically: `_try_recover_models` now falls back to the legacy `{uid}-{n}` parse (only when the stripped base UID is a model the supervisor still knows) and rewrites the UID to the new format.
- **Live state is not migrated**: replicas launched by an older version and still running (supervisor restart against old workers, or mixed supervisor/worker versions) cannot be re-tracked, because the old-format UIDs are baked into running actors. Upgrade supervisor and workers together and relaunch models that were running before the upgrade.
