### PR TITLE
ENH: add #system_pandas# to virtualenv system marker whitelist

### DIFF
--- a/xinference/core/tests/test_utils.py
+++ b/xinference/core/tests/test_utils.py
@@ -15,6 +15,7 @@
 from ..utils import (
     build_replica_model_uid,
     build_subpool_envs_for_virtual_env,
+    filter_virtualenv_packages_by_markers,
     iter_replica_model_uid,
     parse_replica_model_uid,
 )
@@ -24,6 +25,21 @@ from ..virtual_env_manager import (
     ensure_system_torch_pin,
     get_xllamacpp_cuda_index_url,
 )
+
+
+def test_filter_virtualenv_packages_keeps_system_pandas_marker():
+    # #system_pandas# is used in model specs (e.g. audio) and must be treated
+    # as a system placeholder like the torch/numpy ones
+    packages = [
+        '#system_pandas# ; #engine# == "vllm"',
+        "#system_pandas#",
+    ]
+    assert filter_virtualenv_packages_by_markers(
+        packages, model_engine="vllm", cuda_version=None
+    ) == ["#system_pandas#", "#system_pandas#"]
+    assert filter_virtualenv_packages_by_markers(
+        packages, model_engine="transformers", cuda_version=None
+    ) == ["#system_pandas#"]
 
 
 def test_replica_model_uid():

--- a/xinference/core/utils.py
+++ b/xinference/core/utils.py
@@ -361,6 +361,7 @@ def filter_virtualenv_packages_by_markers(
         "#system_torchvision#",
         "#system_torchcodec#",
         "#system_numpy#",
+        "#system_pandas#",
     }
 
     def _marker_allows(marker: str) -> bool:


### PR DESCRIPTION
## What do these changes do?

`filter_virtualenv_packages_by_markers` keeps `#system_*#` placeholders intact (for xoscar to resolve later) via a hardcoded whitelist, but the whitelist only covered the torch-family and numpy placeholders. Model specs already use `#system_pandas#` (7 occurrences in the audio model spec), which currently falls through to the generic marker path. That path happens to produce an equivalent result today, but relies on incidental behavior — add pandas to the whitelist so all placeholders used in model specs are handled consistently, and add a regression test.

Related: xorbitsai/xoscar#194 makes `#system_*#` resolution degrade gracefully when the host environment lacks the package (relevant for minimal-install 3.0 hosts). Once that lands in a release, the `xoscar` version requirement in `setup.cfg` should be bumped accordingly.

## Check code requirements

- [x] tests added / passed (`xinference/core/tests/test_utils.py`, 23 passed)
- [x] passes `black --check` / `isort --check-only`

🤖 Generated with [Claude Code](https://claude.com/claude-code)