### PR TITLE
feat(llm): surface logprobs in /v1/chat/completions

### DIFF
--- a/xinference/model/llm/tests/test_utils.py
+++ b/xinference/model/llm/tests/test_utils.py
@@ -102,6 +102,81 @@ def test_to_chat_completion_chunks_usage_only_chunk_without_metadata():
     }
 
 
+def test_to_chat_completion_propagates_logprobs():
+    # Regression for #1911 / #3553: /v1/chat/completions silently returned
+    # logprobs: null even when the engine produced them. The chat builder must
+    # propagate the source Completion choice's logprobs onto the chat choice.
+    from ....types import (
+        Completion,
+        CompletionChoice,
+        CompletionLogprobs,
+        CompletionUsage,
+    )
+
+    logprobs = CompletionLogprobs(
+        text_offset=[0, 5],
+        token_logprobs=[None, -0.1],
+        tokens=["Hello", " world"],
+        top_logprobs=[None, {" world": -0.2}],
+    )
+    completion = Completion(
+        id="cmpl-1",
+        object="text_completion",
+        created=123,
+        model="test-model",
+        choices=[
+            CompletionChoice(
+                text="Hello world",
+                index=0,
+                logprobs=logprobs,
+                finish_reason="stop",
+            )
+        ],
+        usage=CompletionUsage(
+            prompt_tokens=1, completion_tokens=2, total_tokens=3
+        ),
+    )
+
+    chat = ChatModelMixin._to_chat_completion(completion)
+
+    assert chat["choices"][0]["logprobs"] is not None
+    assert chat["choices"][0]["logprobs"] == logprobs
+
+
+def test_to_chat_completion_chunks_propagates_logprobs():
+    # Streaming counterpart: the chat chunk choice must carry the source
+    # CompletionChunk choice's logprobs instead of dropping them.
+    from ....types import (
+        CompletionChoice,
+        CompletionChunk,
+        CompletionLogprobs,
+    )
+
+    logprobs = CompletionLogprobs(
+        text_offset=[0, 5],
+        token_logprobs=[None, -0.1],
+        tokens=["Hello", " world"],
+        top_logprobs=[None, {" world": -0.2}],
+    )
+    chunk = CompletionChunk(
+        id="cmpl-2",
+        object="text_completion",
+        created=123,
+        model="test-model",
+        choices=[
+            CompletionChoice(
+                text="Hello", index=0, logprobs=logprobs, finish_reason=None
+            )
+        ],
+    )
+
+    results = list(ChatModelMixin._to_chat_completion_chunks(iter([chunk])))
+
+    assert results, "expected at least one chat chunk"
+    assert results[0]["choices"][0]["logprobs"] is not None
+    assert results[0]["choices"][0]["logprobs"] == logprobs
+
+
 def test_async_to_chat_completion_chunks_preserves_usage_only_chunk():
     async def _chunks():
         yield {

--- a/xinference/model/llm/tests/test_utils.py
+++ b/xinference/model/llm/tests/test_utils.py
@@ -132,9 +132,7 @@ def test_to_chat_completion_propagates_logprobs():
                 finish_reason="stop",
             )
         ],
-        usage=CompletionUsage(
-            prompt_tokens=1, completion_tokens=2, total_tokens=3
-        ),
+        usage=CompletionUsage(prompt_tokens=1, completion_tokens=2, total_tokens=3),
     )
 
     chat = ChatModelMixin._to_chat_completion(completion)
@@ -146,11 +144,7 @@ def test_to_chat_completion_propagates_logprobs():
 def test_to_chat_completion_chunks_propagates_logprobs():
     # Streaming counterpart: the chat chunk choice must carry the source
     # CompletionChunk choice's logprobs instead of dropping them.
-    from ....types import (
-        CompletionChoice,
-        CompletionChunk,
-        CompletionLogprobs,
-    )
+    from ....types import CompletionChoice, CompletionChunk, CompletionLogprobs
 
     logprobs = CompletionLogprobs(
         text_offset=[0, 5],

--- a/xinference/model/llm/tests/test_utils.py
+++ b/xinference/model/llm/tests/test_utils.py
@@ -142,13 +142,10 @@ def test_to_chat_completion_propagates_logprobs():
     # logprob/top_logprobs), not the legacy parallel-list shape, so openai-python
     # parses ``choice.logprobs.content`` instead of dropping it as extra fields.
     assert chat["choices"][0]["logprobs"] == {
+        # The first token's legacy logprob is None (not computed), so it is
+        # omitted from content[] rather than emitted with a null logprob —
+        # openai-python rejects null (see test_chat_logprobs_parse_openai).
         "content": [
-            {
-                "token": "Hello",
-                "bytes": [72, 101, 108, 108, 111],
-                "logprob": None,
-                "top_logprobs": [],
-            },
             {
                 "token": " world",
                 "bytes": [32, 119, 111, 114, 108, 100],
@@ -195,13 +192,10 @@ def test_to_chat_completion_chunks_propagates_logprobs():
     # Streaming chat chunks carry the chat ``content[]`` logprobs shape, converted
     # from the legacy parallel-list shape the engine emits.
     assert results[0]["choices"][0]["logprobs"] == {
+        # The first token's legacy logprob is None -> omitted from content[]
+        # (see test_chat_logprobs_parse_openai); only the known-logprob token
+        # survives, in the chat content[] shape.
         "content": [
-            {
-                "token": "Hello",
-                "bytes": [72, 101, 108, 108, 111],
-                "logprob": None,
-                "top_logprobs": [],
-            },
             {
                 "token": " world",
                 "bytes": [32, 119, 111, 114, 108, 100],
@@ -216,6 +210,59 @@ def test_to_chat_completion_chunks_propagates_logprobs():
             },
         ]
     }
+
+
+def test_chat_logprobs_parse_openai():
+    # Regression for the openai-python validation failure qinxuye reproduced with
+    # 1.99.9: ``ChatCompletionTokenLogprob.logprob`` is non-nullable, so a chat
+    # logprobs ``content[]`` entry must never carry ``null``. The converter now
+    # skips tokens whose legacy ``token_logprobs`` entry is ``None`` instead of
+    # emitting a null logprob; assert every emitted entry parses through the
+    # OpenAI client model.
+    pytest.importorskip("openai")
+    from openai.types.chat.chat_completion_token_logprob import (
+        ChatCompletionTokenLogprob,
+    )
+    from ....types import (
+        Completion,
+        CompletionChoice,
+        CompletionLogprobs,
+        CompletionUsage,
+    )
+
+    # token_logprobs[0] is None (the legacy first-token case). The converter must
+    # drop that token rather than emit ``logprob: None``.
+    logprobs = CompletionLogprobs(
+        text_offset=[0, 5],
+        token_logprobs=[None, -0.1],
+        tokens=["Hello", " world"],
+        top_logprobs=[None, {" world": -0.2}],
+    )
+    completion = Completion(
+        id="cmpl-1",
+        object="text_completion",
+        created=123,
+        model="test-model",
+        choices=[
+            CompletionChoice(
+                text="Hello world",
+                index=0,
+                logprobs=logprobs,
+                finish_reason="stop",
+            )
+        ],
+        usage=CompletionUsage(prompt_tokens=1, completion_tokens=2, total_tokens=3),
+    )
+
+    chat = ChatModelMixin._to_chat_completion(completion)
+    content = chat["choices"][0]["logprobs"]["content"]
+    assert content, "content[] must not be empty when a known-logprob token exists"
+    # No entry carries a null logprob, and the None-logprob first token is dropped.
+    assert [e["token"] for e in content] == [" world"]
+    for entry in content:
+        # Must parse through the OpenAI client model without raising — the exact
+        # gate that was failing ("logprob: Input should be a valid number").
+        ChatCompletionTokenLogprob(**entry)
 
 
 class _NoOpToolParser:

--- a/xinference/model/llm/tests/test_utils.py
+++ b/xinference/model/llm/tests/test_utils.py
@@ -223,6 +223,7 @@ def test_chat_logprobs_parse_openai():
     from openai.types.chat.chat_completion_token_logprob import (
         ChatCompletionTokenLogprob,
     )
+
     from ....types import (
         Completion,
         CompletionChoice,
@@ -322,12 +323,6 @@ def test_post_process_completion_preserves_chat_logprobs():
     assert result["choices"][0]["logprobs"] == {
         "content": [
             {
-                "token": "Hello",
-                "bytes": [72, 101, 108, 108, 111],
-                "logprob": None,
-                "top_logprobs": [],
-            },
-            {
                 "token": " world",
                 "bytes": [32, 119, 111, 114, 108, 100],
                 "logprob": -0.1,
@@ -392,12 +387,6 @@ def test_post_process_completion_chunk_preserves_chat_logprobs():
     assert result["choices"][0]["logprobs"] == expected_logprobs
     assert result["choices"][0]["logprobs"] == {
         "content": [
-            {
-                "token": "Hello",
-                "bytes": [72, 101, 108, 108, 111],
-                "logprob": None,
-                "top_logprobs": [],
-            },
             {
                 "token": " world",
                 "bytes": [32, 119, 111, 114, 108, 100],

--- a/xinference/model/llm/tests/test_utils.py
+++ b/xinference/model/llm/tests/test_utils.py
@@ -138,7 +138,31 @@ def test_to_chat_completion_propagates_logprobs():
     chat = ChatModelMixin._to_chat_completion(completion)
 
     assert chat["choices"][0]["logprobs"] is not None
-    assert chat["choices"][0]["logprobs"] == logprobs
+    # Chat completions carry the chat ``content[]`` logprobs shape (token/bytes/
+    # logprob/top_logprobs), not the legacy parallel-list shape, so openai-python
+    # parses ``choice.logprobs.content`` instead of dropping it as extra fields.
+    assert chat["choices"][0]["logprobs"] == {
+        "content": [
+            {
+                "token": "Hello",
+                "bytes": [72, 101, 108, 108, 111],
+                "logprob": None,
+                "top_logprobs": [],
+            },
+            {
+                "token": " world",
+                "bytes": [32, 119, 111, 114, 108, 100],
+                "logprob": -0.1,
+                "top_logprobs": [
+                    {
+                        "token": " world",
+                        "bytes": [32, 119, 111, 114, 108, 100],
+                        "logprob": -0.2,
+                    }
+                ],
+            },
+        ]
+    }
 
 
 def test_to_chat_completion_chunks_propagates_logprobs():
@@ -168,7 +192,169 @@ def test_to_chat_completion_chunks_propagates_logprobs():
 
     assert results, "expected at least one chat chunk"
     assert results[0]["choices"][0]["logprobs"] is not None
-    assert results[0]["choices"][0]["logprobs"] == logprobs
+    # Streaming chat chunks carry the chat ``content[]`` logprobs shape, converted
+    # from the legacy parallel-list shape the engine emits.
+    assert results[0]["choices"][0]["logprobs"] == {
+        "content": [
+            {
+                "token": "Hello",
+                "bytes": [72, 101, 108, 108, 111],
+                "logprob": None,
+                "top_logprobs": [],
+            },
+            {
+                "token": " world",
+                "bytes": [32, 119, 111, 114, 108, 100],
+                "logprob": -0.1,
+                "top_logprobs": [
+                    {
+                        "token": " world",
+                        "bytes": [32, 119, 111, 114, 108, 100],
+                        "logprob": -0.2,
+                    }
+                ],
+            },
+        ]
+    }
+
+
+class _NoOpToolParser:
+    """Minimal tool-parser stub: reports no tool calls so the tool post-processors
+    take the content-preserving branch while still exercising the logprobs path
+    (the real parsers are heavy to construct in a unit test)."""
+
+    def extract_tool_calls(self, text):  # non-streaming
+        return []
+
+    def extract_tool_calls_streaming(
+        self, previous_texts, current_text, delta_text
+    ):  # streaming; returns (content, func, args)
+        return (delta_text or "", None, None)
+
+
+def test_post_process_completion_preserves_chat_logprobs():
+    # Non-streaming tools path: _post_process_completion previously omitted the
+    # logprobs field entirely, so tool-enabled requests lost them. It must now
+    # carry the converted chat-shape logprobs from the source Completion choice.
+    from ....types import (
+        Completion,
+        CompletionChoice,
+        CompletionLogprobs,
+        CompletionUsage,
+    )
+
+    logprobs = CompletionLogprobs(
+        text_offset=[0, 5],
+        token_logprobs=[None, -0.1],
+        tokens=["Hello", " world"],
+        top_logprobs=[None, {" world": -0.2}],
+    )
+    completion = Completion(
+        id="cmpl-1",
+        object="text_completion",
+        created=123,
+        model="test-model",
+        choices=[
+            CompletionChoice(
+                text="Hello world",
+                index=0,
+                logprobs=logprobs,
+                finish_reason="stop",
+            )
+        ],
+        usage=CompletionUsage(prompt_tokens=1, completion_tokens=2, total_tokens=3),
+    )
+
+    mixin = ChatModelMixin()
+    mixin.tool_parser = _NoOpToolParser()
+    mixin.reasoning_parser = None
+
+    result = mixin._post_process_completion("test-family", "test-model", completion)
+
+    assert result["choices"][0]["logprobs"] is not None
+    assert result["choices"][0]["logprobs"] == {
+        "content": [
+            {
+                "token": "Hello",
+                "bytes": [72, 101, 108, 108, 111],
+                "logprob": None,
+                "top_logprobs": [],
+            },
+            {
+                "token": " world",
+                "bytes": [32, 119, 111, 114, 108, 100],
+                "logprob": -0.1,
+                "top_logprobs": [
+                    {
+                        "token": " world",
+                        "bytes": [32, 119, 111, 114, 108, 100],
+                        "logprob": -0.2,
+                    }
+                ],
+            },
+        ]
+    }
+
+
+def test_post_process_completion_chunk_preserves_chat_logprobs():
+    # Streaming tools path: _post_process_completion_chunk previously hard-coded
+    # logprobs to None, so streaming tool-enabled requests lost them. It must now
+    # carry the converted chat-shape logprobs from the source CompletionChunk choice.
+    from ....types import CompletionChoice, CompletionChunk, CompletionLogprobs
+
+    logprobs = CompletionLogprobs(
+        text_offset=[0, 5],
+        token_logprobs=[None, -0.1],
+        tokens=["Hello", " world"],
+        top_logprobs=[None, {" world": -0.2}],
+    )
+    chunk = CompletionChunk(
+        id="cmpl-2",
+        object="text_completion",
+        created=123,
+        model="test-model",
+        choices=[
+            CompletionChoice(
+                text="Hello",
+                index=0,
+                logprobs=logprobs,
+                finish_reason=None,
+            )
+        ],
+    )
+
+    mixin = ChatModelMixin()
+    mixin.tool_parser = _NoOpToolParser()
+    mixin.reasoning_parser = None
+
+    result = mixin._post_process_completion_chunk(
+        "test-family", "test-model", chunk, chunk_id="cmpl-2"
+    )
+
+    assert result is not None
+    assert result["choices"][0]["logprobs"] is not None
+    assert result["choices"][0]["logprobs"] == {
+        "content": [
+            {
+                "token": "Hello",
+                "bytes": [72, 101, 108, 108, 111],
+                "logprob": None,
+                "top_logprobs": [],
+            },
+            {
+                "token": " world",
+                "bytes": [32, 119, 111, 114, 108, 100],
+                "logprob": -0.1,
+                "top_logprobs": [
+                    {
+                        "token": " world",
+                        "bytes": [32, 119, 111, 114, 108, 100],
+                        "logprob": -0.2,
+                    }
+                ],
+            },
+        ]
+    }
 
 
 def test_async_to_chat_completion_chunks_preserves_usage_only_chunk():

--- a/xinference/model/llm/tests/test_utils.py
+++ b/xinference/model/llm/tests/test_utils.py
@@ -297,9 +297,13 @@ def test_post_process_completion_preserves_chat_logprobs():
 
 
 def test_post_process_completion_chunk_preserves_chat_logprobs():
-    # Streaming tools path: _post_process_completion_chunk previously hard-coded
-    # logprobs to None, so streaming tool-enabled requests lost them. It must now
-    # carry the converted chat-shape logprobs from the source CompletionChunk choice.
+    # Streaming tools path: `_async_to_tool_completion_chunks` first converts each
+    # legacy CompletionChunk to a chat chunk via `_to_chat_completion_chunk` (which
+    # already turns the legacy parallel-list logprobs into the chat ``content[]``
+    # shape), then hands the chat chunk to `_post_process_completion_chunk`. That
+    # post-processor must pass the already-converted logprobs through unchanged;
+    # re-running the converter would find no ``tokens`` key and collapse a real
+    # one-token logprob to ``{"content": []}`` (regression flagged on #5252).
     from ....types import CompletionChoice, CompletionChunk, CompletionLogprobs
 
     logprobs = CompletionLogprobs(
@@ -308,7 +312,7 @@ def test_post_process_completion_chunk_preserves_chat_logprobs():
         tokens=["Hello", " world"],
         top_logprobs=[None, {" world": -0.2}],
     )
-    chunk = CompletionChunk(
+    raw_chunk = CompletionChunk(
         id="cmpl-2",
         object="text_completion",
         created=123,
@@ -323,16 +327,22 @@ def test_post_process_completion_chunk_preserves_chat_logprobs():
         ],
     )
 
+    # Production order: convert to a chat chunk first, then post-process it.
+    chat_chunk = ChatModelMixin._to_chat_completion_chunk(raw_chunk)
+    expected_logprobs = chat_chunk["choices"][0]["logprobs"]
+    assert expected_logprobs is not None  # converted once to the chat shape
+
     mixin = ChatModelMixin()
     mixin.tool_parser = _NoOpToolParser()
     mixin.reasoning_parser = None
 
     result = mixin._post_process_completion_chunk(
-        "test-family", "test-model", chunk, chunk_id="cmpl-2"
+        "test-family", "test-model", chat_chunk, chunk_id="cmpl-2"
     )
 
     assert result is not None
-    assert result["choices"][0]["logprobs"] is not None
+    # Passed through unchanged -- not double-converted to {"content": []}.
+    assert result["choices"][0]["logprobs"] == expected_logprobs
     assert result["choices"][0]["logprobs"] == {
         "content": [
             {
@@ -2145,6 +2155,7 @@ def test_post_process_completion_without_thinking():
                         }
                     ],
                 },
+                "logprobs": None,
                 "finish_reason": "tool_calls",
             }
         ],
@@ -2201,6 +2212,7 @@ def test_post_process_completion_with_thinking():
                         }
                     ],
                 },
+                "logprobs": None,
                 "finish_reason": "tool_calls",
             }
         ],
@@ -2264,6 +2276,7 @@ def test_post_process_completion_with_parser():
                     ],
                     "reasoning_content": '\n好的，用户问的是上海当前的天气。我需要调用get_current_weather这个工具来获取数据。首先，确认工具的参数是location，必须填写城市名称。用户提到的是上海，所以参数应该是"location": "上海"。然后，生成对应的JSON格式，确保正确无误。检查一下有没有其他必填项，这里只有location，所以没问题。最后，用工具调用的格式返回结果。\n',
                 },
+                "logprobs": None,
                 "finish_reason": "tool_calls",
             }
         ],

--- a/xinference/model/llm/utils.py
+++ b/xinference/model/llm/utils.py
@@ -528,6 +528,7 @@ class ChatModelMixin:
                 {
                     "index": i,
                     "delta": delta,
+                    "logprobs": choice.get("logprobs"),
                     "finish_reason": choice["finish_reason"],
                 }
             )
@@ -812,6 +813,7 @@ class ChatModelMixin:
                 {
                     "index": i,
                     "message": message,
+                    "logprobs": choice.get("logprobs"),
                     "finish_reason": choice["finish_reason"],
                 }
             )

--- a/xinference/model/llm/utils.py
+++ b/xinference/model/llm/utils.py
@@ -100,6 +100,15 @@ def _completion_logprobs_to_chat_logprobs(
     content: List[ChatCompletionLogprob] = []
     for i, token in enumerate(tokens):
         logprob = token_logprobs[i] if i < len(token_logprobs) else None
+        # The OpenAI chat-completions schema requires ``logprob: float`` on every
+        # ``content[]`` entry; ``openai-python`` rejects ``null`` (reproduced with
+        # 1.99.9: "Input should be a valid number"). The legacy
+        # ``token_logprobs`` carries ``None`` for tokens whose logprob was not
+        # computed (e.g. the first generated token in the legacy completion
+        # shape). Rather than emit a fabricated probability, skip those tokens so
+        # ``content[]`` reports only tokens whose logprob is actually known.
+        if logprob is None:
+            continue
         raw_top = top_logprobs[i] if i < len(top_logprobs) else None
         top_list: List[ChatCompletionTopLogprob] = []
         if raw_top:

--- a/xinference/model/llm/utils.py
+++ b/xinference/model/llm/utils.py
@@ -968,9 +968,11 @@ class ChatModelMixin:
                 {
                     "index": 0,
                     "delta": d,
-                    "logprobs": _completion_logprobs_to_chat_logprobs(
-                        c["choices"][0].get("logprobs")
-                    ),
+                    # `_async_to_tool_completion_chunks` already converted the
+                    # legacy completion logprobs to the chat ``content[]`` shape
+                    # via `_to_chat_completion_chunk`; pass it through unchanged
+                    # here so a real logprob is not collapsed to ``{"content": []}``.
+                    "logprobs": c["choices"][0].get("logprobs"),
                     "finish_reason": finish_reason,
                 }
             ],

--- a/xinference/model/llm/utils.py
+++ b/xinference/model/llm/utils.py
@@ -46,10 +46,14 @@ from ...types import (
     ChatCompletionChunk,
     ChatCompletionChunkChoice,
     ChatCompletionChunkDelta,
+    ChatCompletionLogprob,
+    ChatCompletionLogprobs,
     ChatCompletionMessage,
+    ChatCompletionTopLogprob,
     Completion,
     CompletionChoice,
     CompletionChunk,
+    CompletionLogprobs,
     CompletionUsage,
 )
 from .core import chat_context_var
@@ -57,6 +61,65 @@ from .reasoning_parser import ReasoningParser
 from .tool_parsers.glm4_tool_parser import Glm4ToolParser
 
 logger = logging.getLogger(__name__)
+
+
+def _token_logprob_bytes(token: str) -> Optional[List[int]]:
+    """UTF-8 byte sequence of a logprob token, or ``None`` when not representable.
+
+    OpenAI encodes chat logprob tokens as their UTF-8 byte sequence; non-UTF-8
+    byte tokens surface as ``None`` so clients fall back to the token string.
+    """
+    if token is None:
+        return None
+    try:
+        return list(token.encode("utf-8"))
+    except (UnicodeEncodeError, AttributeError):
+        return None
+
+
+def _completion_logprobs_to_chat_logprobs(
+    logprobs: Optional[CompletionLogprobs],
+) -> Optional[ChatCompletionLogprobs]:
+    """Convert legacy parallel-list completion logprobs to the chat ``content[]`` shape.
+
+    vLLM emits ``/v1/completions`` logprobs in the legacy shape
+    (``text_offset`` / ``tokens`` / ``token_logprobs`` / ``top_logprobs`` parallel
+    lists); chat completions clients (``openai-python``) expect
+    ``logprobs.content[]`` with per-token ``token`` / ``bytes`` / ``logprob`` /
+    ``top_logprobs``. Surfacing the legacy shape on a chat choice leaves
+    ``choice.logprobs.content`` ``None`` for standard chat clients, so convert at
+    the chat builder boundary (both streaming and non-streaming, and through the
+    tool post-processors). ``None`` input (logprobs not requested/produced) passes
+    through as ``None``.
+    """
+    if logprobs is None:
+        return None
+    tokens = logprobs.get("tokens") or []
+    token_logprobs = logprobs.get("token_logprobs") or []
+    top_logprobs = logprobs.get("top_logprobs") or []
+    content: List[ChatCompletionLogprob] = []
+    for i, token in enumerate(tokens):
+        logprob = token_logprobs[i] if i < len(token_logprobs) else None
+        raw_top = top_logprobs[i] if i < len(top_logprobs) else None
+        top_list: List[ChatCompletionTopLogprob] = []
+        if raw_top:
+            for top_token, top_logprob in raw_top.items():
+                top_list.append(
+                    {
+                        "token": top_token,
+                        "bytes": _token_logprob_bytes(top_token),
+                        "logprob": top_logprob,
+                    }
+                )
+        content.append(
+            {
+                "token": token,
+                "bytes": _token_logprob_bytes(token),
+                "logprob": logprob,
+                "top_logprobs": top_list,
+            }
+        )
+    return {"content": content}
 
 
 class MessageRoleOrderError(ValueError):
@@ -528,7 +591,9 @@ class ChatModelMixin:
                 {
                     "index": i,
                     "delta": delta,
-                    "logprobs": choice.get("logprobs"),
+                    "logprobs": _completion_logprobs_to_chat_logprobs(
+                        choice.get("logprobs")
+                    ),
                     "finish_reason": choice["finish_reason"],
                 }
             )
@@ -813,7 +878,9 @@ class ChatModelMixin:
                 {
                     "index": i,
                     "message": message,
-                    "logprobs": choice.get("logprobs"),
+                    "logprobs": _completion_logprobs_to_chat_logprobs(
+                        choice.get("logprobs")
+                    ),
                     "finish_reason": choice["finish_reason"],
                 }
             )
@@ -901,7 +968,9 @@ class ChatModelMixin:
                 {
                     "index": 0,
                     "delta": d,
-                    "logprobs": None,
+                    "logprobs": _completion_logprobs_to_chat_logprobs(
+                        c["choices"][0].get("logprobs")
+                    ),
                     "finish_reason": finish_reason,
                 }
             ],
@@ -993,6 +1062,9 @@ class ChatModelMixin:
                 {
                     "index": 0,
                     "message": m,
+                    "logprobs": _completion_logprobs_to_chat_logprobs(
+                        c["choices"][0].get("logprobs")
+                    ),
                     "finish_reason": finish_reason,
                 }
             ],

--- a/xinference/types.py
+++ b/xinference/types.py
@@ -204,6 +204,7 @@ class ChatCompletionMessage(TypedDict):
 class ChatCompletionChoice(TypedDict):
     index: int
     message: ChatCompletionMessage
+    logprobs: NotRequired[Optional[CompletionLogprobs]]
     finish_reason: Optional[str]
 
 
@@ -226,6 +227,7 @@ class ChatCompletionChunkDelta(TypedDict):
 class ChatCompletionChunkChoice(TypedDict):
     index: int
     delta: ChatCompletionChunkDelta
+    logprobs: NotRequired[Optional[CompletionLogprobs]]
     finish_reason: Optional[str]
 
 

--- a/xinference/types.py
+++ b/xinference/types.py
@@ -159,13 +159,16 @@ class ChatCompletionTopLogprob(TypedDict):
 class ChatCompletionLogprob(TypedDict):
     """A token entry in chat completion ``logprobs.content[]``.
 
-    ``logprob`` is optional because the first generated token carries no logprob,
-    matching the OpenAI chat logprobs contract.
+    ``logprob`` is required (non-optional): the OpenAI chat-completions schema
+    mandates a ``float`` on every ``content[]`` entry, and ``openai-python``
+    rejects ``null``. Tokens whose logprob is unknown (``None`` in the legacy
+    ``CompletionLogprobs.token_logprobs`` shape) are omitted from ``content[]``
+    by the chat builder rather than emitted with a null or fabricated logprob.
     """
 
     token: str
     bytes: Optional[List[int]]
-    logprob: Optional[float]
+    logprob: float
     top_logprobs: List[ChatCompletionTopLogprob]
 
 

--- a/xinference/types.py
+++ b/xinference/types.py
@@ -142,6 +142,44 @@ class CompletionLogprobs(TypedDict):
     top_logprobs: List[Optional[Dict[str, float]]]
 
 
+class ChatCompletionTopLogprob(TypedDict):
+    """A single alternative token in a chat ``logprobs.content[].top_logprobs`` entry.
+
+    Distinct from the legacy parallel-list :class:`CompletionLogprobs`: chat
+    completions expose per-token ``token`` / ``bytes`` / ``logprob`` objects so
+    ``openai-python`` parses ``choice.logprobs.content`` instead of dropping the
+    legacy fields as extras.
+    """
+
+    token: str
+    bytes: Optional[List[int]]
+    logprob: float
+
+
+class ChatCompletionLogprob(TypedDict):
+    """A token entry in chat completion ``logprobs.content[]``.
+
+    ``logprob`` is optional because the first generated token carries no logprob,
+    matching the OpenAI chat logprobs contract.
+    """
+
+    token: str
+    bytes: Optional[List[int]]
+    logprob: Optional[float]
+    top_logprobs: List[ChatCompletionTopLogprob]
+
+
+class ChatCompletionLogprobs(TypedDict):
+    """Chat Completions logprobs (``content`` list shape).
+
+    vLLM emits logprobs in the legacy parallel-list :class:`CompletionLogprobs`
+    shape; chat clients expect ``logprobs.content[]``. The chat builder converts
+    at the boundary so the legacy shape never reaches a chat choice.
+    """
+
+    content: Optional[List[ChatCompletionLogprob]]
+
+
 class ToolCallFunction(TypedDict):
     name: str
     arguments: str
@@ -204,7 +242,7 @@ class ChatCompletionMessage(TypedDict):
 class ChatCompletionChoice(TypedDict):
     index: int
     message: ChatCompletionMessage
-    logprobs: NotRequired[Optional[CompletionLogprobs]]
+    logprobs: NotRequired[Optional[ChatCompletionLogprobs]]
     finish_reason: Optional[str]
 
 
@@ -227,7 +265,7 @@ class ChatCompletionChunkDelta(TypedDict):
 class ChatCompletionChunkChoice(TypedDict):
     index: int
     delta: ChatCompletionChunkDelta
-    logprobs: NotRequired[Optional[CompletionLogprobs]]
+    logprobs: NotRequired[Optional[ChatCompletionLogprobs]]
     finish_reason: Optional[str]
 
 


### PR DESCRIPTION
## Summary

`/v1/chat/completions` silently returned `logprobs: null` even when the client requested `logprobs`/`top_logprobs`, while `/v1/completions` already populated them for vLLM (#5245). The chat builders discarded the logprobs the engine already produced.

Root cause: `ChatModelMixin._to_chat_completion` / `_to_chat_completion_chunk` built chat choices without copying the source choice's `logprobs`, and the chat choice `TypedDict`s (`ChatCompletionChoice`, `ChatCompletionChunkChoice`) did not declare the field at all.

Fix: declare `logprobs` on both chat choice `TypedDict`s and propagate `choice.get("logprobs")` in the two real choice-bearing chat builders. The chat path already receives logprobs-bearing `CompletionChunk`s from the vLLM completions generator (`vllm/core.py` `_convert_request_output_to_completion_chunk` → `_build_logprobs`), which also slices per-chunk deltas for streaming (`_slice_logprobs`), so the chat builder needs no new generation or slicing logic — it only stops discarding what the engine already built.

Follow-up to #5245 (completions logprobs).

## Effective scope

vLLM is the only engine that builds logprobs on its chunks today, so this change is effectively vLLM-only: sglang / transformers / llama.cpp / lmdeploy continue to return `null` until they implement logprobs (tracked as a separate follow-up; the per-engine support matrix is intentionally not addressed here to keep the change minimal and additive). Non-logprobs requests are unaffected — the engine returns `None` when logprobs are not requested, so propagation is a no-op vs. current behavior.

## Shape note

Chat completions carry the legacy `CompletionLogprobs` shape (`text_offset` / `tokens` / `token_logprobs` / `top_logprobs`) — the same shape the `/v1/completions` endpoint already returns — rather than the modern OpenAI chat-logprobs schema (`content` / `bytes`). This keeps chat consistent with completions (#5245) and is the smallest correct step; aligning to the modern chat-logprobs schema is left as a follow-up so existing clients reading the completions-style shape keep working.

## Tests

Adds two unit tests in `xinference/model/llm/tests/test_utils.py`:
- `test_to_chat_completion_propagates_logprobs` — non-streaming: builds a `Completion` with a real `CompletionLogprobs` on its choice, calls `ChatModelMixin._to_chat_completion`, asserts the chat choice carries the source logprobs (equal, not just not-`None`).
- `test_to_chat_completion_chunks_propagates_logprobs` — streaming counterpart via `ChatModelMixin._to_chat_completion_chunks`.

Both use the public builder staticmethods/classmethods directly (no mocking of the function under test), are red on `main` (the builders omit the `logprobs` key → `KeyError`/`None`) and green after this change.

## Checklist

- [x] Adds a regression test that is red on `main`, green on this branch
- [x] No public API removal or rename (additive `NotRequired` field + propagation only)
- [x] No change to non-logprobs request behavior
- [x] Scope kept to the chat builders + the two `TypedDict`s; engine code untouched