### PR TITLE
docs: update release notes links from xinference.io to xinference.co

### DIFF
--- a/doc/source/getting_started/release_notes.rst
+++ b/doc/source/getting_started/release_notes.rst
@@ -9,47 +9,47 @@ For detailed updates, please visit the corresponding links below.
 +-----------------+--------------------------------------------------------------------------------+
 | Version         | Release Notes                                                                  |
 +=================+================================================================================+
-| v3.0.0          | `View release notes <https://xinference.io/release_notes/v3.0.0.html>`_        |
+| v3.0.0          | `View release notes <https://xinference.co/release_notes/v3.0.0.html>`_        |
 +-----------------+--------------------------------------------------------------------------------+
-| v2.12.0         | `View release notes <https://xinference.io/release_notes/v2.12.0.html>`_       |
+| v2.12.0         | `View release notes <https://xinference.co/release_notes/v2.12.0.html>`_       |
 +-----------------+--------------------------------------------------------------------------------+
-| v2.11.0         | `View release notes <https://xinference.io/release_notes/v2.11.0.html>`_       |
+| v2.11.0         | `View release notes <https://xinference.co/release_notes/v2.11.0.html>`_       |
 +-----------------+--------------------------------------------------------------------------------+
-| v2.10.0         | `View release notes <https://xinference.io/release_notes/v2.10.0.html>`_       |
+| v2.10.0         | `View release notes <https://xinference.co/release_notes/v2.10.0.html>`_       |
 +-----------------+--------------------------------------------------------------------------------+
-| v2.9.0          | `View release notes <https://xinference.io/release_notes/v2.9.0.html>`_        |
+| v2.9.0          | `View release notes <https://xinference.co/release_notes/v2.9.0.html>`_        |
 +-----------------+--------------------------------------------------------------------------------+
-| v2.8.0          | `View release notes <https://xinference.io/release_notes/v2.8.0.html>`_        |
+| v2.8.0          | `View release notes <https://xinference.co/release_notes/v2.8.0.html>`_        |
 +-----------------+--------------------------------------------------------------------------------+
-| v2.7.0          | `View release notes <https://xinference.io/release_notes/v2.7.0.html>`_        |
+| v2.7.0          | `View release notes <https://xinference.co/release_notes/v2.7.0.html>`_        |
 +-----------------+--------------------------------------------------------------------------------+
-| v2.5.0          | `View release notes <https://xinference.io/release_notes/v2.5.0.html>`_        |
+| v2.5.0          | `View release notes <https://xinference.co/release_notes/v2.5.0.html>`_        |
 +-----------------+--------------------------------------------------------------------------------+
-| v2.4.0          | `View release notes <https://xinference.io/release_notes/v2.4.0.html>`_        |
+| v2.4.0          | `View release notes <https://xinference.co/release_notes/v2.4.0.html>`_        |
 +-----------------+--------------------------------------------------------------------------------+
-| v2.3.0          | `View release notes <https://xinference.io/release_notes/v2.3.0.html>`_        |
+| v2.3.0          | `View release notes <https://xinference.co/release_notes/v2.3.0.html>`_        |
 +-----------------+--------------------------------------------------------------------------------+
-| v2.2.0          | `View release notes <https://xinference.io/release_notes/v2.2.0.html>`_        |
+| v2.2.0          | `View release notes <https://xinference.co/release_notes/v2.2.0.html>`_        |
 +-----------------+--------------------------------------------------------------------------------+
-| v2.1.0          | `View release notes <https://xinference.io/release_notes/v2.1.0.html>`_        |
+| v2.1.0          | `View release notes <https://xinference.co/release_notes/v2.1.0.html>`_        |
 +-----------------+--------------------------------------------------------------------------------+
-| v2.0.0          | `View release notes <https://xinference.io/release_notes/v2.0.0.html>`_        |
+| v2.0.0          | `View release notes <https://xinference.co/release_notes/v2.0.0.html>`_        |
 +-----------------+--------------------------------------------------------------------------------+
-| v1.17.0         | `View release notes <https://xinference.io/release_notes/v1.17.0.html>`_       |
+| v1.17.0         | `View release notes <https://xinference.co/release_notes/v1.17.0.html>`_       |
 +-----------------+--------------------------------------------------------------------------------+
-| v1.16.0         | `View release notes <https://xinference.io/release_notes/v1.16.0.html>`_       |
+| v1.16.0         | `View release notes <https://xinference.co/release_notes/v1.16.0.html>`_       |
 +-----------------+--------------------------------------------------------------------------------+
-| v1.15.0         | `View release notes <https://xinference.io/release_notes/v1.15.0.html>`_       |
+| v1.15.0         | `View release notes <https://xinference.co/release_notes/v1.15.0.html>`_       |
 +-----------------+--------------------------------------------------------------------------------+
-| v1.14.0         | `View release notes <https://xinference.io/release_notes/v1.14.0.html>`_       |
+| v1.14.0         | `View release notes <https://xinference.co/release_notes/v1.14.0.html>`_       |
 +-----------------+--------------------------------------------------------------------------------+
-| v1.13.0         | `View release notes <https://xinference.io/release_notes/v1.13.0.html>`_       |
+| v1.13.0         | `View release notes <https://xinference.co/release_notes/v1.13.0.html>`_       |
 +-----------------+--------------------------------------------------------------------------------+
-| v1.12.0         | `View release notes <https://xinference.io/release_notes/v1.12.0.html>`_       |
+| v1.12.0         | `View release notes <https://xinference.co/release_notes/v1.12.0.html>`_       |
 +-----------------+--------------------------------------------------------------------------------+
-| v1.11.0.post1   | `View release notes <https://xinference.io/release_notes/v1.11.0.post1.html>`_ |
+| v1.11.0.post1   | `View release notes <https://xinference.co/release_notes/v1.11.0.post1.html>`_ |
 +-----------------+--------------------------------------------------------------------------------+
-| v1.10.1         | `View release notes <https://xinference.io/release_notes/v1.10.1.html>`_       |
+| v1.10.1         | `View release notes <https://xinference.co/release_notes/v1.10.1.html>`_       |
 +-----------------+--------------------------------------------------------------------------------+
 
 ----

--- a/doc/source/locale/de/LC_MESSAGES/getting_started/release_notes.po
+++ b/doc/source/locale/de/LC_MESSAGES/getting_started/release_notes.po
@@ -41,190 +41,190 @@ msgid "v3.0.0"
 msgstr "v3.0.0"
 
 #: ../../source/getting_started/release_notes.rst:12
-msgid "`View release notes <https://xinference.io/release_notes/v3.0.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v3.0.0.html>`_"
 msgstr ""
 "`Versionshinweise anzeigen "
-"<https://xinference.io/release_notes/v3.0.0.html>`_"
+"<https://xinference.co/release_notes/v3.0.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:14
 msgid "v2.12.0"
 msgstr "v2.12.0"
 
 #: ../../source/getting_started/release_notes.rst:14
-msgid "`View release notes <https://xinference.io/release_notes/v2.12.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v2.12.0.html>`_"
 msgstr ""
 "`Versionshinweise anzeigen "
-"<https://xinference.io/release_notes/v2.12.0.html>`_"
+"<https://xinference.co/release_notes/v2.12.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:16
 msgid "v2.11.0"
 msgstr "v2.11.0"
 
 #: ../../source/getting_started/release_notes.rst:16
-msgid "`View release notes <https://xinference.io/release_notes/v2.11.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v2.11.0.html>`_"
 msgstr ""
 "`Versionshinweise anzeigen "
-"<https://xinference.io/release_notes/v2.11.0.html>`_"
+"<https://xinference.co/release_notes/v2.11.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:18
 msgid "v2.10.0"
 msgstr "v2.10.0"
 
 #: ../../source/getting_started/release_notes.rst:18
-msgid "`View release notes <https://xinference.io/release_notes/v2.10.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v2.10.0.html>`_"
 msgstr ""
 "`Versionshinweise anzeigen "
-"<https://xinference.io/release_notes/v2.10.0.html>`_"
+"<https://xinference.co/release_notes/v2.10.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:20
 msgid "v2.9.0"
 msgstr "v2.9.0"
 
 #: ../../source/getting_started/release_notes.rst:20
-msgid "`View release notes <https://xinference.io/release_notes/v2.9.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v2.9.0.html>`_"
 msgstr ""
 "`Versionshinweise anzeigen "
-"<https://xinference.io/release_notes/v2.9.0.html>`_"
+"<https://xinference.co/release_notes/v2.9.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:22
 msgid "v2.8.0"
 msgstr "v2.8.0"
 
 #: ../../source/getting_started/release_notes.rst:22
-msgid "`View release notes <https://xinference.io/release_notes/v2.8.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v2.8.0.html>`_"
 msgstr ""
 "`Versionshinweise anzeigen "
-"<https://xinference.io/release_notes/v2.8.0.html>`_"
+"<https://xinference.co/release_notes/v2.8.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:24
 msgid "v2.7.0"
 msgstr "v2.7.0"
 
 #: ../../source/getting_started/release_notes.rst:24
-msgid "`View release notes <https://xinference.io/release_notes/v2.7.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v2.7.0.html>`_"
 msgstr ""
 "`Versionshinweise ansehen "
-"<https://xinference.io/release_notes/v2.7.0.html>`_"
+"<https://xinference.co/release_notes/v2.7.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:26
 msgid "v2.5.0"
 msgstr "v2.5.0"
 
 #: ../../source/getting_started/release_notes.rst:26
-msgid "`View release notes <https://xinference.io/release_notes/v2.5.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v2.5.0.html>`_"
 msgstr ""
 "`Versionshinweise anzeigen "
-"<https://xinference.io/release_notes/v2.5.0.html>`_"
+"<https://xinference.co/release_notes/v2.5.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:28
 msgid "v2.4.0"
 msgstr "v2.4.0"
 
 #: ../../source/getting_started/release_notes.rst:28
-msgid "`View release notes <https://xinference.io/release_notes/v2.4.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v2.4.0.html>`_"
 msgstr ""
 "`Versionshinweise anzeigen "
-"<https://xinference.io/release_notes/v2.4.0.html>`_"
+"<https://xinference.co/release_notes/v2.4.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:30
 msgid "v2.3.0"
 msgstr "v2.3.0"
 
 #: ../../source/getting_started/release_notes.rst:30
-msgid "`View release notes <https://xinference.io/release_notes/v2.3.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v2.3.0.html>`_"
 msgstr ""
 "`Versionshinweise anzeigen "
-"<https://xinference.io/release_notes/v2.3.0.html>`_"
+"<https://xinference.co/release_notes/v2.3.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:32
 msgid "v2.2.0"
 msgstr "v2.2.0"
 
 #: ../../source/getting_started/release_notes.rst:32
-msgid "`View release notes <https://xinference.io/release_notes/v2.2.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v2.2.0.html>`_"
 msgstr ""
 "`Versionshinweise anzeigen "
-"<https://xinference.io/release_notes/v2.2.0.html>`_"
+"<https://xinference.co/release_notes/v2.2.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:34
 msgid "v2.1.0"
 msgstr "v2.1.0"
 
 #: ../../source/getting_started/release_notes.rst:34
-msgid "`View release notes <https://xinference.io/release_notes/v2.1.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v2.1.0.html>`_"
 msgstr ""
 "`Versionshinweise anzeigen "
-"<https://xinference.io/release_notes/v2.1.0.html>`_"
+"<https://xinference.co/release_notes/v2.1.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:36
 msgid "v2.0.0"
 msgstr "v2.0.0"
 
 #: ../../source/getting_started/release_notes.rst:36
-msgid "`View release notes <https://xinference.io/release_notes/v2.0.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v2.0.0.html>`_"
 msgstr ""
 "`Versionshinweise anzeigen "
-"<https://xinference.io/release_notes/v2.0.0.html>`_"
+"<https://xinference.co/release_notes/v2.0.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:38
 msgid "v1.17.0"
 msgstr "v1.17.0"
 
 #: ../../source/getting_started/release_notes.rst:38
-msgid "`View release notes <https://xinference.io/release_notes/v1.17.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v1.17.0.html>`_"
 msgstr ""
 "`Versionshinweise anzeigen "
-"<https://xinference.io/release_notes/v1.17.0.html>`_"
+"<https://xinference.co/release_notes/v1.17.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:40
 msgid "v1.16.0"
 msgstr "v1.16.0"
 
 #: ../../source/getting_started/release_notes.rst:40
-msgid "`View release notes <https://xinference.io/release_notes/v1.16.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v1.16.0.html>`_"
 msgstr ""
 "`Versionshinweise ansehen "
-"<https://xinference.io/release_notes/v1.16.0.html>`_"
+"<https://xinference.co/release_notes/v1.16.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:42
 msgid "v1.15.0"
 msgstr "v1.15.0"
 
 #: ../../source/getting_started/release_notes.rst:42
-msgid "`View release notes <https://xinference.io/release_notes/v1.15.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v1.15.0.html>`_"
 msgstr ""
 "`Versionshinweise ansehen "
-"<https://xinference.io/release_notes/v1.15.0.html>`_"
+"<https://xinference.co/release_notes/v1.15.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:44
 msgid "v1.14.0"
 msgstr "v1.14.0"
 
 #: ../../source/getting_started/release_notes.rst:44
-msgid "`View release notes <https://xinference.io/release_notes/v1.14.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v1.14.0.html>`_"
 msgstr ""
 "`Versionshinweise anzeigen "
-"<https://xinference.io/release_notes/v1.14.0.html>`_"
+"<https://xinference.co/release_notes/v1.14.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:46
 msgid "v1.13.0"
 msgstr "v1.13.0"
 
 #: ../../source/getting_started/release_notes.rst:46
-msgid "`View release notes <https://xinference.io/release_notes/v1.13.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v1.13.0.html>`_"
 msgstr ""
 "`Versionshinweise anzeigen "
-"<https://xinference.io/release_notes/v1.13.0.html>`_"
+"<https://xinference.co/release_notes/v1.13.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:48
 msgid "v1.12.0"
 msgstr "v1.12.0"
 
 #: ../../source/getting_started/release_notes.rst:48
-msgid "`View release notes <https://xinference.io/release_notes/v1.12.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v1.12.0.html>`_"
 msgstr ""
 "`Versionshinweise anzeigen "
-"<https://xinference.io/release_notes/v1.12.0.html>`_"
+"<https://xinference.co/release_notes/v1.12.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:50
 msgid "v1.11.0.post1"
@@ -233,20 +233,20 @@ msgstr "v1.11.0.post1"
 #: ../../source/getting_started/release_notes.rst:50
 msgid ""
 "`View release notes "
-"<https://xinference.io/release_notes/v1.11.0.post1.html>`_"
+"<https://xinference.co/release_notes/v1.11.0.post1.html>`_"
 msgstr ""
 "`Versionshinweise anzeigen "
-"<https://xinference.io/release_notes/v1.11.0.post1.html>`_"
+"<https://xinference.co/release_notes/v1.11.0.post1.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:52
 msgid "v1.10.1"
 msgstr "v1.10.1"
 
 #: ../../source/getting_started/release_notes.rst:52
-msgid "`View release notes <https://xinference.io/release_notes/v1.10.1.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v1.10.1.html>`_"
 msgstr ""
 "`Versionshinweise anzeigen "
-"<https://xinference.io/release_notes/v1.10.1.html>`_"
+"<https://xinference.co/release_notes/v1.10.1.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:57
 msgid ""
@@ -255,4 +255,3 @@ msgid ""
 msgstr ""
 "Für weitere historische Versionen und Quellcode besuchen Sie bitte GitHub"
 " Releases: https://github.com/xorbitsai/inference/releases"
-

--- a/doc/source/locale/es/LC_MESSAGES/getting_started/release_notes.po
+++ b/doc/source/locale/es/LC_MESSAGES/getting_started/release_notes.po
@@ -42,190 +42,190 @@ msgid "v3.0.0"
 msgstr "v3.0.0"
 
 #: ../../source/getting_started/release_notes.rst:12
-msgid "`View release notes <https://xinference.io/release_notes/v3.0.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v3.0.0.html>`_"
 msgstr ""
 "`Consultar las notas de la versión "
-"<https://xinference.io/release_notes/v3.0.0.html>`_"
+"<https://xinference.co/release_notes/v3.0.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:14
 msgid "v2.12.0"
 msgstr "v2.12.0"
 
 #: ../../source/getting_started/release_notes.rst:14
-msgid "`View release notes <https://xinference.io/release_notes/v2.12.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v2.12.0.html>`_"
 msgstr ""
 "`Ver las notas de la versión "
-"<https://xinference.io/release_notes/v2.12.0.html>`_"
+"<https://xinference.co/release_notes/v2.12.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:16
 msgid "v2.11.0"
 msgstr "v2.11.0"
 
 #: ../../source/getting_started/release_notes.rst:16
-msgid "`View release notes <https://xinference.io/release_notes/v2.11.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v2.11.0.html>`_"
 msgstr ""
 "`Ver las notas de la versión "
-"<https://xinference.io/release_notes/v2.11.0.html>`_"
+"<https://xinference.co/release_notes/v2.11.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:18
 msgid "v2.10.0"
 msgstr "v2.10.0"
 
 #: ../../source/getting_started/release_notes.rst:18
-msgid "`View release notes <https://xinference.io/release_notes/v2.10.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v2.10.0.html>`_"
 msgstr ""
 "`Consulta las notas de la versión "
-"<https://xinference.io/release_notes/v2.10.0.html>`_"
+"<https://xinference.co/release_notes/v2.10.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:20
 msgid "v2.9.0"
 msgstr "v2.9.0"
 
 #: ../../source/getting_started/release_notes.rst:20
-msgid "`View release notes <https://xinference.io/release_notes/v2.9.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v2.9.0.html>`_"
 msgstr ""
 "`Consulte las notas de la versión "
-"<https://xinference.io/release_notes/v2.9.0.html>`_"
+"<https://xinference.co/release_notes/v2.9.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:22
 msgid "v2.8.0"
 msgstr "v2.8.0"
 
 #: ../../source/getting_started/release_notes.rst:22
-msgid "`View release notes <https://xinference.io/release_notes/v2.8.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v2.8.0.html>`_"
 msgstr ""
 "`Ver notas de la versión "
-"<https://xinference.io/release_notes/v2.8.0.html>`_"
+"<https://xinference.co/release_notes/v2.8.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:24
 msgid "v2.7.0"
 msgstr "v2.7.0"
 
 #: ../../source/getting_started/release_notes.rst:24
-msgid "`View release notes <https://xinference.io/release_notes/v2.7.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v2.7.0.html>`_"
 msgstr ""
 "`Ver las notas de la versión "
-"<https://xinference.io/release_notes/v2.7.0.html>`_"
+"<https://xinference.co/release_notes/v2.7.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:26
 msgid "v2.5.0"
 msgstr "v2.5.0"
 
 #: ../../source/getting_started/release_notes.rst:26
-msgid "`View release notes <https://xinference.io/release_notes/v2.5.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v2.5.0.html>`_"
 msgstr ""
 "`Ver las notas de la versión "
-"<https://xinference.io/release_notes/v2.5.0.html>`_"
+"<https://xinference.co/release_notes/v2.5.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:28
 msgid "v2.4.0"
 msgstr "v2.4.0"
 
 #: ../../source/getting_started/release_notes.rst:28
-msgid "`View release notes <https://xinference.io/release_notes/v2.4.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v2.4.0.html>`_"
 msgstr ""
 "`Consulta las notas de la versión "
-"<https://xinference.io/release_notes/v2.4.0.html>`_"
+"<https://xinference.co/release_notes/v2.4.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:30
 msgid "v2.3.0"
 msgstr "v2.3.0"
 
 #: ../../source/getting_started/release_notes.rst:30
-msgid "`View release notes <https://xinference.io/release_notes/v2.3.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v2.3.0.html>`_"
 msgstr ""
 "`Consulte las notas de la versión "
-"<https://xinference.io/release_notes/v2.3.0.html>`_"
+"<https://xinference.co/release_notes/v2.3.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:32
 msgid "v2.2.0"
 msgstr "v2.2.0"
 
 #: ../../source/getting_started/release_notes.rst:32
-msgid "`View release notes <https://xinference.io/release_notes/v2.2.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v2.2.0.html>`_"
 msgstr ""
 "`Ver las notas de la versión "
-"<https://xinference.io/release_notes/v2.2.0.html>`_"
+"<https://xinference.co/release_notes/v2.2.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:34
 msgid "v2.1.0"
 msgstr "v2.1.0"
 
 #: ../../source/getting_started/release_notes.rst:34
-msgid "`View release notes <https://xinference.io/release_notes/v2.1.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v2.1.0.html>`_"
 msgstr ""
 "`Ver las notas de la versión "
-"<https://xinference.io/release_notes/v2.1.0.html>`_"
+"<https://xinference.co/release_notes/v2.1.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:36
 msgid "v2.0.0"
 msgstr "v2.0.0"
 
 #: ../../source/getting_started/release_notes.rst:36
-msgid "`View release notes <https://xinference.io/release_notes/v2.0.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v2.0.0.html>`_"
 msgstr ""
 "`Consultar las notas de la versión "
-"<https://xinference.io/release_notes/v2.0.0.html>`_"
+"<https://xinference.co/release_notes/v2.0.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:38
 msgid "v1.17.0"
 msgstr "v1.17.0"
 
 #: ../../source/getting_started/release_notes.rst:38
-msgid "`View release notes <https://xinference.io/release_notes/v1.17.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v1.17.0.html>`_"
 msgstr ""
 "`Ver notas de la versión "
-"<https://xinference.io/release_notes/v1.17.0.html>`_"
+"<https://xinference.co/release_notes/v1.17.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:40
 msgid "v1.16.0"
 msgstr "v1.16.0"
 
 #: ../../source/getting_started/release_notes.rst:40
-msgid "`View release notes <https://xinference.io/release_notes/v1.16.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v1.16.0.html>`_"
 msgstr ""
 "`Ver las notas de la versión "
-"<https://xinference.io/release_notes/v1.16.0.html>`_"
+"<https://xinference.co/release_notes/v1.16.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:42
 msgid "v1.15.0"
 msgstr "v1.15.0"
 
 #: ../../source/getting_started/release_notes.rst:42
-msgid "`View release notes <https://xinference.io/release_notes/v1.15.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v1.15.0.html>`_"
 msgstr ""
 "`Ver las notas de la versión "
-"<https://xinference.io/release_notes/v1.15.0.html>`_"
+"<https://xinference.co/release_notes/v1.15.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:44
 msgid "v1.14.0"
 msgstr "v1.14.0"
 
 #: ../../source/getting_started/release_notes.rst:44
-msgid "`View release notes <https://xinference.io/release_notes/v1.14.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v1.14.0.html>`_"
 msgstr ""
 "`Ver las notas de la versión "
-"<https://xinference.io/release_notes/v1.14.0.html>`_"
+"<https://xinference.co/release_notes/v1.14.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:46
 msgid "v1.13.0"
 msgstr "v1.13.0"
 
 #: ../../source/getting_started/release_notes.rst:46
-msgid "`View release notes <https://xinference.io/release_notes/v1.13.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v1.13.0.html>`_"
 msgstr ""
 "`Consultar las notas de la versión "
-"<https://xinference.io/release_notes/v1.13.0.html>`_"
+"<https://xinference.co/release_notes/v1.13.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:48
 msgid "v1.12.0"
 msgstr "v1.12.0"
 
 #: ../../source/getting_started/release_notes.rst:48
-msgid "`View release notes <https://xinference.io/release_notes/v1.12.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v1.12.0.html>`_"
 msgstr ""
 "`Ver las notas de la versión "
-"<https://xinference.io/release_notes/v1.12.0.html>`_"
+"<https://xinference.co/release_notes/v1.12.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:50
 msgid "v1.11.0.post1"
@@ -234,20 +234,20 @@ msgstr "v1.11.0.post1"
 #: ../../source/getting_started/release_notes.rst:50
 msgid ""
 "`View release notes "
-"<https://xinference.io/release_notes/v1.11.0.post1.html>`_"
+"<https://xinference.co/release_notes/v1.11.0.post1.html>`_"
 msgstr ""
 "`Ver las notas de la versión "
-"<https://xinference.io/release_notes/v1.11.0.post1.html>`_"
+"<https://xinference.co/release_notes/v1.11.0.post1.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:52
 msgid "v1.10.1"
 msgstr "v1.10.1"
 
 #: ../../source/getting_started/release_notes.rst:52
-msgid "`View release notes <https://xinference.io/release_notes/v1.10.1.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v1.10.1.html>`_"
 msgstr ""
 "`Ver notas de la versión "
-"<https://xinference.io/release_notes/v1.10.1.html>`_"
+"<https://xinference.co/release_notes/v1.10.1.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:57
 msgid ""
@@ -256,4 +256,3 @@ msgid ""
 msgstr ""
 "Para más versiones históricas y el código fuente, visita GitHub Releases:"
 " https://github.com/xorbitsai/inference/releases"
-

--- a/doc/source/locale/fr/LC_MESSAGES/getting_started/release_notes.po
+++ b/doc/source/locale/fr/LC_MESSAGES/getting_started/release_notes.po
@@ -42,190 +42,190 @@ msgid "v3.0.0"
 msgstr "v3.0.0"
 
 #: ../../source/getting_started/release_notes.rst:12
-msgid "`View release notes <https://xinference.io/release_notes/v3.0.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v3.0.0.html>`_"
 msgstr ""
 "`Voir les notes de version "
-"<https://xinference.io/release_notes/v3.0.0.html>`_"
+"<https://xinference.co/release_notes/v3.0.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:14
 msgid "v2.12.0"
 msgstr "v2.12.0"
 
 #: ../../source/getting_started/release_notes.rst:14
-msgid "`View release notes <https://xinference.io/release_notes/v2.12.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v2.12.0.html>`_"
 msgstr ""
 "`Voir les notes de version "
-"<https://xinference.io/release_notes/v2.12.0.html>`_"
+"<https://xinference.co/release_notes/v2.12.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:16
 msgid "v2.11.0"
 msgstr "v2.11.0"
 
 #: ../../source/getting_started/release_notes.rst:16
-msgid "`View release notes <https://xinference.io/release_notes/v2.11.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v2.11.0.html>`_"
 msgstr ""
 "`Voir les notes de version "
-"<https://xinference.io/release_notes/v2.11.0.html>`_"
+"<https://xinference.co/release_notes/v2.11.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:18
 msgid "v2.10.0"
 msgstr "v2.10.0"
 
 #: ../../source/getting_started/release_notes.rst:18
-msgid "`View release notes <https://xinference.io/release_notes/v2.10.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v2.10.0.html>`_"
 msgstr ""
 "`Consultez les notes de version "
-"<https://xinference.io/release_notes/v2.10.0.html>`_"
+"<https://xinference.co/release_notes/v2.10.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:20
 msgid "v2.9.0"
 msgstr "v2.9.0"
 
 #: ../../source/getting_started/release_notes.rst:20
-msgid "`View release notes <https://xinference.io/release_notes/v2.9.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v2.9.0.html>`_"
 msgstr ""
 "`Voir les notes de version "
-"<https://xinference.io/release_notes/v2.9.0.html>`_"
+"<https://xinference.co/release_notes/v2.9.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:22
 msgid "v2.8.0"
 msgstr "v2.8.0"
 
 #: ../../source/getting_started/release_notes.rst:22
-msgid "`View release notes <https://xinference.io/release_notes/v2.8.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v2.8.0.html>`_"
 msgstr ""
 "`Voir les notes de version "
-"<https://xinference.io/release_notes/v2.8.0.html>`_"
+"<https://xinference.co/release_notes/v2.8.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:24
 msgid "v2.7.0"
 msgstr "v2.7.0"
 
 #: ../../source/getting_started/release_notes.rst:24
-msgid "`View release notes <https://xinference.io/release_notes/v2.7.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v2.7.0.html>`_"
 msgstr ""
 "`Consultez les notes de version "
-"<https://xinference.io/release_notes/v2.7.0.html>`_"
+"<https://xinference.co/release_notes/v2.7.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:26
 msgid "v2.5.0"
 msgstr "v2.5.0"
 
 #: ../../source/getting_started/release_notes.rst:26
-msgid "`View release notes <https://xinference.io/release_notes/v2.5.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v2.5.0.html>`_"
 msgstr ""
 "`Consultez les notes de version "
-"<https://xinference.io/release_notes/v2.5.0.html>`_"
+"<https://xinference.co/release_notes/v2.5.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:28
 msgid "v2.4.0"
 msgstr "v2.4.0"
 
 #: ../../source/getting_started/release_notes.rst:28
-msgid "`View release notes <https://xinference.io/release_notes/v2.4.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v2.4.0.html>`_"
 msgstr ""
 "`Voir les notes de version "
-"<https://xinference.io/release_notes/v2.4.0.html>`_"
+"<https://xinference.co/release_notes/v2.4.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:30
 msgid "v2.3.0"
 msgstr "v2.3.0"
 
 #: ../../source/getting_started/release_notes.rst:30
-msgid "`View release notes <https://xinference.io/release_notes/v2.3.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v2.3.0.html>`_"
 msgstr ""
 "`Consultez les notes de version "
-"<https://xinference.io/release_notes/v2.3.0.html>`_"
+"<https://xinference.co/release_notes/v2.3.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:32
 msgid "v2.2.0"
 msgstr "v2.2.0"
 
 #: ../../source/getting_started/release_notes.rst:32
-msgid "`View release notes <https://xinference.io/release_notes/v2.2.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v2.2.0.html>`_"
 msgstr ""
 "`Voir les notes de version "
-"<https://xinference.io/release_notes/v2.2.0.html>`_"
+"<https://xinference.co/release_notes/v2.2.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:34
 msgid "v2.1.0"
 msgstr "v2.1.0"
 
 #: ../../source/getting_started/release_notes.rst:34
-msgid "`View release notes <https://xinference.io/release_notes/v2.1.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v2.1.0.html>`_"
 msgstr ""
 "`Voir les notes de version "
-"<https://xinference.io/release_notes/v2.1.0.html>`_"
+"<https://xinference.co/release_notes/v2.1.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:36
 msgid "v2.0.0"
 msgstr "v2.0.0"
 
 #: ../../source/getting_started/release_notes.rst:36
-msgid "`View release notes <https://xinference.io/release_notes/v2.0.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v2.0.0.html>`_"
 msgstr ""
 "`Voir les notes de version "
-"<https://xinference.io/release_notes/v2.0.0.html>`_"
+"<https://xinference.co/release_notes/v2.0.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:38
 msgid "v1.17.0"
 msgstr "v1.17.0"
 
 #: ../../source/getting_started/release_notes.rst:38
-msgid "`View release notes <https://xinference.io/release_notes/v1.17.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v1.17.0.html>`_"
 msgstr ""
 "`Consultez les notes de version "
-"<https://xinference.io/release_notes/v1.17.0.html>`_"
+"<https://xinference.co/release_notes/v1.17.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:40
 msgid "v1.16.0"
 msgstr "v1.16.0"
 
 #: ../../source/getting_started/release_notes.rst:40
-msgid "`View release notes <https://xinference.io/release_notes/v1.16.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v1.16.0.html>`_"
 msgstr ""
 "`Consultez les notes de version "
-"<https://xinference.io/release_notes/v1.16.0.html>`_"
+"<https://xinference.co/release_notes/v1.16.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:42
 msgid "v1.15.0"
 msgstr "v1.15.0"
 
 #: ../../source/getting_started/release_notes.rst:42
-msgid "`View release notes <https://xinference.io/release_notes/v1.15.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v1.15.0.html>`_"
 msgstr ""
 "`Voir les notes de version "
-"<https://xinference.io/release_notes/v1.15.0.html>`_"
+"<https://xinference.co/release_notes/v1.15.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:44
 msgid "v1.14.0"
 msgstr "v1.14.0"
 
 #: ../../source/getting_started/release_notes.rst:44
-msgid "`View release notes <https://xinference.io/release_notes/v1.14.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v1.14.0.html>`_"
 msgstr ""
 "`Voir les notes de version "
-"<https://xinference.io/release_notes/v1.14.0.html>`_"
+"<https://xinference.co/release_notes/v1.14.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:46
 msgid "v1.13.0"
 msgstr "v1.13.0"
 
 #: ../../source/getting_started/release_notes.rst:46
-msgid "`View release notes <https://xinference.io/release_notes/v1.13.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v1.13.0.html>`_"
 msgstr ""
 "`Voir les notes de version "
-"<https://xinference.io/release_notes/v1.13.0.html>`_"
+"<https://xinference.co/release_notes/v1.13.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:48
 msgid "v1.12.0"
 msgstr "v1.12.0"
 
 #: ../../source/getting_started/release_notes.rst:48
-msgid "`View release notes <https://xinference.io/release_notes/v1.12.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v1.12.0.html>`_"
 msgstr ""
 "`Consultez les notes de version "
-"<https://xinference.io/release_notes/v1.12.0.html>`_"
+"<https://xinference.co/release_notes/v1.12.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:50
 msgid "v1.11.0.post1"
@@ -234,20 +234,20 @@ msgstr "v1.11.0.post1"
 #: ../../source/getting_started/release_notes.rst:50
 msgid ""
 "`View release notes "
-"<https://xinference.io/release_notes/v1.11.0.post1.html>`_"
+"<https://xinference.co/release_notes/v1.11.0.post1.html>`_"
 msgstr ""
 "`Voir les notes de version "
-"<https://xinference.io/release_notes/v1.11.0.post1.html>`_"
+"<https://xinference.co/release_notes/v1.11.0.post1.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:52
 msgid "v1.10.1"
 msgstr "v1.10.1"
 
 #: ../../source/getting_started/release_notes.rst:52
-msgid "`View release notes <https://xinference.io/release_notes/v1.10.1.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v1.10.1.html>`_"
 msgstr ""
 "`Voir les notes de version "
-"<https://xinference.io/release_notes/v1.10.1.html>`_"
+"<https://xinference.co/release_notes/v1.10.1.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:57
 msgid ""
@@ -256,4 +256,3 @@ msgid ""
 msgstr ""
 "Pour plus de versions historiques et le code source, veuillez visiter les"
 " versions GitHub : https://github.com/xorbitsai/inference/releases"
-

--- a/doc/source/locale/it/LC_MESSAGES/getting_started/release_notes.po
+++ b/doc/source/locale/it/LC_MESSAGES/getting_started/release_notes.po
@@ -41,190 +41,190 @@ msgid "v3.0.0"
 msgstr "v3.0.0"
 
 #: ../../source/getting_started/release_notes.rst:12
-msgid "`View release notes <https://xinference.io/release_notes/v3.0.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v3.0.0.html>`_"
 msgstr ""
 "`Visualizza le note di rilascio "
-"<https://xinference.io/release_notes/v3.0.0.html>`_"
+"<https://xinference.co/release_notes/v3.0.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:14
 msgid "v2.12.0"
 msgstr "v2.12.0"
 
 #: ../../source/getting_started/release_notes.rst:14
-msgid "`View release notes <https://xinference.io/release_notes/v2.12.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v2.12.0.html>`_"
 msgstr ""
 "`Vedi note di versione "
-"<https://xinference.io/release_notes/v2.12.0.html>`_"
+"<https://xinference.co/release_notes/v2.12.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:16
 msgid "v2.11.0"
 msgstr "v2.11.0"
 
 #: ../../source/getting_started/release_notes.rst:16
-msgid "`View release notes <https://xinference.io/release_notes/v2.11.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v2.11.0.html>`_"
 msgstr ""
 "`Vedi note di versione "
-"<https://xinference.io/release_notes/v2.11.0.html>`_"
+"<https://xinference.co/release_notes/v2.11.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:18
 msgid "v2.10.0"
 msgstr "v2.10.0"
 
 #: ../../source/getting_started/release_notes.rst:18
-msgid "`View release notes <https://xinference.io/release_notes/v2.10.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v2.10.0.html>`_"
 msgstr ""
 "`Visualizza le note di rilascio "
-"<https://xinference.io/release_notes/v2.10.0.html>`_"
+"<https://xinference.co/release_notes/v2.10.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:20
 msgid "v2.9.0"
 msgstr "v2.9.0"
 
 #: ../../source/getting_started/release_notes.rst:20
-msgid "`View release notes <https://xinference.io/release_notes/v2.9.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v2.9.0.html>`_"
 msgstr ""
 "`Vedi le note di rilascio "
-"<https://xinference.io/release_notes/v2.9.0.html>`_"
+"<https://xinference.co/release_notes/v2.9.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:22
 msgid "v2.8.0"
 msgstr "v2.8.0"
 
 #: ../../source/getting_started/release_notes.rst:22
-msgid "`View release notes <https://xinference.io/release_notes/v2.8.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v2.8.0.html>`_"
 msgstr ""
 "`Visualizza le note di rilascio "
-"<https://xinference.io/release_notes/v2.8.0.html>`_"
+"<https://xinference.co/release_notes/v2.8.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:24
 msgid "v2.7.0"
 msgstr "v2.7.0"
 
 #: ../../source/getting_started/release_notes.rst:24
-msgid "`View release notes <https://xinference.io/release_notes/v2.7.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v2.7.0.html>`_"
 msgstr ""
 "`Visualizzare le note di rilascio "
-"<https://xinference.io/release_notes/v2.7.0.html>`_"
+"<https://xinference.co/release_notes/v2.7.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:26
 msgid "v2.5.0"
 msgstr "v2.5.0"
 
 #: ../../source/getting_started/release_notes.rst:26
-msgid "`View release notes <https://xinference.io/release_notes/v2.5.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v2.5.0.html>`_"
 msgstr ""
 "`Visualizza le note di rilascio "
-"<https://xinference.io/release_notes/v2.5.0.html>`_"
+"<https://xinference.co/release_notes/v2.5.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:28
 msgid "v2.4.0"
 msgstr "v2.4.0"
 
 #: ../../source/getting_started/release_notes.rst:28
-msgid "`View release notes <https://xinference.io/release_notes/v2.4.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v2.4.0.html>`_"
 msgstr ""
 "`Visualizza le note di versione "
-"<https://xinference.io/release_notes/v2.4.0.html>`_"
+"<https://xinference.co/release_notes/v2.4.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:30
 msgid "v2.3.0"
 msgstr "v2.3.0"
 
 #: ../../source/getting_started/release_notes.rst:30
-msgid "`View release notes <https://xinference.io/release_notes/v2.3.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v2.3.0.html>`_"
 msgstr ""
 "`Visualizza le note di rilascio "
-"<https://xinference.io/release_notes/v2.3.0.html>`_"
+"<https://xinference.co/release_notes/v2.3.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:32
 msgid "v2.2.0"
 msgstr "v2.2.0"
 
 #: ../../source/getting_started/release_notes.rst:32
-msgid "`View release notes <https://xinference.io/release_notes/v2.2.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v2.2.0.html>`_"
 msgstr ""
 "`Vedi le note di rilascio "
-"<https://xinference.io/release_notes/v2.2.0.html>`_"
+"<https://xinference.co/release_notes/v2.2.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:34
 msgid "v2.1.0"
 msgstr "v2.1.0"
 
 #: ../../source/getting_started/release_notes.rst:34
-msgid "`View release notes <https://xinference.io/release_notes/v2.1.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v2.1.0.html>`_"
 msgstr ""
 "`Visualizza le note di rilascio "
-"<https://xinference.io/release_notes/v2.1.0.html>`_"
+"<https://xinference.co/release_notes/v2.1.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:36
 msgid "v2.0.0"
 msgstr "v2.0.0"
 
 #: ../../source/getting_started/release_notes.rst:36
-msgid "`View release notes <https://xinference.io/release_notes/v2.0.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v2.0.0.html>`_"
 msgstr ""
 "`Visualizza le note di rilascio "
-"<https://xinference.io/release_notes/v2.0.0.html>`_"
+"<https://xinference.co/release_notes/v2.0.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:38
 msgid "v1.17.0"
 msgstr "v1.17.0"
 
 #: ../../source/getting_started/release_notes.rst:38
-msgid "`View release notes <https://xinference.io/release_notes/v1.17.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v1.17.0.html>`_"
 msgstr ""
 "`Visualizza le note di rilascio "
-"<https://xinference.io/release_notes/v1.17.0.html>`_"
+"<https://xinference.co/release_notes/v1.17.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:40
 msgid "v1.16.0"
 msgstr "v1.16.0"
 
 #: ../../source/getting_started/release_notes.rst:40
-msgid "`View release notes <https://xinference.io/release_notes/v1.16.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v1.16.0.html>`_"
 msgstr ""
 "`Visualizza le note di rilascio "
-"<https://xinference.io/release_notes/v1.16.0.html>`_"
+"<https://xinference.co/release_notes/v1.16.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:42
 msgid "v1.15.0"
 msgstr "v1.15.0"
 
 #: ../../source/getting_started/release_notes.rst:42
-msgid "`View release notes <https://xinference.io/release_notes/v1.15.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v1.15.0.html>`_"
 msgstr ""
 "`Visualizza le note di rilascio "
-"<https://xinference.io/release_notes/v1.15.0.html>`_"
+"<https://xinference.co/release_notes/v1.15.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:44
 msgid "v1.14.0"
 msgstr "v1.14.0"
 
 #: ../../source/getting_started/release_notes.rst:44
-msgid "`View release notes <https://xinference.io/release_notes/v1.14.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v1.14.0.html>`_"
 msgstr ""
 "`Visualizza le note di versione "
-"<https://xinference.io/release_notes/v1.14.0.html>`_"
+"<https://xinference.co/release_notes/v1.14.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:46
 msgid "v1.13.0"
 msgstr "v1.13.0"
 
 #: ../../source/getting_started/release_notes.rst:46
-msgid "`View release notes <https://xinference.io/release_notes/v1.13.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v1.13.0.html>`_"
 msgstr ""
 "`Visualizza le note di versione "
-"<https://xinference.io/release_notes/v1.13.0.html>`_"
+"<https://xinference.co/release_notes/v1.13.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:48
 msgid "v1.12.0"
 msgstr "v1.12.0"
 
 #: ../../source/getting_started/release_notes.rst:48
-msgid "`View release notes <https://xinference.io/release_notes/v1.12.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v1.12.0.html>`_"
 msgstr ""
 "`Vedi le note di rilascio "
-"<https://xinference.io/release_notes/v1.12.0.html>`_"
+"<https://xinference.co/release_notes/v1.12.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:50
 msgid "v1.11.0.post1"
@@ -233,20 +233,20 @@ msgstr "v1.11.0.post1"
 #: ../../source/getting_started/release_notes.rst:50
 msgid ""
 "`View release notes "
-"<https://xinference.io/release_notes/v1.11.0.post1.html>`_"
+"<https://xinference.co/release_notes/v1.11.0.post1.html>`_"
 msgstr ""
 "`Visualizza le note di versione "
-"<https://xinference.io/release_notes/v1.11.0.post1.html>`_"
+"<https://xinference.co/release_notes/v1.11.0.post1.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:52
 msgid "v1.10.1"
 msgstr "v1.10.1"
 
 #: ../../source/getting_started/release_notes.rst:52
-msgid "`View release notes <https://xinference.io/release_notes/v1.10.1.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v1.10.1.html>`_"
 msgstr ""
 "`Visualizza le note di rilascio "
-"<https://xinference.io/release_notes/v1.10.1.html>`_"
+"<https://xinference.co/release_notes/v1.10.1.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:57
 msgid ""
@@ -255,4 +255,3 @@ msgid ""
 msgstr ""
 "Per ulteriori versioni storiche e codice sorgente, visitare GitHub "
 "Releases: https://github.com/xorbitsai/inference/releases"
-

--- a/doc/source/locale/zh_CN/LC_MESSAGES/getting_started/release_notes.po
+++ b/doc/source/locale/zh_CN/LC_MESSAGES/getting_started/release_notes.po
@@ -39,7 +39,7 @@ msgid "v3.0.0"
 msgstr "v3.0.0"
 
 #: ../../source/getting_started/release_notes.rst:12
-msgid "`View release notes <https://xinference.io/release_notes/v3.0.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v3.0.0.html>`_"
 msgstr "`查看版本说明 <https://xinference.cn/release_notes/v3.0.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:14
@@ -47,7 +47,7 @@ msgid "v2.12.0"
 msgstr "v2.12.0"
 
 #: ../../source/getting_started/release_notes.rst:14
-msgid "`View release notes <https://xinference.io/release_notes/v2.12.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v2.12.0.html>`_"
 msgstr "`查看版本说明 <https://xinference.cn/release_notes/v2.12.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:16
@@ -55,7 +55,7 @@ msgid "v2.11.0"
 msgstr "v2.11.0"
 
 #: ../../source/getting_started/release_notes.rst:16
-msgid "`View release notes <https://xinference.io/release_notes/v2.11.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v2.11.0.html>`_"
 msgstr "`查看版本说明 <https://xinference.cn/release_notes/v2.11.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:18
@@ -63,7 +63,7 @@ msgid "v2.10.0"
 msgstr "v2.10.0"
 
 #: ../../source/getting_started/release_notes.rst:18
-msgid "`View release notes <https://xinference.io/release_notes/v2.10.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v2.10.0.html>`_"
 msgstr "`查看版本说明 <https://xinference.cn/release_notes/v2.10.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:20
@@ -71,7 +71,7 @@ msgid "v2.9.0"
 msgstr "v2.9.0"
 
 #: ../../source/getting_started/release_notes.rst:20
-msgid "`View release notes <https://xinference.io/release_notes/v2.9.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v2.9.0.html>`_"
 msgstr "`查看版本说明 <https://xinference.cn/release_notes/v2.9.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:22
@@ -79,7 +79,7 @@ msgid "v2.8.0"
 msgstr "v2.8.0"
 
 #: ../../source/getting_started/release_notes.rst:22
-msgid "`View release notes <https://xinference.io/release_notes/v2.8.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v2.8.0.html>`_"
 msgstr "`查看版本说明 <https://xinference.cn/release_notes/v2.8.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:24
@@ -87,7 +87,7 @@ msgid "v2.7.0"
 msgstr "v2.7.0"
 
 #: ../../source/getting_started/release_notes.rst:24
-msgid "`View release notes <https://xinference.io/release_notes/v2.7.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v2.7.0.html>`_"
 msgstr "`查看版本说明 <https://xinference.cn/release_notes/v2.7.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:26
@@ -95,7 +95,7 @@ msgid "v2.5.0"
 msgstr "v2.5.0"
 
 #: ../../source/getting_started/release_notes.rst:26
-msgid "`View release notes <https://xinference.io/release_notes/v2.5.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v2.5.0.html>`_"
 msgstr "`查看版本说明 <https://xinference.cn/release_notes/v2.5.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:28
@@ -103,7 +103,7 @@ msgid "v2.4.0"
 msgstr "v2.4.0"
 
 #: ../../source/getting_started/release_notes.rst:28
-msgid "`View release notes <https://xinference.io/release_notes/v2.4.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v2.4.0.html>`_"
 msgstr "`查看版本说明 <https://xinference.cn/release_notes/v2.4.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:30
@@ -111,7 +111,7 @@ msgid "v2.3.0"
 msgstr "v2.3.0"
 
 #: ../../source/getting_started/release_notes.rst:30
-msgid "`View release notes <https://xinference.io/release_notes/v2.3.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v2.3.0.html>`_"
 msgstr "`查看版本说明 <https://xinference.cn/release_notes/v2.3.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:32
@@ -119,7 +119,7 @@ msgid "v2.2.0"
 msgstr "v2.2.0"
 
 #: ../../source/getting_started/release_notes.rst:32
-msgid "`View release notes <https://xinference.io/release_notes/v2.2.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v2.2.0.html>`_"
 msgstr "`查看版本说明 <https://xinference.cn/release_notes/v2.2.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:34
@@ -127,7 +127,7 @@ msgid "v2.1.0"
 msgstr "v2.1.0"
 
 #: ../../source/getting_started/release_notes.rst:34
-msgid "`View release notes <https://xinference.io/release_notes/v2.1.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v2.1.0.html>`_"
 msgstr "`查看版本说明 <https://xinference.cn/release_notes/v2.1.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:36
@@ -135,7 +135,7 @@ msgid "v2.0.0"
 msgstr "v2.0.0"
 
 #: ../../source/getting_started/release_notes.rst:36
-msgid "`View release notes <https://xinference.io/release_notes/v2.0.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v2.0.0.html>`_"
 msgstr "`查看版本说明 <https://xinference.cn/release_notes/v2.0.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:38
@@ -143,7 +143,7 @@ msgid "v1.17.0"
 msgstr "v1.17.0"
 
 #: ../../source/getting_started/release_notes.rst:38
-msgid "`View release notes <https://xinference.io/release_notes/v1.17.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v1.17.0.html>`_"
 msgstr "`查看版本说明 <https://xinference.cn/release_notes/v1.17.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:40
@@ -151,7 +151,7 @@ msgid "v1.16.0"
 msgstr "v1.16.0"
 
 #: ../../source/getting_started/release_notes.rst:40
-msgid "`View release notes <https://xinference.io/release_notes/v1.16.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v1.16.0.html>`_"
 msgstr "`查看版本说明 <https://xinference.cn/release_notes/v1.16.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:42
@@ -159,7 +159,7 @@ msgid "v1.15.0"
 msgstr "v1.15.0"
 
 #: ../../source/getting_started/release_notes.rst:42
-msgid "`View release notes <https://xinference.io/release_notes/v1.15.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v1.15.0.html>`_"
 msgstr "`查看版本说明 <https://xinference.cn/release_notes/v1.15.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:44
@@ -167,7 +167,7 @@ msgid "v1.14.0"
 msgstr "v1.14.0"
 
 #: ../../source/getting_started/release_notes.rst:44
-msgid "`View release notes <https://xinference.io/release_notes/v1.14.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v1.14.0.html>`_"
 msgstr "`查看版本说明 <https://xinference.cn/release_notes/v1.14.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:46
@@ -175,7 +175,7 @@ msgid "v1.13.0"
 msgstr "v1.13.0"
 
 #: ../../source/getting_started/release_notes.rst:46
-msgid "`View release notes <https://xinference.io/release_notes/v1.13.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v1.13.0.html>`_"
 msgstr "`查看版本说明 <https://xinference.cn/release_notes/v1.13.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:48
@@ -183,7 +183,7 @@ msgid "v1.12.0"
 msgstr "v1.12.0"
 
 #: ../../source/getting_started/release_notes.rst:48
-msgid "`View release notes <https://xinference.io/release_notes/v1.12.0.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v1.12.0.html>`_"
 msgstr "`查看版本说明 <https://xinference.cn/release_notes/v1.12.0.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:50
@@ -193,7 +193,7 @@ msgstr "v1.11.0.post1"
 #: ../../source/getting_started/release_notes.rst:50
 msgid ""
 "`View release notes "
-"<https://xinference.io/release_notes/v1.11.0.post1.html>`_"
+"<https://xinference.co/release_notes/v1.11.0.post1.html>`_"
 msgstr "`查看版本说明 <https://xinference.cn/release_notes/v1.11.0.post1.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:52
@@ -201,7 +201,7 @@ msgid "v1.10.1"
 msgstr "v1.10.1"
 
 #: ../../source/getting_started/release_notes.rst:52
-msgid "`View release notes <https://xinference.io/release_notes/v1.10.1.html>`_"
+msgid "`View release notes <https://xinference.co/release_notes/v1.10.1.html>`_"
 msgstr "`查看版本说明 <https://xinference.cn/release_notes/v1.10.1.html>`_"
 
 #: ../../source/getting_started/release_notes.rst:57
@@ -211,4 +211,3 @@ msgid ""
 msgstr ""
 "更多历史版本及源代码，请访问 GitHub "
 "Releases：https://github.com/xorbitsai/inference/releases"
-


### PR DESCRIPTION
Update all release-note hyperlinks on the Release Notes page (v1.10.1 through v3.0.0) from the xinference.io domain to xinference.co. Link-only change; table formatting and the GitHub releases link are unchanged.