### PR TITLE
feat: support deploying R3-embedding-0.6b and R3-rerank-0.6b models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,6 +137,7 @@ dmypy.json
 # IDEs
 .idea
 .vscode
+.trae
 *.iml
 
 # VIM

--- a/xinference/model/embedding/model_spec.json
+++ b/xinference/model/embedding/model_spec.json
@@ -1260,6 +1260,44 @@
   },
   {
     "version": 2,
+    "model_name": "R3-embedding-0.6b",
+    "dimensions": 1024,
+    "max_tokens": 32768,
+    "language": [
+      "en",
+      "zh"
+    ],
+    "model_specs": [
+      {
+        "model_format": "pytorch",
+        "model_src": {
+          "huggingface": {
+            "model_id": "tencent/R3-embedding-0.6b",
+            "quantizations": [
+              "none"
+            ]
+          },
+          "modelscope": {
+            "model_id": "Tencent-Hunyuan/R3-embedding-0.6b",
+            "quantizations": [
+              "none"
+            ]
+          }
+        }
+      }
+    ],
+    "updated_at": 1785312000,
+    "featured": false,
+    "virtualenv": {
+      "packages": [
+        "#sentence_transformers_dependencies# ; #engine# == \"sentence_transformers\"",
+        "#system_torchvision# ; #engine# == \"sentence_transformers\"",
+        "#system_torch# ; #engine# == \"sentence_transformers\""
+      ]
+    }
+  },
+  {
+    "version": 2,
     "model_name": "Qwen3-Embedding-0.6B",
     "dimensions": 1024,
     "max_tokens": 32768,

--- a/xinference/model/embedding/sentence_transformers/core.py
+++ b/xinference/model/embedding/sentence_transformers/core.py
@@ -254,8 +254,11 @@ class SentenceTransformerEmbeddingModel(EmbeddingModel, BatchMixin):
                 model_kwargs=model_kwargs,
                 truncate_dim=dimensions,
             )
-        elif "qwen3" in self.model_family.model_name.lower():
-            # qwen3 embedding
+        elif (
+            "qwen3" in self.model_family.model_name.lower()
+            or "r3-embedding" in self.model_family.model_name.lower()
+        ):
+            # qwen3 embedding (also covers R3-embedding, fine-tuned from Qwen3)
             flash_attn_enabled = self._kwargs.get(
                 "enable_flash_attn", is_flash_attn_available()
             )

--- a/xinference/model/rerank/model_spec.json
+++ b/xinference/model/rerank/model_spec.json
@@ -366,6 +366,44 @@
   },
   {
     "version": 2,
+    "model_name": "R3-rerank-0.6b",
+    "type": "normal",
+    "language": [
+      "en",
+      "zh"
+    ],
+    "max_tokens": 40960,
+    "model_specs": [
+      {
+        "model_format": "pytorch",
+        "model_src": {
+          "huggingface": {
+            "model_id": "tencent/R3-rerank-0.6b",
+            "quantizations": [
+              "none"
+            ]
+          },
+          "modelscope": {
+            "model_id": "Tencent-Hunyuan/R3-rerank-0.6b",
+            "quantizations": [
+              "none"
+            ]
+          }
+        }
+      }
+    ],
+    "updated_at": 1785312000,
+    "featured": false,
+    "virtualenv": {
+      "packages": [
+        "#sentence_transformers_dependencies# ; #engine# == \"sentence_transformers\"",
+        "#system_torchvision# ; #engine# == \"sentence_transformers\"",
+        "#system_torch# ; #engine# == \"sentence_transformers\""
+      ]
+    }
+  },
+  {
+    "version": 2,
     "model_name": "Qwen3-Reranker-0.6B",
     "type": "normal",
     "language": [

--- a/xinference/model/rerank/sentence_transformers/core.py
+++ b/xinference/model/rerank/sentence_transformers/core.py
@@ -98,6 +98,7 @@ class SentenceTransformerRerankModel(RerankModel, BatchMixin):
             self.model_family.type == "normal"
             and "qwen3" not in self.model_family.model_name.lower()
             and "jina-reranker-v3" not in self.model_family.model_name.lower()
+            and "r3-rerank" not in self.model_family.model_name.lower()
         ):
             # sentence-transformers >= 5.4 imports torchcodec at import time and
             # only tolerates ImportError/OSError; a broken (version-mismatched)
@@ -146,8 +147,9 @@ class SentenceTransformerRerankModel(RerankModel, BatchMixin):
         elif (
             "qwen3" in self.model_family.model_name.lower()
             or "jina-reranker-v3" in self.model_family.model_name.lower()
+            or "r3-rerank" in self.model_family.model_name.lower()
         ):
-            # qwen3-reranker
+            # qwen3-reranker (also covers R3-rerank, fine-tuned from Qwen3-Reranker)
             # now we use transformers
             # TODO: support engines for rerank models
             try:
@@ -330,6 +332,7 @@ class SentenceTransformerRerankModel(RerankModel, BatchMixin):
             self.model_family.type == "normal"
             and "qwen3" not in self.model_family.model_name.lower()
             and "jina-reranker-v3" not in self.model_family.model_name.lower()
+            and "r3-rerank" not in self.model_family.model_name.lower()
         ):
             logger.debug("Passing processed sentences: %s", sentence_combinations)
 
@@ -364,11 +367,18 @@ class SentenceTransformerRerankModel(RerankModel, BatchMixin):
         elif (
             "qwen3" in self.model_family.model_name.lower()
             or "jina-reranker-v3" in self.model_family.model_name.lower()
+            or "r3-rerank" in self.model_family.model_name.lower()
         ):
 
             def format_instruction(instruction, query, doc):
                 if instruction is None:
-                    instruction = "Given a web search query, retrieve relevant passages that answer the query"
+                    if "r3-rerank" in self.model_family.model_name.lower():
+                        instruction = (
+                            "Given a user request, retrieve the agent skill "
+                            "that solves it."
+                        )
+                    else:
+                        instruction = "Given a web search query, retrieve relevant passages that answer the query"
                 output = "<Instruct>: {instruction}\n<Query>: {query}\n<Document>: {doc}".format(
                     instruction=instruction, query=query, doc=doc
                 )
@@ -594,16 +604,9 @@ class SentenceTransformerRerankModel(RerankModel, BatchMixin):
                 if return_len:
                     if (
                         self.model_family.type == "normal"
-                        and "qwen3" not in self.model_family.model_name.lower()
-                        and "jina-reranker-v3"
-                        not in self.model_family.model_name.lower()
-                    ):
-                        input_len = sum(
-                            self._get_input_tokens_slice(offset, offset + n)
-                        )
-                    elif (
-                        "qwen3" in self.model_family.model_name.lower()
+                        or "qwen3" in self.model_family.model_name.lower()
                         or "jina-reranker-v3" in self.model_family.model_name.lower()
+                        or "r3-rerank" in self.model_family.model_name.lower()
                     ):
                         input_len = sum(
                             self._get_input_tokens_slice(offset, offset + n)


### PR DESCRIPTION
Register R3-embedding-0.6b and R3-rerank-0.6b from Tencent's R3-Skill two-stage retriever for agent skill routing.

- R3-embedding-0.6b: bi-encoder based on Qwen3, 1024 dims, 32768 max tokens. Routes to XSentenceTransformer loading path (same as Qwen3-Embedding) since the model architecture is Qwen3Model.

- R3-rerank-0.6b: cross-encoder based on Qwen3ForCausalLM, 40960 max tokens. Routes to the Qwen3-Reranker loading path (AutoModelForCausalLM with yes/no token scoring) since sentence_transformers 3.x CrossEncoder cannot load CausalLM architectures. The chat template and scoring mechanism are identical to Qwen3-Reranker (R3-rerank is fine-tuned from Qwen3-Reranker-0.6B).

Both models require trust_remote_code and are registered with virtualenv packages for the sentence_transformers engine.