### PR TITLE
FIX: suppress GPU warnings in CPU image

### DIFF
--- a/xinference/core/tests/test_subpool_hardening.py
+++ b/xinference/core/tests/test_subpool_hardening.py
@@ -419,9 +419,23 @@ async def test_kill_gpu_orphans_by_ppid_no_orphans_returns_empty(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
+async def test_startup_cleanup_skips_without_nvidia_gpu(monkeypatch):
+    import xinference.core.worker as w
+
+    monkeypatch.setattr(w, "get_available_device_env_name", lambda: None)
+    self = _make_worker()
+    with patch("xinference.core.worker._nvml_init_with_timeout") as mock_init:
+        await self._cleanup_gpu_orphans_on_startup()
+    mock_init.assert_not_called()
+
+
 async def test_startup_cleanup_nvml_failure_degrades(monkeypatch):
     import xinference.core.worker as w
 
+    monkeypatch.setattr(
+        w, "get_available_device_env_name", lambda: "CUDA_VISIBLE_DEVICES"
+    )
+    monkeypatch.setattr(w, "gpu_count", lambda: 1)
     monkeypatch.setattr(w, "_nvml_init_with_timeout", lambda timeout=10: False)
     self = _make_worker()
     # Must not raise and must not attempt any snapshot/kill.
@@ -433,6 +447,10 @@ async def test_startup_cleanup_nvml_failure_degrades(monkeypatch):
 async def test_startup_cleanup_no_orphans_returns_cleanly(monkeypatch):
     import xinference.core.worker as w
 
+    monkeypatch.setattr(
+        w, "get_available_device_env_name", lambda: "CUDA_VISIBLE_DEVICES"
+    )
+    monkeypatch.setattr(w, "gpu_count", lambda: 1)
     monkeypatch.setattr(w, "_nvml_init_with_timeout", lambda timeout=10: True)
     monkeypatch.setattr(
         "xinference.core.worker._snapshot_gpu_occupying_pids", lambda devs: set()
@@ -447,6 +465,10 @@ async def test_startup_cleanup_no_orphans_returns_cleanly(monkeypatch):
 async def test_startup_cleanup_kills_orphans(monkeypatch):
     import xinference.core.worker as w
 
+    monkeypatch.setattr(
+        w, "get_available_device_env_name", lambda: "CUDA_VISIBLE_DEVICES"
+    )
+    monkeypatch.setattr(w, "gpu_count", lambda: 1)
     monkeypatch.setattr(w, "_nvml_init_with_timeout", lambda timeout=10: True)
 
     # nvmlDeviceGetCount inside the method (pynvml is imported locally).

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -912,6 +912,20 @@ class WorkerActor(xo.StatelessActor):
         driver cannot block startup. Never raises — failures degrade to a
         warning and rely on H2/C as backstops.
         """
+        # This cleanup is NVIDIA-specific.  CPU images still install pynvml as
+        # a lightweight runtime dependency, but they do not expose NVML (or any
+        # CUDA devices) to the container.  Avoid an unnecessary 10-second
+        # nvmlInit timeout and a misleading warning in that environment.  The
+        # environment-name check also excludes non-NVIDIA accelerators.
+        if (
+            get_available_device_env_name() != "CUDA_VISIBLE_DEVICES"
+            or gpu_count() == 0
+        ):
+            logger.debug(
+                "Startup GPU orphan cleanup skipped: no NVIDIA GPU devices detected"
+            )
+            return
+
         if not _nvml_init_with_timeout():
             logger.warning(
                 "Startup GPU orphan cleanup skipped: pynvml init failed or "

--- a/xinference/deploy/docker/Dockerfile.cpu
+++ b/xinference/deploy/docker/Dockerfile.cpu
@@ -14,22 +14,12 @@ RUN apt-get -y update \
   && apt install -y build-essential curl procps git libgl1 \
   && apt-get -yq clean
 
-# GPTQModel requires torchao.  torchao 0.16.0 also publishes a cp310-abi3
-# wheel containing optional CUDA extensions; pip prefers it on Python 3.11,
-# even in this CPU-only image.  Select the pure-Python wheel explicitly so
-# importing torchao does not try to load those unusable CUDA libraries.
 ARG PIP_INDEX=https://pypi.org/simple
-ARG TORCHAO_VERSION=0.16.0
 COPY xinference/deploy/docker/requirements_cpu/ /opt/inference/xinference/deploy/docker/requirements_cpu/
 RUN --mount=type=cache,target=/root/.cache/pip \
     python -m pip install --upgrade -i "$PIP_INDEX" pip "setuptools<82" wheel "packaging>=24.2" && \
     pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu && \
     pip install -i "$PIP_INDEX" --upgrade-strategy only-if-needed -r /opt/inference/xinference/deploy/docker/requirements_cpu/requirements_cpu-base.txt && \
-    mkdir -p /tmp/torchao-pure && \
-    pip download -i "$PIP_INDEX" --no-deps --only-binary=:all: --platform any \
-      --dest /tmp/torchao-pure "torchao==$TORCHAO_VERSION" && \
-    pip install --no-deps /tmp/torchao-pure/torchao-*.whl && \
-    rm -rf /tmp/torchao-pure && \
     pip install -i "$PIP_INDEX" --no-build-isolation "gptqmodel<6.0.0" && \
     pip install -i "$PIP_INDEX" --upgrade-strategy only-if-needed -r /opt/inference/xinference/deploy/docker/requirements_cpu/requirements_cpu-ml.txt && \
     pip install -i "$PIP_INDEX" --upgrade-strategy  only-if-needed -r /opt/inference/xinference/deploy/docker/requirements_cpu/requirements_cpu-models.txt && \

--- a/xinference/deploy/docker/Dockerfile.cpu
+++ b/xinference/deploy/docker/Dockerfile.cpu
@@ -14,12 +14,22 @@ RUN apt-get -y update \
   && apt install -y build-essential curl procps git libgl1 \
   && apt-get -yq clean
 
+# GPTQModel requires torchao.  torchao 0.16.0 also publishes a cp310-abi3
+# wheel containing optional CUDA extensions; pip prefers it on Python 3.11,
+# even in this CPU-only image.  Select the pure-Python wheel explicitly so
+# importing torchao does not try to load those unusable CUDA libraries.
 ARG PIP_INDEX=https://pypi.org/simple
+ARG TORCHAO_VERSION=0.16.0
 COPY xinference/deploy/docker/requirements_cpu/ /opt/inference/xinference/deploy/docker/requirements_cpu/
 RUN --mount=type=cache,target=/root/.cache/pip \
     python -m pip install --upgrade -i "$PIP_INDEX" pip "setuptools<82" wheel "packaging>=24.2" && \
     pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu && \
     pip install -i "$PIP_INDEX" --upgrade-strategy only-if-needed -r /opt/inference/xinference/deploy/docker/requirements_cpu/requirements_cpu-base.txt && \
+    mkdir -p /tmp/torchao-pure && \
+    pip download -i "$PIP_INDEX" --no-deps --only-binary=:all: --platform any \
+      --dest /tmp/torchao-pure "torchao==$TORCHAO_VERSION" && \
+    pip install --no-deps /tmp/torchao-pure/torchao-*.whl && \
+    rm -rf /tmp/torchao-pure && \
     pip install -i "$PIP_INDEX" --no-build-isolation "gptqmodel<6.0.0" && \
     pip install -i "$PIP_INDEX" --upgrade-strategy only-if-needed -r /opt/inference/xinference/deploy/docker/requirements_cpu/requirements_cpu-ml.txt && \
     pip install -i "$PIP_INDEX" --upgrade-strategy  only-if-needed -r /opt/inference/xinference/deploy/docker/requirements_cpu/requirements_cpu-models.txt && \


### PR DESCRIPTION
Partially addresses #5237




** Summary**

- Skip NVIDIA GPU orphan cleanup when no CUDA devices are detected.
- Add tests covering startup cleanup behavior without NVIDIA GPUs.