### PR TITLE
fix(i18n): change SSO button text from Keycloak to generic SSO

### DIFF
--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -652,7 +652,7 @@ const en = {
     mustChangePasswordDesc: 'You need to change your password before continuing on first login.',
     changePasswordUserMissing: 'Unable to identify the current user. Please log in again.',
     or: 'or',
-    ssoLogin: 'Sign in with Keycloak',
+    ssoLogin: 'Sign in with SSO',
   },
   setup: {
     welcome: 'Welcome to Xinference',

--- a/frontend/src/i18n/locales/ja.ts
+++ b/frontend/src/i18n/locales/ja.ts
@@ -651,7 +651,7 @@ const ja = {
     mustChangePasswordDesc: '初回ログイン時は、続行する前にパスワードを変更してください。',
     changePasswordUserMissing: '現在のユーザーを識別できません。もう一度ログインしてください。',
     or: 'または',
-    ssoLogin: 'Keycloak でログイン',
+    ssoLogin: 'SSO でログイン',
   },
   setup: {
     welcome: 'Xinference へようこそ',

--- a/frontend/src/i18n/locales/ko.ts
+++ b/frontend/src/i18n/locales/ko.ts
@@ -645,7 +645,7 @@ const ko = {
     mustChangePasswordDesc: '첫 로그인 시 계속하기 전에 비밀번호를 변경해야 합니다.',
     changePasswordUserMissing: '현재 사용자를 식별할 수 없습니다. 다시 로그인해주세요.',
     or: '또는',
-    ssoLogin: 'Keycloak으로 로그인',
+    ssoLogin: 'SSO로 로그인',
   },
   setup: {
     welcome: 'Xinference에 오신 것을 환영합니다',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -407,7 +407,7 @@ const zh = {
     mustChangePasswordDesc: '首次登录，需要先修改密码才能继续使用。',
     changePasswordUserMissing: '无法识别当前用户，请重新登录后再试。',
     or: '或',
-    ssoLogin: '使用 Keycloak 登录',
+    ssoLogin: '使用 SSO 登录',
   },
   setup: {
     welcome: '欢迎使用 Xinference',


### PR DESCRIPTION
## Summary

Changes the SSO login button text on the login page from vendor-specific 'Keycloak' to the provider-neutral 'SSO' across all 4 supported languages.

## Problem

The login page SSO button text hardcodes 'Keycloak' (introduced in #5218), but the backend OIDC client in `xinference/api/oauth2/advanced/oidc.py` is a generic OIDC implementation — the issuer is configured via `XINFERENCE_OIDC_ISSUER` and can point to any OIDC-compliant identity provider. The UI text should not imply a vendor lock-in that doesn't exist.

## Changes

4 files, 1 line each:

| File | Before | After |
|---|---|---|
| `frontend/src/i18n/locales/zh.ts` | `使用 Keycloak 登录` | `使用 SSO 登录` |
| `frontend/src/i18n/locales/en.ts` | `Sign in with Keycloak` | `Sign in with SSO` |
| `frontend/src/i18n/locales/ja.ts` | `Keycloak でログイン` | `SSO でログイン` |
| `frontend/src/i18n/locales/ko.ts` | `Keycloak으로 로그인` | `SSO로 로그인` |

## What's NOT changed

- i18n key name (`login.ssoLogin`) — only the string value
- Button visibility logic, click handler, redirect URL
- Backend OIDC flow

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)