### PR TITLE
fix(audio): don't reopen a NamedTemporaryFile so TTS works on Windows (#5261)

### DIFF
--- a/xinference/model/audio/utils.py
+++ b/xinference/model/audio/utils.py
@@ -122,28 +122,39 @@ def audio_to_bytes(response_format: str, sample_rate: int, tensor: "torch.Tensor
                 torchaudio.save(out, tensor, sample_rate, format=response_format)
                 return out.getvalue()
     else:
+        import os
         import tempfile
 
-        with tempfile.NamedTemporaryFile(
-            delete=True, suffix=f".{response_format}"
-        ) as temp_file:
+        # ``NamedTemporaryFile`` keeps its own handle open for the whole
+        # ``with`` block. On Windows that handle carries ``O_TEMPORARY``
+        # (delete-on-close) and is not opened with ``FILE_SHARE_DELETE``, so
+        # any second open of the same path -- both ``torchaudio.save`` and the
+        # read-back below -- fails with ``PermissionError: [WinError 32]``.
+        # Create the file, close our handle immediately, and clean it up
+        # ourselves instead.
+        fd, temp_path = tempfile.mkstemp(suffix=f".{response_format}")
+        os.close(fd)
+        try:
             if response_pcm:
                 logger.debug(f"PCM output, num_channels: 1, sample_rate: {sample_rate}")
                 torchaudio.save(
-                    temp_file.name,
+                    temp_path,
                     tensor,
                     sample_rate,
                     format="wav",
                     encoding="PCM_S",
                 )
                 # Read the temporary file and extract PCM data
-                with open(temp_file.name, "rb") as f:
+                with open(temp_path, "rb") as f:
                     wav_bytes = f.read()
                 return _extract_pcm_from_wav_bytes(wav_bytes)
             else:
-                torchaudio.save(
-                    temp_file.name, tensor, sample_rate, format=response_format
-                )
+                torchaudio.save(temp_path, tensor, sample_rate, format=response_format)
                 # Read the temporary file and return its content
-                with open(temp_file.name, "rb") as f:
+                with open(temp_path, "rb") as f:
                     return f.read()
+        finally:
+            try:
+                os.remove(temp_path)
+            except OSError:
+                logger.debug("Failed to remove temporary file %s", temp_path)


### PR DESCRIPTION
## Problem

Fixes #5261.

`torchaudio >= 2.9.0` dropped the in-memory save path, so `audio_to_bytes()` writes the waveform to a `tempfile.NamedTemporaryFile` and reads it back:

```python
with tempfile.NamedTemporaryFile(delete=True, suffix=f".{response_format}") as temp_file:
    torchaudio.save(temp_file.name, tensor, sample_rate, ...)
    with open(temp_file.name, "rb") as f:
        return f.read()
```

`NamedTemporaryFile` keeps *its own* handle open for the whole `with` block. On Windows that handle is created with `O_TEMPORARY` (delete-on-close) and is **not** opened with `FILE_SHARE_DELETE`, so any second open of the same path fails with a sharing violation. Both reopens here hit it — `torchaudio.save()` opening the path to write, and the `open(..., "rb")` read-back — so every `/v1/audio/speech` request on Windows dies with:

```
PermissionError: [WinError 32] The process cannot access the file because it is being used by another process
```

## Fix

Create the temp file with `tempfile.mkstemp()`, close our handle immediately, and delete the file in a `finally` block. Nothing else about the function changes.

This keeps the temp file from leaking (a plain `delete=False` without cleanup would leave one file per TTS request in `%TEMP%`), and behaviour on Linux/macOS is unchanged — those platforms never had the sharing restriction, and the file is still removed on every path, including exceptions.

## Verification

Ran both the current `main` version and the patched version of `audio_to_bytes()` on Windows 11 / Python 3.12, with a stub `torchaudio.save` that opens the path by name (as the real one does) and `torchaudio.version.__version__ = "2.9.0"` to select the affected branch:

| | `format="wav"` | `format="pcm"` |
|---|---|---|
| `main` | ❌ `PermissionError: [Errno 13] Permission denied: ...\tmpy74piv66.wav` | ❌ `PermissionError: [Errno 13] Permission denied: ...\tmpcm039fvk.pcm` |
| this PR | ✅ 52 bytes returned | ✅ 8 bytes returned (PCM payload, header stripped) |

Temp directory scanned before/after: no leftover files from the patched run.

Linters, at the versions pinned in `.pre-commit-config.yaml` — `black` 25.1.0, `ruff` 0.15.22, `isort` 5.12.0 — all pass on the changed file.

> Note: this branch is based on my fork's `main`, which sits behind upstream, because syncing it requires a `workflow` token scope I don't have. The diff is a single commit touching only `xinference/model/audio/utils.py`, and that file's `audio_to_bytes()` is byte-identical between the fork base and current upstream `main`, so it merges cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
