### PR TITLE
fix(vllm): add #system_numpy# and pin vllm to 0.21.0 for Ornith/qwen3.5/qwen3.6

### DIFF
--- a/xinference/model/llm/llm_family.json
+++ b/xinference/model/llm/llm_family.json
@@ -30168,7 +30168,8 @@
         "transformers>=5.2.0 ; #engine# == \"Transformers\"",
         "qwen-vl-utils!=0.0.9 ; #engine# == \"Transformers\"",
         "qwen_omni_utils==0.0.9 ; #engine# == \"vllm\"",
-        "vllm>=0.17.0 ; #engine# == \"vllm\"",
+        "#system_numpy# ; #engine# == \"vllm\"",
+        "vllm==0.21.0 ; #engine# == \"vllm\"",
         "transformers==4.57.6 ; #engine# == \"vllm\"",
         "ninja ; #engine# == \"vllm\"",
         "#llama_cpp_dependencies# ; #engine# == \"llama.cpp\""
@@ -30926,6 +30927,7 @@
         "transformers>=5.2.0 ; #engine# == \"Transformers\"",
         "qwen-vl-utils!=0.0.9 ; #engine# == \"Transformers\"",
         "qwen_omni_utils ; #engine# == \"vllm\"",
+        "#system_numpy# ; #engine# == \"vllm\"",
         "vllm==0.21.0 ; #engine# == \"vllm\"",
         "ninja ; #engine# == \"vllm\"",
         "#llama_cpp_dependencies# ; #engine# == \"llama.cpp\""
@@ -32778,7 +32780,8 @@
         "sglang_dependencies ; #engine# == \"sglang\"",
         "transformers>=5.2.0 ; #engine# == \"Transformers\"",
         "qwen_omni_utils ; #engine# == \"vllm\"",
-        "vllm>=0.17.0 ; #engine# == \"vllm\"",
+        "#system_numpy# ; #engine# == \"vllm\"",
+        "vllm==0.21.0 ; #engine# == \"vllm\"",
         "transformers==4.57.6 ; #engine# == \"vllm\"",
         "ninja ; #engine# == \"vllm\"",
         "#llama_cpp_dependencies# ; #engine# == \"llama.cpp\""


### PR DESCRIPTION
## Summary

Fix two vllm dependency issues affecting three models that use `qwen_omni_utils`:

### 1. `#system_numpy#` missing (all three models)

`qwen_omni_utils` transitively depends on `librosa` → `numba`. In environments where numpy 2.5+ is available, uv resolves numpy to 2.5.1 which conflicts with numba (all py3.12-compatible numba versions require `numpy<2.5`). uv then backtracks numba to 0.53.1, which requires Python<3.10, causing a build failure on Python 3.12.

Adding `#system_numpy#` pins numpy to the system version, keeping it below 2.5 and compatible with numba. Consistent with 160+ other models already using this marker, including sibling models `Nex-N2` (same architecture) and `gemma-4` (same dependency).

### 2. `vllm>=0.17.0` too loose (Ornith-1.0-35B, qwen3.5)

These models pin `transformers==4.57.6` (v4) for vllm engine, but `vllm>=0.17.0` allows vllm 0.24+ to be resolved when the worker has a newer vllm installed. vllm 0.24+ dropped transformers v4 support, causing `ImportError`.

Pinning to `vllm==0.21.0` aligns with sibling model `qwen3.6`, which already uses this exact pin. vllm 0.21.0 supports both transformers v4 and the `Qwen3_5MoeForConditionalGeneration` architecture.

## Changes

| Model | `#system_numpy#` | `vllm` pin |
|-------|-----------------|------------|
| Ornith-1.0-35B | added | `>=0.17.0` → `==0.21.0` |
| qwen3.5 | added | `>=0.17.0` → `==0.21.0` |
| qwen3.6 | added | `==0.21.0` (unchanged) |

## Verification

- [x] `python -c "import json; json.load(open(...))"` — JSON valid
- [x] Consistent with upstream patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)
