### PR TITLE
feat(rerank): support jina-reranker-v3.5 with its native listwise API

### DIFF
--- a/xinference/model/rerank/model_spec.json
+++ b/xinference/model/rerank/model_spec.json
@@ -630,6 +630,45 @@
   },
   {
     "version": 2,
+    "model_name": "jina-reranker-v3.5",
+    "type": "normal",
+    "language": [
+      "en",
+      "zh",
+      "multilingual"
+    ],
+    "max_tokens": 131072,
+    "model_specs": [
+      {
+        "model_format": "pytorch",
+        "model_src": {
+          "huggingface": {
+            "model_id": "jinaai/jina-reranker-v3.5",
+            "quantizations": [
+              "none"
+            ]
+          },
+          "modelscope": {
+            "model_id": "jinaai/jina-reranker-v3.5",
+            "quantizations": [
+              "none"
+            ]
+          }
+        }
+      }
+    ],
+    "updated_at": 1782864000,
+    "featured": false,
+    "virtualenv": {
+      "packages": [
+        "#sentence_transformers_dependencies# ; #engine# == \"sentence_transformers\"",
+        "#system_torchvision# ; #engine# == \"sentence_transformers\"",
+        "#system_torch# ; #engine# == \"sentence_transformers\""
+      ]
+    }
+  },
+  {
+    "version": 2,
     "model_name": "Qwen3-VL-Reranker-8B",
     "type": "normal",
     "language": [

--- a/xinference/model/rerank/sentence_transformers/core.py
+++ b/xinference/model/rerank/sentence_transformers/core.py
@@ -143,6 +143,39 @@ class SentenceTransformerRerankModel(RerankModel, BatchMixin):
             if self._use_fp16:
                 self._model.model.half()
             self._tokenizer = self._model.tokenizer
+        elif "jina-reranker-v3.5" in self.model_family.model_name.lower():
+            # jina-reranker-v3.5 ships custom modeling code (JinaForRanking)
+            # with a native listwise `rerank()` API; use it instead of the
+            # Qwen3-style yes/no scoring applied to jina-reranker-v3. Note
+            # that "jina-reranker-v3" is a substring of "jina-reranker-v3.5",
+            # so this branch must precede the jina-reranker-v3 one.
+            try:
+                from transformers import AutoModel, AutoTokenizer
+            except ImportError:
+                error_message = "Failed to import module 'transformers'"
+                installation_guide = [
+                    "Please make sure 'transformers' is installed. ",
+                    "You can install it by `pip install transformers`\n",
+                ]
+
+                raise ImportError(f"{error_message}\n\n{''.join(installation_guide)}")
+
+            if not allow_trust_remote_code(self.model_family):
+                raise ValueError(
+                    "Loading this model executes code shipped in the model "
+                    "repository; set XINFERENCE_TRUST_REMOTE_CODE=1 to allow it."
+                )
+            self._tokenizer = AutoTokenizer.from_pretrained(
+                self._model_path, trust_remote_code=True
+            )
+            model_kwargs: Dict[str, Any] = {"device_map": "auto", "torch_dtype": "auto"}
+            if enable_flash_attn:
+                model_kwargs["attn_implementation"] = "flash_attention_2"
+            model_kwargs.update(self._kwargs)
+            logger.debug("Loading jina-reranker-v3.5 with kwargs %s", model_kwargs)
+            self._model = AutoModel.from_pretrained(
+                self._model_path, trust_remote_code=True, **model_kwargs
+            ).eval()
         elif (
             "qwen3" in self.model_family.model_name.lower()
             or "jina-reranker-v3" in self.model_family.model_name.lower()
@@ -243,20 +276,23 @@ class SentenceTransformerRerankModel(RerankModel, BatchMixin):
         # in the _rerank method instead.
         self._token_tracking_data = threading.local()
 
-        # Create a simple wrapper for return value conversion only
-        try:
-            original_predict = self._model.predict
+        # Create a simple wrapper for return value conversion only.
+        # Models scored through a native API (e.g. jina-reranker-v3.5's
+        # listwise `rerank()`) expose no `predict`; skip wrapping for them.
+        if hasattr(self._model, "predict"):
+            try:
+                original_predict = self._model.predict
 
-            def wrapped_predict(*args, **kwargs):
-                result = original_predict(*args, **kwargs)
-                # Convert SequenceClassifierOutput to dict if needed
-                if hasattr(result, "logits") and not hasattr(result, "scores"):
-                    return {"scores": result.logits}
-                return result
+                def wrapped_predict(*args, **kwargs):
+                    result = original_predict(*args, **kwargs)
+                    # Convert SequenceClassifierOutput to dict if needed
+                    if hasattr(result, "logits") and not hasattr(result, "scores"):
+                        return {"scores": result.logits}
+                    return result
 
-            self._model.predict = wrapped_predict
-        except Exception as e:
-            logger.warning(f"Failed to wrap predict method: {e}")
+                self._model.predict = wrapped_predict
+            except Exception as e:
+                logger.warning(f"Failed to wrap predict method: {e}")
 
     def _reset_token_tracking(self):
         """Reset token tracking counters."""
@@ -301,6 +337,10 @@ class SentenceTransformerRerankModel(RerankModel, BatchMixin):
         return_len: Optional[bool],
         **kwargs,
     ) -> List[Any]:
+        # Pop batch offsets early so they are not forwarded to model APIs
+        # (predict, compute_score, rerank, etc.). Only the jina-reranker-v3.5
+        # branch uses this to preserve per-request isolation.
+        batch_offsets = kwargs.pop("_batch_offsets", None)
         if self._vl_reranker is not None:
             return self._rerank_vl(documents, query, **kwargs)
         assert self._model is not None
@@ -361,6 +401,34 @@ class SentenceTransformerRerankModel(RerankModel, BatchMixin):
             if similarity_scores.dtype == torch.bfloat16:
                 similarity_scores = torch.float16
                 similarity_scores = similarity_scores.float()
+        elif "jina-reranker-v3.5" in self.model_family.model_name.lower():
+            # Native listwise API: returns dicts sorted by score desc, each
+            # carrying the original document index. Map back to input order
+            # so the shared sorting logic below works unchanged.
+            #
+            # Jina v3.5 is genuinely listwise: its native implementation
+            # computes query embeddings and block weights from the full
+            # candidate set, so mixing documents from different requests
+            # would change scores. Call rerank() once per original request
+            # (using batch offsets) to preserve request isolation.
+            if not documents:
+                similarity_scores = []
+            else:
+                similarity_scores = [0.0] * len(documents)
+                if batch_offsets is not None:
+                    for offset, n in batch_offsets:
+                        req_docs = documents[offset : offset + n]
+                        if not req_docs:
+                            continue
+                        results = self._model.rerank(query[offset], req_docs)
+                        for r in results:
+                            similarity_scores[offset + int(r["index"])] = float(
+                                r["relevance_score"]
+                            )
+                else:
+                    results = self._model.rerank(query[0], documents)
+                    for r in results:
+                        similarity_scores[int(r["index"])] = float(r["relevance_score"])
         elif (
             "qwen3" in self.model_family.model_name.lower()
             or "jina-reranker-v3" in self.model_family.model_name.lower()
@@ -560,7 +628,9 @@ class SentenceTransformerRerankModel(RerankModel, BatchMixin):
             kwargs = group["kwargs"]
             offsets = group["offsets"]
             indices = group["indices"]
-            score_list = self._rerank(documents, query, **kwargs)
+            score_list = self._rerank(
+                documents, query, _batch_offsets=offsets, **kwargs
+            )
             top_n = kwargs.pop("top_n", None)
             return_documents = kwargs.pop("return_documents", None)
             return_len = kwargs.pop("return_len", None)

--- a/xinference/model/rerank/sentence_transformers/tests/test_sentence_transformers.py
+++ b/xinference/model/rerank/sentence_transformers/tests/test_sentence_transformers.py
@@ -1,4 +1,7 @@
 import shutil
+from unittest.mock import MagicMock
+
+import pytest
 
 from ...cache_manager import RerankCacheManager
 from ...core import RerankModelFamilyV2, TransformersRerankSpecV1
@@ -54,3 +57,81 @@ async def test_model():
     finally:
         if model_path is not None:
             shutil.rmtree(model_path, ignore_errors=True)
+
+
+def test_jina_reranker_v35_batch_isolation():
+    """Regression test: batched requests with the same query but different
+    document lists must each be passed to model.rerank() separately.
+
+    Jina v3.5 is genuinely listwise – its native implementation computes
+    query embeddings and block weights from the full candidate set, so
+    mixing documents from independent requests would change scores even
+    when the query text is identical.
+    """
+    model_family = RerankModelFamilyV2(
+        version=2,
+        model_name="jina-reranker-v3.5",
+        type="normal",
+        max_tokens=8192,
+        language=["en"],
+        model_specs=[
+            TransformersRerankSpecV1(
+                model_id="jinaai/jina-reranker-v3.5",
+                model_format="pytorch",
+            )
+        ],
+    )
+
+    # Create instance without calling __init__ (no model download needed)
+    model = SentenceTransformerRerankModel.__new__(SentenceTransformerRerankModel)
+    model.model_family = model_family
+    model._vl_reranker = None
+
+    # Track which (query, documents) pairs are sent to the native reranker
+    rerank_calls: list = []
+
+    def mock_rerank(query, documents):
+        rerank_calls.append((query, list(documents)))
+        # Return one result per document, sorted by index
+        return [
+            {"index": i, "relevance_score": 0.9 - i * 0.1}
+            for i in range(len(documents))
+        ]
+
+    mock_model = MagicMock()
+    mock_model.rerank = mock_rerank
+    model._model = mock_model
+
+    # Simulate the batch handler coalescing two requests with the SAME
+    # query but different document lists:
+    #   Request 1: query="Q", docs=["A", "B"]       (offset 0, size 2)
+    #   Request 2: query="Q", docs=["C", "D", "E"]  (offset 2, size 3)
+    documents = ["A", "B", "C", "D", "E"]
+    query = ["Q"] * 5
+    batch_offsets = [(0, 2), (2, 3)]
+
+    scores = model._rerank(
+        documents,
+        query,
+        None,  # top_n
+        None,  # max_chunks_per_doc
+        True,  # return_documents
+        False,  # return_len
+        _batch_offsets=batch_offsets,
+    )
+
+    # The native reranker must be called once per request, not once total
+    assert len(rerank_calls) == 2, f"Expected 2 rerank() calls, got {len(rerank_calls)}"
+    # First call: only documents from request 1
+    assert rerank_calls[0][0] == "Q"
+    assert rerank_calls[0][1] == ["A", "B"]
+    # Second call: only documents from request 2
+    assert rerank_calls[1][0] == "Q"
+    assert rerank_calls[1][1] == ["C", "D", "E"]
+    # Scores should be mapped back to the correct positions
+    assert len(scores) == 5
+    assert scores[0] == pytest.approx(0.9)  # A
+    assert scores[1] == pytest.approx(0.8)  # B
+    assert scores[2] == pytest.approx(0.9)  # C
+    assert scores[3] == pytest.approx(0.8)  # D
+    assert scores[4] == pytest.approx(0.7)  # E


### PR DESCRIPTION
jina-reranker-v3.5 is a 0.6B multilingual listwise reranker (drop-in upgrade to v3) built on Qwen3 with custom modeling code (JinaForRanking) that scores a query against many documents in one forward pass via its native `model.rerank()` API, instead of the Qwen3-style yes/no token scoring used for jina-reranker-v3.

- Register jina-reranker-v3.5 in rerank model_spec.json (HF + ModelScope, sentence_transformers engine only; vLLM rerank engine does not support the JinaForRanking architecture).
- Add a dedicated load() branch using AutoModel with trust_remote_code and dtype="auto"; it must precede the jina-reranker-v3 branch since "jina-reranker-v3" is a substring of "jina-reranker-v3.5".
- Add a dedicated _rerank() branch that maps the native sorted results back to input order so shared sorting/top_n logic stays unchanged.
- Skip wrapping `model.predict` for models that expose no predict method (e.g. JinaForRanking) to avoid a noisy warning on every load.