### PR TITLE
fix(mlx): keep VLM generation on a dedicated thread

### DIFF
--- a/xinference/model/llm/mlx/core.py
+++ b/xinference/model/llm/mlx/core.py
@@ -1363,6 +1363,13 @@ class MLXVisionModel(MLXModel, ChatModelMixin):
                 executor = self._mlx_executor
         return executor.submit(fn, *args, **kwargs).result()
 
+    def stop(self):
+        with _mlx_executor_lock:
+            executor = self._mlx_executor
+            self._mlx_executor = None
+        if executor is not None:
+            executor.shutdown(wait=False)
+
     def _iterate_on_mlx_thread(
         self, iterator: Iterator[CompletionChunk]
     ) -> Iterator[CompletionChunk]:

--- a/xinference/model/llm/mlx/core.py
+++ b/xinference/model/llm/mlx/core.py
@@ -27,6 +27,7 @@ from pathlib import Path
 from typing import (
     Any,
     AsyncGenerator,
+    Callable,
     Dict,
     Iterator,
     List,
@@ -62,6 +63,28 @@ from ..utils import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _ensure_mlx_vlm_thread_local_stream() -> Any:
+    """Use an MLX generation stream that is safe across worker threads."""
+    import mlx.core as mx
+
+    mlx_vlm_generate = importlib.import_module("mlx_vlm.generate")
+    thread_local_stream_type = getattr(mx, "ThreadLocalStream", None)
+    new_thread_local_stream = getattr(mx, "new_thread_local_stream", None)
+    if thread_local_stream_type is None or new_thread_local_stream is None:
+        return mlx_vlm_generate
+
+    generation_stream = getattr(mlx_vlm_generate, "generation_stream", None)
+    if not isinstance(generation_stream, thread_local_stream_type):
+        setattr(
+            mlx_vlm_generate,
+            "generation_stream",
+            new_thread_local_stream(mx.default_device()),
+        )
+        logger.debug("Replaced mlx-vlm generation stream with a thread-local stream")
+
+    return mlx_vlm_generate
 
 
 class MLXBatchModel:
@@ -1301,6 +1324,50 @@ class MLXChatModel(MLXModel, ChatModelMixin):
 class MLXVisionModel(MLXModel, ChatModelMixin):
     allow_batch: bool = False
 
+    def __init__(
+        self,
+        model_uid: str,
+        model_family: "LLMFamilyV2",
+        model_path: str,
+        model_config: Optional[MLXModelConfig] = None,
+        peft_model: Optional[List[LoRA]] = None,
+    ):
+        super().__init__(
+            model_uid,
+            model_family,
+            model_path,
+            model_config,
+            peft_model,
+        )
+        self._mlx_executor: Optional[concurrent.futures.ThreadPoolExecutor] = None
+
+    def _run_on_mlx_thread(
+        self, fn: Callable[..., Any], *args: Any, **kwargs: Any
+    ) -> Any:
+        if self._mlx_executor is None:
+            self._mlx_executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+        return self._mlx_executor.submit(fn, *args, **kwargs).result()
+
+    def _iterate_on_mlx_thread(
+        self, iterator: Iterator[CompletionChunk]
+    ) -> Iterator[CompletionChunk]:
+        def _next_or_done():
+            try:
+                return True, next(iterator)
+            except StopIteration:
+                return False, None
+
+        try:
+            while True:
+                has_item, item = self._run_on_mlx_thread(_next_or_done)
+                if not has_item:
+                    break
+                yield item
+        finally:
+            close = getattr(iterator, "close", None)
+            if close is not None:
+                self._run_on_mlx_thread(close)
+
     @classmethod
     def check_lib(cls) -> Union[bool, Tuple[bool, str]]:
         dep_check = check_dependency_available("mlx_vlm", "mlx_vlm")
@@ -1336,6 +1403,22 @@ class MLXVisionModel(MLXModel, ChatModelMixin):
         return generate_config
 
     def generate(
+        self,
+        prompt: Union[str, Dict[str, Any]],
+        generate_config: Optional[MLXGenerateConfig] = None,
+        from_chat: bool = False,
+    ) -> Union[Completion, Iterator[CompletionChunk]]:
+        stream = bool(generate_config and generate_config.get("stream", False))
+        result = self._run_on_mlx_thread(
+            self._generate, prompt, generate_config, from_chat
+        )
+        if stream:
+            assert isinstance(result, Iterator)
+            return self._iterate_on_mlx_thread(result)
+        assert not isinstance(result, Iterator)
+        return result
+
+    def _generate(
         self,
         prompt: Union[str, Dict[str, Any]],
         generate_config: Optional[MLXGenerateConfig] = None,
@@ -1416,6 +1499,9 @@ class MLXVisionModel(MLXModel, ChatModelMixin):
         return load(self.model_path)
 
     def load(self):
+        self._run_on_mlx_thread(self._load)
+
+    def _load(self):
         from mlx_lm.utils import load_config
 
         if self._n_worker > 1:
@@ -1453,7 +1539,8 @@ class MLXVisionModel(MLXModel, ChatModelMixin):
         except ImportError:
             # for mlx-lm >= 0.22.3
             from mlx_lm.generate import GenerationResponse
-        from mlx_vlm.generate import generate_step
+        mlx_vlm_generate = _ensure_mlx_vlm_thread_local_stream()
+        generate_step = mlx_vlm_generate.generate_step
 
         inputs = kwargs.pop("prompt_token_ids")
         stop_token_ids = kwargs.pop("stop_token_ids", [])

--- a/xinference/model/llm/mlx/core.py
+++ b/xinference/model/llm/mlx/core.py
@@ -64,6 +64,9 @@ from ..utils import (
 
 logger = logging.getLogger(__name__)
 
+_mlx_vlm_stream_lock = threading.Lock()
+_mlx_executor_lock = threading.Lock()
+
 
 def _ensure_mlx_vlm_thread_local_stream() -> Any:
     """Use an MLX generation stream that is safe across worker threads."""
@@ -77,12 +80,17 @@ def _ensure_mlx_vlm_thread_local_stream() -> Any:
 
     generation_stream = getattr(mlx_vlm_generate, "generation_stream", None)
     if not isinstance(generation_stream, thread_local_stream_type):
-        setattr(
-            mlx_vlm_generate,
-            "generation_stream",
-            new_thread_local_stream(mx.default_device()),
-        )
-        logger.debug("Replaced mlx-vlm generation stream with a thread-local stream")
+        with _mlx_vlm_stream_lock:
+            generation_stream = getattr(mlx_vlm_generate, "generation_stream", None)
+            if not isinstance(generation_stream, thread_local_stream_type):
+                setattr(
+                    mlx_vlm_generate,
+                    "generation_stream",
+                    new_thread_local_stream(mx.default_device()),
+                )
+                logger.debug(
+                    "Replaced mlx-vlm generation stream with a thread-local stream"
+                )
 
     return mlx_vlm_generate
 
@@ -1344,9 +1352,16 @@ class MLXVisionModel(MLXModel, ChatModelMixin):
     def _run_on_mlx_thread(
         self, fn: Callable[..., Any], *args: Any, **kwargs: Any
     ) -> Any:
-        if self._mlx_executor is None:
-            self._mlx_executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
-        return self._mlx_executor.submit(fn, *args, **kwargs).result()
+        executor = self._mlx_executor
+        if executor is None:
+            with _mlx_executor_lock:
+                if self._mlx_executor is None:
+                    self._mlx_executor = concurrent.futures.ThreadPoolExecutor(
+                        max_workers=1,
+                        thread_name_prefix=f"mlx-{self.model_uid}",
+                    )
+                executor = self._mlx_executor
+        return executor.submit(fn, *args, **kwargs).result()
 
     def _iterate_on_mlx_thread(
         self, iterator: Iterator[CompletionChunk]

--- a/xinference/model/llm/mlx/tests/test_mlx.py
+++ b/xinference/model/llm/mlx/tests/test_mlx.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 import base64
+import concurrent.futures
+import importlib
 import os
 import platform
 import sys
@@ -21,6 +23,36 @@ import threading
 import pytest
 
 from .....client import Client
+
+
+@pytest.mark.skipif(
+    sys.platform != "darwin" or platform.processor() != "arm",
+    reason="MLX only works for Apple silicon chip",
+)
+def test_mlx_vlm_generation_stream_is_thread_local(monkeypatch):
+    import mlx.core as mx
+
+    from ..core import _ensure_mlx_vlm_thread_local_stream
+
+    mlx_vlm_generate = importlib.import_module("mlx_vlm.generate")
+    monkeypatch.setattr(
+        mlx_vlm_generate,
+        "generation_stream",
+        mx.new_stream(mx.default_device()),
+    )
+
+    _ensure_mlx_vlm_thread_local_stream()
+
+    assert isinstance(mlx_vlm_generate.generation_stream, mx.ThreadLocalStream)
+
+    def generate_on_worker_thread():
+        with mx.stream(mlx_vlm_generate.generation_stream):
+            result = mx.arange(4) + 1
+        mx.async_eval(result)
+        return result.tolist()
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+        assert executor.submit(generate_on_worker_thread).result() == [1, 2, 3, 4]
 
 
 class InferenceThread(threading.Thread):
@@ -144,6 +176,18 @@ def test_load_mlx_vision(setup):
     assert "content" in completion["choices"][0]["message"]
     assert "content" in completion["choices"][0]["message"]
     assert len(completion["choices"][0]["message"]["content"]) != 0
+
+    chunks = list(
+        model.chat(
+            messages,
+            generate_config={
+                "stream": True,
+                "stream_options": {"include_usage": True},
+                "max_tokens": 4,
+            },
+        )
+    )
+    assert any(chunk.get("choices") for chunk in chunks)
 
 
 @pytest.mark.skipif(

--- a/xinference/model/llm/mlx/tests/test_mlx.py
+++ b/xinference/model/llm/mlx/tests/test_mlx.py
@@ -25,6 +25,29 @@ import pytest
 from .....client import Client
 
 
+def test_mlx_vision_model_stop_shuts_down_executor():
+    from ..core import MLXVisionModel
+
+    model = object.__new__(MLXVisionModel)
+    model.model_uid = "shutdown-test"
+    model._mlx_executor = None
+
+    worker_name = model._run_on_mlx_thread(lambda: threading.current_thread().name)
+    executor = model._mlx_executor
+
+    assert worker_name.startswith("mlx-shutdown-test")
+    assert executor is not None
+
+    model.stop()
+
+    assert model._mlx_executor is None
+    with pytest.raises(RuntimeError, match="cannot schedule new futures"):
+        executor.submit(lambda: None)
+
+    # Teardown can safely be retried if initialization only partially completed.
+    model.stop()
+
+
 @pytest.mark.skipif(
     sys.platform != "darwin" or platform.processor() != "arm",
     reason="MLX only works for Apple silicon chip",

--- a/xinference/model/llm/mlx/tests/test_mlx.py
+++ b/xinference/model/llm/mlx/tests/test_mlx.py
@@ -32,6 +32,11 @@ from .....client import Client
 def test_mlx_vlm_generation_stream_is_thread_local(monkeypatch):
     import mlx.core as mx
 
+    if not hasattr(mx, "ThreadLocalStream") or not hasattr(
+        mx, "new_thread_local_stream"
+    ):
+        pytest.skip("MLX version does not support thread-local streams")
+
     from ..core import _ensure_mlx_vlm_thread_local_stream
 
     mlx_vlm_generate = importlib.import_module("mlx_vlm.generate")


### PR DESCRIPTION
## Summary

- run MLX VLM model loading and generation on one dedicated thread
- replace mlx-vlm's thread-bound generation stream with a thread-local stream when supported
- add unit and REST streaming coverage for the cross-thread failure

## Root cause

`ModelActor` uses a shared thread pool for synchronous model calls and generator iteration. With recent MLX releases, a regular Metal stream can only be used from the thread where it was created. `mlx-vlm 0.4.4` still creates a regular global generation stream, so model loading and later generation could use different threads and fail with `There is no Stream(gpu, N) in current thread`.

The executor is initialized lazily after the model has crossed the xoscar process boundary, so the model instance remains serializable during actor creation.

## Impact

MLX vision models can serve both streaming and non-streaming requests with the current `mlx 0.32.0`, `mlx-lm 0.31.3`, and `mlx-vlm 0.4.4` combination without pinning `mlx-lm` below 0.31.3.

## Validation

- `pytest -vv xinference/model/llm/mlx/tests/test_mlx.py::test_mlx_vlm_generation_stream_is_thread_local xinference/model/llm/mlx/tests/test_mlx.py::test_load_mlx_vision`
- `pre-commit run --files xinference/model/llm/mlx/core.py xinference/model/llm/mlx/tests/test_mlx.py`
- `git diff --check`
