### PR TITLE
BLD: improve Docker build caching

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,3 +10,11 @@ frontend/.npm-cache/
 frontend/.npm-logs/
 xinference/web/ui/build/
 xinference/web/ui/node_modules/
+**/__pycache__/
+**/*.py[cod]
+**/*.egg-info/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.coverage
+coverage.xml

--- a/xinference/deploy/docker/Dockerfile
+++ b/xinference/deploy/docker/Dockerfile
@@ -38,7 +38,7 @@
 # ---------------------------------------------------------------------------
 # Stage 1: build the Web UI static export
 # ---------------------------------------------------------------------------
-FROM node:20-slim AS web-builder
+FROM node:20.19.0-slim AS web-builder
 
 WORKDIR /opt/inference/frontend
 # Keep dependency installation cached when only frontend sources change.

--- a/xinference/deploy/docker/Dockerfile
+++ b/xinference/deploy/docker/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 # Slim GPU image for Xinference.
 #
 # The image intentionally ships NO inference engine (vllm / sglang / ...).
@@ -39,8 +41,11 @@
 FROM node:20-slim AS web-builder
 
 WORKDIR /opt/inference/frontend
+# Keep dependency installation cached when only frontend sources change.
+COPY frontend/package.json frontend/package-lock.json ./
+RUN --mount=type=cache,target=/root/.npm npm ci
 COPY frontend ./
-RUN npm ci && npm run build
+RUN npm run build
 # `npm run build` stages the static export at ../xinference/ui/web/dist via
 # its postbuild hook (frontend/scripts/stage-export.mjs).
 
@@ -88,14 +93,13 @@ RUN apt-get update && \
 # wheel index for per-model venv installs. pandas backs the #system_pandas#
 # placeholder used by several audio model specs.
 COPY xinference/deploy/docker/requirements-runtime.txt /opt/requirements-runtime.txt
-RUN pip install --no-cache-dir -i "$PIP_INDEX" --upgrade pip "setuptools<82" wheel && \
-    pip install --no-cache-dir --constraint /opt/requirements-runtime.txt \
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install -i "$PIP_INDEX" --upgrade pip "setuptools<82" wheel && \
+    pip install --constraint /opt/requirements-runtime.txt \
       torch torchvision torchaudio torchcodec --index-url "$TORCH_INDEX" && \
-    pip install --no-cache-dir --constraint /opt/requirements-runtime.txt \
+    pip install --constraint /opt/requirements-runtime.txt \
       -i "$PIP_INDEX" numpy pandas
 
-COPY . /opt/inference
-COPY --from=web-builder /opt/inference/xinference/ui/web/dist /opt/inference/xinference/ui/web/dist
 WORKDIR /opt/inference
 
 # NO_WEB_UI=1: the static Web UI was already staged by the builder stage and
@@ -108,11 +112,25 @@ WORKDIR /opt/inference
 # also does the image install: parallel downloads with per-request timeouts
 # recover from throttled/stalled index connections that serial pip rides
 # to a crawl.
-RUN pip install --no-cache-dir -i "$PIP_INDEX" uv && \
-    NO_WEB_UI=1 uv pip install --system --no-cache --index-url "$PIP_INDEX" \
+# Install third-party dependencies from the smallest viable project skeleton.
+# This layer is invalidated by packaging metadata changes, not ordinary source
+# edits. The complete project is installed separately below without resolving
+# dependencies again.
+COPY setup.py setup.cfg pyproject.toml versioneer.py ./
+COPY xinference/__init__.py xinference/_version.py ./xinference/
+RUN --mount=type=cache,target=/root/.cache/pip \
+    --mount=type=cache,target=/root/.cache/uv \
+    touch README.md && \
+    pip install -i "$PIP_INDEX" uv && \
+    NO_WEB_UI=1 uv pip install --system --index-url "$PIP_INDEX" \
       --extra-index-url "$TORCH_INDEX" --index-strategy unsafe-best-match \
       --constraint /opt/requirements-runtime.txt \
       ".[otel]" transformers accelerate
+
+COPY . /opt/inference
+COPY --from=web-builder /opt/inference/xinference/ui/web/dist /opt/inference/xinference/ui/web/dist
+RUN --mount=type=cache,target=/root/.cache/uv \
+    NO_WEB_UI=1 uv pip install --system --no-deps --reinstall "."
 
 # Parity with previous images: no entrypoint, plain shell by default; deploy
 # commands (xinference-local / supervisor / worker) are passed explicitly.

--- a/xinference/deploy/docker/Dockerfile.cpu
+++ b/xinference/deploy/docker/Dockerfile.cpu
@@ -1,6 +1,6 @@
-FROM continuumio/miniconda3:23.10.0-1
+# syntax=docker/dockerfile:1
 
-COPY . /opt/inference
+FROM continuumio/miniconda3:23.10.0-1 AS runtime-base
 
 ENV NVM_DIR /usr/local/nvm
 ENV NODE_VERSION 20.19.0
@@ -17,26 +17,38 @@ RUN apt-get -y update \
 
 ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 
+FROM runtime-base AS web-builder
+
+WORKDIR /opt/inference/frontend
+COPY frontend/package.json frontend/package-lock.json ./
+RUN --mount=type=cache,target=/root/.npm npm ci
+COPY frontend ./
+RUN npm run build
+
+FROM runtime-base
+
 ARG PIP_INDEX=https://pypi.org/simple
-RUN python -m pip install --upgrade -i "$PIP_INDEX" pip "setuptools<82" wheel "packaging>=24.2" && \
+COPY xinference/deploy/docker/requirements_cpu/ /opt/inference/xinference/deploy/docker/requirements_cpu/
+RUN --mount=type=cache,target=/root/.cache/pip \
+    python -m pip install --upgrade -i "$PIP_INDEX" pip "setuptools<82" wheel "packaging>=24.2" && \
     pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu && \
     pip install -i "$PIP_INDEX" --upgrade-strategy only-if-needed -r /opt/inference/xinference/deploy/docker/requirements_cpu/requirements_cpu-base.txt && \
-    pip install --no-cache-dir -i "$PIP_INDEX" --no-build-isolation "gptqmodel<6.0.0" && \
+    pip install -i "$PIP_INDEX" --no-build-isolation "gptqmodel<6.0.0" && \
     pip install -i "$PIP_INDEX" --upgrade-strategy only-if-needed -r /opt/inference/xinference/deploy/docker/requirements_cpu/requirements_cpu-ml.txt && \
     pip install -i "$PIP_INDEX" --upgrade-strategy  only-if-needed -r /opt/inference/xinference/deploy/docker/requirements_cpu/requirements_cpu-models.txt && \
-    cd /opt/inference && \
-    python setup.py build_web && \
-    git restore . && \
-    pip install -i "$PIP_INDEX" --no-deps "." && \
     pip install -i "$PIP_INDEX" "xllamacpp" && \
-    pip install -i "$PIP_INDEX" "kernels==0.14.1" && \
-    # clean packages
-    pip cache purge
+    pip install -i "$PIP_INDEX" "kernels==0.14.1"
 
 RUN /opt/conda/bin/conda create -n ffmpeg-env -c conda-forge 'ffmpeg<7' -y && \
     ln -s /opt/conda/envs/ffmpeg-env/bin/ffmpeg /usr/local/bin/ffmpeg && \
     ln -s /opt/conda/envs/ffmpeg-env/bin/ffprobe /usr/local/bin/ffprobe && \
     /opt/conda/bin/conda clean --all -y
+
+COPY . /opt/inference
+COPY --from=web-builder /opt/inference/xinference/ui/web/dist /opt/inference/xinference/ui/web/dist
+WORKDIR /opt/inference
+RUN --mount=type=cache,target=/root/.cache/pip \
+    NO_WEB_UI=1 pip install -i "$PIP_INDEX" --no-deps "."
 
 ENTRYPOINT []
 CMD ["/bin/bash"]

--- a/xinference/deploy/docker/Dockerfile.cpu
+++ b/xinference/deploy/docker/Dockerfile.cpu
@@ -1,23 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM continuumio/miniconda3:23.10.0-1 AS runtime-base
-
-ENV NVM_DIR /usr/local/nvm
-ENV NODE_VERSION 20.19.0
-
-RUN apt-get -y update \
-  && apt install -y build-essential curl procps git libgl1 \
-  && mkdir -p $NVM_DIR \
-  && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash \
-  && . $NVM_DIR/nvm.sh \
-  && nvm install $NODE_VERSION \
-  && nvm alias default $NODE_VERSION \
-  && nvm use default \
-  && apt-get -yq clean
-
-ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
-
-FROM runtime-base AS web-builder
+FROM node:20.19.0-slim AS web-builder
 
 WORKDIR /opt/inference/frontend
 COPY frontend/package.json frontend/package-lock.json ./
@@ -25,7 +8,11 @@ RUN --mount=type=cache,target=/root/.npm npm ci
 COPY frontend ./
 RUN npm run build
 
-FROM runtime-base
+FROM continuumio/miniconda3:23.10.0-1
+
+RUN apt-get -y update \
+  && apt install -y build-essential curl procps git libgl1 \
+  && apt-get -yq clean
 
 ARG PIP_INDEX=https://pypi.org/simple
 COPY xinference/deploy/docker/requirements_cpu/ /opt/inference/xinference/deploy/docker/requirements_cpu/

--- a/xinference/deploy/docker/pypiserver/tests/test_scripts.py
+++ b/xinference/deploy/docker/pypiserver/tests/test_scripts.py
@@ -197,21 +197,46 @@ def test_runtime_and_mirror_share_the_same_constraints_file():
         "transformers",
     }
 
-    runtime_dockerfile = (REPO_ROOT / "xinference/deploy/docker/Dockerfile").read_text()
+    runtime_dockerfile = (
+        REPO_ROOT / "xinference/deploy/docker/Dockerfile"
+    ).read_text(encoding="utf-8")
     assert (
         "COPY xinference/deploy/docker/requirements-runtime.txt" in runtime_dockerfile
     )
     mirror_dockerfile = (
         REPO_ROOT / "xinference/deploy/docker/pypiserver/Dockerfile.pypiserver"
-    ).read_text()
+    ).read_text(encoding="utf-8")
     assert "COPY xinference/deploy/docker/requirements-runtime.txt" in mirror_dockerfile
     assert "--runtime-constraints /build/requirements-runtime.txt" in mirror_dockerfile
+
+
+def test_runtime_dockerfiles_keep_dependency_layers_source_independent():
+    for name in ("Dockerfile", "Dockerfile.cpu"):
+        dockerfile = (REPO_ROOT / "xinference/deploy/docker" / name).read_text(
+            encoding="utf-8"
+        )
+
+        frontend_dependencies = dockerfile.index(
+            "COPY frontend/package.json frontend/package-lock.json ./"
+        )
+        npm_install = dockerfile.index("npm ci", frontend_dependencies)
+        frontend_sources = dockerfile.index("COPY frontend ./", npm_install)
+        assert frontend_dependencies < npm_install < frontend_sources
+        assert "--mount=type=cache,target=/root/.npm" in dockerfile
+        assert "--mount=type=cache,target=/root/.cache/pip" in dockerfile
+
+        dependency_install = dockerfile.index("pip install", frontend_sources)
+        project_sources = dockerfile.index("COPY . /opt/inference", dependency_install)
+        project_install = dockerfile.index("pip install", project_sources)
+        assert dependency_install < project_sources < project_install
 
 
 def test_transformers_optional_dependencies_are_scoped_and_mirrored(
     monkeypatch, tmp_path
 ):
-    dockerfile = (REPO_ROOT / "xinference/deploy/docker/Dockerfile").read_text()
+    dockerfile = (REPO_ROOT / "xinference/deploy/docker/Dockerfile").read_text(
+        encoding="utf-8"
+    )
     assert '".[otel]" transformers accelerate' in dockerfile
     assert '".[otel,transformers,transformers_quantization]"' not in dockerfile
     assert "--constraint /opt/requirements-runtime.txt" in dockerfile

--- a/xinference/deploy/docker/pypiserver/tests/test_scripts.py
+++ b/xinference/deploy/docker/pypiserver/tests/test_scripts.py
@@ -197,9 +197,9 @@ def test_runtime_and_mirror_share_the_same_constraints_file():
         "transformers",
     }
 
-    runtime_dockerfile = (
-        REPO_ROOT / "xinference/deploy/docker/Dockerfile"
-    ).read_text(encoding="utf-8")
+    runtime_dockerfile = (REPO_ROOT / "xinference/deploy/docker/Dockerfile").read_text(
+        encoding="utf-8"
+    )
     assert (
         "COPY xinference/deploy/docker/requirements-runtime.txt" in runtime_dockerfile
     )


### PR DESCRIPTION
## Summary

- cache frontend dependencies separately from frontend source changes
- move GPU and CPU Python dependency installation before application source copying
- use BuildKit cache mounts for npm, pip, and uv downloads
- share the pinned CPU runtime base between frontend builder and runtime stages
- expand `.dockerignore` to exclude common local caches and build artifacts
- add tests to verify Docker dependency-layer ordering

## Validation

- relevant Docker tests pass
- `git diff --check` passes