### PR TITLE
fix(gemma): keep quotes inside tool call arguments

### DIFF
--- a/xinference/model/llm/tool_parsers/gemma_tool_parser.py
+++ b/xinference/model/llm/tool_parsers/gemma_tool_parser.py
@@ -22,14 +22,12 @@ class GemmaToolParser(ToolParser):
     def __init__(self):
         self.tool_call_start_token = "<|tool_call>"
         self.tool_call_end_token = "<tool_call|>"
+        self.string_token = '<|"|>'
+
         self.tool_call_regex = re.compile(
             r"(<\|tool_call\>.*?<tool_call\|>)", re.DOTALL
         )
         self.call_header_regex = re.compile(r"call\s*:\s*([^{\s]+)", re.IGNORECASE)
-
-    @staticmethod
-    def _replace_quotes(text: str) -> str:
-        return text.replace('<|"|>', '"')
 
     @staticmethod
     def _quote_keys(text: str) -> str:
@@ -47,12 +45,42 @@ class GemmaToolParser(ToolParser):
                 break
         return text
 
+    def _arguments_to_json(self, arg_block: str) -> str:
+        """Rewrite Gemma's argument block as JSON.
+
+        Gemma delimits strings with ``<|"|>`` rather than quoting them, so the
+        text between two of those tokens is a literal: it may itself contain
+        double quotes, backslashes or newlines, and re-emitting it verbatim
+        would produce invalid JSON. Each string is therefore re-encoded, and
+        bare keys are quoted only in the structural text between strings — a
+        value containing something like ``a,b:c`` must not be mistaken for one.
+        """
+        segments: List[str] = []
+        structural: List[str] = []
+        index = 0
+        token = self.string_token
+        while index < len(arg_block):
+            if arg_block.startswith(token, index):
+                end = arg_block.find(token, index + len(token))
+                if end == -1:
+                    raise ValueError("Unterminated string in tool call arguments")
+                segments.append(self._quote_keys("".join(structural)))
+                structural = []
+                segments.append(
+                    json.dumps(arg_block[index + len(token) : end], ensure_ascii=False)
+                )
+                index = end + len(token)
+            else:
+                structural.append(arg_block[index])
+                index += 1
+        segments.append(self._quote_keys("".join(structural)))
+        return "".join(segments)
+
     def _parse_arguments(self, arg_block: str) -> Dict[str, Any]:
-        cleaned = self._replace_quotes(arg_block.strip())
+        cleaned = arg_block.strip()
         if not cleaned:
             return {}
-        normalized = self._quote_keys(cleaned)
-        return json.loads(normalized)
+        return json.loads(self._arguments_to_json(cleaned))
 
     def _parse_tool_call_block(
         self, block: str

--- a/xinference/model/llm/tool_parsers/tests/test_gemma_tool_parser.py
+++ b/xinference/model/llm/tool_parsers/tests/test_gemma_tool_parser.py
@@ -46,3 +46,70 @@ def test_streaming_ignores_processed_block(parser):
     current = block + " more text"
     result = parser.extract_tool_calls_streaming(previous, current, " more text")
     assert result == (" more text", None, None)
+
+
+def test_string_values_may_contain_quotes(parser):
+    # Gemma delimits strings with <|"|> instead of quoting them, so a value is
+    # free to contain double quotes. Replacing the delimiters textually and
+    # handing the result to json.loads broke on exactly this, which is what
+    # every routing prompt that quotes the user back produces.
+    output = (
+        "<|tool_call>call:select_execution_pattern"
+        '{action:<|"|>final_answer<|"|>,'
+        'reason:<|"|>The user said "你好" (Hello), a simple greeting.<|"|>,'
+        "requires_current_or_external_facts:false}"
+        "<tool_call|>"
+    )
+
+    result = parser.extract_tool_calls(output)
+
+    assert result == [
+        (
+            None,
+            "select_execution_pattern",
+            {
+                "action": "final_answer",
+                "reason": 'The user said "你好" (Hello), a simple greeting.',
+                "requires_current_or_external_facts": False,
+            },
+        )
+    ]
+
+
+def test_string_values_may_look_like_arguments(parser):
+    # A key is only a key in the structural text between strings; `b:` inside a
+    # value must survive verbatim rather than being quoted as one.
+    output = (
+        "<|tool_call>call:note"
+        '{text:<|"|>a,b:c and a backslash \\ plus a\nnewline<|"|>}'
+        "<tool_call|>"
+    )
+
+    result = parser.extract_tool_calls(output)
+
+    assert result == [
+        (None, "note", {"text": "a,b:c and a backslash \\ plus a\nnewline"})
+    ]
+
+
+def test_empty_and_repeated_arguments(parser):
+    # Empty strings are two delimiters back to back, and Gemma sometimes emits a
+    # key twice; the later value wins, as in JSON.
+    output = (
+        "<|tool_call>call:probe"
+        '{missing_verification:<|"|><|"|>,flag:true,flag:false}'
+        "<tool_call|>"
+    )
+
+    result = parser.extract_tool_calls(output)
+
+    assert result == [(None, "probe", {"missing_verification": "", "flag": False})]
+
+
+def test_unterminated_string_is_reported_as_text(parser):
+    output = '<|tool_call>call:note{text:<|"|>never closed}<tool_call|>'
+
+    result = parser.extract_tool_calls(output)
+
+    # unparsable blocks come back as content rather than a bogus tool call
+    assert result == [(output, None, None)]


### PR DESCRIPTION
## Symptom

An agent that routes through a decision tool call reports that the model returned no tool call:

> Auto routing failed because the model did not return the required decision tool call. Please retry.

The model in fact returned exactly what was asked. Here is the raw output from `gemma-4` served by the MLX engine:

```
<|tool_call>call:select_execution_pattern{action:<|"|>final_answer<|"|>,
answer:<|"|>你好！请问有什么我可以帮您的？<|"|>,
reason:<|"|>The user said "你好" (Hello), which is a simple greeting. A conversational response is appropriate.<|"|>,
requires_current_or_external_facts:false}<tool_call|>
```

## Cause

Gemma delimits string arguments with `<|"|>` rather than quoting them, so a value is free to contain double quotes of its own. `_parse_arguments` replaced those delimiters with `"` textually and handed the result to `json.loads`:

```
Failed to parse Gemma tool call: ..., error: Expecting ',' delimiter: line 1 column 163 (char 162)
```

Character 162 is the `"` in `said "你好"`. The block then falls back to being returned as plain text, so callers relying on `tool_calls` get an empty list. Quoting the user back is what most routing and classification prompts produce, so this fires constantly rather than at the margins.

Textual replacement had a second consequence: key quoting ran over the whole string, so a value like `a,b:c` had its inner `b:` rewritten into a key.

## Fix

Rewrite the argument block by scanning it: text between two `<|"|>` tokens is re-encoded with `json.dumps`, and bare keys are quoted only in the structural text between strings. Values may then contain quotes, backslashes, newlines, or anything that looks like an argument. An unterminated string is reported as text, as before.

## Tests

Four new cases, all against `GemmaToolParser` directly:

- a value containing double quotes (the reported failure, with the payload above)
- a value containing `a,b:c`, a backslash and a newline
- an empty string (`<|"|><|"|>`) and a repeated key
- an unterminated string, which must stay text rather than become a bogus tool call

The first two fail against the previous implementation. Full tool-parser suite: 70 passed.