### PR TITLE
docs: note OpenAI client base_url for multi-model gateways

### DIFF
--- a/doc/source/getting_started/using_xinference.rst
+++ b/doc/source/getting_started/using_xinference.rst
@@ -334,6 +334,10 @@ The following OpenAI APIs are supported:
 
 - Embeddings: `https://platform.openai.com/docs/api-reference/embeddings <https://platform.openai.com/docs/api-reference/embeddings>`_
 
+The same ``OpenAI(base_url=...)`` client pattern works with any OpenAI-compatible
+multi-model gateway when you are not self-hosting Xinference — for example
+`DaoXE <https://daoxe.com>`_ at ``https://api.daoxe.com/v1``.
+
 Xinference also supports Anthropic API via base url ``http://127.0.0.1:9997/anthropic``, you can use Xinference in Claude Code and so forth.
 Refer to :ref:`anthropic client <anthropic_client>` for more details.
 


### PR DESCRIPTION
## Summary

The getting-started guide already shows `OpenAI(base_url=\"http://127.0.0.1:9997/v1\")` against self-hosted Xinference.

This PR adds a short note that the same client pattern works with OpenAI-compatible multi-model gateways when not self-hosting, using [DaoXE](https://daoxe.com) (`https://api.daoxe.com/v1`) as one concrete example.

Docs only — no runtime behavior changes.

## Test plan

- [ ] RST still builds on Read the Docs
- [ ] Local Xinference client example unchanged
- [ ] Tip is clearly optional