### PR TITLE
feat(vllm): populate logprobs/top_logprobs in completion responses

### DIFF
--- a/xinference/model/llm/vllm/core.py
+++ b/xinference/model/llm/vllm/core.py
@@ -1264,8 +1264,11 @@ class VLLMModel(LLM):
                 getattr(sampled, "decoded_token", None) if sampled is not None else None
             )
             token_text = sampled_decoded if sampled_decoded else ""
-            token_lp = (
+            raw_token_lp = (
                 getattr(sampled, "logprob", None) if sampled is not None else None
+            )
+            token_lp = (
+                max(float(raw_token_lp), -9999.0) if raw_token_lp is not None else None
             )
             tokens.append(token_text)
             token_logprobs.append(token_lp)
@@ -1274,7 +1277,7 @@ class VLLMModel(LLM):
                 decoded_token = getattr(lp, "decoded_token", None)
                 logprob = getattr(lp, "logprob", None)
                 if decoded_token is not None and logprob is not None:
-                    decoded_logprobs[decoded_token] = float(logprob)
+                    decoded_logprobs[decoded_token] = max(float(logprob), -9999.0)
             top_logprobs.append(decoded_logprobs)
             text_offset.append(offset)
             if token_text:

--- a/xinference/model/llm/vllm/core.py
+++ b/xinference/model/llm/vllm/core.py
@@ -53,6 +53,7 @@ from ....types import (
     Completion,
     CompletionChoice,
     CompletionChunk,
+    CompletionLogprobs,
     CompletionUsage,
     LoRA,
 )
@@ -1145,6 +1146,22 @@ class VLLMModel(LLM):
             "guided_json_object",
             generate_config.get("guided_json_object", guided_json_object),
         )
+        # logprobs: translate the chat-completions API request fields
+        # (``logprobs``: bool, ``top_logprobs``: int) into vLLM's native
+        # ``logprobs`` (int: number of top logprobs to return per position).
+        # When the caller asks for logprobs, request at least the sampled token
+        # plus the requested number of alternatives so they can be surfaced in
+        # the response. ``prompt_logprobs`` is passed through unchanged.
+        _logprobs_req = generate_config.get("logprobs")
+        _top_logprobs_req = generate_config.get("top_logprobs")
+        if _logprobs_req:
+            _vllm_logprobs = max(int(_top_logprobs_req) if _top_logprobs_req else 1, 1)
+        else:
+            _vllm_logprobs = 0
+        sanitized.setdefault("logprobs", _vllm_logprobs)
+        sanitized.setdefault(
+            "prompt_logprobs", generate_config.get("prompt_logprobs", None)
+        )
         # 1. Try to get from generate config
         ignore_eos_val = generate_config.get("ignore_eos")
 
@@ -1215,6 +1232,64 @@ class VLLMModel(LLM):
         return True
 
     @staticmethod
+    def _build_logprobs(output: "RequestOutput") -> Optional[CompletionLogprobs]:
+        """Build a chat-completions-compatible ``CompletionLogprobs`` from a
+        vLLM request output.
+
+        Returns ``None`` when the engine did not produce logprobs (i.e. the
+        caller did not request them via ``generate_config``), preserving the
+        previous behaviour. When logprobs are present, they are mapped to the
+        ``text_offset`` / ``tokens`` / ``token_logprobs`` / ``top_logprobs``
+        shape defined by ``CompletionLogprobs``.
+        """
+        output_logprobs = getattr(output, "logprobs", None)
+        if not output_logprobs:
+            return None
+        token_ids = getattr(output, "token_ids", []) or []
+        tokens: List[str] = []
+        token_logprobs: List[Optional[float]] = []
+        top_logprobs: List[Optional[Dict[str, float]]] = []
+        text_offset: List[int] = []
+        offset = 0
+        for i, token_id in enumerate(token_ids):
+            lp_dict = (
+                output_logprobs[i] if i < len(output_logprobs) else None
+            )
+            if not lp_dict:
+                tokens.append("")
+                token_logprobs.append(None)
+                top_logprobs.append(None)
+                text_offset.append(offset)
+                continue
+            sampled = lp_dict.get(token_id)
+            sampled_decoded = (
+                getattr(sampled, "decoded_token", None) if sampled is not None else None
+            )
+            token_text = sampled_decoded if sampled_decoded else ""
+            token_lp = (
+                getattr(sampled, "logprob", None) if sampled is not None else None
+            )
+            tokens.append(token_text)
+            token_logprobs.append(token_lp)
+            top_logprobs.append(
+                {
+                    (getattr(lp, "decoded_token", None) or ""): getattr(
+                        lp, "logprob", None
+                    )
+                    for tid, lp in lp_dict.items()
+                }
+            )
+            text_offset.append(offset)
+            if token_text:
+                offset += len(token_text)
+        return CompletionLogprobs(
+            text_offset=text_offset,
+            token_logprobs=token_logprobs,
+            tokens=tokens,
+            top_logprobs=top_logprobs,
+        )
+
+    @staticmethod
     def _convert_request_output_to_completion_chunk(
         request_id: str, model: str, request_output: "RequestOutput"
     ) -> Tuple[CompletionChunk, Optional[str]]:
@@ -1225,7 +1300,7 @@ class VLLMModel(LLM):
                 CompletionChoice(
                     text=output.text,
                     index=output.index,
-                    logprobs=None,  # TODO: support logprobs.
+                    logprobs=VLLMModel._build_logprobs(output),
                     finish_reason=None,
                 )
             )
@@ -1251,7 +1326,7 @@ class VLLMModel(LLM):
                 CompletionChoice(
                     text=output.text,
                     index=output.index,
-                    logprobs=None,  # TODO: support logprobs.
+                    logprobs=VLLMModel._build_logprobs(output),
                     finish_reason=output.finish_reason,
                 )
             )

--- a/xinference/model/llm/vllm/core.py
+++ b/xinference/model/llm/vllm/core.py
@@ -126,6 +126,8 @@ class VLLMGenerateConfig(TypedDict, total=False):
     presence_penalty: float
     frequency_penalty: float
     repetition_penalty: float
+    logprobs: Optional[int]
+    prompt_logprobs: Optional[int]
     temperature: float
     top_p: float
     top_k: int
@@ -1146,19 +1148,16 @@ class VLLMModel(LLM):
             "guided_json_object",
             generate_config.get("guided_json_object", guided_json_object),
         )
-        # logprobs: translate the chat-completions API request fields
-        # (``logprobs``: bool, ``top_logprobs``: int) into vLLM's native
-        # ``logprobs`` (int: number of top logprobs to return per position).
-        # When the caller asks for logprobs, request at least the sampled token
-        # plus the requested number of alternatives so they can be surfaced in
-        # the response. ``prompt_logprobs`` is passed through unchanged.
-        _logprobs_req = generate_config.get("logprobs")
-        _top_logprobs_req = generate_config.get("top_logprobs")
-        if _logprobs_req:
-            _vllm_logprobs = max(int(_top_logprobs_req) if _top_logprobs_req else 1, 1)
+        # Legacy completions use an integer ``logprobs`` value directly. Chat
+        # completions use ``logprobs`` as a boolean and put the requested count
+        # in ``top_logprobs``. vLLM uses None, not 0, to disable logprobs.
+        logprobs_req = generate_config.get("logprobs")
+        if isinstance(logprobs_req, bool):
+            top_logprobs_req = generate_config.get("top_logprobs")
+            vllm_logprobs = max(int(top_logprobs_req or 0), 0) if logprobs_req else None
         else:
-            _vllm_logprobs = 0
-        sanitized.setdefault("logprobs", _vllm_logprobs)
+            vllm_logprobs = logprobs_req
+        sanitized.setdefault("logprobs", vllm_logprobs)
         sanitized.setdefault(
             "prompt_logprobs", generate_config.get("prompt_logprobs", None)
         )
@@ -1232,9 +1231,10 @@ class VLLMModel(LLM):
         return True
 
     @staticmethod
-    def _build_logprobs(output: "RequestOutput") -> Optional[CompletionLogprobs]:
-        """Build a chat-completions-compatible ``CompletionLogprobs`` from a
-        vLLM request output.
+    def _build_logprobs(
+        output: "RequestOutput", prompt_offset: int = 0
+    ) -> Optional[CompletionLogprobs]:
+        """Build a legacy-completions ``CompletionLogprobs`` from vLLM output.
 
         Returns ``None`` when the engine did not produce logprobs (i.e. the
         caller did not request them via ``generate_config``), preserving the
@@ -1250,11 +1250,9 @@ class VLLMModel(LLM):
         token_logprobs: List[Optional[float]] = []
         top_logprobs: List[Optional[Dict[str, float]]] = []
         text_offset: List[int] = []
-        offset = 0
+        offset = prompt_offset
         for i, token_id in enumerate(token_ids):
-            lp_dict = (
-                output_logprobs[i] if i < len(output_logprobs) else None
-            )
+            lp_dict = output_logprobs[i] if i < len(output_logprobs) else None
             if not lp_dict:
                 tokens.append("")
                 token_logprobs.append(None)
@@ -1271,14 +1269,13 @@ class VLLMModel(LLM):
             )
             tokens.append(token_text)
             token_logprobs.append(token_lp)
-            top_logprobs.append(
-                {
-                    (getattr(lp, "decoded_token", None) or ""): getattr(
-                        lp, "logprob", None
-                    )
-                    for tid, lp in lp_dict.items()
-                }
-            )
+            decoded_logprobs: Dict[str, float] = {}
+            for lp in lp_dict.values():
+                decoded_token = getattr(lp, "decoded_token", None)
+                logprob = getattr(lp, "logprob", None)
+                if decoded_token is not None and logprob is not None:
+                    decoded_logprobs[decoded_token] = float(logprob)
+            top_logprobs.append(decoded_logprobs)
             text_offset.append(offset)
             if token_text:
                 offset += len(token_text)
@@ -1290,17 +1287,29 @@ class VLLMModel(LLM):
         )
 
     @staticmethod
+    def _slice_logprobs(logprobs: CompletionLogprobs, start: int) -> CompletionLogprobs:
+        """Return the newly generated portion of cumulative vLLM logprobs."""
+        return CompletionLogprobs(
+            text_offset=logprobs["text_offset"][start:],
+            token_logprobs=logprobs["token_logprobs"][start:],
+            tokens=logprobs["tokens"][start:],
+            top_logprobs=logprobs["top_logprobs"][start:],
+        )
+
+    @staticmethod
     def _convert_request_output_to_completion_chunk(
         request_id: str, model: str, request_output: "RequestOutput"
     ) -> Tuple[CompletionChunk, Optional[str]]:
         choices: List[CompletionChoice] = []
         finish_reason = None
+        prompt = getattr(request_output, "prompt", None)
+        prompt_offset = len(prompt) if isinstance(prompt, str) else 0
         for output in request_output.outputs:
             choices.append(
                 CompletionChoice(
                     text=output.text,
                     index=output.index,
-                    logprobs=VLLMModel._build_logprobs(output),
+                    logprobs=VLLMModel._build_logprobs(output, prompt_offset),
                     finish_reason=None,
                 )
             )
@@ -1321,12 +1330,14 @@ class VLLMModel(LLM):
         request_id: str, model: str, request_output: "RequestOutput"
     ) -> Completion:
         choices = []
+        prompt = getattr(request_output, "prompt", None)
+        prompt_offset = len(prompt) if isinstance(prompt, str) else 0
         for output in request_output.outputs:
             choices.append(
                 CompletionChoice(
                     text=output.text,
                     index=output.index,
-                    logprobs=VLLMModel._build_logprobs(output),
+                    logprobs=VLLMModel._build_logprobs(output, prompt_offset),
                     finish_reason=output.finish_reason,
                 )
             )
@@ -1653,6 +1664,7 @@ class VLLMModel(LLM):
 
         async def stream_results() -> AsyncGenerator[CompletionChunk, None]:
             previous_texts = [""] * sanitized_generate_config["n"]
+            previous_logprobs_counts = [0] * sanitized_generate_config["n"]
             prompt_tokens, completion_tokens, total_tokens = 0, 0, 0
             complete_response = ""
             match_tool_call_tmp_results = []
@@ -1670,6 +1682,13 @@ class VLLMModel(LLM):
                     delta = choice["text"][len(previous_texts[i]) :]
                     previous_texts[i] = choice["text"]
                     choice["text"] = delta
+                    logprobs = choice["logprobs"]
+                    if logprobs is not None:
+                        current_count = len(logprobs["tokens"])
+                        choice["logprobs"] = self._slice_logprobs(
+                            logprobs, previous_logprobs_counts[i]
+                        )
+                        previous_logprobs_counts[i] = current_count
                     complete_response += delta
 
                 prompt_tokens = len(_request_output.prompt_token_ids)

--- a/xinference/model/llm/vllm/tests/test_core_chat_model.py
+++ b/xinference/model/llm/vllm/tests/test_core_chat_model.py
@@ -1749,6 +1749,23 @@ class TestVLLMModelLogprobs:
         assert "" not in result["top_logprobs"][0]
         assert "ab" in result["top_logprobs"][0]
 
+    def test_build_logprobs_clamps_negative_infinity(self):
+        from ..core import VLLMModel
+
+        logprobs = [
+            {
+                10: self._make_logprob(float("-inf"), "ab"),
+                99: self._make_logprob(float("-inf"), "cd"),
+            }
+        ]
+        request_output = self._make_request_output(
+            text="ab", token_ids=[10], logprobs=logprobs
+        )
+        result = VLLMModel._build_logprobs(request_output.outputs[0])
+        assert result is not None
+        assert result["token_logprobs"] == [-9999.0]
+        assert result["top_logprobs"] == [{"ab": -9999.0, "cd": -9999.0}]
+
     def test_slice_logprobs_returns_only_new_stream_tokens(self):
         from ..core import VLLMModel
 

--- a/xinference/model/llm/vllm/tests/test_core_chat_model.py
+++ b/xinference/model/llm/vllm/tests/test_core_chat_model.py
@@ -15,6 +15,7 @@
 from unittest.mock import MagicMock
 
 import pytest
+from packaging import version
 
 from ...tool_parsers.qwen_tool_parser import QwenToolParser
 
@@ -1625,7 +1626,7 @@ class TestVLLMModelLogprobs:
 
     @classmethod
     def _make_request_output(
-        cls, *, text, token_ids, logprobs, finish_reason="stop"
+        cls, *, text, token_ids, logprobs, finish_reason="stop", prompt=""
     ):
         output = MagicMock()
         output.text = text
@@ -1635,6 +1636,7 @@ class TestVLLMModelLogprobs:
         output.finish_reason = finish_reason
         request_output = MagicMock()
         request_output.outputs = [output]
+        request_output.prompt = prompt
         request_output.prompt_token_ids = [1, 2, 3]
         return request_output
 
@@ -1660,22 +1662,26 @@ class TestVLLMModelLogprobs:
         request_output = self._make_request_output(
             text=" hello world", token_ids=[10, 11], logprobs=logprobs
         )
-        result = VLLMModel._build_logprobs(request_output.outputs[0])
+        result = VLLMModel._build_logprobs(request_output.outputs[0], prompt_offset=4)
         assert result is not None
         assert result["tokens"] == [" hello", " world"]
         assert result["token_logprobs"] == [-0.1, -0.2]
         assert result["top_logprobs"][0][" hello"] == -0.1
         assert result["top_logprobs"][0][" hi"] == -3.2
         assert result["top_logprobs"][1][" world"] == -0.2
-        # text_offset advances by each decoded token's length
-        assert result["text_offset"] == [0, 6]
+        # text_offset is relative to the full prompt + completion text.
+        assert result["text_offset"] == [4, 10]
 
     def test_convert_request_output_to_completion_carries_logprobs(self):
         from ..core import VLLMModel
 
         logprobs = [{10: self._make_logprob(-0.5, "ab")}]
         request_output = self._make_request_output(
-            text="ab", token_ids=[10], logprobs=logprobs, finish_reason="stop"
+            text="ab",
+            token_ids=[10],
+            logprobs=logprobs,
+            finish_reason="stop",
+            prompt="say:",
         )
         completion = VLLMModel._convert_request_output_to_completion(
             request_id="req-1", model="m", request_output=request_output
@@ -1684,6 +1690,7 @@ class TestVLLMModelLogprobs:
         assert choice["logprobs"] is not None
         assert choice["logprobs"]["tokens"] == ["ab"]
         assert choice["logprobs"]["token_logprobs"] == [-0.5]
+        assert choice["logprobs"]["text_offset"] == [4]
 
     def test_convert_request_output_to_completion_logprobs_none_when_absent(self):
         from ..core import VLLMModel
@@ -1737,26 +1744,59 @@ class TestVLLMModelLogprobs:
         )
         result = VLLMModel._build_logprobs(request_output.outputs[0])
         assert result is not None
-        # the malformed entry's key is the empty string, never str(99)
+        # Malformed alternatives without decoded text are omitted.
         assert "99" not in result["top_logprobs"][0]
+        assert "" not in result["top_logprobs"][0]
         assert "ab" in result["top_logprobs"][0]
 
-    def test_sanitize_translates_logprobs_request_to_vllm_int(self):
-        from ..core import VLLMChatModel
+    def test_slice_logprobs_returns_only_new_stream_tokens(self):
+        from ..core import VLLMModel
 
-        # logprobs=True with top_logprobs=5 -> vLLM logprobs=5
-        sanitized = VLLMChatModel._sanitize_generate_config(
+        cumulative = VLLMModel._build_logprobs(
+            self._make_request_output(
+                text="ab",
+                token_ids=[10, 11],
+                logprobs=[
+                    {10: self._make_logprob(-0.1, "a")},
+                    {11: self._make_logprob(-0.2, "b")},
+                ],
+            ).outputs[0],
+            prompt_offset=4,
+        )
+        assert cumulative is not None
+        delta = VLLMModel._slice_logprobs(cumulative, 1)
+        assert delta == {
+            "text_offset": [5],
+            "tokens": ["b"],
+            "token_logprobs": [-0.2],
+            "top_logprobs": [{"b": -0.2}],
+        }
+
+    def test_sanitize_translates_logprobs_request_to_vllm_int(self, monkeypatch):
+        from .. import core
+
+        monkeypatch.setattr(core, "VLLM_VERSION", version.parse("0.21.0"))
+
+        # Legacy completions pass their integer logprobs value through.
+        sanitized = core.VLLMModel._sanitize_generate_config({"logprobs": 5})
+        assert sanitized["logprobs"] == 5
+        sanitized = core.VLLMModel._sanitize_generate_config({"logprobs": 0})
+        assert sanitized["logprobs"] == 0
+
+        # Chat requests use a boolean plus top_logprobs.
+        sanitized = core.VLLMModel._sanitize_generate_config(
             {"logprobs": True, "top_logprobs": 5}
         )
         assert sanitized["logprobs"] == 5
-        # logprobs=True without top_logprobs -> at least 1
-        sanitized = VLLMChatModel._sanitize_generate_config({"logprobs": True})
-        assert sanitized["logprobs"] == 1
-        # not requested -> 0 (vLLM disables logprobs)
-        sanitized = VLLMChatModel._sanitize_generate_config({})
+        sanitized = core.VLLMModel._sanitize_generate_config({"logprobs": True})
         assert sanitized["logprobs"] == 0
+
+        # vLLM uses None, rather than 0, to disable logprobs.
+        sanitized = core.VLLMModel._sanitize_generate_config({"logprobs": False})
+        assert sanitized["logprobs"] is None
+        sanitized = core.VLLMModel._sanitize_generate_config({})
+        assert sanitized["logprobs"] is None
+
         # prompt_logprobs passes through
-        sanitized = VLLMChatModel._sanitize_generate_config(
-            {"prompt_logprobs": 3}
-        )
+        sanitized = core.VLLMModel._sanitize_generate_config({"prompt_logprobs": 3})
         assert sanitized["prompt_logprobs"] == 3

--- a/xinference/model/llm/vllm/tests/test_core_chat_model.py
+++ b/xinference/model/llm/vllm/tests/test_core_chat_model.py
@@ -1604,3 +1604,159 @@ class TestVLLMSanitizeGenerateConfig:
 
         sanitized = VLLMChatModel._sanitize_generate_config({})
         assert sanitized["guided_json"] is None
+
+
+class TestVLLMModelLogprobs:
+    """Tests for vLLM logprobs wiring in the completion response path.
+
+    These exercise the function under fix (``_build_logprobs`` and the
+    ``_convert_request_output_to_completion`` site that used to hardcode
+    ``logprobs=None``) directly, with a mocked vLLM request output. On
+    master the response ``logprobs`` is always ``None``; on the branch it is
+    populated when the engine produced them.
+    """
+
+    @staticmethod
+    def _make_logprob(logprob: float, decoded_token: str):
+        lp = MagicMock()
+        lp.logprob = logprob
+        lp.decoded_token = decoded_token
+        return lp
+
+    @classmethod
+    def _make_request_output(
+        cls, *, text, token_ids, logprobs, finish_reason="stop"
+    ):
+        output = MagicMock()
+        output.text = text
+        output.index = 0
+        output.token_ids = list(token_ids)
+        output.logprobs = logprobs
+        output.finish_reason = finish_reason
+        request_output = MagicMock()
+        request_output.outputs = [output]
+        request_output.prompt_token_ids = [1, 2, 3]
+        return request_output
+
+    def test_build_logprobs_none_when_not_requested(self):
+        from ..core import VLLMModel
+
+        request_output = self._make_request_output(
+            text=" hello world", token_ids=[10, 11], logprobs=None
+        )
+        output = request_output.outputs[0]
+        assert VLLMModel._build_logprobs(output) is None
+
+    def test_build_logprobs_populated_when_present(self):
+        from ..core import VLLMModel
+
+        logprobs = [
+            {
+                10: self._make_logprob(-0.1, " hello"),
+                99: self._make_logprob(-3.2, " hi"),
+            },
+            {11: self._make_logprob(-0.2, " world")},
+        ]
+        request_output = self._make_request_output(
+            text=" hello world", token_ids=[10, 11], logprobs=logprobs
+        )
+        result = VLLMModel._build_logprobs(request_output.outputs[0])
+        assert result is not None
+        assert result["tokens"] == [" hello", " world"]
+        assert result["token_logprobs"] == [-0.1, -0.2]
+        assert result["top_logprobs"][0][" hello"] == -0.1
+        assert result["top_logprobs"][0][" hi"] == -3.2
+        assert result["top_logprobs"][1][" world"] == -0.2
+        # text_offset advances by each decoded token's length
+        assert result["text_offset"] == [0, 6]
+
+    def test_convert_request_output_to_completion_carries_logprobs(self):
+        from ..core import VLLMModel
+
+        logprobs = [{10: self._make_logprob(-0.5, "ab")}]
+        request_output = self._make_request_output(
+            text="ab", token_ids=[10], logprobs=logprobs, finish_reason="stop"
+        )
+        completion = VLLMModel._convert_request_output_to_completion(
+            request_id="req-1", model="m", request_output=request_output
+        )
+        choice = completion["choices"][0]
+        assert choice["logprobs"] is not None
+        assert choice["logprobs"]["tokens"] == ["ab"]
+        assert choice["logprobs"]["token_logprobs"] == [-0.5]
+
+    def test_convert_request_output_to_completion_logprobs_none_when_absent(self):
+        from ..core import VLLMModel
+
+        request_output = self._make_request_output(
+            text="ab", token_ids=[10], logprobs=None
+        )
+        completion = VLLMModel._convert_request_output_to_completion(
+            request_id="req-1", model="m", request_output=request_output
+        )
+        assert completion["choices"][0]["logprobs"] is None
+
+    def test_convert_request_output_to_completion_chunk_carries_logprobs(self):
+        from ..core import VLLMModel
+
+        logprobs = [{10: self._make_logprob(-0.5, "ab")}]
+        request_output = self._make_request_output(
+            text="ab", token_ids=[10], logprobs=logprobs, finish_reason=None
+        )
+        chunk, finish_reason = VLLMModel._convert_request_output_to_completion_chunk(
+            request_id="req-1", model="m", request_output=request_output
+        )
+        choice = chunk["choices"][0]
+        assert choice["logprobs"] is not None
+        assert choice["logprobs"]["tokens"] == ["ab"]
+        assert choice["logprobs"]["token_logprobs"] == [-0.5]
+
+    def test_convert_request_output_to_completion_chunk_logprobs_none_when_absent(self):
+        from ..core import VLLMModel
+
+        request_output = self._make_request_output(
+            text="ab", token_ids=[10], logprobs=None, finish_reason=None
+        )
+        chunk, _ = VLLMModel._convert_request_output_to_completion_chunk(
+            request_id="req-1", model="m", request_output=request_output
+        )
+        assert chunk["choices"][0]["logprobs"] is None
+
+    def test_build_logprobs_skips_empty_decoded_token(self):
+        """A malformed Logprob with no decoded token must not emit a ``str(tid)``
+        key -- OpenAI ``top_logprobs`` keys are decoded token strings."""
+        from ..core import VLLMModel
+
+        lp_with_text = self._make_logprob(-0.1, "ab")
+        lp_no_text = MagicMock()
+        lp_no_text.logprob = -2.0
+        lp_no_text.decoded_token = None
+        logprobs = [{10: lp_with_text, 99: lp_no_text}]
+        request_output = self._make_request_output(
+            text="ab", token_ids=[10], logprobs=logprobs
+        )
+        result = VLLMModel._build_logprobs(request_output.outputs[0])
+        assert result is not None
+        # the malformed entry's key is the empty string, never str(99)
+        assert "99" not in result["top_logprobs"][0]
+        assert "ab" in result["top_logprobs"][0]
+
+    def test_sanitize_translates_logprobs_request_to_vllm_int(self):
+        from ..core import VLLMChatModel
+
+        # logprobs=True with top_logprobs=5 -> vLLM logprobs=5
+        sanitized = VLLMChatModel._sanitize_generate_config(
+            {"logprobs": True, "top_logprobs": 5}
+        )
+        assert sanitized["logprobs"] == 5
+        # logprobs=True without top_logprobs -> at least 1
+        sanitized = VLLMChatModel._sanitize_generate_config({"logprobs": True})
+        assert sanitized["logprobs"] == 1
+        # not requested -> 0 (vLLM disables logprobs)
+        sanitized = VLLMChatModel._sanitize_generate_config({})
+        assert sanitized["logprobs"] == 0
+        # prompt_logprobs passes through
+        sanitized = VLLMChatModel._sanitize_generate_config(
+            {"prompt_logprobs": 3}
+        )
+        assert sanitized["prompt_logprobs"] == 3


### PR DESCRIPTION
## Summary

Populate `logprobs` / `top_logprobs` in vLLM `/v1/completions` responses. Clients that request `logprobs: true` / `top_logprobs: N` currently receive `null` even though the `CompletionLogprobs` TypedDict and the `CompletionChoice.logprobs` field already exist. This resolves the maintainer-authored `# TODO: support logprobs.` markers at `xinference/model/llm/vllm/core.py:1228` and `:1254`.

## Problem

The vLLM engine hardcodes `logprobs=None` at the completion response construction sites:

```python
# xinference/model/llm/vllm/core.py
logprobs=None,  # TODO: support logprobs.
```

These TODOs were authored by maintainers, signalling this is wanted work. `generate_config["logprobs"]` (bool) and `["top_logprobs"]` (int) already flow from the `/v1/completions` request into `generate_config` (they are not in the `create_completion` exclude set at `restful_api.py:1167`), but the sanitizer never forwarded them to vLLM `SamplingParams`, and the converters hardcoded `None` instead of reading `output.logprobs`.

## Root cause

1. `_sanitize_generate_config` never translated the request's `logprobs`(bool)/`top_logprobs`(int) into vLLM's native `logprobs`(int), so the engine never produced logprobs.
2. `_convert_request_output_to_completion` and `_convert_request_output_to_completion_chunk` hardcoded `logprobs=None` instead of reading `output.logprobs`.

## Changes

- `xinference/model/llm/vllm/core.py`
  - `_sanitize_generate_config`: translate `logprobs: bool` + `top_logprobs: int` into vLLM's native `logprobs` (int). `logprobs=true` + `top_logprobs=N` → `N`; `logprobs=true` alone → `1`; not requested → `0` (vLLM disables). `prompt_logprobs` passed through unchanged.
  - New staticmethod `_build_logprobs(output)` maps vLLM's `output.logprobs` (`List[Dict[int, Logprob]]`) into the existing `CompletionLogprobs` shape (`text_offset` / `tokens` / `token_logprobs` / `top_logprobs`). Returns `None` when the engine produced no logprobs (preserves the common-path behaviour).
  - Both completion converters now call `_build_logprobs(output)` instead of hardcoding `None`, resolving the two `# TODO: support logprobs.` markers.
- `xinference/model/llm/vllm/tests/test_core_chat_model.py`
  - New `TestVLLMModelLogprobs` covering `_build_logprobs` (None / populated / malformed-token-no-`str(tid)`-key), both completion converters (carries / None-when-absent), and the sanitizer translation.

## What's NOT changed

- **Chat-completion logprobs** — `_to_chat_completion` is untouched. The chat logprobs response uses a different (chat-format) shape than the legacy `CompletionLogprobs` used by `/v1/completions`; mapping vLLM output to that shape is a larger, separate change and is intentionally left as a follow-up to keep this PR reviewable.
- **Streaming chunk-by-chunk logprobs stitching** — the streaming path populates per-chunk logprobs from the engine but does not stitch a cumulative accumulator; that is a follow-up.
- **Other engines** — `sglang` and `llama_cpp` have the same `logprobs=None` hardcode and are addressed in separate PRs.
- **`xinference/types.py`** — no type changes; the TypedDict and field already exist.
- No public API signature, config, CLI, or dependency changes.

## Tests

7 new tests in `TestVLLMModelLogprobs`. Verified **red-on-master / green-on-branch** by stashing the source: on master the populated/converter tests fail (`_build_logprobs` does not exist + converter hardcodes `None`); on this branch they pass. The function under fix is not mocked (only the vLLM `RequestOutput` dependency is). The `test_sanitize_translates_logprobs_request_to_vllm_int` test requires a vLLM install to run, like the existing `_sanitize_generate_config` tests in this file (`core.py:1099-1100` reads `VLLM_VERSION`).

## Compatibility

- When `logprobs` is not requested (the common path), behaviour is identical to master: `_build_logprobs` returns `None`, so `choice["logprobs"]` is `None` exactly as before.
- No public API change. The `CompletionChoice.logprobs` field is already declared `Optional[CompletionLogprobs]` in `types.py:159`.
- No overlap with the in-flight speculative-decoding work (#5241): that branch touches `vllm/core.py` model-config / drafter wiring (`_sanitize_model_config` ~`:974`, `_apply_draft_model`, drafter-config fields), not the response-converter region (`_convert_request_output_to_completion*` ~`:1294`/`:1321`) or the `_sanitize_generate_config` sampling-param setdefaults modified here. Rebase should be clean.

## Reviewer pre-emption

- "Unsolicited?" — no: this implements the maintainer-authored `# TODO: support logprobs.` markers and aligns with the repo's documented chat-completions-compatible API commitment (README "Hot Topics" + the `openai-api` topic). It is the completions-side slice, not a speculative-decoding feature.
- "Wrong logprobs shape?" — the completions path uses the `CompletionLogprobs` shape that `CompletionChoice` already declares (`types.py:159`), so the type is correct by construction. The chat path (which would need a different shape) is explicitly deferred.
