### PR TITLE
docs: add v3.1.0 to release notes index

### DIFF
--- a/doc/source/getting_started/release_notes.rst
+++ b/doc/source/getting_started/release_notes.rst
@@ -9,6 +9,8 @@ For detailed updates, please visit the corresponding links below.
 +-----------------+--------------------------------------------------------------------------------+
 | Version         | Release Notes                                                                  |
 +=================+================================================================================+
+| v3.1.0          | `View release notes <https://xinference.co/release_notes/v3.1.0.html>`_        |
++-----------------+--------------------------------------------------------------------------------+
 | v3.0.0          | `View release notes <https://xinference.co/release_notes/v3.0.0.html>`_        |
 +-----------------+--------------------------------------------------------------------------------+
 | v2.12.0         | `View release notes <https://xinference.co/release_notes/v2.12.0.html>`_       |

--- a/doc/source/locale/de/LC_MESSAGES/getting_started/release_notes.po
+++ b/doc/source/locale/de/LC_MESSAGES/getting_started/release_notes.po
@@ -255,3 +255,11 @@ msgid ""
 msgstr ""
 "Für weitere historische Versionen und Quellcode besuchen Sie bitte GitHub"
 " Releases: https://github.com/xorbitsai/inference/releases"
+
+#: ../../source/getting_started/release_notes.rst:12
+msgid "v3.1.0"
+msgstr "v3.1.0"
+
+#: ../../source/getting_started/release_notes.rst:12
+msgid "`View release notes <https://xinference.co/release_notes/v3.1.0.html>`_"
+msgstr "`Versionshinweise anzeigen <https://xinference.co/release_notes/v3.1.0.html>`_"

--- a/doc/source/locale/es/LC_MESSAGES/getting_started/release_notes.po
+++ b/doc/source/locale/es/LC_MESSAGES/getting_started/release_notes.po
@@ -256,3 +256,11 @@ msgid ""
 msgstr ""
 "Para más versiones históricas y el código fuente, visita GitHub Releases:"
 " https://github.com/xorbitsai/inference/releases"
+
+#: ../../source/getting_started/release_notes.rst:12
+msgid "v3.1.0"
+msgstr "v3.1.0"
+
+#: ../../source/getting_started/release_notes.rst:12
+msgid "`View release notes <https://xinference.co/release_notes/v3.1.0.html>`_"
+msgstr "`Ver las notas de la versión <https://xinference.co/release_notes/v3.1.0.html>`_"

--- a/doc/source/locale/fr/LC_MESSAGES/getting_started/release_notes.po
+++ b/doc/source/locale/fr/LC_MESSAGES/getting_started/release_notes.po
@@ -256,3 +256,11 @@ msgid ""
 msgstr ""
 "Pour plus de versions historiques et le code source, veuillez visiter les"
 " versions GitHub : https://github.com/xorbitsai/inference/releases"
+
+#: ../../source/getting_started/release_notes.rst:12
+msgid "v3.1.0"
+msgstr "v3.1.0"
+
+#: ../../source/getting_started/release_notes.rst:12
+msgid "`View release notes <https://xinference.co/release_notes/v3.1.0.html>`_"
+msgstr "`Voir les notes de version <https://xinference.co/release_notes/v3.1.0.html>`_"

--- a/doc/source/locale/it/LC_MESSAGES/getting_started/release_notes.po
+++ b/doc/source/locale/it/LC_MESSAGES/getting_started/release_notes.po
@@ -255,3 +255,11 @@ msgid ""
 msgstr ""
 "Per ulteriori versioni storiche e codice sorgente, visitare GitHub "
 "Releases: https://github.com/xorbitsai/inference/releases"
+
+#: ../../source/getting_started/release_notes.rst:12
+msgid "v3.1.0"
+msgstr "v3.1.0"
+
+#: ../../source/getting_started/release_notes.rst:12
+msgid "`View release notes <https://xinference.co/release_notes/v3.1.0.html>`_"
+msgstr "`Visualizza le note di rilascio <https://xinference.co/release_notes/v3.1.0.html>`_"

--- a/doc/source/locale/ja/LC_MESSAGES/getting_started/release_notes.po
+++ b/doc/source/locale/ja/LC_MESSAGES/getting_started/release_notes.po
@@ -210,3 +210,11 @@ msgid ""
 msgstr ""
 "その他の過去バージョンやソースコードは、GitHub "
 "Releasesをご覧ください：https://github.com/xorbitsai/inference/releases"
+
+#: ../../source/getting_started/release_notes.rst:12
+msgid "v3.1.0"
+msgstr "v3.1.0"
+
+#: ../../source/getting_started/release_notes.rst:12
+msgid "`View release notes <https://xinference.co/release_notes/v3.1.0.html>`_"
+msgstr "`バージョン説明を確認 <https://xinference.co/release_notes/v3.1.0.html>`_"

--- a/doc/source/locale/ko/LC_MESSAGES/getting_started/release_notes.po
+++ b/doc/source/locale/ko/LC_MESSAGES/getting_started/release_notes.po
@@ -211,3 +211,11 @@ msgid ""
 msgstr ""
 "더 많은 이전 버전 및 소스 코드는 GitHub Releases를 방문하세요: "
 "https://github.com/xorbitsai/inference/releases"
+
+#: ../../source/getting_started/release_notes.rst:12
+msgid "v3.1.0"
+msgstr "v3.1.0"
+
+#: ../../source/getting_started/release_notes.rst:12
+msgid "`View release notes <https://xinference.co/release_notes/v3.1.0.html>`_"
+msgstr "`버전 설명 보기 <https://xinference.co/release_notes/v3.1.0.html>`_"

--- a/doc/source/locale/pt_BR/LC_MESSAGES/getting_started/release_notes.po
+++ b/doc/source/locale/pt_BR/LC_MESSAGES/getting_started/release_notes.po
@@ -239,3 +239,11 @@ msgid ""
 msgstr ""
 "Para mais versões históricas e código-fonte, acesse GitHub Releases: "
 "https://github.com/xorbitsai/inference/releases"
+
+#: ../../source/getting_started/release_notes.rst:12
+msgid "v3.1.0"
+msgstr "v3.1.0"
+
+#: ../../source/getting_started/release_notes.rst:12
+msgid "`View release notes <https://xinference.co/release_notes/v3.1.0.html>`_"
+msgstr "`Ver notas da versão <https://xinference.co/release_notes/v3.1.0.html>`_"

--- a/doc/source/locale/zh_CN/LC_MESSAGES/getting_started/release_notes.po
+++ b/doc/source/locale/zh_CN/LC_MESSAGES/getting_started/release_notes.po
@@ -211,3 +211,11 @@ msgid ""
 msgstr ""
 "更多历史版本及源代码，请访问 GitHub "
 "Releases：https://github.com/xorbitsai/inference/releases"
+
+#: ../../source/getting_started/release_notes.rst:12
+msgid "v3.1.0"
+msgstr "v3.1.0"
+
+#: ../../source/getting_started/release_notes.rst:12
+msgid "`View release notes <https://xinference.co/release_notes/v3.1.0.html>`_"
+msgstr "`查看版本说明 <https://xinference.cn/release_notes/v3.1.0.html>`_"

--- a/doc/source/locale/zh_TW/LC_MESSAGES/getting_started/release_notes.po
+++ b/doc/source/locale/zh_TW/LC_MESSAGES/getting_started/release_notes.po
@@ -211,3 +211,4 @@ msgid ""
 msgstr ""
 "更多歷史版本及原始碼，請造訪 GitHub "
 "Releases：https://github.com/xorbitsai/inference/releases"
+ Xinference/Xagent

--- a/doc/source/locale/zh_TW/LC_MESSAGES/getting_started/release_notes.po
+++ b/doc/source/locale/zh_TW/LC_MESSAGES/getting_started/release_notes.po
@@ -211,4 +211,11 @@ msgid ""
 msgstr ""
 "更多歷史版本及原始碼，請造訪 GitHub "
 "Releases：https://github.com/xorbitsai/inference/releases"
- Xinference/Xagent
+ 
+#: ../../source/getting_started/release_notes.rst:12
+msgid "v3.1.0"
+msgstr "v3.1.0"
+
+#: ../../source/getting_started/release_notes.rst:12
+msgid "`View release notes <https://xinference.co/release_notes/v3.1.0.html>`_"
+msgstr "`查看版本說明 <https://xinference.cn/release_notes/v3.1.0.html>`_"


### PR DESCRIPTION
Add a v3.1.0 row to the release notes index table, linking to https://xinference.co/release_notes/v3.1.0.html. Follows the existing table format (grid alignment preserved).