### PR TITLE
ci: use merge-base diff for PR GPU tests

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -79,9 +79,13 @@ jobs:
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             base_sha="${{ github.event.pull_request.base.sha }}"
             head_sha="${{ github.event.pull_request.head.sha }}"
+            # Match GitHub's PR diff: exclude commits added to the base branch
+            # after the PR branch diverged.
+            diff_range="$base_sha...$head_sha"
           else
             base_sha="${{ github.event.before }}"
             head_sha="${{ github.sha }}"
+            diff_range="$base_sha..$head_sha"
           fi
 
           full=false
@@ -90,7 +94,7 @@ jobs:
           # Fall back to a full run when there is no usable diff base (new
           # branch, or a force push whose previous head no longer exists).
           if [ -z "$base_sha" ] || [[ "$base_sha" =~ ^0+$ ]] \
-              || ! git diff --name-only "$base_sha" "$head_sha" > changed-files.txt 2>/dev/null; then
+              || ! git diff --name-only "$diff_range" > changed-files.txt 2>/dev/null; then
             full=true
           else
             # Map each changed path to the GPU test group(s) it affects.


### PR DESCRIPTION
## Summary

- use a merge-base (three-dot) diff when detecting GPU-relevant pull request changes
- preserve the existing two-point diff behavior for push events

## Root cause

The workflow compared the pull request base tip directly with the head tip. When the base branch advanced after the pull request branch diverged, files changed only on the base branch appeared in `changed-files.txt`. Shared API or core files then selected all GPU test groups even for a frontend-only pull request.

## Impact

Frontend-only pull requests no longer consume the GPU runner because of unrelated commits added to `main` after branch divergence.

## Validation

- replayed PR #5222 with its event base/head SHAs: detection changed from 18 files, including unrelated API/core files, to the correct 11 frontend-only files
- verified the push two-point range produces the same file set as the previous push comparison
- parsed `.github/workflows/python.yaml` with PyYAML
- ran `git diff --check`
