### PR TITLE
fix(pypiserver): emit model source paths with forward slashes

### DIFF
--- a/xinference/deploy/docker/pypiserver/generate_package_lists.py
+++ b/xinference/deploy/docker/pypiserver/generate_package_lists.py
@@ -128,7 +128,10 @@ def iter_virtualenv_packages(
             data = json.loads(json_path.read_text(encoding="utf-8"))
         except (UnicodeDecodeError, json.JSONDecodeError):
             continue
-        rel = str(json_path.relative_to(model_dir))
+        # Use forward slashes so the emitted source labels are identical across
+        # platforms (Path str-ifies with backslashes on Windows), keeping the
+        # generated package lists and their tests portable.
+        rel = json_path.relative_to(model_dir).as_posix()
         for model_name, packages in _walk(data, "<unknown>"):
             yield rel, model_name, packages
 


### PR DESCRIPTION
## Problem

The Windows CI jobs (`build_test_job (windows-latest, 3.10 / 3.13)`) fail on `main` — independently of the PR under test — with:

```
FAILED xinference/deploy/docker/pypiserver/tests/test_scripts.py::test_transformers_optional_dependencies_are_scoped_and_mirrored
AssertionError: assert 'llm/llm_family.json:qwen3.5 (Transformers)' in ['llm\\llm_family.json:...']
```

## Root cause

`generate_package_lists.py` labels each per-model pin with its JSON path:

```python
rel = str(json_path.relative_to(model_dir))
```

`str(Path)` uses OS-native separators, so on Windows this yields backslash labels (`llm\llm_family.json:...`) while Linux/macOS produce forward slashes. This makes the generated package lists platform-dependent and breaks the test, which expects the forward-slash form. Introduced in #5202; it fails on every open PR's Windows jobs because it lives on `main`.

## Fix

Use `Path.as_posix()` so the emitted source labels are identical on every platform.

```python
rel = json_path.relative_to(model_dir).as_posix()
```

## Verification

- The previously failing test passes locally.
- A `PureWindowsPath` simulation confirms the label was `llm\llm_family.json:...` before (fails the assertion) and is `llm/llm_family.json:...` after (matches) — so the Windows jobs will go green.
- `pre-commit` (black/flake8/isort/mypy/codespell) passes.