### PR TITLE
fix(model): avoid Set-changed-during-iteration crash and gc.get_objects() overhead under concurrent downloads

### DIFF
--- a/xinference/model/tests/test_utils.py
+++ b/xinference/model/tests/test_utils.py
@@ -15,6 +15,7 @@
 import asyncio
 import shutil
 import sys
+import threading
 
 import pytest
 from tqdm.auto import tqdm
@@ -74,6 +75,67 @@ def test_tqdm_patch():
             all_bar.update(6)
 
     assert downloader.done
+
+
+def test_concurrent_progress_no_set_mutation():
+    """Two concurrent downloaders race the progress sets: one thread creates
+    new download bars and calls .update() (so patched_update grows
+    _download_progresses), while another polls get_progress(). On main this
+    raises "RuntimeError: Set changed size during iteration"; the per-instance
+    _progress_lock + snapshot in get_progress makes it safe.
+
+    Under CPython's default ~5ms switch interval the mutation rarely lands
+    mid-iteration, so the crash is flaky on main (and can even pass 8/8). We
+    tighten sys.setswitchinterval to force frequent GIL handoffs so the
+    mutation coincides with the poller's iteration deterministically: red on
+    main, green on the branch. The original interval is restored in finally.
+    """
+    d1 = CancellableDownloader(cancel_error_cls=RuntimeError)
+    d2 = CancellableDownloader(cancel_error_cls=RuntimeError)
+    errors = []
+
+    orig_si = sys.getswitchinterval()
+    sys.setswitchinterval(1e-4)
+    try:
+        with d1, d2:
+            stop = threading.Event()
+
+            def updater():
+                try:
+                    # seed a few download bars first
+                    for _ in range(5):
+                        bar = tqdm(total=1000000, unit="B")
+                        bar.update(1)
+                    while not stop.is_set():
+                        # a NEW bar each iteration -> add() grows the set size
+                        bar = tqdm(total=1000000, unit="B")
+                        bar.update(1)
+                        bar.close()
+                except RuntimeError as e:
+                    errors.append(("updater", e))
+
+            def poller():
+                while not stop.is_set():
+                    try:
+                        d1.get_progress()
+                        d2.get_progress()
+                    except RuntimeError as e:
+                        errors.append(("poller", e))
+                        return
+
+            tu = threading.Thread(target=updater)
+            tp = threading.Thread(target=poller)
+            tu.start()
+            tp.start()
+            # run the race for ~1s; a timeout + Event keeps CI from hanging
+            tp.join(timeout=1.2)
+            stop.set()
+            tu.join(timeout=3.0)
+            tp.join(timeout=3.0)
+    finally:
+        sys.setswitchinterval(orig_si)
+
+    assert not errors, f"concurrent get_progress raised: {errors}"
 
 
 def test_extract_engine_markers_from_packages():

--- a/xinference/model/tests/test_utils.py
+++ b/xinference/model/tests/test_utils.py
@@ -138,6 +138,107 @@ def test_concurrent_progress_no_set_mutation():
     assert not errors, f"concurrent get_progress raised: {errors}"
 
 
+def test_class_level_bookkeeping_no_per_instance_shadow():
+    """qinxuye #5257 round-4 ask #1: _active_instances / _original_update /
+    _original_update_plain must be routed through the class (type(self)), not
+    ``self``. The old ``self._original_update = ...`` shadowed the class
+    attribute, so two concurrent downloaders each saw the class-level None,
+    patched tqdm independently, and the first to exit restored tqdm.update
+    while the second was still active."""
+    # Clean class state, independent of test ordering.
+    CancellableDownloader._active_instances = 0
+    CancellableDownloader._original_update = None
+    CancellableDownloader._original_update_plain = None
+    CancellableDownloader._active_registry.clear()
+    original_update = tqdm.update
+
+    d1 = CancellableDownloader(cancel_error_cls=RuntimeError)
+    d2 = CancellableDownloader(cancel_error_cls=RuntimeError)
+    d1.__enter__()
+    d2.__enter__()
+    try:
+        # Shared class-level counter, no per-instance shadow.
+        assert CancellableDownloader._active_instances == 2
+        assert "_active_instances" not in vars(d1)
+        assert "_active_instances" not in vars(d2)
+        # Originals stored on the class, no per-instance shadow.
+        assert CancellableDownloader._original_update is original_update
+        assert CancellableDownloader._original_update_plain is not None
+        for d in (d1, d2):
+            assert "_original_update" not in vars(d)
+            assert "_original_update_plain" not in vars(d)
+        # tqdm stays patched while any instance is active.
+        assert tqdm.update is not original_update
+
+        # d1 exits while d2 is still active: must NOT restore tqdm yet (the
+        # concrete reproduction: "first downloader exiting while the second
+        # remained active: tqdm.update was restored too early").
+        d1.__exit__(None, None, None)
+        assert CancellableDownloader._active_instances == 1
+        assert (
+            tqdm.update is not original_update
+        ), "tqdm.update was restored while a downloader is still active"
+    finally:
+        if CancellableDownloader._active_instances > 0:
+            d2.__exit__(None, None, None)
+    # last instance out -> counter 0 and tqdm restored
+    assert CancellableDownloader._active_instances == 0
+    assert tqdm.update is original_update
+
+
+def test_reset_holds_lock_against_progress_poller():
+    """qinxuye #5257 round-4 ask #2: reset() must take _progress_lock around
+    both clears. During __exit__ the progress-upload thread can already have
+    passed its done check and entered get_progress() while cleanup calls
+    reset(); the unlocked clear raced the set iteration and raised
+    "Set changed size during iteration"."""
+    CancellableDownloader._active_instances = 0
+    CancellableDownloader._original_update = None
+    CancellableDownloader._original_update_plain = None
+    CancellableDownloader._active_registry.clear()
+    d = CancellableDownloader(cancel_error_cls=RuntimeError)
+    with d:
+        for _ in range(20):
+            bar = tqdm(total=1000000, unit="B")
+            bar.update(1)
+        errors = []
+        orig_si = sys.getswitchinterval()
+        sys.setswitchinterval(1e-4)
+        try:
+            stop = threading.Event()
+
+            def poller():
+                while not stop.is_set():
+                    try:
+                        d.get_progress()
+                    except RuntimeError as e:
+                        errors.append(e)
+                        return
+
+            def resetter():
+                while not stop.is_set():
+                    try:
+                        bar = tqdm(total=1000000, unit="B")
+                        bar.update(1)  # patched_update grows the set under the lock
+                        d.reset()  # must clear under the same lock
+                    except RuntimeError as e:
+                        errors.append(e)
+                        return
+
+            tp = threading.Thread(target=poller)
+            tr = threading.Thread(target=resetter)
+            tp.start()
+            tr.start()
+            tp.join(timeout=1.2)
+            stop.set()
+            tr.join(timeout=3.0)
+            tp.join(timeout=3.0)
+        finally:
+            sys.setswitchinterval(orig_si)
+
+    assert not errors, f"reset/get_progress race raised: {errors}"
+
+
 def test_extract_engine_markers_from_packages():
     packages = [
         'vllm ; #engine# == "vllm"',

--- a/xinference/model/tests/test_utils.py
+++ b/xinference/model/tests/test_utils.py
@@ -239,6 +239,30 @@ def test_reset_holds_lock_against_progress_poller():
     assert not errors, f"reset/get_progress race raised: {errors}"
 
 
+def test_active_registry_snapshot_holds_global_lock():
+    """The tqdm hook must snapshot the registry under its mutation lock."""
+
+    class LockCheckingSet(set):
+        def __iter__(self):
+            assert CancellableDownloader._global_lock.locked()
+            return super().__iter__()
+
+    original_registry = CancellableDownloader._active_registry
+    CancellableDownloader._active_instances = 0
+    CancellableDownloader._original_update = None
+    CancellableDownloader._original_update_plain = None
+    CancellableDownloader._active_registry = LockCheckingSet()
+
+    downloader = CancellableDownloader(cancel_error_cls=RuntimeError)
+    try:
+        with downloader:
+            bar = tqdm(total=1, disable=True)
+            bar.update(1)
+            bar.close()
+    finally:
+        CancellableDownloader._active_registry = original_registry
+
+
 def test_extract_engine_markers_from_packages():
     packages = [
         'vllm ; #engine# == "vllm"',

--- a/xinference/model/utils.py
+++ b/xinference/model/utils.py
@@ -924,8 +924,13 @@ class CancellableDownloader:
         self._patched_instances: Set[int] = set()
 
     def reset(self):
-        self._main_progresses.clear()
-        self._download_progresses.clear()
+        # Hold _progress_lock around both clears so a concurrent get_progress()
+        # caller (e.g. the progress-upload thread that already passed its done
+        # check) cannot be mid-iteration when the sets are cleared — that race
+        # raised "Set changed size during iteration".
+        with self._progress_lock:
+            self._main_progresses.clear()
+            self._download_progresses.clear()
 
     def get_progress(self) -> float:
         if self.done:
@@ -990,19 +995,26 @@ class CancellableDownloader:
         raise self._cancel_error_cls(error_msg)
 
     def patch_tqdm(self):
-        # Use class-level patching to avoid conflicts
+        # Use class-level patching to avoid conflicts. Route the bookkeeping
+        # through the class (type(self)), not `self`: assigning to
+        # self._original_update creates a per-instance attribute that shadows
+        # the class attribute, so two concurrent downloaders each observe the
+        # class-level None, patch tqdm independently, and keep their own
+        # originals — the first to exit then restores tqdm.update while the
+        # second is still active.
         with self._patch_lock:
             import tqdm as tqdm_module
+            cls = type(self)
 
-            if self._original_update is None:
-                self._original_update = tqdm.update
-            if self._original_update_plain is None:
-                self._original_update_plain = tqdm_module.tqdm.update
+            if cls._original_update is None:
+                cls._original_update = tqdm.update
+            if cls._original_update_plain is None:
+                cls._original_update_plain = tqdm_module.tqdm.update
 
-            if self._original_update is None or self._original_update_plain is None:
+            if cls._original_update is None or cls._original_update_plain is None:
                 return
 
-            original_update_plain = self._original_update_plain
+            original_update_plain = cls._original_update_plain
 
             # Thread-safe patched update
             def patched_update(tqdm_instance, n):
@@ -1042,30 +1054,35 @@ class CancellableDownloader:
 
     def unpatch_tqdm(self):
         with self._patch_lock:
-            if self._original_update is not None and self._active_instances == 0:
+            cls = type(self)
+            if cls._original_update is not None and cls._active_instances == 0:
                 import tqdm as tqdm_module
 
-                tqdm.update = self._original_update
-                self._original_update = None
-                if self._original_update_plain is not None:
-                    tqdm_module.tqdm.update = self._original_update_plain
-                    self._original_update_plain = None
+                tqdm.update = cls._original_update
+                cls._original_update = None
+                if cls._original_update_plain is not None:
+                    tqdm_module.tqdm.update = cls._original_update_plain
+                    cls._original_update_plain = None
 
     def __enter__(self):
-        # Use global lock to prevent concurrent patching
+        # Use global lock to prevent concurrent patching. _active_instances is
+        # class-level bookkeeping (routed through type(self)) so concurrent
+        # downloaders share one counter instead of each shadowing it per-instance.
         with self._global_lock:
-            if self._active_instances == 0:
+            cls = type(self)
+            if cls._active_instances == 0:
                 self.patch_tqdm()
-            self._active_instances += 1
-            CancellableDownloader._active_registry.add(self)
+            cls._active_instances += 1
+            cls._active_registry.add(self)
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         # Use global lock to prevent concurrent unpatching
         with self._global_lock:
-            self._active_instances -= 1
-            CancellableDownloader._active_registry.discard(self)
-            if self._active_instances == 0:
+            cls = type(self)
+            cls._active_instances -= 1
+            cls._active_registry.discard(self)
+            if cls._active_instances == 0:
                 self.unpatch_tqdm()
         try:
             self._done_event.set()

--- a/xinference/model/utils.py
+++ b/xinference/model/utils.py
@@ -896,6 +896,7 @@ def set_all_random_seed(seed: int):
 class CancellableDownloader:
     _global_lock = threading.Lock()
     _active_instances = 0
+    _active_registry: Set["CancellableDownloader"] = set()
     _original_update = None  # Class-level original update method (tqdm.auto.tqdm)
     _original_update_plain = None  # Class-level original update method (tqdm.tqdm)
     _patch_lock = threading.Lock()  # Additional lock for patching operations
@@ -910,6 +911,10 @@ class CancellableDownloader:
             self._cancelled = threading.Event()
         self._done_event = threading.Event()
         self._cancel_error_cls = cancel_error_cls
+        # Guards mutation/iteration of the progress sets below; a new download
+        # bar can be added by patched_update (download thread) while another
+        # thread iterates the same set in get_progress().
+        self._progress_lock = threading.RLock()
         # progress for tqdm that is main
         self._main_progresses: Set[tqdm] = set()
         # progress for file downloader
@@ -928,8 +933,15 @@ class CancellableDownloader:
             return 1.0
         # Don't return 1.0 when cancelled, calculate actual progress
 
+        # Snapshot the progress sets under the lock: patched_update (download
+        # thread) can add a new bar mid-iteration, which would otherwise raise
+        # "Set changed size during iteration".
+        with self._progress_lock:
+            main_progresses = list(self._main_progresses)
+            download_progresses = list(self._download_progresses)
+
         tasks = finished_tasks = 0
-        for main_progress in self._main_progresses:
+        for main_progress in main_progresses:
             tasks += main_progress.total or 0
             finished_tasks += main_progress.n
 
@@ -940,7 +952,7 @@ class CancellableDownloader:
         finished_ratio = finished_tasks / tasks
 
         all_download_progress = finished_download_progress = 0
-        for download_progress in self._download_progresses:
+        for download_progress in download_progresses:
             # we skip finished download
             if download_progress.n == download_progress.total:
                 continue
@@ -994,14 +1006,10 @@ class CancellableDownloader:
 
             # Thread-safe patched update
             def patched_update(tqdm_instance, n):
-                import gc
-
-                # Get all CancellableDownloader instances and check for cancellation
-                downloaders = [
-                    obj
-                    for obj in gc.get_objects()
-                    if isinstance(obj, CancellableDownloader)
-                ]
+                # Iterate the bounded active-instance registry instead of
+                # gc.get_objects(): the whole-heap traversal stalled the GIL
+                # on every progress tick and scanned O(heap) objects.
+                downloaders = list(CancellableDownloader._active_registry)
 
                 for downloader in downloaders:
                     # if download cancelled, throw error
@@ -1019,7 +1027,10 @@ class CancellableDownloader:
                             )
 
                     if progresses is not None:
-                        progresses.add(tqdm_instance)
+                        # Guard the mutation: a concurrent get_progress()
+                        # caller may be iterating this very set.
+                        with downloader._progress_lock:
+                            progresses.add(tqdm_instance)
                     else:
                         logger.debug(f"No progresses found for downloader {downloader}")
 
@@ -1046,12 +1057,14 @@ class CancellableDownloader:
             if self._active_instances == 0:
                 self.patch_tqdm()
             self._active_instances += 1
+            CancellableDownloader._active_registry.add(self)
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         # Use global lock to prevent concurrent unpatching
         with self._global_lock:
             self._active_instances -= 1
+            CancellableDownloader._active_registry.discard(self)
             if self._active_instances == 0:
                 self.unpatch_tqdm()
         try:

--- a/xinference/model/utils.py
+++ b/xinference/model/utils.py
@@ -1004,6 +1004,7 @@ class CancellableDownloader:
         # second is still active.
         with self._patch_lock:
             import tqdm as tqdm_module
+
             cls = type(self)
 
             if cls._original_update is None:
@@ -1021,7 +1022,8 @@ class CancellableDownloader:
                 # Iterate the bounded active-instance registry instead of
                 # gc.get_objects(): the whole-heap traversal stalled the GIL
                 # on every progress tick and scanned O(heap) objects.
-                downloaders = list(CancellableDownloader._active_registry)
+                with CancellableDownloader._global_lock:
+                    downloaders = list(CancellableDownloader._active_registry)
 
                 for downloader in downloaders:
                     # if download cancelled, throw error


### PR DESCRIPTION
## Summary

`CancellableDownloader` monkeypatches the **global** `tqdm.update`/`tqdm.tqdm.update` with `patched_update`. Under concurrent model launches (`XINFERENCE_MAX_CONCURRENT_LAUNCHES`, default `5`), that global hook has two problems on the default config:

1. **`RuntimeError: Set changed size during iteration`** — `patched_update` (running in the download thread) calls `progresses.add(tqdm_instance)` on each active downloader's `_main_progresses` / `_download_progresses`, while the progress thread (`_upload_download_progress` → `get_progress()`) iterates the same set. When a new download-shard bar is added mid-iteration, the iterator raises. This is reachable on the default config with ≥2 concurrent launches.
2. **Per-tick `gc.get_objects()` whole-heap scan** — `patched_update` traversed the entire Python heap to find active `CancellableDownloader` instances on *every* `tqdm.update` call, an O(heap) scan per progress tick (vs O(active) after this change).

This PR fixes both with a minimal, in-idiom change confined to the `CancellableDownloader` class (it already uses `threading.Lock` for `_global_lock` / `_patch_lock`; this mirrors that discipline).

## Changes

- **Crash fix** — add a per-instance `self._progress_lock = threading.RLock()`. In `get_progress()`, snapshot the progress sets via `list(...)` under the lock before iterating; in `patched_update()`, guard each `progresses.add(tqdm_instance)` with `with downloader._progress_lock:`. This serializes the mutation against the snapshot taken in `get_progress()`, eliminating the `Set changed size during iteration` race. Snapshot-then-iterate is intentional eventual consistency for a polled progress reporter (a bar added after the snapshot is missed in that call but present in the next, since it persists in the set).
- **Scan-cost fix** — replace the `gc.get_objects()` whole-heap traversal with a bounded class-level registry `CancellableDownloader._active_registry`, maintained under the existing `_global_lock` (`__enter__` adds `self`, `__exit__` discards `self`). `patched_update` now iterates `list(CancellableDownloader._active_registry)` — O(active) instead of O(heap). The registry is a correct strict subset of what `gc.get_objects()` returned (active instances only), preserving the intended "act on active downloaders" semantics.

## Out of scope (intentional)

`patched_update` still calls `raise_error()` if **any** active downloader is cancelled (cross-fire cancel: cancelling downloader A can raise in downloader B's download thread). Properly fixing that requires attributing each `tqdm` instance to its owning downloader, which is a larger redesign of the global-patch model and is left as a follow-up. This PR deliberately keeps the scope to the reproducible crash + the per-tick scan cost.

## Test

Adds `test_concurrent_progress_no_set_mutation`: two `CancellableDownloader`s entered concurrently; one thread creates new download `tqdm` bars (`unit="B"`) and calls `.update()` (growing `_download_progresses` via the global `patched_update`), another thread polls `get_progress()`. Asserts no `RuntimeError` is raised. Uses only public API (`from ..utils import CancellableDownloader`, real `tqdm`, `threading`) — no mocking of the code under fix. A `threading.Event` stop + `join(timeout=…)` guard prevents CI hangs.

The reproduction is timing-dependent: under CPython's default ~5 ms switch interval the set mutation rarely lands mid-iteration, so the test tightens `sys.setswitchinterval(1e-4)` (saved and restored in `try/finally`) to force frequent GIL handoffs so the mutation coincides with the poller's iteration. Under that enforced interval the test is **red on `main`** (raises `RuntimeError: Set changed size during iteration`) and **green on this branch**.

## Why this shape

- Mirrors the class's existing lock discipline (`_global_lock` / `_patch_lock`) — no new abstraction introduced.
- Small surgical PR (~85 LoC, 2 files), matching the repo's median PR size.
- The crash is a `RuntimeError` on the default config (not a theoretical edge case), so the reproduction is self-justifying.
