### PR TITLE
feat(webui): add auto-refresh to audit center

### DIFF
--- a/frontend/src/components/pages/audit-center/index.tsx
+++ b/frontend/src/components/pages/audit-center/index.tsx
@@ -203,7 +203,6 @@ export default function AuditCenter() {
   const [selectedRecord, setSelectedRecord] = useState<AuditRecord | null>(null);
   const requestSeqRef = useRef(0);
   const [refreshInterval, setRefreshInterval] = useState(0);
-  const refreshTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const queryParams = useMemo(() => {
     const params = new URLSearchParams();
@@ -223,9 +222,13 @@ export default function AuditCenter() {
     return params;
   }, [filters, pageFrom, timeRange]);
 
-  const fetchAuditRecords = useCallback(async () => {
+  const fetchAuditRecords = useCallback(async (silent = false) => {
     const seq = ++requestSeqRef.current;
-    setLoading(true);
+    // Background refreshes stay silent so the table does not flip to the
+    // loading spinner every interval; only user-initiated fetches show it.
+    if (!silent) {
+      setLoading(true);
+    }
     try {
       const data = await request.get<AuditSearchResponse>(
         '/v1/audit/search?' + queryParams.toString()
@@ -252,16 +255,10 @@ export default function AuditCenter() {
   }, [fetchAuditRecords]);
 
   useEffect(() => {
-    if (refreshTimerRef.current) {
-      clearInterval(refreshTimerRef.current);
-      refreshTimerRef.current = null;
-    }
     if (refreshInterval > 0) {
-      refreshTimerRef.current = setInterval(() => fetchAuditRecords(), refreshInterval);
+      const timer = setInterval(() => fetchAuditRecords(true), refreshInterval);
+      return () => clearInterval(timer);
     }
-    return () => {
-      if (refreshTimerRef.current) clearInterval(refreshTimerRef.current);
-    };
   }, [fetchAuditRecords, refreshInterval]);
 
   useEffect(() => {
@@ -373,7 +370,7 @@ export default function AuditCenter() {
                   variant="outline"
                   size="icon"
                   aria-label={t('auditCenter.refresh')}
-                  onClick={fetchAuditRecords}
+                  onClick={() => fetchAuditRecords()}
                   disabled={loading}
                 >
                   <RefreshCw className={cn('size-4', loading && 'animate-spin')} />

--- a/frontend/src/components/pages/audit-center/index.tsx
+++ b/frontend/src/components/pages/audit-center/index.tsx
@@ -32,7 +32,8 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table';
-import { DEFAULT_LOG_TIME_RANGE } from '@/constants/logs';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { DEFAULT_LOG_TIME_RANGE, LOG_REFRESH_OPTIONS } from '@/constants/logs';
 import { useI18n } from '@/contexts/i18n-context';
 import request from '@/lib/request';
 import { cn, copyToClipboard } from '@/lib/utils';
@@ -201,6 +202,8 @@ export default function AuditCenter() {
   const [pageFrom, setPageFrom] = useState(0);
   const [selectedRecord, setSelectedRecord] = useState<AuditRecord | null>(null);
   const requestSeqRef = useRef(0);
+  const [refreshInterval, setRefreshInterval] = useState(0);
+  const refreshTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const queryParams = useMemo(() => {
     const params = new URLSearchParams();
@@ -247,6 +250,19 @@ export default function AuditCenter() {
   useEffect(() => {
     fetchAuditRecords();
   }, [fetchAuditRecords]);
+
+  useEffect(() => {
+    if (refreshTimerRef.current) {
+      clearInterval(refreshTimerRef.current);
+      refreshTimerRef.current = null;
+    }
+    if (refreshInterval > 0) {
+      refreshTimerRef.current = setInterval(() => fetchAuditRecords(), refreshInterval);
+    }
+    return () => {
+      if (refreshTimerRef.current) clearInterval(refreshTimerRef.current);
+    };
+  }, [fetchAuditRecords, refreshInterval]);
 
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -350,10 +366,33 @@ export default function AuditCenter() {
               setPageFrom(0);
             }}
           />
-          <Button variant="outline" onClick={fetchAuditRecords} disabled={loading}>
-            <RefreshCw className={cn('mr-2 h-4 w-4', loading && 'animate-spin')} />
-            {t('auditCenter.refresh')}
-          </Button>
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="outline"
+                  size="icon"
+                  aria-label={t('auditCenter.refresh')}
+                  onClick={fetchAuditRecords}
+                  disabled={loading}
+                >
+                  <RefreshCw className={cn('size-4', loading && 'animate-spin')} />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>{t('auditCenter.refresh')}</TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+          <Select
+            value={refreshInterval}
+            onChange={(value) => setRefreshInterval(Number(value || 0))}
+            options={LOG_REFRESH_OPTIONS.map((option) => ({
+              value: option.value,
+              label: t(option.labelKey),
+              prefix: <RefreshCw className="size-4" />,
+            }))}
+            allowClear={false}
+            className="w-32"
+          />
         </div>
       }
     >

--- a/frontend/src/components/pages/audit-center/index.tsx
+++ b/frontend/src/components/pages/audit-center/index.tsx
@@ -202,6 +202,9 @@ export default function AuditCenter() {
   const [pageFrom, setPageFrom] = useState(0);
   const [selectedRecord, setSelectedRecord] = useState<AuditRecord | null>(null);
   const requestSeqRef = useRef(0);
+  // Tracks whether the latest fetch is still pending so the auto-refresh
+  // interval can skip a tick instead of stacking overlapping requests.
+  const inFlightRef = useRef(false);
   const [refreshInterval, setRefreshInterval] = useState(0);
 
   const queryParams = useMemo(() => {
@@ -224,6 +227,7 @@ export default function AuditCenter() {
 
   const fetchAuditRecords = useCallback(async (silent = false) => {
     const seq = ++requestSeqRef.current;
+    inFlightRef.current = true;
     // Background refreshes stay silent so the table does not flip to the
     // loading spinner every interval; only user-initiated fetches show it.
     if (!silent) {
@@ -239,12 +243,16 @@ export default function AuditCenter() {
         setTotal(data.total || 0);
       }
     } catch {
-      if (seq === requestSeqRef.current) {
+      // A transient failure during a silent background refresh must not wipe
+      // the table — keep the last good results. Foreground (user-initiated)
+      // fetches keep the original clear-on-error behavior.
+      if (!silent && seq === requestSeqRef.current) {
         setRecords([]);
         setTotal(0);
       }
     } finally {
       if (seq === requestSeqRef.current) {
+        inFlightRef.current = false;
         setLoading(false);
       }
     }
@@ -256,7 +264,13 @@ export default function AuditCenter() {
 
   useEffect(() => {
     if (refreshInterval > 0) {
-      const timer = setInterval(() => fetchAuditRecords(true), refreshInterval);
+      const timer = setInterval(() => {
+        // Skip a tick while a request is in flight so a slow/hung query does
+        // not stack overlapping requests or make every response stale.
+        if (!inFlightRef.current) {
+          fetchAuditRecords(true);
+        }
+      }, refreshInterval);
       return () => clearInterval(timer);
     }
   }, [fetchAuditRecords, refreshInterval]);


### PR DESCRIPTION
## Summary

Bring the audit records table to parity with the refresh UX already present
in the log center and monitor center:

- Add an auto-refresh interval selector that reuses the shared
  `LOG_REFRESH_OPTIONS` constant.
- Replace the text manual-refresh button with a tooltip-wrapped icon button
  (the manual refresh action is unchanged).

## Verification

- `npx eslint src/components/pages/audit-center/index.tsx`: 0 errors / 0 warnings.
- `npm run build` (incl. `tsc`): succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)