### PR TITLE
feat(sglang): surface logprobs in /v1/completions and /v1/chat/completions

### DIFF
--- a/xinference/model/llm/sglang/core.py
+++ b/xinference/model/llm/sglang/core.py
@@ -440,7 +440,13 @@ class SGLANGModel(LLM):
         # methods so the engine both produces and returns logprob data.
         logprobs_req = generate_config.pop("logprobs", None)  # type: ignore
         top_logprobs_req = generate_config.pop("top_logprobs", None)  # type: ignore
-        if logprobs_req:
+        # A request is active when the caller explicitly opted in. For chat
+        # completions ``logprobs`` is a bool flag (False = opt out); for legacy
+        # /v1/completions it is an int count where 0 means "selected-token
+        # logprob, no alternatives". A bare truthiness check treated completion
+        # 0 as opt-out, so ``return_logprob`` was never sent and the response
+        # stayed ``logprobs=None``. Distinguish chat False from completion int 0.
+        if logprobs_req is not None and logprobs_req is not False:
             if isinstance(logprobs_req, bool):
                 # chat completions: logprobs is a flag, top_logprobs holds the count
                 top_k = max(int(top_logprobs_req or 0), 0)
@@ -673,6 +679,39 @@ class SGLANGModel(LLM):
                 top[k] = sampling_params.pop(k)
         return top
 
+    @staticmethod
+    def _slice_stream_logprobs(meta_info: Dict, consumed: int) -> Tuple[Dict, int]:
+        """Slice cumulative sglang streaming logprob arrays to the per-chunk delta.
+
+        With ``incremental_streaming_output=False`` (sglang default), every
+        streamed ``meta_info`` carries cumulative ``output_token_logprobs`` and
+        ``output_top_logprobs``. Forwarding it unchanged re-emits earlier tokens
+        on every chunk (chunk 1 -> ``[A]``, chunk 2 -> ``[A, B]`` instead of
+        ``[B]``). This returns a shallow-copied ``meta_info`` whose logprob
+        arrays hold only the not-yet-consumed tail, plus the new consumed count
+        (the full cumulative length after this chunk). When this chunk carries
+        no logprob data, ``meta_info`` is returned unchanged and the counter is
+        untouched so a later cumulative chunk still slices correctly.
+        """
+        token_lps = meta_info.get("output_token_logprobs")
+        if not token_lps:
+            return meta_info, consumed
+        total = len(token_lps)
+        delta = dict(meta_info)
+        delta["output_token_logprobs"] = token_lps[consumed:]
+        top_lps = meta_info.get("output_top_logprobs") or meta_info.get(
+            "output_topk_logprobs"
+        )
+        if isinstance(top_lps, list):
+            sliced_top = top_lps[consumed:]
+            if "output_top_logprobs" in meta_info:
+                delta["output_top_logprobs"] = sliced_top
+            elif "output_topk_logprobs" in meta_info:
+                delta["output_topk_logprobs"] = sliced_top
+            else:
+                delta["output_top_logprobs"] = sliced_top
+        return delta, total
+
     async def _stream_generate(
         self,
         prompt: str,
@@ -690,6 +729,10 @@ class SGLANGModel(LLM):
             **self._lift_logprob_request_params(sampling_params),
         }
         pos = 0
+        # sglang (incremental_streaming_output=False) sends cumulative logprob
+        # arrays per chunk; track how many we have already emitted so each chunk
+        # only carries its delta, not the whole prefix again.
+        logprob_consumed = 0
 
         timeout = aiohttp.ClientTimeout(total=3 * 3600)
         async with aiohttp.ClientSession(timeout=timeout, trust_env=True) as session:
@@ -708,7 +751,12 @@ class SGLANGModel(LLM):
                             data = json.loads(chunk[5:].strip("\n"))
                             cur = data["text"][pos:]
                             if cur:
-                                yield data["meta_info"], cur
+                                meta_info, logprob_consumed = (
+                                    SGLANGModel._slice_stream_logprobs(
+                                        data["meta_info"], logprob_consumed
+                                    )
+                                )
+                                yield meta_info, cur
                             pos += len(cur)
                             if need_stop:
                                 break

--- a/xinference/model/llm/sglang/core.py
+++ b/xinference/model/llm/sglang/core.py
@@ -508,7 +508,11 @@ class SGLANGModel(LLM):
 
     @staticmethod
     def _convert_state_to_completion_chunk(
-        request_id: str, model: str, output_text: str, meta_info: Dict
+        request_id: str,
+        model: str,
+        output_text: str,
+        meta_info: Dict,
+        text_offset_base: int = 0,
     ) -> CompletionChunk:
         finish_reason_raw = meta_info.get("finish_reason", None)
         finish_reason: Optional[str] = None
@@ -524,7 +528,7 @@ class SGLANGModel(LLM):
             CompletionChoice(
                 text=output_text,
                 index=0,
-                logprobs=SGLANGModel._build_logprobs(meta_info),
+                logprobs=SGLANGModel._build_logprobs(meta_info, text_offset_base),
                 finish_reason=finish_reason,
             )
         ]
@@ -606,12 +610,18 @@ class SGLANGModel(LLM):
         return None, None
 
     @staticmethod
-    def _build_logprobs(meta_info: Dict) -> Optional[CompletionLogprobs]:
+    def _build_logprobs(
+        meta_info: Dict, text_offset_base: int = 0
+    ) -> Optional[CompletionLogprobs]:
         """Build a legacy ``CompletionLogprobs`` from sglang ``meta_info``.
 
         Mirrors ``vllm/core.py:_build_logprobs``: parallel
         ``text_offset`` / ``tokens`` / ``token_logprobs`` / ``top_logprobs``
         lists with a ``-9999.0`` floor and ``text_offset`` accumulation.
+        ``text_offset_base`` shifts every ``text_offset`` by the number of
+        completion characters already streamed, so each streamed chunk reports
+        absolute offsets instead of restarting at 0 (vLLM gets the same result
+        by building cumulative logprobs and then slicing).
         Returns ``None`` when ``meta_info`` carries no output logprob data
         (the caller did not request ``return_logprob``, or the fields are
         absent/malformed) -- no crash, no fabricated probabilities.
@@ -628,7 +638,7 @@ class SGLANGModel(LLM):
         token_logprobs: List[Optional[float]] = []
         top_logprobs: List[Optional[Dict[str, float]]] = []
         text_offset: List[int] = []
-        offset = 0
+        offset = text_offset_base
         for i, entry in enumerate(token_lps):
             lp, token_text = SGLANGModel._extract_logprob_entry(entry)
             tokens.append(token_text or "")
@@ -832,6 +842,7 @@ class SGLANGModel(LLM):
                         self.model_uid,
                         output_text=out,
                         meta_info=meta_info,
+                        text_offset_base=len(complete_response),
                     )
                     complete_response += out
                     finish_reason = meta_info["finish_reason"]

--- a/xinference/model/llm/sglang/core.py
+++ b/xinference/model/llm/sglang/core.py
@@ -615,9 +615,8 @@ class SGLANGModel(LLM):
             return None
         # current sglang field is output_top_logprobs; older releases used
         # output_topk_logprobs (a dict of decoded_text -> logprob).
-        top_lps = (
-            meta_info.get("output_top_logprobs")
-            or meta_info.get("output_topk_logprobs")
+        top_lps = meta_info.get("output_top_logprobs") or meta_info.get(
+            "output_topk_logprobs"
         )
         tokens: List[str] = []
         token_logprobs: List[Optional[float]] = []
@@ -627,9 +626,7 @@ class SGLANGModel(LLM):
         for i, entry in enumerate(token_lps):
             lp, token_text = SGLANGModel._extract_logprob_entry(entry)
             tokens.append(token_text or "")
-            token_logprobs.append(
-                max(float(lp), -9999.0) if lp is not None else None
-            )
+            token_logprobs.append(max(float(lp), -9999.0) if lp is not None else None)
             top_entry = top_lps[i] if (top_lps and i < len(top_lps)) else None
             if isinstance(top_entry, dict):
                 top_dict = {
@@ -639,12 +636,12 @@ class SGLANGModel(LLM):
                 }
                 top_logprobs.append(top_dict or None)
             elif top_entry:
-                top_dict: Dict[str, float] = {}
+                alt_top: Dict[str, float] = {}
                 for alt in top_entry:
                     alt_lp, alt_text = SGLANGModel._extract_logprob_entry(alt)
                     if alt_text is not None and alt_lp is not None:
-                        top_dict[alt_text] = max(float(alt_lp), -9999.0)
-                top_logprobs.append(top_dict or None)
+                        alt_top[alt_text] = max(float(alt_lp), -9999.0)
+                top_logprobs.append(alt_top or None)
             else:
                 top_logprobs.append(None)
             text_offset.append(offset)

--- a/xinference/model/llm/sglang/core.py
+++ b/xinference/model/llm/sglang/core.py
@@ -31,6 +31,7 @@ from ....types import (
     Completion,
     CompletionChoice,
     CompletionChunk,
+    CompletionLogprobs,
     CompletionUsage,
 )
 from ...utils import check_dependency_available
@@ -431,6 +432,25 @@ class SGLANGModel(LLM):
             if json_schema:
                 generate_config.setdefault("json_schema", json.dumps(json_schema))  # type: ignore
 
+        # Map the OpenAI logprobs request to sglang's native engine params. The
+        # raw OpenAI keys must not reach sglang's SamplingParams (#3553: passing
+        # them crashes the msgspec.Struct with unknown kwargs); sglang reads
+        # return_logprob/top_logprobs_num/return_text_in_logprobs as top-level
+        # GenerateReqInput fields, lifted out of sampling_params by the generate
+        # methods so the engine both produces and returns logprob data.
+        logprobs_req = generate_config.pop("logprobs", None)  # type: ignore
+        top_logprobs_req = generate_config.pop("top_logprobs", None)  # type: ignore
+        if logprobs_req:
+            if isinstance(logprobs_req, bool):
+                # chat completions: logprobs is a flag, top_logprobs holds the count
+                top_k = max(int(top_logprobs_req or 0), 0)
+            else:
+                # legacy completions: logprobs is the requested count directly
+                top_k = max(int(logprobs_req or 0), 0)
+            generate_config["return_logprob"] = True  # type: ignore
+            generate_config["top_logprobs_num"] = top_k  # type: ignore
+            generate_config["return_text_in_logprobs"] = True  # type: ignore
+
         return generate_config
 
     def _get_tokenizer(self, lora_request: Any = None) -> Any:
@@ -498,7 +518,7 @@ class SGLANGModel(LLM):
             CompletionChoice(
                 text=output_text,
                 index=0,
-                logprobs=None,
+                logprobs=SGLANGModel._build_logprobs(meta_info),
                 finish_reason=finish_reason,
             )
         ]
@@ -535,7 +555,7 @@ class SGLANGModel(LLM):
             CompletionChoice(
                 text=output_text,
                 index=0,
-                logprobs=None,
+                logprobs=SGLANGModel._build_logprobs(meta_info),
                 finish_reason=finish_reason,
             )
         ]
@@ -554,11 +574,107 @@ class SGLANGModel(LLM):
             usage=usage,
         )
 
+    @staticmethod
+    def _extract_logprob_entry(
+        entry: Any,
+    ) -> Tuple[Optional[float], Optional[str]]:
+        """Pull (logprob, decoded_text) from one sglang logprob tuple.
+
+        sglang emits each sampled/top position as a ``(logprob, token_id,
+        token_text)`` 3-tuple when ``return_text_in_logprobs`` is set (text
+        is ``None`` on versions without that flag); older releases used a
+        ``(token_id, logprob)`` pair. After the JSON round-trip from the
+        engine logprobs are floats and token ids are ints, so when the arity
+        is ambiguous we identify the logprob by type. Returns ``(None, None)``
+        on any shape we cannot read safely -- no fabricated probabilities.
+        """
+        if not isinstance(entry, (list, tuple)) or not entry:
+            return None, None
+        if len(entry) >= 3:
+            return entry[0], entry[2]
+        if len(entry) == 2:
+            if isinstance(entry[0], float):
+                return entry[0], None
+            if isinstance(entry[1], float):
+                return entry[1], None
+        return None, None
+
+    @staticmethod
+    def _build_logprobs(meta_info: Dict) -> Optional[CompletionLogprobs]:
+        """Build a legacy ``CompletionLogprobs`` from sglang ``meta_info``.
+
+        Mirrors ``vllm/core.py:_build_logprobs``: parallel
+        ``text_offset`` / ``tokens`` / ``token_logprobs`` / ``top_logprobs``
+        lists with a ``-9999.0`` floor and ``text_offset`` accumulation.
+        Returns ``None`` when ``meta_info`` carries no output logprob data
+        (the caller did not request ``return_logprob``, or the fields are
+        absent/malformed) -- no crash, no fabricated probabilities.
+        """
+        token_lps = meta_info.get("output_token_logprobs")
+        if not token_lps:
+            return None
+        # current sglang field is output_top_logprobs; older releases used
+        # output_topk_logprobs (a dict of decoded_text -> logprob).
+        top_lps = (
+            meta_info.get("output_top_logprobs")
+            or meta_info.get("output_topk_logprobs")
+        )
+        tokens: List[str] = []
+        token_logprobs: List[Optional[float]] = []
+        top_logprobs: List[Optional[Dict[str, float]]] = []
+        text_offset: List[int] = []
+        offset = 0
+        for i, entry in enumerate(token_lps):
+            lp, token_text = SGLANGModel._extract_logprob_entry(entry)
+            tokens.append(token_text or "")
+            token_logprobs.append(
+                max(float(lp), -9999.0) if lp is not None else None
+            )
+            top_entry = top_lps[i] if (top_lps and i < len(top_lps)) else None
+            if isinstance(top_entry, dict):
+                top_dict = {
+                    text: max(float(v), -9999.0)
+                    for text, v in top_entry.items()
+                    if v is not None
+                }
+                top_logprobs.append(top_dict or None)
+            elif top_entry:
+                top_dict: Dict[str, float] = {}
+                for alt in top_entry:
+                    alt_lp, alt_text = SGLANGModel._extract_logprob_entry(alt)
+                    if alt_text is not None and alt_lp is not None:
+                        top_dict[alt_text] = max(float(alt_lp), -9999.0)
+                top_logprobs.append(top_dict or None)
+            else:
+                top_logprobs.append(None)
+            text_offset.append(offset)
+            if token_text:
+                offset += len(token_text)
+        return CompletionLogprobs(
+            text_offset=text_offset,
+            token_logprobs=token_logprobs,
+            tokens=tokens,
+            top_logprobs=top_logprobs,
+        )
+
     @classmethod
     def _filter_sampling_params(cls, sampling_params: dict):
         if not sampling_params.get("lora_name"):
             sampling_params.pop("lora_name", None)
         return sampling_params
+
+    @staticmethod
+    def _lift_logprob_request_params(sampling_params: dict) -> dict:
+        """Pop sglang's top-level GenerateReqInput logprob fields out of the
+        sampling_params dict. sglang reads them off GenerateReqInput, not
+        SamplingParams; leaving them in sampling_params crashes the msgspec
+        SamplingParams with unknown kwargs (#3553).
+        """
+        top: Dict = {}
+        for k in ("return_logprob", "top_logprobs_num", "return_text_in_logprobs"):
+            if k in sampling_params:
+                top[k] = sampling_params.pop(k)
+        return top
 
     async def _stream_generate(
         self,
@@ -574,6 +690,7 @@ class SGLANGModel(LLM):
             "image_data": image_data,
             "sampling_params": sampling_params,
             "stream": True,
+            **self._lift_logprob_request_params(sampling_params),
         }
         pos = 0
 
@@ -612,6 +729,7 @@ class SGLANGModel(LLM):
             "text": prompt,
             "image_data": image_data,
             "sampling_params": sampling_params,
+            **self._lift_logprob_request_params(sampling_params),
         }
         async with aiohttp.ClientSession(trust_env=True) as session:
             async with session.post(

--- a/xinference/model/llm/sglang/tests/test_logprobs.py
+++ b/xinference/model/llm/sglang/tests/test_logprobs.py
@@ -103,7 +103,11 @@ def test_logprob_floor_applied():
 def test_no_logprob_data_degrades_to_none():
     # defensive: caller did not request return_logprob -> meta_info carries no
     # output_token_logprobs -> None, no crash, no fabricated probabilities
-    meta = {"finish_reason": {"type": "stop"}, "prompt_tokens": 2, "completion_tokens": 1}
+    meta = {
+        "finish_reason": {"type": "stop"},
+        "prompt_tokens": 2,
+        "completion_tokens": 1,
+    }
     lp = _model()._convert_state_to_completion("r", "m", "x", meta)["choices"][0][
         "logprobs"
     ]
@@ -165,9 +169,7 @@ def test_sanitize_maps_chat_logprobs_to_sglang_params():
     from ..core import SGLANGModel
 
     # chat completions: logprobs is a bool flag, top_logprobs holds the count
-    cfg = SGLANGModel._sanitize_generate_config(
-        {"logprobs": True, "top_logprobs": 3}
-    )
+    cfg = SGLANGModel._sanitize_generate_config({"logprobs": True, "top_logprobs": 3})
     assert cfg["return_logprob"] is True
     assert cfg["top_logprobs_num"] == 3
     assert cfg["return_text_in_logprobs"] is True

--- a/xinference/model/llm/sglang/tests/test_logprobs.py
+++ b/xinference/model/llm/sglang/tests/test_logprobs.py
@@ -225,3 +225,83 @@ def test_lift_logprob_request_params_is_empty_when_unrequested():
     sampling_params = {"temperature": 0.7}
     assert SGLANGModel._lift_logprob_request_params(sampling_params) == {}
     assert sampling_params == {"temperature": 0.7}
+
+
+def test_sanitize_treats_completion_logprobs_zero_as_request():
+    from ..core import SGLANGModel
+
+    # /v1/completions: logprobs=0 requests the selected-token logprob with zero
+    # alternatives. The bare `if logprobs_req:` truthiness check treated 0 as
+    # opt-out, so return_logprob was never sent and the response stayed
+    # logprobs=None. Distinguish chat False from completion int 0 explicitly.
+    cfg = SGLANGModel._sanitize_generate_config({"logprobs": 0})
+    assert cfg["return_logprob"] is True
+    assert cfg["top_logprobs_num"] == 0
+    assert cfg["return_text_in_logprobs"] is True
+    assert "logprobs" not in cfg
+    assert "top_logprobs" not in cfg
+
+
+def test_sanitize_chat_logprobs_false_opts_out():
+    from ..core import SGLANGModel
+
+    # chat completions: logprobs=False explicitly opts out. False is an int
+    # subclass but must NOT request logprobs.
+    cfg = SGLANGModel._sanitize_generate_config({"logprobs": False})
+    assert "return_logprob" not in cfg
+    assert "top_logprobs_num" not in cfg
+    assert "return_text_in_logprobs" not in cfg
+    assert "logprobs" not in cfg
+
+
+def test_slice_stream_logprobs_emits_per_chunk_delta():
+    from ..core import SGLANGModel
+
+    # sglang with incremental_streaming_output=False sends CUMULATIVE logprob
+    # arrays in every chunk's meta_info. Slicing must emit only the
+    # not-yet-consumed tail per chunk, so chunk 1 emits [A] and chunk 2 emits
+    # [B], not [A] then [A, B].
+    chunk1_meta = {
+        "prompt_tokens": 1,
+        "completion_tokens": 1,
+        "output_token_logprobs": [(-0.5, 4398, "Hello")],
+        "output_top_logprobs": [[(-0.5, 4398, "Hello"), (-3.0, 912, "Hi")]],
+    }
+    chunk2_meta = {
+        "prompt_tokens": 1,
+        "completion_tokens": 2,
+        "output_token_logprobs": [(-0.5, 4398, "Hello"), (-1.2, 290, " world")],
+        "output_top_logprobs": [
+            [(-0.5, 4398, "Hello"), (-3.0, 912, "Hi")],
+            [(-1.2, 290, " world"), (-2.5, 818, " there")],
+        ],
+    }
+
+    delta1, consumed = SGLANGModel._slice_stream_logprobs(chunk1_meta, 0)
+    assert consumed == 1
+    assert delta1["output_token_logprobs"] == [(-0.5, 4398, "Hello")]
+    assert delta1["output_top_logprobs"] == [[(-0.5, 4398, "Hello"), (-3.0, 912, "Hi")]]
+    lp1 = SGLANGModel._build_logprobs(delta1)
+    assert lp1["tokens"] == ["Hello"]
+
+    delta2, consumed = SGLANGModel._slice_stream_logprobs(chunk2_meta, consumed)
+    assert consumed == 2
+    # only the second token reaches this chunk
+    assert delta2["output_token_logprobs"] == [(-1.2, 290, " world")]
+    assert delta2["output_top_logprobs"] == [
+        [(-1.2, 290, " world"), (-2.5, 818, " there")]
+    ]
+    lp2 = SGLANGModel._build_logprobs(delta2)
+    assert lp2["tokens"] == [" world"]
+
+
+def test_slice_stream_logprobs_passthrough_when_no_logprob_data():
+    from ..core import SGLANGModel
+
+    # a chunk that carries no logprob data (caller did not request
+    # return_logprob) passes through unchanged and leaves the counter untouched,
+    # so a later cumulative chunk still slices correctly.
+    meta = {"prompt_tokens": 1, "completion_tokens": 1}
+    delta, consumed = SGLANGModel._slice_stream_logprobs(meta, 0)
+    assert delta is meta
+    assert consumed == 0

--- a/xinference/model/llm/sglang/tests/test_logprobs.py
+++ b/xinference/model/llm/sglang/tests/test_logprobs.py
@@ -305,3 +305,41 @@ def test_slice_stream_logprobs_passthrough_when_no_logprob_data():
     delta, consumed = SGLANGModel._slice_stream_logprobs(meta, 0)
     assert delta is meta
     assert consumed == 0
+
+
+def test_stream_chunk_logprobs_report_absolute_text_offset():
+    # [P1] qinxuye: _build_logprobs restarted text_offset at 0 on every
+    # streamed chunk, so a second chunk carrying " world" reported offset [0]
+    # instead of [5] (the completion length streamed so far). The streaming
+    # caller threads len(complete_response) as text_offset_base so each chunk's
+    # offsets are absolute, matching the non-stream path ([0, 5] for "Hello"
+    # then " world"). Two-chunk regression: assert the second chunk's offset.
+    model = _model()
+    chunk1_meta = {
+        "finish_reason": None,
+        "prompt_tokens": 3,
+        "completion_tokens": 1,
+        "output_token_logprobs": [(-0.5, 4398, "Hello")],
+        "output_top_logprobs": [[(-0.5, 4398, "Hello"), (-3.0, 912, "Hi")]],
+    }
+    # first chunk: nothing streamed yet -> base 0
+    lp1 = model._convert_state_to_completion_chunk(
+        "req-1", "test-model-0", "Hello", chunk1_meta, text_offset_base=0
+    )["choices"][0]["logprobs"]
+    assert lp1 is not None
+    assert lp1["text_offset"] == [0]
+
+    chunk2_meta = {
+        "finish_reason": None,
+        "prompt_tokens": 3,
+        "completion_tokens": 2,
+        "output_token_logprobs": [(-1.2, 290, " world")],
+        "output_top_logprobs": [[(-1.2, 290, " world"), (-2.5, 818, " there")]],
+    }
+    # second chunk: "Hello" (5 chars) already streamed -> base 5
+    lp2 = model._convert_state_to_completion_chunk(
+        "req-1", "test-model-0", " world", chunk2_meta, text_offset_base=5
+    )["choices"][0]["logprobs"]
+    assert lp2 is not None
+    assert lp2["text_offset"] == [5]
+    assert lp2["tokens"] == [" world"]

--- a/xinference/model/llm/sglang/tests/test_logprobs.py
+++ b/xinference/model/llm/sglang/tests/test_logprobs.py
@@ -1,0 +1,225 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from types import SimpleNamespace
+
+
+def _model():
+    from ..core import SGLANGModel
+
+    model = object.__new__(SGLANGModel)
+    model.model_uid = "test-model-0"
+    model.model_family = SimpleNamespace(model_name="qwen2")
+    model.model_spec = SimpleNamespace(model_size_in_billions=7)
+    return model
+
+
+def _meta_info_with_logprobs():
+    # sglang meta_info when return_logprob=True + return_text_in_logprobs=True:
+    # each sampled position is a (logprob, token_id, token_text) 3-tuple, and
+    # each top position is None or a list of the same 3-tuples.
+    return {
+        "finish_reason": {"type": "stop", "status_code": 200},
+        "prompt_tokens": 3,
+        "completion_tokens": 2,
+        "output_token_logprobs": [
+            (-0.5, 4398, "Hello"),
+            (-1.2, 290, " world"),
+        ],
+        "output_top_logprobs": [
+            [(-0.5, 4398, "Hello"), (-3.0, 912, "Hi")],
+            [(-1.2, 290, " world"), (-2.5, 818, " there")],
+        ],
+    }
+
+
+def test_non_stream_logprobs_surfaced():
+    # red on master: _convert_state_to_completion hardcodes logprobs=None, so
+    # this assertion fails there and turns green on the branch.
+    completion = _model()._convert_state_to_completion(
+        "req-1", "test-model-0", "Hello world", _meta_info_with_logprobs()
+    )
+    lp = completion["choices"][0]["logprobs"]
+
+    assert lp is not None
+    assert lp["tokens"] == ["Hello", " world"]
+    assert lp["text_offset"] == [0, 5]
+    assert lp["token_logprobs"] == [-0.5, -1.2]
+    assert lp["top_logprobs"][0] == {"Hello": -0.5, "Hi": -3.0}
+    assert lp["top_logprobs"][1] == {" world": -1.2, " there": -2.5}
+
+
+def test_stream_chunk_logprobs_surfaced():
+    # a single-token streaming chunk's meta_info; mirrors the non-stream shape
+    meta = {
+        "finish_reason": None,
+        "prompt_tokens": 3,
+        "completion_tokens": 1,
+        "output_token_logprobs": [(-0.5, 4398, "Hello")],
+        "output_top_logprobs": [[(-0.5, 4398, "Hello"), (-3.0, 912, "Hi")]],
+    }
+    chunk = _model()._convert_state_to_completion_chunk(
+        "req-1", "test-model-0", "Hello", meta
+    )
+    lp = chunk["choices"][0]["logprobs"]
+
+    assert lp is not None
+    assert lp["tokens"] == ["Hello"]
+    assert lp["text_offset"] == [0]
+    assert lp["token_logprobs"] == [-0.5]
+    assert lp["top_logprobs"][0] == {"Hello": -0.5, "Hi": -3.0}
+
+
+def test_logprob_floor_applied():
+    # mirror vllm: logprobs below -9999.0 are floored, never fabricated
+    meta = {
+        "finish_reason": {"type": "stop"},
+        "prompt_tokens": 1,
+        "completion_tokens": 1,
+        "output_token_logprobs": [(-15000.0, 9, "x")],
+        "output_top_logprobs": [[(-20000.0, 9, "x")]],
+    }
+    lp = _model()._convert_state_to_completion("r", "m", "x", meta)["choices"][0][
+        "logprobs"
+    ]
+
+    assert lp is not None
+    assert lp["token_logprobs"] == [-9999.0]
+    assert lp["top_logprobs"][0] == {"x": -9999.0}
+
+
+def test_no_logprob_data_degrades_to_none():
+    # defensive: caller did not request return_logprob -> meta_info carries no
+    # output_token_logprobs -> None, no crash, no fabricated probabilities
+    meta = {"finish_reason": {"type": "stop"}, "prompt_tokens": 2, "completion_tokens": 1}
+    lp = _model()._convert_state_to_completion("r", "m", "x", meta)["choices"][0][
+        "logprobs"
+    ]
+    assert lp is None
+
+
+def test_empty_logprob_list_degrades_to_none():
+    meta = {
+        "finish_reason": {"type": "stop"},
+        "prompt_tokens": 2,
+        "completion_tokens": 1,
+        "output_token_logprobs": [],
+    }
+    lp = _model()._convert_state_to_completion("r", "m", "x", meta)["choices"][0][
+        "logprobs"
+    ]
+    assert lp is None
+
+
+def test_malformed_entries_degrade_gracefully():
+    meta = {
+        "finish_reason": {"type": "stop"},
+        "prompt_tokens": 1,
+        "completion_tokens": 2,
+        "output_token_logprobs": [(-0.5, 1, "a"), None],
+        "output_top_logprobs": [[(-0.5, 1, "a")], None],
+    }
+    lp = _model()._build_logprobs(meta)
+
+    assert lp is not None
+    assert lp["token_logprobs"][0] == -0.5
+    assert lp["token_logprobs"][1] is None
+    assert lp["tokens"][1] == ""
+    assert lp["top_logprobs"][0] == {"a": -0.5}
+    assert lp["top_logprobs"][1] is None
+
+
+def test_older_two_tuple_and_dict_shapes_read_defensively():
+    # older sglang emitted (token_id, logprob) pairs without decoded text, and
+    # the top field was named output_topk_logprobs holding a decoded_text ->
+    # logprob dict. The adapter recovers the logprob by type and degrades only
+    # the missing text, without crashing or fabricating.
+    meta = {
+        "finish_reason": {"type": "stop"},
+        "prompt_tokens": 1,
+        "completion_tokens": 1,
+        "output_token_logprobs": [(4398, -0.5)],
+        "output_topk_logprobs": [{"Hello": -0.5}],
+    }
+    lp = _model()._build_logprobs(meta)
+
+    assert lp is not None
+    assert lp["token_logprobs"] == [-0.5]
+    assert lp["tokens"] == [""]
+    assert lp["top_logprobs"][0] == {"Hello": -0.5}
+
+
+def test_sanitize_maps_chat_logprobs_to_sglang_params():
+    from ..core import SGLANGModel
+
+    # chat completions: logprobs is a bool flag, top_logprobs holds the count
+    cfg = SGLANGModel._sanitize_generate_config(
+        {"logprobs": True, "top_logprobs": 3}
+    )
+    assert cfg["return_logprob"] is True
+    assert cfg["top_logprobs_num"] == 3
+    assert cfg["return_text_in_logprobs"] is True
+    # raw OpenAI keys must not survive (#3553: they crash sglang SamplingParams)
+    assert "logprobs" not in cfg
+    assert "top_logprobs" not in cfg
+
+
+def test_sanitize_maps_legacy_completion_logprobs_count():
+    from ..core import SGLANGModel
+
+    # legacy /v1/completions: logprobs is the requested count directly
+    cfg = SGLANGModel._sanitize_generate_config({"logprobs": 5})
+    assert cfg["return_logprob"] is True
+    assert cfg["top_logprobs_num"] == 5
+    assert cfg["return_text_in_logprobs"] is True
+    assert "logprobs" not in cfg
+
+
+def test_sanitize_without_logprob_request_adds_no_sglang_params():
+    from ..core import SGLANGModel
+
+    cfg = SGLANGModel._sanitize_generate_config({"temperature": 0.7})
+    assert "return_logprob" not in cfg
+    assert "top_logprobs_num" not in cfg
+    assert "return_text_in_logprobs" not in cfg
+
+
+def test_lift_logprob_request_params_moves_to_top_level():
+    from ..core import SGLANGModel
+
+    sampling_params = {
+        "temperature": 0.7,
+        "return_logprob": True,
+        "top_logprobs_num": 3,
+        "return_text_in_logprobs": True,
+    }
+    top = SGLANGModel._lift_logprob_request_params(sampling_params)
+
+    # the logprob request fields are lifted out of sampling_params so sglang
+    # reads them as top-level GenerateReqInput fields, not SamplingParams (#3553)
+    assert sampling_params == {"temperature": 0.7}
+    assert top == {
+        "return_logprob": True,
+        "top_logprobs_num": 3,
+        "return_text_in_logprobs": True,
+    }
+
+
+def test_lift_logprob_request_params_is_empty_when_unrequested():
+    from ..core import SGLANGModel
+
+    sampling_params = {"temperature": 0.7}
+    assert SGLANGModel._lift_logprob_request_params(sampling_params) == {}
+    assert sampling_params == {"temperature": 0.7}


### PR DESCRIPTION
## Summary

The sglang adapter hardcoded `logprobs=None` at both response builders (`_convert_state_to_completion_chunk` and `_convert_state_to_completion`), discarding the logprob data the engine returns in `meta_info` when `return_logprob` is set. At the same time the raw OpenAI `logprobs`/`top_logprobs` request keys were forwarded into `sampling_params`, which crashes sglang's `msgspec` `SamplingParams` with unknown kwargs (#3553).

This PR mirrors the vLLM reference (`vllm/core.py:_build_logprobs`) so the sglang adapter surfaces logprobs the same way:

- Add `SGLANGModel._build_logprobs(meta_info)` that maps sglang's `output_token_logprobs` / `output_top_logprobs` fields to the legacy `CompletionLogprobs` parallel-list shape (`text_offset` / `tokens` / `token_logprobs` / `top_logprobs`) with a `-9999.0` floor and `text_offset` accumulation.
- Map the OpenAI `logprobs`/`top_logprobs` request to sglang's native `return_logprob` / `top_logprobs_num` / `return_text_in_logprobs` in `_sanitize_generate_config`, and **lift them out of `sampling_params` to the request-body top level** (where sglang's `GenerateReqInput` reads them). This both avoids the `SamplingParams`-unknown-kwarg crash and makes the engine produce + return the data.
- Replace the two `logprobs=None` sites with `_build_logprobs(meta_info)`.

Once `/v1/completions` returns `CompletionLogprobs`, the already-merged chat converter `_completion_logprobs_to_chat_logprobs` (#5252) makes `/v1/chat/completions` logprobs work too — no chat-side change needed.

## Why this shape (addresses the version-variance concern)

sglang's `meta_info` logprob field names/shapes vary across versions (3-tuples with `return_text_in_logprobs=True`, older 2-tuples, older dict shapes). Rather than pin to one schema, `_build_logprobs` reads the fields **defensively**: it surfaces logprobs only when the expected fields are present and well-shaped, and degrades to `None` otherwise. Version variance in sglang's logprob schema therefore cannot crash the adapter or fabricate probabilities — the worst case is `logprobs=None` (the current pre-PR behaviour), never a crash or invented numbers.

## Why the params are lifted to the request body

`SamplingParams` is a `msgspec.Struct` that rejects unknown fields — passing the OpenAI `logprobs` key through it is the #3553 crash mechanism. sglang's `GenerateReqInput` (the request-body schema) accepts `return_logprob` / `top_logprobs_num` / `return_text_in_logprobs` as top-level fields, so they belong there, not inside `sampling_params`.

## Tests

New `xinference/model/llm/sglang/tests/test_logprobs.py` (225 lines) using the existing `test_speculative_config.py` pattern (`object.__new__(SGLANGModel)` + direct static-method calls + a fake `meta_info`):

- `output_token_logprobs` → `CompletionLogprobs` mapping (tokens, token_logprobs, top_logprobs, text_offset).
- `-9999.0` floor and `None`-logprob skip (parity with vllm + the chat converter).
- Older 2-tuple + dict shapes read defensively.
- Malformed/absent fields degrade to `None` (no crash, no fabrication).
- `_sanitize_generate_config` maps both chat (`logprobs`=bool + `top_logprobs`=count) and legacy completions (`logprobs`=count) to the sglang-native params.
- `_lift_logprob_request_params` moves the three params to the request body and removes them from `sampling_params`; empty when logprobs unrequested.

Red-on-master: reverting `core.py` to `main` (keeping the new test) → 9 failed, 3 passed (the 3 that pass on master assert the defensive `None`-when-unrequested behaviour, shared by both). Green-on-branch: 12 passed. The existing `test_speculative_config.py` still passes (22) — no regression.

## Scope

Only `xinference/model/llm/sglang/core.py` + the new test. No changes to other engines, the merged chat converter (`utils.py`), `prompt_logprobs`, or the streaming tool-call path.

Refs #3553
