### PR TITLE
fix: stabilize Jina v5 and Qwen3 reranker deployment

### DIFF
--- a/xinference/core/tests/test_utils.py
+++ b/xinference/core/tests/test_utils.py
@@ -23,6 +23,7 @@ from ..virtual_env_manager import (
     XLLAMACPP_CUDA_INDEX_URLS,
     ensure_system_torch_pin,
     get_xllamacpp_cuda_index_url,
+    pin_sentence_transformers_numpy_abi,
 )
 
 
@@ -353,6 +354,55 @@ def test_ensure_system_torch_pin_deduplicates_same_marker():
     result = ensure_system_torch_pin(packages)
     assert result.count('#system_torch# ; #engine# == "x"') == 1
     assert len(result) == 3
+
+
+def test_pin_sentence_transformers_numpy_abi(monkeypatch):
+    import importlib.metadata
+
+    versions = {
+        "numpy": "1.26.4",
+        "scipy": "1.13.1",
+        "scikit-learn": "1.4.2",
+        "pandas": "2.2.2",
+    }
+
+    def _version(name):
+        try:
+            return versions[name]
+        except KeyError:
+            raise importlib.metadata.PackageNotFoundError(name)
+
+    monkeypatch.setattr(importlib.metadata, "version", _version)
+    result = pin_sentence_transformers_numpy_abi(
+        ["sentence_transformers"], "sentence_transformers"
+    )
+    assert result == [
+        "sentence_transformers",
+        "numpy==1.26.4",
+        "scipy==1.13.1",
+        "scikit-learn==1.4.2",
+        "pandas==2.2.2",
+    ]
+
+
+def test_pin_sentence_transformers_numpy_abi_preserves_explicit_requirements(
+    monkeypatch,
+):
+    import importlib.metadata
+
+    monkeypatch.setattr(importlib.metadata, "version", lambda _name: "1.0")
+    packages = ["sentence_transformers", "numpy>=2", "scipy==1.12.0"]
+    result = pin_sentence_transformers_numpy_abi(packages, "sentence_transformers")
+    assert result[: len(packages)] == packages
+    assert "numpy==1.0" not in result
+    assert "scipy==1.0" not in result
+    assert "scikit-learn==1.0" in result
+    assert "pandas==1.0" in result
+
+
+def test_pin_sentence_transformers_numpy_abi_other_engine_is_noop():
+    packages = ["xllamacpp"]
+    assert pin_sentence_transformers_numpy_abi(packages, "llama.cpp") is packages
 
 
 def test_build_subpool_envs_for_virtual_env_disabled():

--- a/xinference/core/virtual_env_manager.py
+++ b/xinference/core/virtual_env_manager.py
@@ -183,6 +183,17 @@ def get_xllamacpp_cuda_index_url(
 # import time with errors like "operator torchvision::nms does not exist".
 TORCH_COMPANION_PACKAGES = {"torchvision", "torchaudio", "torchcodec"}
 
+# Packages with compiled NumPy extensions that are commonly present in the
+# parent environment used by sentence-transformers.  The child venv is created
+# with --system-site-packages, so upgrading only part of this stack can leave an
+# inherited binary linked against a different NumPy ABI.
+SENTENCE_TRANSFORMERS_NUMPY_ABI_PACKAGES = (
+    "numpy",
+    "scipy",
+    "scikit-learn",
+    "pandas",
+)
+
 
 def ensure_system_torch_pin(packages: List[str]) -> List[str]:
     """
@@ -273,6 +284,59 @@ def ensure_system_torch_pin(packages: List[str]) -> List[str]:
             torch_entry,
         )
     return packages + to_inject
+
+
+def pin_sentence_transformers_numpy_abi(
+    packages: List[str], model_engine: Optional[str]
+) -> List[str]:
+    """
+    Keep an inherited sentence-transformers scientific stack ABI-compatible.
+
+    Virtual environments use ``--system-site-packages``.  When uv resolves a
+    new sentence-transformers installation, it may install a newer NumPy,
+    SciPy, or scikit-learn into the child while continuing to inherit pandas
+    (or another compiled extension) from the parent.  The mixed stack then
+    fails at import time with errors such as ``numpy.core.multiarray failed to
+    import``.
+
+    Pin only packages that are already installed in the parent, and never
+    replace an explicit model requirement.  Missing packages remain free to be
+    resolved and installed normally, which is important for slim runtimes.
+    """
+    if not model_engine or model_engine.lower() != "sentence_transformers":
+        return packages
+
+    from importlib import metadata
+
+    from packaging.requirements import InvalidRequirement, Requirement
+    from packaging.utils import canonicalize_name
+
+    explicitly_requested = set()
+    for package in packages:
+        requirement = package.split(";", 1)[0].strip()
+        if not requirement or requirement.startswith("#"):
+            continue
+        try:
+            explicitly_requested.add(canonicalize_name(Requirement(requirement).name))
+        except InvalidRequirement:
+            continue
+
+    pins: List[str] = []
+    for distribution_name in SENTENCE_TRANSFORMERS_NUMPY_ABI_PACKAGES:
+        canonical_name = canonicalize_name(distribution_name)
+        if canonical_name in explicitly_requested:
+            continue
+        try:
+            version = metadata.version(distribution_name)
+        except metadata.PackageNotFoundError:
+            continue
+        pins.append(f"{distribution_name}=={version}")
+
+    if pins:
+        logger.info(
+            "Pinning inherited sentence-transformers NumPy ABI packages: %s", pins
+        )
+    return packages + pins
 
 
 def extract_cuda_version_from_url(url: str) -> Optional[str]:

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -110,6 +110,7 @@ from .virtual_env_manager import (
     get_engine_critical_dependency_specs,
     get_engine_model_format_virtualenv_packages,
     is_cuda_compatible,
+    pin_sentence_transformers_numpy_abi,
     resolve_virtualenv_python_path,
 )
 
@@ -2877,6 +2878,7 @@ class WorkerActor(xo.StatelessActor):
         # version, and the ABI mismatch crashes the model subprocess on relaunch
         # (issue #5156).
         packages = ensure_system_torch_pin(packages)
+        packages = pin_sentence_transformers_numpy_abi(packages, model_engine)
 
         conf = dict(settings)
         conf.pop("packages", None)

--- a/xinference/model/embedding/model_spec.json
+++ b/xinference/model/embedding/model_spec.json
@@ -1612,7 +1612,7 @@
     ],
     "virtualenv": {
       "packages": [
-        "sentence_transformers",
+        "sentence_transformers>=5.2.0",
         "einops",
         "peft==0.18.1",
         "accelerate>=0.28.0",
@@ -1653,7 +1653,7 @@
     ],
     "virtualenv": {
       "packages": [
-        "sentence_transformers",
+        "sentence_transformers>=5.2.0",
         "einops",
         "peft==0.18.1",
         "accelerate>=0.28.0",
@@ -1694,7 +1694,7 @@
     ],
     "virtualenv": {
       "packages": [
-        "sentence_transformers",
+        "sentence_transformers>=5.2.0",
         "einops",
         "peft==0.18.1",
         "accelerate>=0.28.0",
@@ -1738,7 +1738,7 @@
     ],
     "virtualenv": {
       "packages": [
-        "sentence_transformers",
+        "sentence_transformers>=5.2.0",
         "einops",
         "peft==0.18.1",
         "accelerate>=0.28.0",

--- a/xinference/model/embedding/tests/test_embedding_models.py
+++ b/xinference/model/embedding/tests/test_embedding_models.py
@@ -80,6 +80,28 @@ def test_engine_supported():
     assert "sentence_transformers" in EMBEDDING_ENGINES[model_name]
 
 
+def test_jina_v5_requires_transformers_5_compatible_sentence_transformers():
+    from packaging.requirements import Requirement
+
+    from .. import _install
+
+    _install()
+    for model_name in (
+        "jina-embeddings-v5-text-nano",
+        "jina-embeddings-v5-text-small",
+        "jina-embeddings-v5-omni-nano",
+        "jina-embeddings-v5-omni-small",
+    ):
+        family = BUILTIN_EMBEDDING_MODELS[model_name][0]
+        assert family.virtualenv is not None
+        sentence_transformers = next(
+            Requirement(package)
+            for package in family.virtualenv.packages
+            if package.startswith("sentence_transformers")
+        )
+        assert str(sentence_transformers.specifier) == ">=5.2.0"
+
+
 def test_bce_embedding_vllm_engine_params_with_virtualenv():
     from ....model.utils import (
         _collect_virtualenv_engine_markers,

--- a/xinference/model/embedding/tests/test_embedding_models.py
+++ b/xinference/model/embedding/tests/test_embedding_models.py
@@ -81,25 +81,39 @@ def test_engine_supported():
 
 
 def test_jina_v5_requires_transformers_5_compatible_sentence_transformers():
-    from packaging.requirements import Requirement
+    from packaging.requirements import InvalidRequirement, Requirement
+    from packaging.utils import canonicalize_name
 
     from .. import _install
 
     _install()
-    for model_name in (
-        "jina-embeddings-v5-text-nano",
-        "jina-embeddings-v5-text-small",
-        "jina-embeddings-v5-omni-nano",
-        "jina-embeddings-v5-omni-small",
-    ):
-        family = BUILTIN_EMBEDDING_MODELS[model_name][0]
-        assert family.virtualenv is not None
-        sentence_transformers = next(
-            Requirement(package)
-            for package in family.virtualenv.packages
-            if package.startswith("sentence_transformers")
-        )
-        assert str(sentence_transformers.specifier) == ">=5.2.0"
+    matched_families = []
+    for families in BUILTIN_EMBEDDING_MODELS.values():
+        for family in families:
+            if family.virtualenv is None:
+                continue
+
+            requirements = {}
+            for package in family.virtualenv.packages:
+                try:
+                    requirement = Requirement(package)
+                except InvalidRequirement:
+                    continue
+                requirements[canonicalize_name(requirement.name)] = requirement
+
+            transformers = requirements.get("transformers")
+            if transformers is None or not any(
+                spec.operator == "==" and spec.version == "5.7.0"
+                for spec in transformers.specifier
+            ):
+                continue
+
+            matched_families.append(family.model_name)
+            sentence_transformers = requirements.get("sentence-transformers")
+            assert sentence_transformers is not None, family.model_name
+            assert str(sentence_transformers.specifier) == ">=5.2.0", family.model_name
+
+    assert matched_families
 
 
 def test_bce_embedding_vllm_engine_params_with_virtualenv():

--- a/xinference/model/rerank/model_spec.json
+++ b/xinference/model/rerank/model_spec.json
@@ -396,41 +396,28 @@
         "model_format": "ggufv2",
         "model_src": {
           "huggingface": {
-            "model_id": "QuantFactory/Qwen3-Reranker-0.6B-GGUF",
+            "model_id": "Voodisss/Qwen3-Reranker-0.6B-GGUF-llama_cpp",
+            "model_revision": "eb9ad47d4e53c2a6abd6158b505f1539d1c5650c",
             "quantizations": [
               "Q2_K",
-              "Q3_K_S",
               "Q3_K_M",
-              "Q3_K_L",
               "Q4_0",
-              "Q4_1",
-              "Q4_K_S",
               "Q4_K_M",
               "Q5_0",
-              "Q5_1",
-              "Q5_K_S",
               "Q5_K_M",
-              "Q6_K",
-              "Q8_0"
+              "Q6_K"
             ],
-            "model_file_name_template": "Qwen3-Reranker-0.6B.{quantization}.gguf"
-          },
-          "modelscope": {
-            "model_id": "QuantFactory/Qwen3-Reranker-0.6B-GGUF",
+            "model_file_name_template": "Qwen3-Reranker-0.6B-{quantization}.gguf"
+          }
+        }
+      },
+      {
+        "model_format": "ggufv2",
+        "model_src": {
+          "huggingface": {
+            "model_id": "Voodisss/Qwen3-Reranker-0.6B-GGUF-llama_cpp",
+            "model_revision": "eb9ad47d4e53c2a6abd6158b505f1539d1c5650c",
             "quantizations": [
-              "Q2_K",
-              "Q3_K_S",
-              "Q3_K_M",
-              "Q3_K_L",
-              "Q4_0",
-              "Q4_1",
-              "Q4_K_S",
-              "Q4_K_M",
-              "Q5_0",
-              "Q5_1",
-              "Q5_K_S",
-              "Q5_K_M",
-              "Q6_K",
               "Q8_0"
             ],
             "model_file_name_template": "Qwen3-Reranker-0.6B.{quantization}.gguf"
@@ -439,7 +426,7 @@
       }
     ],
     "featured": false,
-    "updated_at": 1784543901,
+    "updated_at": 1784861071,
     "virtualenv": {
       "packages": [
         "#sentence_transformers_dependencies# ; #engine# == \"sentence_transformers\"",
@@ -483,41 +470,28 @@
         "model_format": "ggufv2",
         "model_src": {
           "huggingface": {
-            "model_id": "QuantFactory/Qwen3-Reranker-4B-GGUF",
+            "model_id": "Voodisss/Qwen3-Reranker-4B-GGUF-llama_cpp",
+            "model_revision": "1b452c803342e73ac3644551b727dfd51a09fd5b",
             "quantizations": [
               "Q2_K",
-              "Q3_K_S",
               "Q3_K_M",
-              "Q3_K_L",
               "Q4_0",
-              "Q4_1",
-              "Q4_K_S",
               "Q4_K_M",
               "Q5_0",
-              "Q5_1",
-              "Q5_K_S",
               "Q5_K_M",
-              "Q6_K",
-              "Q8_0"
+              "Q6_K"
             ],
-            "model_file_name_template": "Qwen3-Reranker-4B.{quantization}.gguf"
-          },
-          "modelscope": {
-            "model_id": "QuantFactory/Qwen3-Reranker-4B-GGUF",
+            "model_file_name_template": "Qwen3-Reranker-4B-{quantization}.gguf"
+          }
+        }
+      },
+      {
+        "model_format": "ggufv2",
+        "model_src": {
+          "huggingface": {
+            "model_id": "Voodisss/Qwen3-Reranker-4B-GGUF-llama_cpp",
+            "model_revision": "1b452c803342e73ac3644551b727dfd51a09fd5b",
             "quantizations": [
-              "Q2_K",
-              "Q3_K_S",
-              "Q3_K_M",
-              "Q3_K_L",
-              "Q4_0",
-              "Q4_1",
-              "Q4_K_S",
-              "Q4_K_M",
-              "Q5_0",
-              "Q5_1",
-              "Q5_K_S",
-              "Q5_K_M",
-              "Q6_K",
               "Q8_0"
             ],
             "model_file_name_template": "Qwen3-Reranker-4B.{quantization}.gguf"
@@ -526,7 +500,7 @@
       }
     ],
     "featured": false,
-    "updated_at": 1784543901,
+    "updated_at": 1784861071,
     "virtualenv": {
       "packages": [
         "#sentence_transformers_dependencies# ; #engine# == \"sentence_transformers\"",
@@ -570,41 +544,28 @@
         "model_format": "ggufv2",
         "model_src": {
           "huggingface": {
-            "model_id": "QuantFactory/Qwen3-Reranker-8B-GGUF",
+            "model_id": "Voodisss/Qwen3-Reranker-8B-GGUF-llama_cpp",
+            "model_revision": "646e3a1fc04936cab940ad02e18ee6b14af46263",
             "quantizations": [
               "Q2_K",
-              "Q3_K_S",
               "Q3_K_M",
-              "Q3_K_L",
               "Q4_0",
-              "Q4_1",
-              "Q4_K_S",
               "Q4_K_M",
               "Q5_0",
-              "Q5_1",
-              "Q5_K_S",
               "Q5_K_M",
-              "Q6_K",
-              "Q8_0"
+              "Q6_K"
             ],
-            "model_file_name_template": "Qwen3-Reranker-8B.{quantization}.gguf"
-          },
-          "modelscope": {
-            "model_id": "QuantFactory/Qwen3-Reranker-8B-GGUF",
+            "model_file_name_template": "Qwen3-Reranker-8B-{quantization}.gguf"
+          }
+        }
+      },
+      {
+        "model_format": "ggufv2",
+        "model_src": {
+          "huggingface": {
+            "model_id": "Voodisss/Qwen3-Reranker-8B-GGUF-llama_cpp",
+            "model_revision": "646e3a1fc04936cab940ad02e18ee6b14af46263",
             "quantizations": [
-              "Q2_K",
-              "Q3_K_S",
-              "Q3_K_M",
-              "Q3_K_L",
-              "Q4_0",
-              "Q4_1",
-              "Q4_K_S",
-              "Q4_K_M",
-              "Q5_0",
-              "Q5_1",
-              "Q5_K_S",
-              "Q5_K_M",
-              "Q6_K",
               "Q8_0"
             ],
             "model_file_name_template": "Qwen3-Reranker-8B.{quantization}.gguf"
@@ -613,7 +574,7 @@
       }
     ],
     "featured": false,
-    "updated_at": 1784543902,
+    "updated_at": 1784861071,
     "virtualenv": {
       "packages": [
         "#sentence_transformers_dependencies# ; #engine# == \"sentence_transformers\"",

--- a/xinference/model/rerank/tests/test_rerank.py
+++ b/xinference/model/rerank/tests/test_rerank.py
@@ -215,3 +215,41 @@ def test_auto_detect_type():
         except EnvironmentError:
             # gated repo, ignore
             continue
+
+
+@pytest.mark.parametrize(
+    ("model_name", "model_revision"),
+    [
+        (
+            "Qwen3-Reranker-0.6B",
+            "eb9ad47d4e53c2a6abd6158b505f1539d1c5650c",
+        ),
+        ("Qwen3-Reranker-4B", "1b452c803342e73ac3644551b727dfd51a09fd5b"),
+        ("Qwen3-Reranker-8B", "646e3a1fc04936cab940ad02e18ee6b14af46263"),
+    ],
+)
+@pytest.mark.parametrize(
+    ("quantization", "separator"),
+    [("Q4_K_M", "-"), ("Q8_0", ".")],
+)
+def test_qwen3_reranker_gguf_uses_llama_cpp_compatible_models(
+    model_name, model_revision, quantization, separator
+):
+    from .. import register_builtin_model
+    from ..rerank_family import match_rerank
+
+    register_builtin_model()
+    family = match_rerank(
+        model_name,
+        model_format="ggufv2",
+        quantization=quantization,
+        download_hub="modelscope",
+    )
+    spec = family.model_specs[0]
+
+    assert spec.model_hub == "huggingface"
+    assert spec.model_id == f"Voodisss/{model_name}-GGUF-llama_cpp"
+    assert spec.model_revision == model_revision
+    assert spec.model_file_name_template == (
+        f"{model_name}{separator}{quantization}.gguf"
+    )


### PR DESCRIPTION
## Summary

- require `sentence-transformers>=5.2.0` for the Jina embeddings v5 family, matching its pinned Transformers 5 runtime
- keep inherited NumPy ABI packages aligned when sentence-transformers runs in a `--system-site-packages` virtual environment
- replace broken Qwen3-Reranker GGUF conversions with llama.cpp-compatible, revision-pinned models
- remove unsupported/broken Qwen3 GGUF quantizations and handle the repositories' distinct Q8 filename convention
- add regression coverage for dependency selection, ABI pin generation, and Qwen3 GGUF source resolution

## Root cause

The Jina v5 virtualenv spec pinned `transformers==5.7.0` but left
`sentence_transformers` unconstrained. Package mirrors could therefore resolve
sentence-transformers 5.1.x, which requires `transformers<5`, and fail during
the uv dry-run.

Even when dependency resolution succeeded, uv could upgrade only part of the
scientific Python stack inside the child virtualenv while inheriting compiled
packages from the parent environment. Mixing NumPy, SciPy, scikit-learn, and
pandas across incompatible ABIs caused import-time failures.

The Qwen3-Reranker GGUF specs referenced community conversions that omitted the
reranker classifier tensor and metadata required by llama.cpp. Those files
could load and return HTTP 200 while producing near-zero, incorrectly ordered
scores. The replacement conversions include the classifier tensor, rank
pooling metadata, output labels, and rerank chat template.

## Validation

- `pre-commit run --files` passed for all modified files
- 30 focused core and embedding tests passed
- 8 focused Qwen3/llama.cpp rerank tests passed
- dependency dry-run succeeded against the Tsinghua PyPI mirror
- deployed `jina-embeddings-v5-text-small` through a real Xinference REST
  server on an RTX 3090 Ti, using ModelScope and virtualenv mode
- `/v1/embeddings` returned HTTP 200 for three inputs with 1024-dimensional
  normalized embeddings; terminate/relaunch against the reused virtualenv also passed
- deployed `Qwen3-Reranker-0.6B` with the sentence-transformers engine on the
  RTX 3090 Ti; English and Chinese `/v1/rerank` requests returned HTTP 200 and
  correct ordering before and after relaunch
- reproduced the broken GGUF source returning incorrect near-zero scores, then
  deployed the replacement Q4_K_M GGUF with xllamacpp on the same GPU
- replacement GGUF returned HTTP 200 with correct English and Chinese ordering;
  the relevant English document scored `0.999512` versus `0.000395` for the
  irrelevant document

## Deployment note

On the GPU test host, the xllamacpp CUDA package index was reachable but its
GitHub Release asset timed out. Supplying the identical official wheel locally
allowed the GGUF runtime test to complete; this is a host egress limitation,
not a package-resolution or model-loading failure.
