### PR TITLE
fix(api): cast replica to int to prevent TypeError on multi-replica launch

### DIFF
--- a/xinference/api/restful_api.py
+++ b/xinference/api/restful_api.py
@@ -783,7 +783,7 @@ class RESTfulAPI(CancelMixin):
         model_format = payload.get("model_format")
         quantization = payload.get("quantization")
         model_type = payload.get("model_type", "LLM")
-        replica = payload.get("replica", 1)
+        replica = int(payload.get("replica", 1))
         n_gpu = payload.get("n_gpu", "auto")
         request_limits = payload.get("request_limits", None)
         peft_model_config = payload.get("peft_model_config", None)
@@ -1014,7 +1014,7 @@ class RESTfulAPI(CancelMixin):
         model_engine = payload.get("model_engine")
         model_type = payload.get("model_type")
         model_version = payload.get("model_version")
-        replica = payload.get("replica", 1)
+        replica = int(payload.get("replica", 1))
         n_gpu = payload.get("n_gpu", "auto")
 
         try:

--- a/xinference/api/restful_api.py
+++ b/xinference/api/restful_api.py
@@ -783,7 +783,18 @@ class RESTfulAPI(CancelMixin):
         model_format = payload.get("model_format")
         quantization = payload.get("quantization")
         model_type = payload.get("model_type", "LLM")
-        replica = int(payload.get("replica", 1))
+        try:
+            replica = int(payload.get("replica", 1))
+        except (TypeError, ValueError):
+            raise HTTPException(
+                status_code=400,
+                detail="Invalid input. The `replica` field must be a valid integer.",
+            )
+        if replica < 1:
+            raise HTTPException(
+                status_code=400,
+                detail="Invalid input. The `replica` field must be at least 1.",
+            )
         n_gpu = payload.get("n_gpu", "auto")
         request_limits = payload.get("request_limits", None)
         peft_model_config = payload.get("peft_model_config", None)
@@ -1014,7 +1025,18 @@ class RESTfulAPI(CancelMixin):
         model_engine = payload.get("model_engine")
         model_type = payload.get("model_type")
         model_version = payload.get("model_version")
-        replica = int(payload.get("replica", 1))
+        try:
+            replica = int(payload.get("replica", 1))
+        except (TypeError, ValueError):
+            raise HTTPException(
+                status_code=400,
+                detail="Invalid input. The `replica` field must be a valid integer.",
+            )
+        if replica < 1:
+            raise HTTPException(
+                status_code=400,
+                detail="Invalid input. The `replica` field must be at least 1.",
+            )
         n_gpu = payload.get("n_gpu", "auto")
 
         try:

--- a/xinference/api/restful_api.py
+++ b/xinference/api/restful_api.py
@@ -92,6 +92,49 @@ from .utils import require_model
 logger = logging.getLogger(__name__)
 
 
+def _validate_replica(value: Any) -> int:
+    """Validate and convert the ``replica`` field from a JSON payload.
+
+    Accepts:
+      - ``int`` (but not ``bool``, which is an ``int`` subclass in Python)
+      - ``str`` representing a valid integer
+
+    Rejects:
+      - ``bool`` (``True`` / ``False``)
+      - ``float`` (fractional values, ``Infinity``, ``NaN``)
+      - ``None``
+      - any other non-integral type
+
+    Returns an ``int >= 1``.
+    Raises ``HTTPException(400)`` on invalid input.
+    """
+    if isinstance(value, bool):
+        raise HTTPException(
+            status_code=400,
+            detail="Invalid input. The `replica` field must be an integer, "
+            "got a boolean.",
+        )
+    if isinstance(value, float):
+        raise HTTPException(
+            status_code=400,
+            detail="Invalid input. The `replica` field must be an integer, "
+            "got a float.",
+        )
+    try:
+        replica = int(value)
+    except (TypeError, ValueError, OverflowError):
+        raise HTTPException(
+            status_code=400,
+            detail="Invalid input. The `replica` field must be a valid integer.",
+        )
+    if replica < 1:
+        raise HTTPException(
+            status_code=400,
+            detail="Invalid input. The `replica` field must be at least 1.",
+        )
+    return replica
+
+
 def _log_setup_required_notice() -> None:
     """Log the first-run setup notice, called while setup is pending.
 
@@ -783,18 +826,7 @@ class RESTfulAPI(CancelMixin):
         model_format = payload.get("model_format")
         quantization = payload.get("quantization")
         model_type = payload.get("model_type", "LLM")
-        try:
-            replica = int(payload.get("replica", 1))
-        except (TypeError, ValueError):
-            raise HTTPException(
-                status_code=400,
-                detail="Invalid input. The `replica` field must be a valid integer.",
-            )
-        if replica < 1:
-            raise HTTPException(
-                status_code=400,
-                detail="Invalid input. The `replica` field must be at least 1.",
-            )
+        replica = _validate_replica(payload.get("replica", 1))
         n_gpu = payload.get("n_gpu", "auto")
         request_limits = payload.get("request_limits", None)
         peft_model_config = payload.get("peft_model_config", None)
@@ -1025,18 +1057,7 @@ class RESTfulAPI(CancelMixin):
         model_engine = payload.get("model_engine")
         model_type = payload.get("model_type")
         model_version = payload.get("model_version")
-        try:
-            replica = int(payload.get("replica", 1))
-        except (TypeError, ValueError):
-            raise HTTPException(
-                status_code=400,
-                detail="Invalid input. The `replica` field must be a valid integer.",
-            )
-        if replica < 1:
-            raise HTTPException(
-                status_code=400,
-                detail="Invalid input. The `replica` field must be at least 1.",
-            )
+        replica = _validate_replica(payload.get("replica", 1))
         n_gpu = payload.get("n_gpu", "auto")
 
         try:

--- a/xinference/api/tests/test_replica_validation.py
+++ b/xinference/api/tests/test_replica_validation.py
@@ -1,0 +1,119 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the ``_validate_replica`` helper and its integration in REST endpoints."""
+
+import math
+
+import pytest
+from fastapi import HTTPException
+
+from ..restful_api import _validate_replica
+
+
+class TestValidateReplica:
+    """Unit tests for ``_validate_replica``."""
+
+    # -- valid inputs -----------------------------------------------------------
+
+    @pytest.mark.parametrize(
+        "value, expected",
+        [
+            (1, 1),
+            (999, 999),
+            (42, 42),
+            pytest.param(  # The frontend sends string numbers
+                "2", 2, id="string_digit"
+            ),
+            pytest.param("10", 10, id="string_number"),
+        ],
+    )
+    def test_valid_input(self, value, expected):
+        assert _validate_replica(value) == expected
+
+    # -- default value ----------------------------------------------------------
+
+    def test_default_one(self):
+        """When the key is absent, ``payload.get("replica", 1)`` passes ``1``."""
+        assert _validate_replica(1) == 1
+
+    # -- rejected: bool ---------------------------------------------------------
+
+    @pytest.mark.parametrize("value", [True, False])
+    def test_rejects_boolean(self, value):
+        with pytest.raises(HTTPException) as exc:
+            _validate_replica(value)
+        assert exc.value.status_code == 400
+        assert "boolean" in exc.value.detail
+
+    # -- rejected: float --------------------------------------------------------
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            1.9,
+            0.5,
+            -3.0,
+            pytest.param(math.inf, id="infinity"),
+            pytest.param(-math.inf, id="negative_infinity"),
+            pytest.param(math.nan, id="nan"),
+        ],
+    )
+    def test_rejects_float(self, value):
+        with pytest.raises(HTTPException) as exc:
+            _validate_replica(value)
+        assert exc.value.status_code == 400
+        assert "float" in exc.value.detail
+
+    # -- rejected: None ---------------------------------------------------------
+
+    def test_rejects_none(self):
+        with pytest.raises(HTTPException) as exc:
+            _validate_replica(None)
+        assert exc.value.status_code == 400
+
+    # -- rejected: non-integer strings ------------------------------------------
+
+    @pytest.mark.parametrize("value", ["abc", "", "1.5", "0x10"])
+    def test_rejects_invalid_string(self, value):
+        with pytest.raises(HTTPException) as exc:
+            _validate_replica(value)
+        assert exc.value.status_code == 400
+
+    # -- rejected: value below 1 ------------------------------------------------
+
+    @pytest.mark.parametrize("value", [0, -1, -100])
+    def test_rejects_less_than_one(self, value):
+        with pytest.raises(HTTPException) as exc:
+            _validate_replica(value)
+        assert exc.value.status_code == 400
+        assert "at least 1" in exc.value.detail
+
+    # -- rejected: unsupported types --------------------------------------------
+
+    @pytest.mark.parametrize("value", [[], {}, b"bytes"])
+    def test_rejects_unsupported_types(self, value):
+        with pytest.raises(HTTPException) as exc:
+            _validate_replica(value)
+        assert exc.value.status_code == 400
+
+    # -- edge: very large float (OverflowError path) ----------------------------
+
+    def test_overflow_error_path(self):
+        """``int(float("inf"))`` would raise ``OverflowError`` if it reached
+        ``int()``, but our float guard rejects it before that point."""
+        with pytest.raises(HTTPException) as exc:
+            _validate_replica(float("inf"))
+        assert exc.value.status_code == 400
+        assert "float" in exc.value.detail


### PR DESCRIPTION

## Summary

Fix a `TypeError: \x27str\x27 object cannot be interpreted as an integer` when launching a model with `replica > 1` via the REST API.

## Root cause

The frontend submits `replica` as a string in the JSON body (e.g. `"replica": "2"`). `payload.get("replica", 1)` returns the raw string, and `list(range("2"))` raises `TypeError`.

Single-replica deployments are unaffected because the frontend usually omits the field entirely, so the default `1` (int) is used.

## Fix

Wrap `payload.get("replica", 1)` with `int()` in both `launch_model()` and `launch_model_by_version()`:

```python
# before
replica = payload.get("replica", 1)

# after
replica = int(payload.get("replica", 1))
```

This handles both integer (`int(1) -> 1`) and string (`int("2") -> 2`) inputs safely.

## Backward compatibility

✅ Fully compatible — `int(1)` is a no-op, `int("2")` produces the correct integer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)