### PR TITLE
feat: PDF input support for the OCR API

### DIFF
--- a/doc/source/models/model_abilities/image.rst
+++ b/doc/source/models/model_abilities/image.rst
@@ -352,7 +352,7 @@ For example, using ``4steps-V1.0``, the inference time is reduced from the origi
 OCR
 --------------------
 
-The OCR API accepts image bytes and returns the OCR text.
+The OCR API accepts image or PDF bytes and returns the OCR text.
 
 We can try OCR API out either via cURL, or Xinference's python client:
 
@@ -381,3 +381,23 @@ We can try OCR API out either via cURL, or Xinference's python client:
   .. code-tab:: text output
 
     <OCR result string>
+
+PDF uploads are rasterized page by page (requires ``pypdfium2``, included in the
+``image`` extra), OCR runs on each page, and the results are merged:
+
+* When the model returns plain text, the page texts are joined with blank lines
+  and the response stays a single string, same as for an image.
+* When the model returns structured results (e.g. with ``return_dict`` style
+  options), the response is ``{"pages": [{"page": 1, "result": ...}, ...]}``.
+
+Two optional PDF-only ``kwargs`` fields are supported: ``pages`` (a 1-based page
+number or list of page numbers to OCR, defaults to all pages) and ``dpi`` (the
+rasterization resolution, defaults to 200):
+
+.. code-block:: bash
+
+    curl -X 'POST' \
+      'http://<XINFERENCE_HOST>:<XINFERENCE_PORT>/v1/images/ocr' \
+      -F model=<MODEL_UID> \
+      -F 'kwargs={"pages": [1, 2], "dpi": 300}' \
+      -F image=@xxx.pdf

--- a/doc/source/models/model_abilities/image.rst
+++ b/doc/source/models/model_abilities/image.rst
@@ -392,7 +392,10 @@ PDF uploads are rasterized page by page (requires ``pypdfium2``, included in the
 
 Two optional PDF-only ``kwargs`` fields are supported: ``pages`` (a 1-based page
 number or list of page numbers to OCR, defaults to all pages) and ``dpi`` (the
-rasterization resolution, defaults to 200):
+rasterization resolution, defaults to 200, capped at 600). Pages are rasterized
+one at a time to keep memory usage flat; at most 200 pages can be OCRed per
+request (use ``pages`` to select a subset of larger documents), and a page whose
+raster would exceed 80 megapixels is rejected — lower ``dpi`` in that case:
 
 .. code-block:: bash
 

--- a/frontend/src/components/pages/running-model-detail/panels/form-panels.tsx
+++ b/frontend/src/components/pages/running-model-detail/panels/form-panels.tsx
@@ -218,9 +218,9 @@ export function OcrPanel() {
     <>
       <FormField name="image" rules={[{ required: true }]}>
         <FileUpload
-          accept="image/*"
-          label="Upload image"
-          description="PNG, JPG, WebP or scanned page"
+          accept="image/*,application/pdf"
+          label="Upload image or PDF"
+          description="PNG, JPG, WebP, scanned page or PDF document"
         />
       </FormField>
       <div className="grid grid-cols-2 gap-3">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,7 @@ dev = [
     "langchain-openai",
     "sphinx-tabs",
     "sphinx-design",
+    "pypdfium2",  # For PDF OCR tests
 ]
 otel = [
     "opentelemetry-api>=1.20.0",
@@ -194,6 +195,7 @@ image = [
     "torch",  # For got_ocr2
     "torchvision",  # For got_ocr2
     "gguf",  # For flux and sd3.5 series
+    "pypdfium2",  # For PDF input on the OCR API
 ]
 video = [
     "diffusers>=0.32.0",

--- a/xinference/api/pdf_ocr.py
+++ b/xinference/api/pdf_ocr.py
@@ -21,7 +21,14 @@ JSON-serializable response body.
 """
 
 import json
+import threading
 from typing import Any, Generator, List, Optional, Tuple, Union
+
+# PDFium is not thread-safe: pypdfium2 documents that concurrent calls,
+# even on different documents, may crash or corrupt the process. Every
+# PDFium operation in this module (document open, page access, rendering,
+# close) must hold this lock; model OCR calls happen outside it.
+_pdfium_lock = threading.Lock()
 
 PDF_MAGIC = b"%PDF"
 DEFAULT_PDF_OCR_DPI = 200
@@ -84,6 +91,10 @@ def rasterize_pdf(
     OCR runs; rendering itself is lazy so only one page's pixels are
     alive at a time. The caller must exhaust or ``close()`` the iterator
     to release the underlying document.
+
+    Safe to call from multiple threads: all PDFium operations are
+    serialized on a module-level lock (PDFium itself is not
+    thread-safe), which is released between pages while OCR runs.
     """
     try:
         import pypdfium2 as pdfium
@@ -99,47 +110,53 @@ def rasterize_pdf(
     dpi = min(float(dpi), float(MAX_PDF_OCR_DPI))
     scale = dpi / 72.0
 
-    pdf = pdfium.PdfDocument(data)
-    try:
-        page_numbers = normalize_pages(pages, len(pdf))
-        if len(page_numbers) > MAX_PDF_OCR_PAGES:
-            raise ValueError(
-                f"{len(page_numbers)} pages selected, at most "
-                f"{MAX_PDF_OCR_PAGES} pages can be OCRed per request; "
-                "use `pages` to select a subset"
-            )
-        for page_number in page_numbers:
-            page = pdf[page_number - 1]
-            try:
-                width, height = page.get_size()
-            finally:
-                page.close()
-            pixels = int(width * scale) * int(height * scale)
-            if pixels > MAX_PDF_OCR_PAGE_PIXELS:
+    with _pdfium_lock:
+        pdf = pdfium.PdfDocument(data)
+        try:
+            page_numbers = normalize_pages(pages, len(pdf))
+            if len(page_numbers) > MAX_PDF_OCR_PAGES:
                 raise ValueError(
-                    f"Page {page_number} would rasterize to {pixels} pixels "
-                    f"at {dpi:g} DPI, exceeding the limit of "
-                    f"{MAX_PDF_OCR_PAGE_PIXELS}; lower `dpi`"
+                    f"{len(page_numbers)} pages selected, at most "
+                    f"{MAX_PDF_OCR_PAGES} pages can be OCRed per request; "
+                    "use `pages` to select a subset"
                 )
-    except Exception:
-        pdf.close()
-        raise
+            for page_number in page_numbers:
+                page = pdf[page_number - 1]
+                try:
+                    width, height = page.get_size()
+                finally:
+                    page.close()
+                pixels = int(width * scale) * int(height * scale)
+                if pixels > MAX_PDF_OCR_PAGE_PIXELS:
+                    raise ValueError(
+                        f"Page {page_number} would rasterize to {pixels} pixels "
+                        f"at {dpi:g} DPI, exceeding the limit of "
+                        f"{MAX_PDF_OCR_PAGE_PIXELS}; lower `dpi`"
+                    )
+        except Exception:
+            pdf.close()
+            raise
 
     def _render() -> Generator[Tuple[int, Any], None, None]:
         try:
             for page_number in page_numbers:
-                page = pdf[page_number - 1]
-                try:
-                    bitmap = page.render(scale=scale)
+                # hold the lock only while PDFium renders; it is released
+                # at the yield so OCR on this page can overlap with other
+                # requests' PDFium work
+                with _pdfium_lock:
+                    page = pdf[page_number - 1]
                     try:
-                        image = bitmap.to_pil()
+                        bitmap = page.render(scale=scale)
+                        try:
+                            image = bitmap.to_pil()
+                        finally:
+                            bitmap.close()
                     finally:
-                        bitmap.close()
-                finally:
-                    page.close()
+                        page.close()
                 yield page_number, image
         finally:
-            pdf.close()
+            with _pdfium_lock:
+                pdf.close()
 
     return _render()
 

--- a/xinference/api/pdf_ocr.py
+++ b/xinference/api/pdf_ocr.py
@@ -1,0 +1,128 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Helpers for PDF input on the ``/v1/images/ocr`` endpoint.
+
+OCR models consume a single PIL image, so PDF uploads are rasterized
+page by page and the per-page OCR results are merged back into one
+JSON-serializable response body.
+"""
+
+import json
+from typing import Any, List, Optional, Tuple, Union
+
+PDF_MAGIC = b"%PDF"
+DEFAULT_PDF_OCR_DPI = 200
+# Rasterizing above this resolution rarely helps OCR quality but can
+# exhaust memory on large pages.
+MAX_PDF_OCR_DPI = 600
+
+
+def is_pdf_upload(content_type: Optional[str], head: bytes) -> bool:
+    """Detect a PDF upload by content type or ``%PDF`` magic bytes."""
+    if content_type and content_type.split(";")[0].strip() == "application/pdf":
+        return True
+    return head.startswith(PDF_MAGIC)
+
+
+def normalize_pages(
+    pages: Optional[Union[int, List[int]]], page_count: int
+) -> List[int]:
+    """Validate the ``pages`` kwarg and return 1-based page numbers.
+
+    ``None`` selects all pages.
+    """
+    if pages is None:
+        return list(range(1, page_count + 1))
+    if isinstance(pages, int) and not isinstance(pages, bool):
+        pages = [pages]
+    if (
+        not isinstance(pages, (list, tuple))
+        or not pages
+        or not all(isinstance(p, int) and not isinstance(p, bool) for p in pages)
+    ):
+        raise ValueError(
+            "`pages` must be a 1-based page number or a non-empty list of "
+            f"1-based page numbers, got: {pages!r}"
+        )
+    for p in pages:
+        if p < 1 or p > page_count:
+            raise ValueError(
+                f"Page {p} is out of range, the PDF has {page_count} page(s)"
+            )
+    return list(pages)
+
+
+def rasterize_pdf(
+    data: bytes,
+    pages: Optional[Union[int, List[int]]] = None,
+    dpi: Union[int, float] = DEFAULT_PDF_OCR_DPI,
+) -> List[Tuple[int, Any]]:
+    """Rasterize a PDF into PIL images.
+
+    Returns a list of ``(page_number, PIL.Image)`` tuples, page numbers
+    being 1-based.
+    """
+    try:
+        import pypdfium2 as pdfium
+    except ImportError:
+        error_message = "Failed to import module 'pypdfium2' required for PDF OCR"
+        installation_guide = [
+            "Please make sure 'pypdfium2' is installed, e.g. with `pip install pypdfium2`\n",
+        ]
+        raise ImportError(f"{error_message}\n\n{''.join(installation_guide)}")
+
+    if not isinstance(dpi, (int, float)) or isinstance(dpi, bool) or dpi <= 0:
+        raise ValueError(f"`dpi` must be a positive number, got: {dpi!r}")
+    dpi = min(float(dpi), float(MAX_PDF_OCR_DPI))
+
+    pdf = pdfium.PdfDocument(data)
+    try:
+        page_numbers = normalize_pages(pages, len(pdf))
+        images = []
+        for page_number in page_numbers:
+            page = pdf[page_number - 1]
+            try:
+                bitmap = page.render(scale=dpi / 72.0)
+                try:
+                    images.append((page_number, bitmap.to_pil()))
+                finally:
+                    bitmap.close()
+            finally:
+                page.close()
+        return images
+    finally:
+        pdf.close()
+
+
+def merge_ocr_page_results(page_results: List[Tuple[int, Any]]) -> str:
+    """Merge per-page OCR results into one JSON response body.
+
+    When every page yields plain text, the texts are joined so the
+    response stays a JSON string like the single-image contract.
+    Otherwise (e.g. ``return_dict=True`` style models) a per-page
+    structure is returned. Either way the body parses with
+    ``response.json()``.
+    """
+    if all(isinstance(result, str) for _, result in page_results):
+        joined = "\n\n".join(result for _, result in page_results)
+        return json.dumps(joined, ensure_ascii=False)
+    merged = {
+        "pages": [
+            {"page": page_number, "result": result}
+            for page_number, result in page_results
+        ]
+    }
+    return json.dumps(merged, ensure_ascii=False)

--- a/xinference/api/pdf_ocr.py
+++ b/xinference/api/pdf_ocr.py
@@ -21,13 +21,19 @@ JSON-serializable response body.
 """
 
 import json
-from typing import Any, List, Optional, Tuple, Union
+from typing import Any, Generator, List, Optional, Tuple, Union
 
 PDF_MAGIC = b"%PDF"
 DEFAULT_PDF_OCR_DPI = 200
 # Rasterizing above this resolution rarely helps OCR quality but can
 # exhaust memory on large pages.
 MAX_PDF_OCR_DPI = 600
+# One request OCRs at most this many pages.
+MAX_PDF_OCR_PAGES = 200
+# A page whose raster would exceed this many pixels (~240 MB of RGB
+# pixels; an A3 page at 600 DPI is ~70 MP) is rejected so a single
+# oversized page cannot exhaust the API process.
+MAX_PDF_OCR_PAGE_PIXELS = 80_000_000
 
 
 def is_pdf_upload(content_type: Optional[str], head: bytes) -> bool:
@@ -69,11 +75,15 @@ def rasterize_pdf(
     data: bytes,
     pages: Optional[Union[int, List[int]]] = None,
     dpi: Union[int, float] = DEFAULT_PDF_OCR_DPI,
-) -> List[Tuple[int, Any]]:
-    """Rasterize a PDF into PIL images.
+) -> Generator[Tuple[int, Any], None, None]:
+    """Rasterize a PDF into PIL images, one page at a time.
 
-    Returns a list of ``(page_number, PIL.Image)`` tuples, page numbers
-    being 1-based.
+    Returns an iterator of ``(page_number, PIL.Image)`` tuples, page
+    numbers being 1-based. Page selection and page sizes are validated
+    eagerly (raising ``ValueError``) so invalid requests fail before any
+    OCR runs; rendering itself is lazy so only one page's pixels are
+    alive at a time. The caller must exhaust or ``close()`` the iterator
+    to release the underlying document.
     """
     try:
         import pypdfium2 as pdfium
@@ -87,24 +97,51 @@ def rasterize_pdf(
     if not isinstance(dpi, (int, float)) or isinstance(dpi, bool) or dpi <= 0:
         raise ValueError(f"`dpi` must be a positive number, got: {dpi!r}")
     dpi = min(float(dpi), float(MAX_PDF_OCR_DPI))
+    scale = dpi / 72.0
 
     pdf = pdfium.PdfDocument(data)
     try:
         page_numbers = normalize_pages(pages, len(pdf))
-        images = []
+        if len(page_numbers) > MAX_PDF_OCR_PAGES:
+            raise ValueError(
+                f"{len(page_numbers)} pages selected, at most "
+                f"{MAX_PDF_OCR_PAGES} pages can be OCRed per request; "
+                "use `pages` to select a subset"
+            )
         for page_number in page_numbers:
             page = pdf[page_number - 1]
             try:
-                bitmap = page.render(scale=dpi / 72.0)
-                try:
-                    images.append((page_number, bitmap.to_pil()))
-                finally:
-                    bitmap.close()
+                width, height = page.get_size()
             finally:
                 page.close()
-        return images
-    finally:
+            pixels = int(width * scale) * int(height * scale)
+            if pixels > MAX_PDF_OCR_PAGE_PIXELS:
+                raise ValueError(
+                    f"Page {page_number} would rasterize to {pixels} pixels "
+                    f"at {dpi:g} DPI, exceeding the limit of "
+                    f"{MAX_PDF_OCR_PAGE_PIXELS}; lower `dpi`"
+                )
+    except Exception:
         pdf.close()
+        raise
+
+    def _render() -> Generator[Tuple[int, Any], None, None]:
+        try:
+            for page_number in page_numbers:
+                page = pdf[page_number - 1]
+                try:
+                    bitmap = page.render(scale=scale)
+                    try:
+                        image = bitmap.to_pil()
+                    finally:
+                        bitmap.close()
+                finally:
+                    page.close()
+                yield page_number, image
+        finally:
+            pdf.close()
+
+    return _render()
 
 
 def merge_ocr_page_results(page_results: List[Tuple[int, Any]]) -> str:

--- a/xinference/api/restful_api.py
+++ b/xinference/api/restful_api.py
@@ -1982,18 +1982,30 @@ class RESTfulAPI(CancelMixin):
                 pages = parsed_kwargs.pop("pages", None)
                 dpi = parsed_kwargs.pop("dpi", DEFAULT_PDF_OCR_DPI)
                 try:
-                    page_images = await asyncio.to_thread(
+                    page_iter = await asyncio.to_thread(
                         rasterize_pdf, image.file.read(), pages=pages, dpi=dpi
                     )
                 except ValueError as ve:
                     raise HTTPException(status_code=400, detail=str(ve))
+                # Pages are rendered lazily, one at a time, so peak memory
+                # stays at a single page regardless of document size.
                 page_results = []
-                for page_number, page_image in page_images:
-                    result = await model_ref.ocr(
-                        image=page_image,
-                        **parsed_kwargs,
-                    )
-                    page_results.append((page_number, json.loads(result)))
+                try:
+                    while True:
+                        item = await asyncio.to_thread(next, page_iter, None)
+                        if item is None:
+                            break
+                        page_number, page_image = item
+                        try:
+                            result = await model_ref.ocr(
+                                image=page_image,
+                                **parsed_kwargs,
+                            )
+                        finally:
+                            page_image.close()
+                        page_results.append((page_number, json.loads(result)))
+                finally:
+                    page_iter.close()
                 body = merge_ocr_page_results(page_results)
                 return Response(content=body, media_type="application/json")
             im = Image.open(image.file)

--- a/xinference/api/restful_api.py
+++ b/xinference/api/restful_api.py
@@ -76,6 +76,13 @@ from ..types import (
     max_tokens_field,
 )
 from .frontend_static import mount_frontend
+from .pdf_ocr import (
+    DEFAULT_PDF_OCR_DPI,
+    PDF_MAGIC,
+    is_pdf_upload,
+    merge_ocr_page_results,
+    rasterize_pdf,
+)
 from .responses import JSONResponse
 from .schemas import (
     AutoConfigLLMRequest,
@@ -1969,17 +1976,43 @@ class RESTfulAPI(CancelMixin):
                 parsed_kwargs = {}
             request_id = parsed_kwargs.get("request_id")
             self._add_running_task(request_id)
+            head = image.file.read(len(PDF_MAGIC))
+            image.file.seek(0)
+            if is_pdf_upload(image.content_type, head):
+                pages = parsed_kwargs.pop("pages", None)
+                dpi = parsed_kwargs.pop("dpi", DEFAULT_PDF_OCR_DPI)
+                try:
+                    page_images = await asyncio.to_thread(
+                        rasterize_pdf, image.file.read(), pages=pages, dpi=dpi
+                    )
+                except ValueError as ve:
+                    raise HTTPException(status_code=400, detail=str(ve))
+                page_results = []
+                for page_number, page_image in page_images:
+                    result = await model_ref.ocr(
+                        image=page_image,
+                        **parsed_kwargs,
+                    )
+                    page_results.append((page_number, json.loads(result)))
+                body = merge_ocr_page_results(page_results)
+                return Response(content=body, media_type="application/json")
             im = Image.open(image.file)
             text = await model_ref.ocr(
                 image=im,
                 **parsed_kwargs,
             )
-            return Response(content=text, media_type="text/plain")
+            # ModelActor.ocr serializes the model's return value to JSON
+            # bytes, and both REST clients parse the body with
+            # response.json() — declaring text/plain here breaks aiohttp's
+            # content-type check on the async client.
+            return Response(content=text, media_type="application/json")
         except asyncio.CancelledError:
             err_str = f"The request has been cancelled: {request_id}"
             logger.error(err_str)
             await self._report_error_event(model_uid, err_str)
             raise HTTPException(status_code=409, detail=err_str)
+        except HTTPException:
+            raise
         except Exception as e:
             e = await self._get_model_last_error(model_ref.uid, e)
             logger.error(e, exc_info=True)

--- a/xinference/api/tests/test_ocr_pdf.py
+++ b/xinference/api/tests/test_ocr_pdf.py
@@ -191,5 +191,22 @@ class TestRasterizePdf:
         assert len(images) == 1
         images[0][1].close()
 
+    def test_concurrent_rasterization(self):
+        """PDFium is not thread-safe; the module-level lock must let
+        concurrent callers interleave safely without deadlocking."""
+        pytest.importorskip("pypdfium2")
+        from concurrent.futures import ThreadPoolExecutor
+
+        def worker(_):
+            pages = []
+            for page_number, image in rasterize_pdf(make_pdf(page_count=3)):
+                pages.append(page_number)
+                image.close()
+            return pages
+
+        with ThreadPoolExecutor(max_workers=8) as executor:
+            results = list(executor.map(worker, range(16)))
+        assert results == [[1, 2, 3]] * 16
+
     def test_pdf_magic_detected_on_generated_pdf(self):
         assert is_pdf_upload(None, make_pdf()[:8])

--- a/xinference/api/tests/test_ocr_pdf.py
+++ b/xinference/api/tests/test_ocr_pdf.py
@@ -20,6 +20,7 @@ import pytest
 
 from ..pdf_ocr import (
     DEFAULT_PDF_OCR_DPI,
+    MAX_PDF_OCR_PAGES,
     is_pdf_upload,
     merge_ocr_page_results,
     normalize_pages,
@@ -27,7 +28,7 @@ from ..pdf_ocr import (
 )
 
 
-def make_pdf(page_count: int = 1) -> bytes:
+def make_pdf(page_count: int = 1, media_box: str = "0 0 200 100") -> bytes:
     """Build a minimal valid PDF with ``page_count`` blank pages."""
     kids = " ".join(f"{3 + i} 0 R" for i in range(page_count))
     objects = [
@@ -35,7 +36,7 @@ def make_pdf(page_count: int = 1) -> bytes:
         f"<</Type /Pages /Kids [{kids}] /Count {page_count}>>".encode(),
     ]
     objects.extend(
-        b"<</Type /Page /Parent 2 0 R /MediaBox [0 0 200 100]>>"
+        f"<</Type /Page /Parent 2 0 R /MediaBox [{media_box}]>>".encode()
         for _ in range(page_count)
     )
     out = bytearray(b"%PDF-1.4\n")
@@ -124,7 +125,7 @@ class TestMergeOcrPageResults:
 class TestRasterizePdf:
     def test_all_pages(self):
         pytest.importorskip("pypdfium2")
-        images = rasterize_pdf(make_pdf(page_count=2))
+        images = list(rasterize_pdf(make_pdf(page_count=2)))
         assert [page_number for page_number, _ in images] == [1, 2]
         for _, image in images:
             # 200x100pt page at the default 200 DPI
@@ -136,7 +137,7 @@ class TestRasterizePdf:
 
     def test_page_selection_and_dpi(self):
         pytest.importorskip("pypdfium2")
-        images = rasterize_pdf(make_pdf(page_count=3), pages=[2], dpi=72)
+        images = list(rasterize_pdf(make_pdf(page_count=3), pages=[2], dpi=72))
         assert len(images) == 1
         page_number, image = images[0]
         assert page_number == 2
@@ -144,7 +145,7 @@ class TestRasterizePdf:
 
     def test_dpi_capped(self):
         pytest.importorskip("pypdfium2")
-        images = rasterize_pdf(make_pdf(), dpi=100000)
+        images = list(rasterize_pdf(make_pdf(), dpi=100000))
         _, image = images[0]
         assert image.width == round(200 * 600 / 72)
 
@@ -153,10 +154,42 @@ class TestRasterizePdf:
         with pytest.raises(ValueError, match="dpi"):
             rasterize_pdf(make_pdf(), dpi=0)
 
-    def test_invalid_pages(self):
+    def test_invalid_pages_raise_before_rendering(self):
         pytest.importorskip("pypdfium2")
+        # validation is eager: the error surfaces at call time, not on
+        # first iteration
         with pytest.raises(ValueError, match="out of range"):
             rasterize_pdf(make_pdf(page_count=2), pages=[3])
+
+    def test_rendering_is_lazy(self):
+        pytest.importorskip("pypdfium2")
+        page_iter = rasterize_pdf(make_pdf(page_count=3))
+        assert not isinstance(page_iter, (list, tuple))
+        page_number, image = next(page_iter)
+        assert page_number == 1
+        image.close()
+        page_iter.close()
+
+    def test_page_count_limit(self):
+        pytest.importorskip("pypdfium2")
+        with pytest.raises(ValueError, match="at most"):
+            rasterize_pdf(make_pdf(page_count=MAX_PDF_OCR_PAGES + 1))
+        # selecting a subset of a large document is fine
+        images = list(
+            rasterize_pdf(make_pdf(page_count=MAX_PDF_OCR_PAGES + 1), pages=[1])
+        )
+        assert len(images) == 1
+
+    def test_page_pixel_limit(self):
+        pytest.importorskip("pypdfium2")
+        # 14400x14400pt (the PDF spec maximum) is ~1.6e9 pixels at 200 DPI
+        huge = make_pdf(media_box="0 0 14400 14400")
+        with pytest.raises(ValueError, match="lower `dpi`"):
+            rasterize_pdf(huge)
+        # the same page is fine at a low enough DPI
+        images = list(rasterize_pdf(huge, dpi=20))
+        assert len(images) == 1
+        images[0][1].close()
 
     def test_pdf_magic_detected_on_generated_pdf(self):
         assert is_pdf_upload(None, make_pdf()[:8])

--- a/xinference/api/tests/test_ocr_pdf.py
+++ b/xinference/api/tests/test_ocr_pdf.py
@@ -1,0 +1,162 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for PDF input support on the ``/v1/images/ocr`` endpoint helpers."""
+
+import json
+
+import pytest
+
+from ..pdf_ocr import (
+    DEFAULT_PDF_OCR_DPI,
+    is_pdf_upload,
+    merge_ocr_page_results,
+    normalize_pages,
+    rasterize_pdf,
+)
+
+
+def make_pdf(page_count: int = 1) -> bytes:
+    """Build a minimal valid PDF with ``page_count`` blank pages."""
+    kids = " ".join(f"{3 + i} 0 R" for i in range(page_count))
+    objects = [
+        b"<</Type /Catalog /Pages 2 0 R>>",
+        f"<</Type /Pages /Kids [{kids}] /Count {page_count}>>".encode(),
+    ]
+    objects.extend(
+        b"<</Type /Page /Parent 2 0 R /MediaBox [0 0 200 100]>>"
+        for _ in range(page_count)
+    )
+    out = bytearray(b"%PDF-1.4\n")
+    offsets = []
+    for i, body in enumerate(objects, start=1):
+        offsets.append(len(out))
+        out += f"{i} 0 obj\n".encode() + body + b"\nendobj\n"
+    xref_pos = len(out)
+    out += f"xref\n0 {len(objects) + 1}\n".encode()
+    out += b"0000000000 65535 f \n"
+    for offset in offsets:
+        out += f"{offset:010d} 00000 n \n".encode()
+    out += (
+        f"trailer\n<</Size {len(objects) + 1} /Root 1 0 R>>\n"
+        f"startxref\n{xref_pos}\n%%EOF\n"
+    ).encode()
+    return bytes(out)
+
+
+class TestIsPdfUpload:
+    def test_by_content_type(self):
+        assert is_pdf_upload("application/pdf", b"")
+        assert is_pdf_upload("application/pdf; charset=binary", b"")
+
+    def test_by_magic_bytes(self):
+        assert is_pdf_upload(None, b"%PDF-1.4\n...")
+        assert is_pdf_upload("application/octet-stream", b"%PDF-1.7")
+
+    def test_negative(self):
+        assert not is_pdf_upload("image/png", b"\x89PNG\r\n\x1a\n")
+        assert not is_pdf_upload(None, b"\xff\xd8\xff\xe0")
+        assert not is_pdf_upload("application/octet-stream", b"")
+
+
+class TestNormalizePages:
+    def test_none_selects_all(self):
+        assert normalize_pages(None, 3) == [1, 2, 3]
+
+    def test_single_int(self):
+        assert normalize_pages(2, 3) == [2]
+
+    def test_list(self):
+        assert normalize_pages([3, 1], 3) == [3, 1]
+
+    def test_out_of_range(self):
+        with pytest.raises(ValueError, match="out of range"):
+            normalize_pages([4], 3)
+        with pytest.raises(ValueError, match="out of range"):
+            normalize_pages([0], 3)
+
+    def test_invalid_types(self):
+        with pytest.raises(ValueError):
+            normalize_pages("1", 3)  # type: ignore[arg-type]
+        with pytest.raises(ValueError):
+            normalize_pages([1.5], 3)  # type: ignore[list-item]
+        with pytest.raises(ValueError):
+            normalize_pages([], 3)
+        with pytest.raises(ValueError):
+            normalize_pages(True, 3)  # type: ignore[arg-type]
+
+
+class TestMergeOcrPageResults:
+    def test_all_text_joined(self):
+        body = merge_ocr_page_results([(1, "hello"), (2, "world")])
+        assert json.loads(body) == "hello\n\nworld"
+
+    def test_single_text_page_matches_image_contract(self):
+        body = merge_ocr_page_results([(1, "hello")])
+        assert json.loads(body) == "hello"
+
+    def test_dict_results_keep_page_structure(self):
+        results = [(1, {"blocks": ["a"]}), (3, {"blocks": ["b"]})]
+        body = merge_ocr_page_results(results)
+        assert json.loads(body) == {
+            "pages": [
+                {"page": 1, "result": {"blocks": ["a"]}},
+                {"page": 3, "result": {"blocks": ["b"]}},
+            ]
+        }
+
+    def test_mixed_results_keep_page_structure(self):
+        body = merge_ocr_page_results([(1, "text"), (2, {"k": "v"})])
+        assert json.loads(body)["pages"][0] == {"page": 1, "result": "text"}
+
+
+class TestRasterizePdf:
+    def test_all_pages(self):
+        pytest.importorskip("pypdfium2")
+        images = rasterize_pdf(make_pdf(page_count=2))
+        assert [page_number for page_number, _ in images] == [1, 2]
+        for _, image in images:
+            # 200x100pt page at the default 200 DPI
+            expected = (
+                round(200 * DEFAULT_PDF_OCR_DPI / 72),
+                round(100 * DEFAULT_PDF_OCR_DPI / 72),
+            )
+            assert (image.width, image.height) == expected
+
+    def test_page_selection_and_dpi(self):
+        pytest.importorskip("pypdfium2")
+        images = rasterize_pdf(make_pdf(page_count=3), pages=[2], dpi=72)
+        assert len(images) == 1
+        page_number, image = images[0]
+        assert page_number == 2
+        assert (image.width, image.height) == (200, 100)
+
+    def test_dpi_capped(self):
+        pytest.importorskip("pypdfium2")
+        images = rasterize_pdf(make_pdf(), dpi=100000)
+        _, image = images[0]
+        assert image.width == round(200 * 600 / 72)
+
+    def test_invalid_dpi(self):
+        pytest.importorskip("pypdfium2")
+        with pytest.raises(ValueError, match="dpi"):
+            rasterize_pdf(make_pdf(), dpi=0)
+
+    def test_invalid_pages(self):
+        pytest.importorskip("pypdfium2")
+        with pytest.raises(ValueError, match="out of range"):
+            rasterize_pdf(make_pdf(page_count=2), pages=[3])
+
+    def test_pdf_magic_detected_on_generated_pdf(self):
+        assert is_pdf_upload(None, make_pdf()[:8])


### PR DESCRIPTION
## What does this PR do?

Adds PDF input support to the OCR pipeline. OCR models (GOT-OCR2, DeepSeek-OCR, PaddleOCR-VL, etc.) are document parsers in practice, but the OCR path was image-only end to end: the Web UI file picker only accepted images, and `/v1/images/ocr` called `PIL.Image.open()` directly so a PDF upload failed with a 500. The Web UI even has a Document Parsing panel that already posts PDFs to this endpoint, which could not work before this change.

### API (`/v1/images/ocr`)

- PDF uploads are detected via the `application/pdf` content type or the `%PDF` magic bytes.
- The PDF is rasterized page by page with `pypdfium2` (pure-wheel, no system deps; lazily imported so installs without the `image` extra are unaffected), the model's `ocr()` runs on each page, and the per-page results are merged:
  - all pages plain text → texts joined with blank lines, response stays a single JSON string exactly like the single-image contract;
  - structured results (e.g. `return_dict=True` style models) → `{"pages": [{"page": 1, "result": ...}, ...]}`.
- Two optional PDF-only `kwargs` fields: `pages` (1-based page number or list, default all pages) and `dpi` (rasterization resolution, default 200, capped at 600). Invalid values return HTTP 400.
- The response `media_type` is now `application/json` (the body always was JSON: `ModelActor.ocr` serializes via `_call_wrapper_json` and both REST clients parse it with `response.json()`). Declaring `text/plain` broke aiohttp's content-type check in the async client.

### Web UI

The OCR panel file picker now accepts `image/*,application/pdf` and the label/description mention PDF.

### Packaging / docs

- `pypdfium2` added to the `image` and `dev` extras.
- The OCR section of `doc/source/models/model_abilities/image.rst` documents PDF input and the `pages`/`dpi` kwargs.

## Test plan

- New tests in `xinference/api/tests/test_ocr_pdf.py` cover PDF detection, page selection validation, result merging, and real rasterization of a minimal hand-built PDF (skipped if `pypdfium2` is missing). `xinference/api/tests` passes locally: 252 passed, 17 skipped.
- Smoke-tested against a live deployment running a DeepDoc OCR model:
  - single-image OCR unchanged (regression);
  - 2-page PDF, plain text: `"HELLOXINFERENCEPAGEONE\n\nPAGETWOPDFOCRTEST"`;
  - 2-page PDF with `return_dict: true`: per-page structure with boxes/scores;
  - `kwargs={"pages": [2], "dpi": 150}`: only page 2 OCRed;
  - `kwargs={"pages": [99]}`: HTTP 400 with a clear message.
- `pre-commit` passes on the changed Python files; `eslint` and `prettier --check` pass on the touched frontend file.

GPU model-runtime paths are unaffected (the change is at the API layer); no GPU CI-only checks were run locally.
