### PR TITLE
ENH: adopt xoscar 0.9.7 graceful #system_*# fallback

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "xoscar>=0.9.6",
+    "xoscar>=0.9.7",
     "torch",
     "pillow",
     "click<8.2.0",

--- a/xinference/core/tests/test_utils.py
+++ b/xinference/core/tests/test_utils.py
@@ -15,6 +15,7 @@
 from ..utils import (
     build_replica_model_uid,
     build_subpool_envs_for_virtual_env,
+    filter_virtualenv_packages_by_markers,
     is_valid_model_uid,
     iter_replica_model_uid,
     merge_virtual_env_packages,
@@ -127,6 +128,21 @@ def test_get_xllamacpp_cuda_index_url():
     assert get_xllamacpp_cuda_index_url(None) is None
     assert get_xllamacpp_cuda_index_url("") is None
     assert get_xllamacpp_cuda_index_url("unknown") is None
+
+
+def test_filter_virtualenv_packages_keeps_system_pandas_marker():
+    # #system_pandas# is used in model specs (e.g. audio) and must be treated
+    # as a system placeholder like the torch/numpy ones
+    packages = [
+        '#system_pandas# ; #engine# == "vllm"',
+        "#system_pandas#",
+    ]
+    assert filter_virtualenv_packages_by_markers(
+        packages, model_engine="vllm", cuda_version=None
+    ) == ["#system_pandas#", "#system_pandas#"]
+    assert filter_virtualenv_packages_by_markers(
+        packages, model_engine="transformers", cuda_version=None
+    ) == ["#system_pandas#"]
 
 
 def test_merge_virtual_env_packages_user_package_overrides_system_marker():

--- a/xinference/core/utils.py
+++ b/xinference/core/utils.py
@@ -488,6 +488,7 @@ def filter_virtualenv_packages_by_markers(
         "#system_torchvision#",
         "#system_torchcodec#",
         "#system_numpy#",
+        "#system_pandas#",
     }
 
     def _marker_allows(marker: str) -> bool:

--- a/xinference/deploy/docker/requirements_cpu/requirements_cpu-base.txt
+++ b/xinference/deploy/docker/requirements_cpu/requirements_cpu-base.txt
@@ -1,4 +1,4 @@
-xoscar>=0.7.2
+xoscar>=0.9.7
 pillow
 click
 tqdm>=4.27


### PR DESCRIPTION
## What do these changes do?

Two related changes for minimal-install (3.0) hosts where numpy/torch/pandas may be absent from the main environment:

1. **Require `xoscar>=0.9.7`** (pyproject.toml). xoscar 0.9.7 ships xorbitsai/xoscar#195: `#system_*#` placeholders degrade gracefully when the host environment lacks the package (installed unpinned with a warning instead of raising `RuntimeError` and failing the model launch), markers are evaluated before placeholder resolution, and host-aligned pins that conflict with other requirements (e.g. a model pinning a newer engine) are dropped on a one-shot retry — including in `skip_installed` mode.

2. **Add `#system_pandas#` to the system marker whitelist** in `filter_virtualenv_packages_by_markers` (`xinference/core/utils.py`). Model specs already use `#system_pandas#` (7 occurrences in the audio model spec), but the whitelist only covered the torch-family and numpy placeholders; the generic marker path it fell through to happens to produce an equivalent result today, but relies on incidental behavior. Adds a regression test.

## Check code requirements

- [x] tests added / passed (`xinference/core/tests/test_utils.py`)
- [x] passes `black --check` / `isort --check-only`
