### PR TITLE
BUG: fix audit center text filters returning no results

### DIFF
--- a/xinference/api/routers/admin.py
+++ b/xinference/api/routers/admin.py
@@ -733,6 +733,35 @@ def _parse_relative_time(expr: str) -> Optional[datetime]:
     return None
 
 
+def _escape_es_wildcard(value: str) -> str:
+    """Escape characters that are special to an Elasticsearch wildcard query."""
+    return value.replace("\\", "\\\\").replace("*", "\\*").replace("?", "\\?")
+
+
+def _match_substring(stored: Any, needle: str) -> bool:
+    """Case-insensitive substring match used by audit free-text filters.
+
+    An empty ``needle`` means the filter is not active and matches everything.
+    """
+    if not needle:
+        return True
+    if not isinstance(stored, str):
+        return False
+    return needle.lower() in stored.lower()
+
+
+def _match_enum(stored: Any, allowed: set) -> bool:
+    """Case-insensitive exact match against a set of allowed values.
+
+    An empty ``allowed`` set means the filter is not active.
+    """
+    if not allowed:
+        return True
+    if not isinstance(stored, str):
+        return False
+    return stored.lower() in allowed
+
+
 async def _search_audit_from_file(
     *,
     time_from: str,
@@ -801,31 +830,25 @@ async def _search_audit_from_file(
                     if t_to and ts > t_to:
                         continue
 
-                if user and entry.get("user") != user:
-                    continue
-                if api_key_name and entry.get("api_key_name") != api_key_name:
-                    continue
-                if model_id and entry.get("model_id") != model_id:
-                    continue
-                if model_name and entry.get("model_name") != model_name:
-                    continue
-                if client_ip and entry.get("client_ip") != client_ip:
-                    continue
-                if status_set and entry.get("status", "").lower() not in status_set:
-                    continue
-                if (
-                    category_set
-                    and entry.get("category", "").lower() not in category_set
+                if not all(
+                    _match_substring(entry.get(field), needle)
+                    for field, needle in (
+                        ("user", user),
+                        ("api_key_name", api_key_name),
+                        ("model_id", model_id),
+                        ("model_name", model_name),
+                        ("client_ip", client_ip),
+                    )
                 ):
                     continue
-                if (
-                    model_type_set
-                    and entry.get("model_type", "").lower() not in model_type_set
-                ):
-                    continue
-                if (
-                    auth_type_set
-                    and entry.get("auth_type", "").lower() not in auth_type_set
+                if not all(
+                    _match_enum(entry.get(field), allowed)
+                    for field, allowed in (
+                        ("status", status_set),
+                        ("category", category_set),
+                        ("model_type", model_type_set),
+                        ("auth_type", auth_type_set),
+                    )
                 ):
                     continue
 
@@ -893,7 +916,20 @@ async def search_audit_logs(
         ("client_ip", client_ip),
     ]:
         if value:
-            filter_clauses.append({"term": {field_name: value}})
+            # Substring, case-insensitive, to match the file-mode semantics.
+            # Query the `.keyword` subfield: under ES dynamic mapping these are
+            # `text` + `.keyword`, and the analyzed `text` field would never
+            # match a value containing uppercase or `-`/`_`/`/`.
+            filter_clauses.append(
+                {
+                    "wildcard": {
+                        f"{field_name}.keyword": {
+                            "value": f"*{_escape_es_wildcard(value)}*",
+                            "case_insensitive": True,
+                        }
+                    }
+                }
+            )
 
     for field_name, value in [
         ("model_type", model_type),

--- a/xinference/api/routers/admin.py
+++ b/xinference/api/routers/admin.py
@@ -818,6 +818,10 @@ async def _search_audit_from_file(
                     entry = json.loads(line)
                 except (json.JSONDecodeError, ValueError):
                     continue
+                # A line may be valid JSON yet not an object (e.g. `null`,
+                # `[1,2]`); `entry.get(...)` below would raise AttributeError.
+                if not isinstance(entry, dict):
+                    continue
 
                 ts_str = entry.get("@timestamp", "")
                 if t_from or t_to:
@@ -839,6 +843,7 @@ async def _search_audit_from_file(
                         ("model_name", model_name),
                         ("client_ip", client_ip),
                     )
+                    if needle
                 ):
                     continue
                 if not all(
@@ -849,6 +854,7 @@ async def _search_audit_from_file(
                         ("model_type", model_type_set),
                         ("auth_type", auth_type_set),
                     )
+                    if allowed
                 ):
                     continue
 
@@ -920,6 +926,13 @@ async def search_audit_logs(
             # Query the `.keyword` subfield: under ES dynamic mapping these are
             # `text` + `.keyword`, and the analyzed `text` field would never
             # match a value containing uppercase or `-`/`_`/`/`.
+            #
+            # NOTE: a leading wildcard cannot use the index and forces a scan of
+            # all terms in the segment. That is acceptable for typical audit
+            # volumes, but on a large index deployments should install an index
+            # template mapping these fields to the `wildcard` type (ES >= 7.9),
+            # or to `text` with an ngram analyzer, which makes this pattern
+            # index-accelerated without changing the query semantics.
             filter_clauses.append(
                 {
                     "wildcard": {

--- a/xinference/api/routers/admin.py
+++ b/xinference/api/routers/admin.py
@@ -738,6 +738,20 @@ def _escape_es_wildcard(value: str) -> str:
     return value.replace("\\", "\\\\").replace("*", "\\*").replace("?", "\\?")
 
 
+def _es_substring_clause(field_name: str, value: str) -> dict[str, Any]:
+    """Build a substring query compatible with common ES string mappings."""
+    pattern = f"*{_escape_es_wildcard(value)}*"
+    return {
+        "bool": {
+            "should": [
+                {"wildcard": {field: {"value": pattern, "case_insensitive": True}}}
+                for field in (field_name, f"{field_name}.keyword")
+            ],
+            "minimum_should_match": 1,
+        }
+    }
+
+
 def _match_substring(stored: Any, needle: str) -> bool:
     """Case-insensitive substring match used by audit free-text filters.
 
@@ -923,26 +937,17 @@ async def search_audit_logs(
     ]:
         if value:
             # Substring, case-insensitive, to match the file-mode semantics.
-            # Query the `.keyword` subfield: under ES dynamic mapping these are
-            # `text` + `.keyword`, and the analyzed `text` field would never
-            # match a value containing uppercase or `-`/`_`/`/`.
+            # Dynamic mapping commonly creates `text` + `.keyword`, while an
+            # index template may map the field directly as `keyword` or
+            # `wildcard`. Query both names so either mapping works. An unmapped
+            # alternative simply contributes no match.
             #
             # NOTE: a leading wildcard cannot use the index and forces a scan of
             # all terms in the segment. That is acceptable for typical audit
             # volumes, but on a large index deployments should install an index
-            # template mapping these fields to the `wildcard` type (ES >= 7.9),
-            # or to `text` with an ngram analyzer, which makes this pattern
-            # index-accelerated without changing the query semantics.
-            filter_clauses.append(
-                {
-                    "wildcard": {
-                        f"{field_name}.keyword": {
-                            "value": f"*{_escape_es_wildcard(value)}*",
-                            "case_insensitive": True,
-                        }
-                    }
-                }
-            )
+            # template mapping these fields directly to the `wildcard` type
+            # (ES >= 7.9), which is covered by the first alternative.
+            filter_clauses.append(_es_substring_clause(field_name, value))
 
     for field_name, value in [
         ("model_type", model_type),

--- a/xinference/api/tests/test_audit_search_filters.py
+++ b/xinference/api/tests/test_audit_search_filters.py
@@ -156,6 +156,11 @@ async def test_malformed_entry_does_not_break_search(tmp_path, monkeypatch):
         # non-string values previously raised AttributeError -> HTTP 500
         json.dumps({"@timestamp": "2026-08-03T16:00:00.000Z", "status": 500}),
         json.dumps({"@timestamp": "2026-08-03T16:00:00.000Z", "model_id": None}),
+        # valid JSON that is not an object: `entry.get(...)` would raise
+        "null",
+        "[1, 2, 3]",
+        '"a bare string"',
+        "42",
     ]
     (log_dir / "audit.log").write_text("\n".join(lines) + "\n", encoding="utf-8")
     monkeypatch.setattr("xinference.constants.XINFERENCE_LOG_DIR", str(log_dir))
@@ -164,6 +169,13 @@ async def test_malformed_entry_does_not_break_search(tmp_path, monkeypatch):
     assert data["total"] == 1
     data = await _search(log_dir / "audit.log", status="success")
     assert data["total"] == 1
+
+    # Also exercise the unfiltered path, which reads `@timestamp` off every
+    # entry and so trips over non-object lines regardless of any filter.
+    data = await _search(log_dir / "audit.log")
+    assert [h["model_id"] for h in data["hits"] if h.get("model_id")] == [
+        "SenseVoiceSmall"
+    ]
 
 
 @pytest.mark.asyncio

--- a/xinference/api/tests/test_audit_search_filters.py
+++ b/xinference/api/tests/test_audit_search_filters.py
@@ -1,0 +1,222 @@
+# Copyright 2022-2026 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from typing import Any, Dict, List
+
+import pytest
+
+from ..routers.admin import _search_audit_from_file, search_audit_logs
+
+ENTRIES: List[Dict[str, Any]] = [
+    {
+        "@timestamp": "2026-08-03T16:24:16.000Z",
+        "user": "admin",
+        "api_key_name": "robot",
+        "model_id": "SenseVoiceSmall",
+        "model_name": "SenseVoiceSmall",
+        "model_type": "audio",
+        "endpoint": "/v1/audio/transcriptions",
+        "status": "success",
+        "category": "inference",
+        "auth_type": "api_key",
+        "client_ip": "117.61.88.85",
+    },
+    {
+        "@timestamp": "2026-08-03T16:24:15.000Z",
+        "user": "alice",
+        "api_key_name": "laptop",
+        "model_id": "qwen2.5-instruct-abc123",
+        "model_name": "qwen2.5-instruct",
+        "model_type": "llm",
+        "endpoint": "/v1/chat/completions",
+        "status": "error",
+        "category": "inference",
+        "auth_type": "bearer",
+        "client_ip": "10.0.0.7",
+    },
+]
+
+
+async def _search(audit_path, **kwargs) -> Dict[str, Any]:
+    params: Dict[str, Any] = dict(
+        time_from="",
+        time_to="",
+        user="",
+        api_key_name="",
+        model_id="",
+        model_name="",
+        model_type="",
+        category="",
+        auth_type="",
+        status="",
+        client_ip="",
+        page_from=0,
+        size=50,
+    )
+    params.update(kwargs)
+    resp = await _search_audit_from_file(**params)
+    return json.loads(resp.body)
+
+
+@pytest.fixture
+def audit_log(tmp_path, monkeypatch):
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    path = log_dir / "audit.log"
+    path.write_text(
+        "\n".join(json.dumps(e, ensure_ascii=False) for e in ENTRIES) + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("xinference.constants.XINFERENCE_LOG_DIR", str(log_dir))
+    monkeypatch.delenv("XINFERENCE_ES_URL", raising=False)
+    return path
+
+
+@pytest.mark.asyncio
+async def test_no_filter_returns_all(audit_log):
+    data = await _search(audit_log)
+    assert data["total"] == 2
+
+
+@pytest.mark.parametrize(
+    "field, needle",
+    [
+        # The exact case reported in the issue: a single-character prefix.
+        ("model_id", "S"),
+        ("model_name", "S"),
+        ("model_id", "SenseVoice"),
+        ("model_name", "sensevoicesmall"),  # case-insensitive
+        ("model_id", "voice"),  # mid-string substring
+        ("user", "adm"),
+        ("api_key_name", "rob"),
+        ("client_ip", "117.61"),  # IP prefix
+    ],
+)
+@pytest.mark.asyncio
+async def test_partial_text_filters_match(audit_log, field, needle):
+    """A partial value must surface the matching record instead of nothing.
+
+    Other records may legitimately also match (e.g. a case-insensitive "S"
+    also hits the "s" in "qwen2.5-instruct"), so assert on inclusion.
+    """
+    data = await _search(audit_log, **{field: needle})
+    assert data["total"] >= 1, f"{field}={needle!r} should match SenseVoiceSmall"
+    assert "SenseVoiceSmall" in [h["model_id"] for h in data["hits"]]
+
+
+@pytest.mark.asyncio
+async def test_exact_value_still_matches(audit_log):
+    data = await _search(audit_log, model_id="SenseVoiceSmall")
+    assert data["total"] == 1
+
+
+@pytest.mark.asyncio
+async def test_non_matching_text_filter_returns_nothing(audit_log):
+    data = await _search(audit_log, model_id="does-not-exist")
+    assert data["total"] == 0
+    assert data["hits"] == []
+
+
+@pytest.mark.asyncio
+async def test_text_filters_are_combined_with_and(audit_log):
+    data = await _search(audit_log, user="admin", model_id="qwen")
+    assert data["total"] == 0
+
+
+@pytest.mark.asyncio
+async def test_enum_filters_remain_exact(audit_log):
+    # `llm` must not match via substring against some longer stored value,
+    # and the dropdown value is matched case-insensitively.
+    assert (await _search(audit_log, model_type="llm"))["total"] == 1
+    assert (await _search(audit_log, model_type="LLM"))["total"] == 1
+    assert (await _search(audit_log, model_type="l"))["total"] == 0
+    assert (await _search(audit_log, status="success"))["total"] == 1
+    assert (await _search(audit_log, model_type="llm,audio"))["total"] == 2
+
+
+@pytest.mark.asyncio
+async def test_malformed_entry_does_not_break_search(tmp_path, monkeypatch):
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    lines = [
+        json.dumps(ENTRIES[0]),
+        "not json at all",
+        # non-string values previously raised AttributeError -> HTTP 500
+        json.dumps({"@timestamp": "2026-08-03T16:00:00.000Z", "status": 500}),
+        json.dumps({"@timestamp": "2026-08-03T16:00:00.000Z", "model_id": None}),
+    ]
+    (log_dir / "audit.log").write_text("\n".join(lines) + "\n", encoding="utf-8")
+    monkeypatch.setattr("xinference.constants.XINFERENCE_LOG_DIR", str(log_dir))
+
+    data = await _search(log_dir / "audit.log", model_id="Sense")
+    assert data["total"] == 1
+    data = await _search(log_dir / "audit.log", status="success")
+    assert data["total"] == 1
+
+
+@pytest.mark.asyncio
+async def test_missing_log_file_returns_empty(tmp_path, monkeypatch):
+    monkeypatch.setattr("xinference.constants.XINFERENCE_LOG_DIR", str(tmp_path))
+    data = await _search(tmp_path / "audit.log")
+    assert data == {"hits": [], "total": 0}
+
+
+@pytest.mark.asyncio
+async def test_es_mode_uses_case_insensitive_wildcard(monkeypatch):
+    """ES mode must use substring semantics on the `.keyword` subfield.
+
+    A `term` query against the analyzed `text` field never matches a value
+    containing uppercase or `-`/`_`/`/`.
+    """
+    captured: Dict[str, Any] = {}
+
+    class _FakeResponse:
+        status = 200
+
+        async def json(self):
+            return {"hits": {"hits": [], "total": {"value": 0}}}
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+    class _FakeSession:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def post(self, url, json=None, headers=None):
+            captured["body"] = json
+            return _FakeResponse()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+    monkeypatch.setenv("XINFERENCE_ES_URL", "http://localhost:9200")
+    monkeypatch.setattr("aiohttp.ClientSession", _FakeSession)
+
+    await search_audit_logs(model_id="Sense*Voice")
+
+    clauses = captured["body"]["query"]["bool"]["filter"]
+    wildcards = [c["wildcard"] for c in clauses if "wildcard" in c]
+    assert len(wildcards) == 1
+    clause = wildcards[0]["model_id.keyword"]
+    assert clause["case_insensitive"] is True
+    # user-typed `*` is escaped rather than treated as a wildcard
+    assert clause["value"] == r"*Sense\*Voice*"

--- a/xinference/api/tests/test_audit_search_filters.py
+++ b/xinference/api/tests/test_audit_search_filters.py
@@ -187,10 +187,10 @@ async def test_missing_log_file_returns_empty(tmp_path, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_es_mode_uses_case_insensitive_wildcard(monkeypatch):
-    """ES mode must use substring semantics on the `.keyword` subfield.
+    """ES mode must support dynamic and explicitly mapped string fields.
 
-    A `term` query against the analyzed `text` field never matches a value
-    containing uppercase or `-`/`_`/`/`.
+    Dynamic mapping creates `text` + `.keyword`, while index templates commonly
+    map audit fields directly as `keyword` or `wildcard`.
     """
     captured: Dict[str, Any] = {}
 
@@ -226,9 +226,18 @@ async def test_es_mode_uses_case_insensitive_wildcard(monkeypatch):
     await search_audit_logs(model_id="Sense*Voice")
 
     clauses = captured["body"]["query"]["bool"]["filter"]
-    wildcards = [c["wildcard"] for c in clauses if "wildcard" in c]
-    assert len(wildcards) == 1
-    clause = wildcards[0]["model_id.keyword"]
-    assert clause["case_insensitive"] is True
-    # user-typed `*` is escaped rather than treated as a wildcard
-    assert clause["value"] == r"*Sense\*Voice*"
+    substring_clauses = [c["bool"] for c in clauses if "bool" in c]
+    assert len(substring_clauses) == 1
+    substring_clause = substring_clauses[0]
+    assert substring_clause["minimum_should_match"] == 1
+
+    wildcards = [c["wildcard"] for c in substring_clause["should"]]
+    assert [next(iter(clause)) for clause in wildcards] == [
+        "model_id",
+        "model_id.keyword",
+    ]
+    for clause in wildcards:
+        query = next(iter(clause.values()))
+        assert query["case_insensitive"] is True
+        # user-typed `*` is escaped rather than treated as a wildcard
+        assert query["value"] == r"*Sense\*Voice*"


### PR DESCRIPTION
Closes #5275

## Problem

In the Audit Center, filtering by **Model ID** or **Model Name** returned an empty table even when matching records were plainly visible, as reported in the issue.

The five free-text filters (user, API key name, model ID, model name, client IP) compared for **exact equality**, but the UI re-queries on every keystroke (500ms debounce). Typing `S` sent `model_id=S`, which never equals `SenseVoiceSmall`, so the table emptied out. The filter only worked if you typed the value character-perfectly — which reads as completely broken.

## Changes

`xinference/api/routers/admin.py`

1. **File mode** (`_search_audit_from_file`) — the five free-text fields now match as case-insensitive substrings. The dropdown-backed fields (status, category, model_type, auth_type) keep exact matching, since substring matching there would let `llm` match unintended values.

2. **ES mode** (`XINFERENCE_ES_URL` set) — was `{"term": {field: value}}`, which was broken independently of the reported issue. No index template ships with the project, so ES dynamic mapping makes these fields `text` + `.keyword`, and a `term` query against the analyzed `text` field never matches a value containing uppercase or `-`/`_`/`/`. Even an exact `SenseVoiceSmall` returned nothing. Now a `case_insensitive` wildcard against the `.keyword` subfield, matching file-mode semantics. User-typed `*` and `?` are escaped so they aren't silently reinterpreted as wildcards.

3. Both helpers type-check the stored value, which also fixes a latent **HTTP 500**: a record with a non-string `status`/`category`/`model_type`/`auth_type` raised `AttributeError` on `.lower()`, uncaught by the surrounding `except OSError`.

No frontend change is needed — it already sends the correct parameter names.

## Testing

New `xinference/api/tests/test_audit_search_filters.py` (16 tests) covers the literal issue repro (`model_id=S`, `model_name=S`), case-insensitivity, mid-string matches, AND-combination across filters, exactness of the enum filters, malformed log lines, and the ES query body shape.

- Verified **10 fail before the fix, all 16 pass after**, so the tests aren't vacuous.
- `test_admin.py` + `test_admin_route_input_validation.py`: pass (37 passed, 1 skipped in total).
- `pre-commit` (black, flake8, isort, mypy, codespell): clean.

## Notes for reviewers

Two adjacent issues found while tracing this, left out to keep the fix scoped — happy to address in a follow-up:

- **Model Name is stored empty for many records.** `resolve_model_info` reads an in-process cache populated only by `list_models()`/`launch_model` on the supervisor's API process, so after a restart it writes `model_name: ""`. Substring matching can't rescue a field that was never stored.
- **Model ID holds two different kinds of value.** The auth path stores the client's raw `model` request string; the REST path stores the resolved UID. The input placeholder says "Model UID", which is only correct for one of them.