### PR TITLE
FIX: log and retry supervisor connection during worker startup

### DIFF
--- a/xinference/client/restful/restful_client.py
+++ b/xinference/client/restful/restful_client.py
@@ -31,6 +31,11 @@ if TYPE_CHECKING:
         VideoList,
     )
 
+# (connect, read) timeout for quick metadata endpoints such as
+# /v1/cluster/auth and /v1/address, which reply immediately on a healthy
+# server. Inference requests are deliberately left without a timeout.
+_METADATA_REQUEST_TIMEOUT = (10, 30)
+
 
 def _get_error_string(response: requests.Response) -> str:
     try:
@@ -1113,7 +1118,9 @@ class Client:
 
     def _check_cluster_authenticated(self):
         url = f"{self.base_url}/v1/cluster/auth"
-        response = self.session.get(url)
+        # Lightweight metadata endpoint queried on every client construction;
+        # bound it so an unresponsive server cannot hang callers indefinitely.
+        response = self.session.get(url, timeout=_METADATA_REQUEST_TIMEOUT)
         # compatible with old version of xinference
         if response.status_code == 404:
             self._cluster_authed = False
@@ -1444,7 +1451,9 @@ class Client:
 
     def _get_supervisor_internal_address(self):
         url = f"{self.base_url}/v1/address"
-        response = self.session.get(url, headers=self._headers)
+        response = self.session.get(
+            url, headers=self._headers, timeout=_METADATA_REQUEST_TIMEOUT
+        )
         if response.status_code != 200:
             raise RuntimeError("Failed to get supervisor internal address")
         response_data = response.json()

--- a/xinference/deploy/cmdline.py
+++ b/xinference/deploy/cmdline.py
@@ -55,6 +55,57 @@ try:
 except ImportError:
     pass
 
+logger = logging.getLogger(__name__)
+
+# How long a starting worker waits for the supervisor REST endpoint to become
+# reachable before giving up: 60 attempts * 5 seconds = 5 minutes.
+_SUPERVISOR_CONNECT_MAX_ATTEMPTS = 60
+_SUPERVISOR_CONNECT_RETRY_INTERVAL = 5.0
+
+
+def _resolve_supervisor_internal_address(
+    endpoint: str,
+    max_attempts: Optional[int] = None,
+    retry_interval: Optional[float] = None,
+) -> str:
+    """Resolve the supervisor's internal actor address via its REST API.
+
+    A worker cannot join the cluster until the supervisor is reachable. This
+    is the first network operation a worker performs, so instead of crashing
+    (or hanging) before emitting any log line, retry with explicit warnings
+    until the supervisor responds or ``max_attempts`` is exhausted.
+    """
+    if max_attempts is None:
+        max_attempts = _SUPERVISOR_CONNECT_MAX_ATTEMPTS
+    if retry_interval is None:
+        retry_interval = _SUPERVISOR_CONNECT_RETRY_INTERVAL
+    for attempt in range(1, max_attempts + 1):
+        try:
+            client = RESTfulClient(base_url=endpoint)
+            return client._get_supervisor_internal_address()
+        except Exception as e:
+            if attempt >= max_attempts:
+                logger.error(
+                    "Failed to connect to supervisor at %s after %d attempts. "
+                    "Please check that the supervisor is running and that the "
+                    "-e/--endpoint value is correct.",
+                    endpoint,
+                    attempt,
+                )
+                raise
+            logger.warning(
+                "Supervisor at %s is not ready (%s: %s), "
+                "retrying in %.0f seconds (attempt %d/%d)",
+                endpoint,
+                type(e).__name__,
+                e,
+                retry_interval,
+                attempt,
+                max_attempts,
+            )
+            time.sleep(retry_interval)
+    raise RuntimeError("unreachable")  # pragma: no cover
+
 
 def get_endpoint(endpoint: Optional[str]) -> str:
     # user didn't specify the endpoint.
@@ -345,8 +396,11 @@ def worker(
 
     endpoint = get_endpoint(endpoint)
 
-    client = RESTfulClient(base_url=endpoint)
-    supervisor_internal_addr = client._get_supervisor_internal_address()
+    logger.info(
+        "Starting Xinference worker. Supervisor endpoint: %s",
+        endpoint,
+    )
+    supervisor_internal_addr = _resolve_supervisor_internal_address(endpoint)
 
     address = f"{host}:{worker_port or get_next_port()}"
     main(

--- a/xinference/deploy/test/test_cmdline.py
+++ b/xinference/deploy/test/test_cmdline.py
@@ -311,6 +311,75 @@ def test_worker_command_passes_endpoint_and_internal_address(monkeypatch):
     assert calls["main_kwargs"]["supervisor_endpoint"] == "http://127.0.0.1:9997"
 
 
+def test_worker_command_retries_until_supervisor_ready(monkeypatch):
+    runner = CliRunner()
+    calls = {"attempts": 0}
+
+    class FlakyRESTfulClient:
+        def __init__(self, base_url):
+            calls["attempts"] += 1
+            if calls["attempts"] < 3:
+                raise ConnectionError("connection refused")
+
+        def _get_supervisor_internal_address(self):
+            return "test://supervisor-internal"
+
+    def fake_main(**kwargs):
+        calls["main_kwargs"] = kwargs
+
+    monkeypatch.setattr(cmdline_module, "RESTfulClient", FlakyRESTfulClient)
+    monkeypatch.setattr(cmdline_module.time, "sleep", lambda _: None)
+    monkeypatch.setattr("xinference.deploy.worker.main", fake_main)
+
+    result = runner.invoke(
+        worker,
+        [
+            "--endpoint",
+            "http://127.0.0.1:9997",
+            "--host",
+            "127.0.0.1",
+            "--worker-port",
+            "12345",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert calls["attempts"] == 3
+    assert calls["main_kwargs"]["supervisor_address"] == "test://supervisor-internal"
+
+
+def test_worker_command_fails_after_exhausting_retries(monkeypatch):
+    runner = CliRunner()
+    calls = {"attempts": 0}
+
+    class UnreachableRESTfulClient:
+        def __init__(self, base_url):
+            calls["attempts"] += 1
+            raise ConnectionError("connection refused")
+
+    monkeypatch.setattr(cmdline_module, "RESTfulClient", UnreachableRESTfulClient)
+    monkeypatch.setattr(cmdline_module.time, "sleep", lambda _: None)
+    monkeypatch.setattr(
+        cmdline_module, "_SUPERVISOR_CONNECT_MAX_ATTEMPTS", 4, raising=True
+    )
+
+    result = runner.invoke(
+        worker,
+        [
+            "--endpoint",
+            "http://127.0.0.1:9997",
+            "--host",
+            "127.0.0.1",
+            "--worker-port",
+            "12345",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert isinstance(result.exception, ConnectionError)
+    assert calls["attempts"] == 4
+
+
 def test_rotate_logs(setup_with_file_logging):
     endpoint, _, log_file = setup_with_file_logging
     client = Client(endpoint)


### PR DESCRIPTION
## What does this PR do?

Fixes #5268.

A starting worker's first network operation is a REST call to the supervisor (`RESTfulClient.__init__` -> `/v1/cluster/auth`, then `/v1/address`), performed **before any first-party log line is emitted, with no timeout and no retry**. When the supervisor endpoint is unreachable, the worker process dies (or hangs) showing nothing but third-party import noise, e.g.:

```
Failed to load .../torchao/_C_cutlass_90a.abi3.so: ...
W0801 11:05:03 ... torch/utils/_pytree.py:630 ...
```

With `restart: always` in docker compose this becomes a silent crash loop, which is exactly the log signature reported in #5268 (repeated torchao import noise, no worker logs). I reproduced both directions on the `v3.1.0-cpu` image:

- Clean environment (supervisor reachable): worker starts normally, so the image itself is fine.
- Unreachable / refused endpoint: worker crashes before its first log line, then restart-loops.

## Changes

- `xinference/deploy/cmdline.py`: log the supervisor endpoint immediately after logging is configured, and resolve the supervisor internal address through a retry loop (5s interval, up to 5 minutes) with explicit warnings carrying the endpoint, the error, and the attempt count. Workers now survive the common "supervisor not up yet" race and join automatically once it becomes reachable; after the retry budget is exhausted the original exception is re-raised with an actionable error message.
- `xinference/client/restful/restful_client.py`: bound the `/v1/cluster/auth` and `/v1/address` metadata GETs with a `(10, 30)` connect/read timeout so an endpoint that accepts TCP but never responds cannot hang client construction indefinitely. Inference requests are deliberately left untouched.
- `xinference/deploy/test/test_cmdline.py`: tests covering retry-then-success and retry-exhaustion.

## Verification

- `pytest xinference/deploy/test/test_cmdline.py -k worker_command` (3 passed).
- `pre-commit run` on the modified files (all hooks passed).
- End-to-end on the `v3.1.0-cpu` Docker image with the patched files mounted in:
  - worker pointed at a dead endpoint now logs `Starting Xinference worker. Supervisor endpoint: ...` followed by `Supervisor at ... is not ready (ConnectionError: ...), retrying in 5 seconds (attempt 1/60)` instead of dying silently;
  - starting the supervisor while the worker was retrying resulted in the worker connecting and reaching `Xinference worker ... started` without a container restart.

Not run: full CI-style test suite (model tests require GPU/network); left to CI.