### PR TITLE
FIX: worker reconnection after supervisor restart

### DIFF
--- a/xinference/core/tests/test_worker.py
+++ b/xinference/core/tests/test_worker.py
@@ -430,6 +430,42 @@ class DummyActorRef:
         self.address = address
 
 
+@pytest.mark.asyncio
+async def test_worker_heartbeat_failure_clears_cached_supervisor_refs():
+    class FailingSupervisorRef:
+        async def receive_heartbeat(self, worker_address: str):
+            raise ConnectionRefusedError("stale supervisor address")
+
+    class DummyWorker:
+        heartbeat = WorkerActor.heartbeat
+        _clear_supervisor_refs = WorkerActor._clear_supervisor_refs
+
+        def __init__(self):
+            self.address = "test://worker"
+            self._supervisor_ref = FailingSupervisorRef()
+            self._registered = True
+            self._status_guard_ref = object()
+            self._event_collector_ref = object()
+            self._cache_tracker_ref = object()
+            self._progress_tracker_ref = object()
+
+        async def get_supervisor_ref(self, add_worker=True):
+            assert not add_worker
+            return self._supervisor_ref
+
+    worker = DummyWorker()
+
+    with pytest.raises(ConnectionRefusedError, match="stale supervisor address"):
+        await worker.heartbeat()
+
+    assert worker._supervisor_ref is None
+    assert not worker._registered
+    assert worker._status_guard_ref is None
+    assert worker._event_collector_ref is None
+    assert worker._cache_tracker_ref is None
+    assert worker._progress_tracker_ref is None
+
+
 class DummyReplicaWorkerRef(DummyActorRef):
     def __init__(self, address: str, models=None):
         super().__init__(address)

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -3935,13 +3935,21 @@ class WorkerActor(xo.StatelessActor):
         (add_worker + record_model_version). Registry recovery is driven solely
         by report_status -> report_worker_status path, per supervisor's
         receive_heartbeat design contract (supervisor.py).
+
+        A transport failure invalidates the cached supervisor references so the
+        next attempt can refresh a supervisor whose internal address changed
+        after a restart.
         """
-        await xo.wait_for(
-            (await self.get_supervisor_ref(add_worker=False)).receive_heartbeat(
-                self.address
-            ),
-            XINFERENCE_TCP_REQUEST_TIMEOUT,
-        )
+        try:
+            await xo.wait_for(
+                (await self.get_supervisor_ref(add_worker=False)).receive_heartbeat(
+                    self.address
+                ),
+                XINFERENCE_TCP_REQUEST_TIMEOUT,
+            )
+        except Exception:
+            self._clear_supervisor_refs()
+            raise
 
     async def _periodical_report_status(self):
         """


### PR DESCRIPTION
Fix worker reconnection after supervisor restart

**Summary**

- Clear cached supervisor references when a worker heartbeat fails.
- Allow the worker to discover the supervisor’s new internal address after restart.
- Restore worker re-registration and model replica recovery.
- Add a regression test for stale supervisor references.

**Testing**

- `python -m compileall`
- `git diff --check`
- Isolated heartbeat reconnection check
- Full pytest unavailable because `xoscar` is not installed locally.