### PR TITLE
BLD: require peft>=0.18.0 for transformers 5.x compatibility

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -455,7 +455,7 @@ jobs:
           pip install tensorizer
           pip install -U "sentence-transformers==5.1.1"
           pip install -U "FlagEmbedding==1.3.5"
-          pip install -U "peft<=0.17.1"
+          pip install -U "peft>=0.18.0"
           pip install "xllamacpp>=0.2.0" --index-url https://xorbitsai.github.io/xllamacpp/whl/cu124 --extra-index-url https://pypi.org/simple
           pip install hf_transfer
           # espeak-ng (TTS phonemization) is not packaged on conda-forge;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,11 @@ dependencies = [
     "nvidia-ml-py",
     "pynvml>=12",
     "async-timeout",
-    "peft<=0.17.1",
+    # peft 0.17.1 and below import HybridCache at module level, which was
+    # removed in transformers 5.0.0. peft declares an unbounded transformers
+    # requirement, so pinning it low silently breaks any transformers 5.x
+    # install (see the sentence-transformers rerank import chain).
+    "peft>=0.18.0",
     "timm",
     "setproctitle",
     "uv",

--- a/xinference/deploy/docker/requirements_cpu/requirements_cpu-ml.txt
+++ b/xinference/deploy/docker/requirements_cpu/requirements_cpu-ml.txt
@@ -11,7 +11,9 @@ bitsandbytes
 tiktoken>=0.6.0
 autoawq!=0.2.6
 optimum
-peft<=0.17.1
+# peft <=0.17.1 imports HybridCache at module level, removed in transformers
+# 5.0.0; keep in sync with the pin in pyproject.toml.
+peft>=0.18.0
 timm
 tensorizer~=2.9.0
 modelscope>=1.19.0


### PR DESCRIPTION
## Problem

Launching any rerank model on the `sentence_transformers` engine fails at load time with:

```
ImportError: Failed to import module 'sentence-transformers': cannot import name
'HybridCache' from 'transformers' (.../transformers/__init__.py)

Please make sure 'sentence-transformers' is installed. You can install it by
`pip install sentence-transformers`
```

The suggested remedy is misleading — `sentence-transformers` is installed and is not the problem.

## Root cause

`peft<=0.17.1` imports `HybridCache` at **module level** in `peft/peft_model.py`:

```python
from transformers import Cache, DynamicCache, EncoderDecoderCache, HybridCache, PreTrainedModel
```

`HybridCache` was removed in **transformers 5.0.0** (present in 4.57.1, gone from 5.0.0 onward). Because `peft` declares an *unbounded* `transformers` requirement, pip resolves the incompatible pair without any warning, so images build fine and the failure only appears at runtime.

The failing import chain:

```
xinference/model/rerank/sentence_transformers/core.py  ->  import sentence_transformers
  -> sentence_transformers/base/model_card.py          ->  from transformers import TrainerCallback
  -> transformers/trainer_utils.py                     ->  from peft import PeftMixedModel, PeftModel
  -> peft/peft_model.py                                ->  ImportError: cannot import name 'HybridCache'
```

`core.py` catches the `ImportError` and re-raises it as "Failed to import module 'sentence-transformers'", which hides the real cause. GGUF LLMs never touch this chain, so on an affected image LLMs work while rerank/embedding models appear broken — which makes this easy to misdiagnose as a rerank bug.

The `<=0.17.1` upper bound was introduced in #4249 while transformers was still 4.x. It became self-inconsistent once `xinference/deploy/docker/requirements-runtime.txt` moved to `transformers==5.13.1`: the GPU image installs xinference under that constraint, and the CPU image pins both in `requirements_cpu-ml.txt` (`transformers>=4.53.3` + `peft<=0.17.1`).

`peft` **0.18.0** moved the `HybridCache` import inside the function that needs it, so it no longer breaks at import time.

## Fix

Require `peft>=0.18.0` in the three places the pin appears:

- `pyproject.toml` — also covers the GPU image, which installs xinference with `--constraint requirements-runtime.txt`
- `xinference/deploy/docker/requirements_cpu/requirements_cpu-ml.txt`
- `.github/workflows/python.yaml`

Comments were added at the first two sites recording the transformers-5.x constraint, so the bound is not lowered again without checking the shipped transformers major version.

## Verification

In a clean venv:

- `transformers==5.13.1` + `peft==0.17.1` installs with no pip warning and reproduces the exact `ImportError` from the report.
- With `peft>=0.18.0` (resolved 0.20.0) against the same `transformers==5.13.1`: `import sentence_transformers`, `from sentence_transformers.cross_encoder import CrossEncoder`, a full `CrossEncoder.predict` rerank call, and `from peft import PeftModel, PeftMixedModel` (used by `llm/transformers/core.py`) all succeed.
- `pre-commit run --files <changed files>` passes; `pyproject.toml` parses and resolves to `peft>=0.18.0`.

Not run locally: rerank tests that require model downloads or GPU, and a full image rebuild — both too costly in this environment. `test_auto_detect_type` fails on my machine both with and without this change, due to a pre-existing local numpy/scipy ABI mismatch unrelated to the patch.