### PR TITLE
fix: add anthropic SDK to core dependencies for route registration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
     "modelscope>=1.19.0",
     "sse_starlette>=1.6.5",  # ensure_bytes API break change: https://github.com/sysid/sse-starlette/issues/65
     "openai>=1.40.0",  # For typing
-    "anthropic",       # For Anthropic protocol typing & route registration
+    "anthropic>=0.25.0",  # For Anthropic protocol typing & route registration
     "python-jose[cryptography]",
     "bcrypt>=4.0.0",
     "aioprometheus[starlette]>=23.12.0",
@@ -279,7 +279,7 @@ benchmark = [
     "psutil",
 ]
 anthropic = [
-    "anthropic",
+    "anthropic",  # no-op: anthropic is now a core dependency, kept for backward compatibility
 ]
 
 [tool.setuptools]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dependencies = [
     "modelscope>=1.19.0",
     "sse_starlette>=1.6.5",  # ensure_bytes API break change: https://github.com/sysid/sse-starlette/issues/65
     "openai>=1.40.0",  # For typing
+    "anthropic",       # For Anthropic protocol typing & route registration
     "python-jose[cryptography]",
     "bcrypt>=4.0.0",
     "aioprometheus[starlette]>=23.12.0",


### PR DESCRIPTION
## Problem

In production deployments where `pip install xinference` is used without extras, the `anthropic` package is not installed. This causes `ANTHROPIC_AVAILABLE` to evaluate to `False`, which prevents registration of three Anthropic protocol routes:

| Method | Path | Behavior when unregistered |
|--------|------|---------------------------|
| POST | `/anthropic/v1/messages` | Returns 405 Method Not Allowed |
| GET | `/anthropic/v1/models` | Returns frontend HTML (SPA catch-all) |
| GET | `/anthropic/v1/models/{model_id}` | Returns frontend HTML (SPA catch-all) |

The 405 error is particularly confusing because:
1. The SPA catch-all route `GET /{full_path:path}` matches the path but only accepts GET
2. A POST request to the same path triggers Starlette's "path matched, method didn't" logic → 405 instead of 404
3. Users see "Method Not Allowed" with no indication that a missing optional dependency is the root cause

## Root Cause

The `openai` SDK is already in core dependencies for typing purposes, but the `anthropic` SDK — which serves the identical purpose of providing type definitions (`ContentBlock`, `Usage`) for Anthropic protocol conversion — is only available as an optional dependency.

## Fix

Add `"anthropic"` to the core `dependencies` list in `pyproject.toml`, directly after the existing `"openai>=1.40.0"` entry.

### Dependency Impact

The `anthropic` SDK's dependency chain is lightweight:
```
anthropic
├── httpx          ← already in core dependencies
├── pydantic       ← already in core dependencies
├── anyio          ← lightweight
├── distro         ← lightweight
├── jiter          ← lightweight
└── sniffio        ← lightweight
```

No GPU/ML dependencies. No new heavy transitive dependencies.

### What this does NOT change

- Does not modify route registration logic (`llm.py`)
- Does not modify `ANTHROPIC_AVAILABLE` guard mechanism (`types.py`)
- Does not modify Anthropic protocol conversion logic (`restful_api.py`)
- The guard remains in place for graceful degradation in edge cases

## Verification

```bash
# In a fresh virtual environment:
pip install -e .
python -c "from anthropic.types import ContentBlock, Usage; print('OK')"
# Expected: OK

# Start xinference-local, deploy a model, then:
curl -X POST http://localhost:9997/anthropic/v1/messages \
  -H 'Content-Type: application/json' \
  -d '{"model":"<model_uid>","max_tokens":100,"messages":[{"role":"user","content":"hi"}]}'
# Expected: Anthropic-format JSON response (not 405)
```

## Related

- `ANTHROPIC_AVAILABLE` guard defined in `xinference/types.py:525-530`
- Routes registered in `xinference/api/routers/llm.py:28`
- `openai` already in core deps at `pyproject.toml:52` (same typing purpose)

🤖 Generated with [Claude Code](https://claude.com/claude-code)