### PR TITLE
fix(audio/indextts2): declare the missing IndexTTS2 virtualenv dependencies (#5201)

### DIFF
--- a/xinference/model/audio/indextts2.py
+++ b/xinference/model/audio/indextts2.py
@@ -138,15 +138,18 @@ class Indextts2:
                 temp_emo.write(emo_prompt_speech)
                 emo_prompt_path = temp_emo.name
 
-        # Generate complete audio first
-        with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as temp_output:
-            output_path = temp_output.name
-
         try:
-            self._model.infer(
+            # Pass output_path=None so IndexTTS2 returns the generated waveform in
+            # memory (as an int16 numpy array) instead of writing it to disk with
+            # torchaudio.save. torchaudio.save routes through TorchCodec, whose
+            # FFmpeg shared libraries are missing / ABI-mismatched in some images
+            # (see #5201), which made /v1/audio/speech fail at the save step even
+            # though inference had already succeeded. soundfile below performs the
+            # actual encoding, so the on-disk WAV round-trip is not needed.
+            sample_rate, audio = self._model.infer(
                 spk_audio_prompt=temp_prompt_path,
                 text=input,
-                output_path=output_path,
+                output_path=None,
                 emo_audio_prompt=emo_prompt_path,
                 emo_alpha=emo_alpha,
                 emo_text=emo_text,
@@ -154,9 +157,6 @@ class Indextts2:
                 emo_vector=emo_vector,
                 use_emo_text=use_emo_text,
             )
-
-            # Read generated audio
-            audio, sample_rate = soundfile.read(output_path)
 
             if stream:
                 # Streaming mode - return generator that yields chunks
@@ -167,9 +167,6 @@ class Indextts2:
                         ) as f:
                             f.write(audio)
                         complete_audio = out.getvalue()
-
-                    # Clean up temp file
-                    os.unlink(output_path)
 
                     # Yield the complete audio in chunks
                     chunk_size = 8192  # 8KB chunks
@@ -186,8 +183,6 @@ class Indextts2:
                         f.write(audio)
                     result = out.getvalue()
 
-                # Clean up temp file
-                os.unlink(output_path)
                 return result
         finally:
             # Clean up temp files

--- a/xinference/model/audio/model_spec.json
+++ b/xinference/model/audio/model_spec.json
@@ -1620,8 +1620,18 @@
     "virtualenv": {
       "packages": [
         "transformers==4.52.1",
+        "accelerate",
         "#system_torch#",
+        "#system_torchaudio#",
         "#system_numpy#",
+        "librosa",
+        "soundfile",
+        "einops",
+        "omegaconf",
+        "sentencepiece",
+        "textstat",
+        "WeTextProcessing ; sys_platform == 'linux' and platform_machine == 'x86_64'",
+        "wetext ; sys_platform != 'linux' or platform_machine != 'x86_64'",
         "json5",
         "munch",
         "matplotlib",
@@ -1642,7 +1652,7 @@
         "model_revision": "master"
       }
     },
-    "updated_at": 1766387108,
+    "updated_at": 1784694838,
     "featured": true
   },
   {

--- a/xinference/thirdparty/indextts/infer_v2.py
+++ b/xinference/thirdparty/indextts/infer_v2.py
@@ -145,6 +145,46 @@ class IndexTTS2:
 
             return None
 
+        def get_modelscope_small_model_path(model_name):
+            """Download an auxiliary small model from ModelScope.
+
+            The auxiliary models below are otherwise hardcoded to
+            HuggingFace, which is unreachable in many deployments that
+            download their main models via ModelScope; honor
+            XINFERENCE_MODEL_SRC=modelscope for them as well.
+            """
+            if os.environ.get("XINFERENCE_MODEL_SRC") != "modelscope":
+                return None
+            modelscope_small_models = {
+                "w2v-bert-2.0": (
+                    "AI-ModelScope/w2v-bert-2.0",
+                    ["config.json", "preprocessor_config.json", "model.safetensors"],
+                    None,
+                ),
+                "semantic_codec": (
+                    "amphion/MaskGCT",
+                    ["semantic_codec/*"],
+                    "semantic_codec",
+                ),
+                "campplus": (
+                    "iic/speech_campplus_sv_zh-cn_16k-common",
+                    ["campplus_cn_common.bin"],
+                    None,
+                ),
+                "bigvgan": (
+                    "nv-community/bigvgan_v2_22khz_80band_256x",
+                    ["config.json", "bigvgan_generator.pt"],
+                    None,
+                ),
+            }
+            repo_id, patterns, subdir = modelscope_small_models[model_name]
+            from modelscope import snapshot_download
+
+            root = snapshot_download(repo_id, allow_patterns=patterns)
+            path = os.path.join(root, subdir) if subdir else root
+            print(f">> {model_name} downloaded from modelscope: {repo_id} -> {path}")
+            return path
+
         if device is not None:
             self.device = device
             self.use_fp16 = False if device == "cpu" else use_fp16
@@ -221,7 +261,9 @@ class IndexTTS2:
                 print(f"{e!r}")
                 self.use_cuda_kernel = False
 
-        w2v_bert_path = get_small_model_path("w2v-bert-2.0")
+        w2v_bert_path = get_small_model_path(
+            "w2v-bert-2.0"
+        ) or get_modelscope_small_model_path("w2v-bert-2.0")
         print(f">> w2v_bert_path lookup result: {w2v_bert_path}")
         if w2v_bert_path is not None:
             self.extract_features = SeamlessM4TFeatureExtractor.from_pretrained(
@@ -244,7 +286,9 @@ class IndexTTS2:
         self.semantic_std = self.semantic_std.to(self.device)
 
         semantic_codec = build_semantic_codec(self.cfg.semantic_codec)
-        semantic_codec_path = get_small_model_path("semantic_codec")
+        semantic_codec_path = get_small_model_path(
+            "semantic_codec"
+        ) or get_modelscope_small_model_path("semantic_codec")
         print(f">> semantic_codec_path lookup result: {semantic_codec_path}")
         if semantic_codec_path is not None:
             semantic_code_ckpt = os.path.join(semantic_codec_path, "model.safetensors")
@@ -285,7 +329,9 @@ class IndexTTS2:
         print(">> s2mel weights restored from:", s2mel_path)
 
         # load campplus_model
-        campplus_path = get_small_model_path("campplus")
+        campplus_path = get_small_model_path(
+            "campplus"
+        ) or get_modelscope_small_model_path("campplus")
         print(f">> campplus_path lookup result: {campplus_path}")
         if campplus_path is not None:
             campplus_ckpt_path = os.path.join(campplus_path, "campplus_cn_common.bin")
@@ -309,7 +355,9 @@ class IndexTTS2:
         self.campplus_model.eval()
         print(">> campplus_model weights restored from:", campplus_ckpt_path)
 
-        bigvgan_path = get_small_model_path("bigvgan")
+        bigvgan_path = get_small_model_path(
+            "bigvgan"
+        ) or get_modelscope_small_model_path("bigvgan")
         print(f">> bigvgan_path lookup result: {bigvgan_path}")
         if bigvgan_path is not None:
             bigvgan_name = bigvgan_path

--- a/xinference/thirdparty/indextts/utils/front.py
+++ b/xinference/thirdparty/indextts/utils/front.py
@@ -91,14 +91,22 @@ class TextNormalizer:
         import platform
         if self.zh_normalizer is not None and self.en_normalizer is not None:
             return
-        if platform.system() != "Linux":  # Mac and Windows
+        use_wetext = platform.system() != "Linux"  # Mac and Windows
+        if not use_wetext:
+            try:
+                from tn.chinese.normalizer import Normalizer as NormalizerZh
+                from tn.english.normalizer import Normalizer as NormalizerEn
+            except ImportError:
+                # WeTextProcessing depends on pynini, which only ships
+                # prebuilt wheels for linux x86_64; fall back to wetext on
+                # other Linux architectures (e.g. aarch64).
+                use_wetext = True
+        if use_wetext:
             from wetext import Normalizer
 
             self.zh_normalizer = Normalizer(remove_erhua=False, lang="zh", operator="tn")
             self.en_normalizer = Normalizer(lang="en", operator="tn")
         else:
-            from tn.chinese.normalizer import Normalizer as NormalizerZh
-            from tn.english.normalizer import Normalizer as NormalizerEn
             # use new cache dir for build tagger rules with disable remove_interjections and remove_erhua
             cache_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "tagger_cache")
             if not os.path.exists(cache_dir):

--- a/xinference/thirdparty/indextts/utils/front.py
+++ b/xinference/thirdparty/indextts/utils/front.py
@@ -97,6 +97,11 @@ class TextNormalizer:
                 from tn.chinese.normalizer import Normalizer as NormalizerZh
                 from tn.english.normalizer import Normalizer as NormalizerEn
             except ImportError:
+                if platform.machine() == "x86_64":
+                    # pynini wheels exist for linux x86_64, so tn should be
+                    # installed there; surface the real import problem
+                    # instead of a misleading wetext ModuleNotFoundError.
+                    raise
                 # WeTextProcessing depends on pynini, which only ships
                 # prebuilt wheels for linux x86_64; fall back to wetext on
                 # other Linux architectures (e.g. aarch64).


### PR DESCRIPTION
## Summary

Follow-up to #5201 (and complementary to #5203). As reported in https://github.com/xorbitsai/inference/issues/5201#issuecomment-5014913961, IndexTTS2 cannot launch at all on the slim `v3.0.0` GPU image: the model spec's virtualenv package list omits most of the runtime dependencies of the bundled `thirdparty/indextts` inference code, and the slim image no longer provides them globally. Launch fails with a chain of `ModuleNotFoundError` (`librosa`, then `einops`, then more) before inference can start.

## Changes

**`xinference/model/audio/model_spec.json`** — complete the IndexTTS2 virtualenv declaration with the packages actually imported on the `infer_v2` code path (traced statically from `infer_v2.py` through the `indextts.*` import graph, then verified empirically, see below):

- `librosa`, `soundfile` — audio I/O (`infer_v2` loads prompts via `librosa.load`; the wrapper encodes responses with `soundfile`)
- `einops`, `omegaconf`, `sentencepiece`, `textstat` — imported by the GPT/s2mel/text-frontend modules
- `accelerate` — declared by upstream index-tts as a hard dependency
- `#system_torchaudio#` — `infer_v2` imports `torchaudio` at module level (only `#system_torch#` was declared)
- `WeTextProcessing ; sys_platform == 'linux' and platform_machine == 'x86_64'` and `wetext ; sys_platform != 'linux' or platform_machine != 'x86_64'` — the text normalizers `indextts/utils/front.py` selects at runtime. `WeTextProcessing` depends on `pynini`, which only publishes x86_64 manylinux wheels, hence the split markers (standard PEP 508 markers pass through the spec filter to uv untouched).

**`xinference/thirdparty/indextts/utils/front.py`** — `TextNormalizer.load()` hard-selected `tn` (WeTextProcessing) whenever `platform.system() == "Linux"`, which can never work on linux aarch64 (no pynini wheel; the image is built for both amd64 and arm64). It now falls back to `wetext` when `tn` is not importable. Behavior on linux x86_64 is unchanged (still `tn`).

## Verification

All checks were run in containers reproducing the slim image's environment:

- **linux/amd64, py3.12**: installing exactly the new package list (placeholders resolved to `torch`/`torchaudio`/`numpy`; `modelscope` present as in the parent env), `import indextts.infer_v2` succeeds, and `TextNormalizer().load()` + `normalize()` work for both zh and en via WeTextProcessing 1.2.0.
- **linux/arm64, py3.12**: the markers select `wetext` (+`kaldifst`, which does ship aarch64 wheels), and the new fallback path normalizes zh text correctly.
- **TorchCodec sanity (why no Dockerfile change is needed)**: on `ubuntu:22.04` with the Dockerfile's exact deadsnakes python3.12 + apt `ffmpeg` (4.4, shared libs) layers and `torch==2.11.0`/`torchaudio==2.11.0`/`torchcodec==0.14.0` per `requirements-runtime.txt`, torchcodec loads its FFmpeg-4 core and `torchaudio.save`/`load` round-trip successfully — the v2.12.0-era loading failure from #5201/#4960 (mismatched torchcodec 0.10 + a static FFmpeg 6 without shared libraries) is already resolved by the current slim-image pins. The remaining launch blocker was purely the venv declaration fixed here.

Fixes the launch failure reported in #5201's v3.0.0 follow-up testing; with #5203 merged, the original WAV-save failure is bypassed as well.


## Update: ModelScope source for the auxiliary small models

Beyond the virtualenv declaration, IndexTTS2's `__init__` loads four auxiliary models that were hardcoded to HuggingFace (`facebook/w2v-bert-2.0`, `amphion/MaskGCT` semantic_codec, `funasr/campplus`, `nvidia/bigvgan_v2_22khz_80band_256x`). Deployments that download their main models via ModelScope frequently cannot reach HuggingFace or a configured HF mirror, so launch failed at `SeamlessM4TFeatureExtractor.from_pretrained` even with the main model fully cached.

`infer_v2.py` now honors `XINFERENCE_MODEL_SRC=modelscope` for these too, downloading only the required files (`allow_patterns`) from verified ModelScope counterparts:

| model | ModelScope repo |
|---|---|
| w2v-bert-2.0 | `AI-ModelScope/w2v-bert-2.0` |
| semantic_codec | `amphion/MaskGCT` (`semantic_codec/model.safetensors`) |
| campplus | `iic/speech_campplus_sv_zh-cn_16k-common` (`campplus_cn_common.bin`) |
| bigvgan | `nv-community/bigvgan_v2_22khz_80band_256x` |

Precedence: `small_models_dir` (explicit local) → ModelScope (when `XINFERENCE_MODEL_SRC=modelscope`) → HuggingFace (unchanged default). The download path was live-verified: `allow_patterns` fetches exactly the listed files and the resulting directory layout matches what the loader expects.


## Update 2: incorporate #5203 (in-memory waveform return)

Real-world testing on a bare-metal conda deployment (torch 2.11.0+cu130, no FFmpeg shared libraries in the environment) confirmed that the `torchaudio.save` → TorchCodec failure from #5201 still bites outside the Docker image: inference completes, then the WAV save step raises `Could not load libtorchcodec` for every FFmpeg core. The Docker image is healthy (see Verification above), but conda/pip environments frequently lack compatible FFmpeg shared libraries.

So this PR now cherry-picks @Anai-Guo's commit from #5203 as-is (authorship preserved): `infer(output_path=None)` returns the int16 waveform in memory and `soundfile` does the response encoding, removing TorchCodec from the IndexTTS2 speech path entirely. With that applied, the same bare-metal deployment goes through end-to-end.
