### PR TITLE
feat: support per-replica worker and GPU placement

### DIFF
--- a/doc/source/user_guide/launch.rst
+++ b/doc/source/user_guide/launch.rst
@@ -50,6 +50,51 @@ Smart Allocation: Number of replicas may differ from GPU count; system intellige
 - Configuration: Replicas=3, GPUs=2
 - Result: GPU0 runs 2 instances, GPU1 runs 1 instance
 
+Per-replica placement
+---------------------
+
+For distributed deployments, ``replica_config`` can pin every replica to a
+specific worker and optional GPU indexes. Worker addresses must use the full
+registered ``IP:port`` value. The number of entries must equal ``replica`` and
+each entry currently supports exactly one worker.
+
+.. code-block:: python
+
+    from xinference.client import Client
+
+    client = Client("http://localhost:9997")
+    model_uid = client.launch_model(
+        model_name="qwen2.5-instruct",
+        model_engine="vllm",
+        replica=2,
+        replica_config=[
+            {
+                "replica_uid": "primary",
+                "devices": [
+                    {
+                        "worker_ip": "192.168.1.10:9978",
+                        "n_gpu": 1,
+                        "gpu_idx": [0],
+                    }
+                ],
+            },
+            {
+                "replica_uid": "secondary",
+                "devices": [
+                    {
+                        "worker_ip": "192.168.1.11:9978",
+                        "n_gpu": 1,
+                        "gpu_idx": [0],
+                    }
+                ],
+            },
+        ],
+    )
+
+``replica_config`` is mutually exclusive with the model-level ``worker_ip``,
+``n_gpu``, and ``gpu_idx`` arguments. Omit ``gpu_idx`` and use ``n_gpu="auto"``
+to let the selected worker allocate GPUs automatically.
+
 GPU Allocation Strategy
 =======================
 

--- a/doc/source/user_guide/launch.rst
+++ b/doc/source/user_guide/launch.rst
@@ -92,8 +92,10 @@ each entry currently supports exactly one worker.
     )
 
 ``replica_config`` is mutually exclusive with the model-level ``worker_ip``,
-``n_gpu``, and ``gpu_idx`` arguments. Omit ``gpu_idx`` and use ``n_gpu="auto"``
-to let the selected worker allocate GPUs automatically.
+``n_gpu``, and ``gpu_idx`` arguments. If ``replica_uid`` is omitted, Xinference
+assigns the stable default ``{model_uid}-{replica_index}`` (for example,
+``my-model-0``). Omit ``gpu_idx`` and use ``n_gpu="auto"`` to let the selected
+worker allocate GPUs automatically.
 
 GPU Allocation Strategy
 =======================

--- a/xinference/api/restful_api.py
+++ b/xinference/api/restful_api.py
@@ -77,6 +77,13 @@ from ..types import (
     max_tokens_field,
 )
 from .frontend_static import mount_frontend
+from .pdf_ocr import (
+    DEFAULT_PDF_OCR_DPI,
+    PDF_MAGIC,
+    is_pdf_upload,
+    merge_ocr_page_results,
+    rasterize_pdf,
+)
 from .responses import JSONResponse
 from .schemas import (
     AutoConfigLLMRequest,
@@ -631,14 +638,16 @@ class RESTfulAPI(CancelMixin):
             os.path.join(lib_location, "ui", "web", "dist"),
         )
         if not mount_frontend(self._app, Path(ui_dist_location)):
-            warnings.warn(f"""
+            warnings.warn(
+                f"""
             The Xinference web UI is not built at expected directory: {ui_dist_location}
             The API keeps serving without the web UI. To enable it, build the
             frontend static export from the repository "frontend/" directory with
             "npm ci && npm run build" (this stages the export at the directory
             above), or set XINFERENCE_FRONTEND_DIST_DIR to an export directory,
             and restart. For frontend development, run "npm run dev" instead.
-            """)
+            """
+            )
 
         config = Config(
             app=self._app,
@@ -942,6 +951,8 @@ class RESTfulAPI(CancelMixin):
                 replica_config=replica_config,
                 **kwargs,
             )
+        except HTTPException:
+            raise
         except ValueError as ve:
             logger.error(str(ve), exc_info=True)
             raise HTTPException(status_code=400, detail=str(ve))
@@ -2017,17 +2028,55 @@ class RESTfulAPI(CancelMixin):
                 parsed_kwargs = {}
             request_id = parsed_kwargs.get("request_id")
             self._add_running_task(request_id)
+            head = image.file.read(len(PDF_MAGIC))
+            image.file.seek(0)
+            if is_pdf_upload(image.content_type, head):
+                pages = parsed_kwargs.pop("pages", None)
+                dpi = parsed_kwargs.pop("dpi", DEFAULT_PDF_OCR_DPI)
+                try:
+                    page_iter = await asyncio.to_thread(
+                        rasterize_pdf, image.file.read(), pages=pages, dpi=dpi
+                    )
+                except ValueError as ve:
+                    raise HTTPException(status_code=400, detail=str(ve))
+                # Pages are rendered lazily, one at a time, so peak memory
+                # stays at a single page regardless of document size.
+                page_results = []
+                try:
+                    while True:
+                        item = await asyncio.to_thread(next, page_iter, None)
+                        if item is None:
+                            break
+                        page_number, page_image = item
+                        try:
+                            result = await model_ref.ocr(
+                                image=page_image,
+                                **parsed_kwargs,
+                            )
+                        finally:
+                            page_image.close()
+                        page_results.append((page_number, json.loads(result)))
+                finally:
+                    page_iter.close()
+                body = merge_ocr_page_results(page_results)
+                return Response(content=body, media_type="application/json")
             im = Image.open(image.file)
             text = await model_ref.ocr(
                 image=im,
                 **parsed_kwargs,
             )
-            return Response(content=text, media_type="text/plain")
+            # ModelActor.ocr serializes the model's return value to JSON
+            # bytes, and both REST clients parse the body with
+            # response.json() — declaring text/plain here breaks aiohttp's
+            # content-type check on the async client.
+            return Response(content=text, media_type="application/json")
         except asyncio.CancelledError:
             err_str = f"The request has been cancelled: {request_id}"
             logger.error(err_str)
             await self._report_error_event(model_uid, err_str)
             raise HTTPException(status_code=409, detail=err_str)
+        except HTTPException:
+            raise
         except Exception as e:
             e = await self._get_model_last_error(model_ref.uid, e)
             logger.error(e, exc_info=True)

--- a/xinference/api/restful_api.py
+++ b/xinference/api/restful_api.py
@@ -147,6 +147,32 @@ def _validate_replica(value: Any) -> int:
     return replica
 
 
+def _parse_replica_config(payload: dict) -> Optional[List[ReplicaConfig]]:
+    """Validate and parse per-replica placement from a launch payload."""
+    replica_config_data = payload.get("replica_config")
+    if replica_config_data is None:
+        return None
+
+    if (
+        payload.get("worker_ip") is not None
+        or payload.get("gpu_idx") is not None
+        or payload.get("n_gpu", "auto") != "auto"
+    ):
+        raise HTTPException(
+            status_code=400,
+            detail="Cannot specify worker_ip / n_gpu / gpu_idx together with "
+            "replica_config.",
+        )
+
+    try:
+        return [ReplicaConfig.from_dict(item) for item in replica_config_data]
+    except Exception as e:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid replica_config: {e}",
+        )
+
+
 def _log_setup_required_notice() -> None:
     """Log the first-run setup notice, called while setup is pending.
 
@@ -853,17 +879,7 @@ class RESTfulAPI(CancelMixin):
         enable_virtual_env = payload.get("enable_virtual_env", None)
         virtual_env_packages = payload.get("virtual_env_packages", None)
         envs = payload.get("envs", None)
-        replica_config = payload.get("replica_config", None)
-        if replica_config is not None:
-            try:
-                replica_config = [
-                    ReplicaConfig.from_dict(item) for item in replica_config
-                ]
-            except Exception as e:
-                raise HTTPException(
-                    status_code=400,
-                    detail=f"Invalid replica_config: {e}",
-                )
+        replica_config = _parse_replica_config(payload)
 
         exclude_keys = {
             "model_uid",
@@ -900,17 +916,6 @@ class RESTfulAPI(CancelMixin):
             raise HTTPException(
                 status_code=400,
                 detail="Invalid input. Please specify the `model_engine` field.",
-            )
-
-        if replica_config is not None and (
-            worker_ip is not None
-            or gpu_idx is not None
-            or payload.get("n_gpu", "auto") != "auto"
-        ):
-            raise HTTPException(
-                status_code=400,
-                detail="Cannot specify worker_ip / n_gpu / gpu_idx together with "
-                "replica_config.",
             )
 
         if isinstance(gpu_idx, int):
@@ -1101,27 +1106,7 @@ class RESTfulAPI(CancelMixin):
         model_version = payload.get("model_version")
         replica = _validate_replica(payload.get("replica", 1))
         n_gpu = payload.get("n_gpu", "auto")
-        replica_config = payload.get("replica_config", None)
-        if replica_config is not None:
-            if (
-                payload.get("worker_ip") is not None
-                or payload.get("gpu_idx") is not None
-                or n_gpu != "auto"
-            ):
-                raise HTTPException(
-                    status_code=400,
-                    detail="Cannot specify worker_ip / n_gpu / gpu_idx together with "
-                    "replica_config.",
-                )
-            try:
-                replica_config = [
-                    ReplicaConfig.from_dict(item) for item in replica_config
-                ]
-            except Exception as e:
-                raise HTTPException(
-                    status_code=400,
-                    detail=f"Invalid replica_config: {e}",
-                )
+        replica_config = _parse_replica_config(payload)
 
         try:
             model_uid = await (

--- a/xinference/api/restful_api.py
+++ b/xinference/api/restful_api.py
@@ -67,6 +67,7 @@ from ..constants import (
 from ..core.event import Event, EventCollectorActor, EventType
 from ..core.exceptions import ModelNotReadyError
 from ..core.http_protocol import create_hardened_http_protocol
+from ..core.replica_config import ReplicaConfig
 from ..core.supervisor import SupervisorActor
 from ..core.utils import CancelMixin
 from ..types import (
@@ -76,13 +77,6 @@ from ..types import (
     max_tokens_field,
 )
 from .frontend_static import mount_frontend
-from .pdf_ocr import (
-    DEFAULT_PDF_OCR_DPI,
-    PDF_MAGIC,
-    is_pdf_upload,
-    merge_ocr_page_results,
-    rasterize_pdf,
-)
 from .responses import JSONResponse
 from .schemas import (
     AutoConfigLLMRequest,
@@ -637,16 +631,14 @@ class RESTfulAPI(CancelMixin):
             os.path.join(lib_location, "ui", "web", "dist"),
         )
         if not mount_frontend(self._app, Path(ui_dist_location)):
-            warnings.warn(
-                f"""
+            warnings.warn(f"""
             The Xinference web UI is not built at expected directory: {ui_dist_location}
             The API keeps serving without the web UI. To enable it, build the
             frontend static export from the repository "frontend/" directory with
             "npm ci && npm run build" (this stages the export at the directory
             above), or set XINFERENCE_FRONTEND_DIST_DIR to an export directory,
             and restart. For frontend development, run "npm run dev" instead.
-            """
-            )
+            """)
 
         config = Config(
             app=self._app,
@@ -852,6 +844,17 @@ class RESTfulAPI(CancelMixin):
         enable_virtual_env = payload.get("enable_virtual_env", None)
         virtual_env_packages = payload.get("virtual_env_packages", None)
         envs = payload.get("envs", None)
+        replica_config = payload.get("replica_config", None)
+        if replica_config is not None:
+            try:
+                replica_config = [
+                    ReplicaConfig.from_dict(item) for item in replica_config
+                ]
+            except Exception as e:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Invalid replica_config: {e}",
+                )
 
         exclude_keys = {
             "model_uid",
@@ -872,6 +875,7 @@ class RESTfulAPI(CancelMixin):
             "enable_virtual_env",
             "virtual_env_packages",
             "envs",
+            "replica_config",
         }
 
         kwargs = {
@@ -887,6 +891,17 @@ class RESTfulAPI(CancelMixin):
             raise HTTPException(
                 status_code=400,
                 detail="Invalid input. Please specify the `model_engine` field.",
+            )
+
+        if replica_config is not None and (
+            worker_ip is not None
+            or gpu_idx is not None
+            or payload.get("n_gpu", "auto") != "auto"
+        ):
+            raise HTTPException(
+                status_code=400,
+                detail="Cannot specify worker_ip / n_gpu / gpu_idx together with "
+                "replica_config.",
             )
 
         if isinstance(gpu_idx, int):
@@ -924,6 +939,7 @@ class RESTfulAPI(CancelMixin):
                 enable_virtual_env=enable_virtual_env,
                 virtual_env_packages=virtual_env_packages,
                 envs=envs,
+                replica_config=replica_config,
                 **kwargs,
             )
         except ValueError as ve:
@@ -1074,6 +1090,27 @@ class RESTfulAPI(CancelMixin):
         model_version = payload.get("model_version")
         replica = _validate_replica(payload.get("replica", 1))
         n_gpu = payload.get("n_gpu", "auto")
+        replica_config = payload.get("replica_config", None)
+        if replica_config is not None:
+            if (
+                payload.get("worker_ip") is not None
+                or payload.get("gpu_idx") is not None
+                or n_gpu != "auto"
+            ):
+                raise HTTPException(
+                    status_code=400,
+                    detail="Cannot specify worker_ip / n_gpu / gpu_idx together with "
+                    "replica_config.",
+                )
+            try:
+                replica_config = [
+                    ReplicaConfig.from_dict(item) for item in replica_config
+                ]
+            except Exception as e:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Invalid replica_config: {e}",
+                )
 
         try:
             model_uid = await (
@@ -1086,7 +1123,11 @@ class RESTfulAPI(CancelMixin):
                 replica=replica,
                 n_gpu=n_gpu,
                 wait_ready=wait_ready,
+                replica_config=replica_config,
             )
+        except ValueError as ve:
+            logger.error(str(ve), exc_info=True)
+            raise HTTPException(status_code=400, detail=str(ve))
         except Exception as e:
             logger.error(str(e), exc_info=True)
             raise HTTPException(status_code=500, detail=str(e))
@@ -1976,55 +2017,17 @@ class RESTfulAPI(CancelMixin):
                 parsed_kwargs = {}
             request_id = parsed_kwargs.get("request_id")
             self._add_running_task(request_id)
-            head = image.file.read(len(PDF_MAGIC))
-            image.file.seek(0)
-            if is_pdf_upload(image.content_type, head):
-                pages = parsed_kwargs.pop("pages", None)
-                dpi = parsed_kwargs.pop("dpi", DEFAULT_PDF_OCR_DPI)
-                try:
-                    page_iter = await asyncio.to_thread(
-                        rasterize_pdf, image.file.read(), pages=pages, dpi=dpi
-                    )
-                except ValueError as ve:
-                    raise HTTPException(status_code=400, detail=str(ve))
-                # Pages are rendered lazily, one at a time, so peak memory
-                # stays at a single page regardless of document size.
-                page_results = []
-                try:
-                    while True:
-                        item = await asyncio.to_thread(next, page_iter, None)
-                        if item is None:
-                            break
-                        page_number, page_image = item
-                        try:
-                            result = await model_ref.ocr(
-                                image=page_image,
-                                **parsed_kwargs,
-                            )
-                        finally:
-                            page_image.close()
-                        page_results.append((page_number, json.loads(result)))
-                finally:
-                    page_iter.close()
-                body = merge_ocr_page_results(page_results)
-                return Response(content=body, media_type="application/json")
             im = Image.open(image.file)
             text = await model_ref.ocr(
                 image=im,
                 **parsed_kwargs,
             )
-            # ModelActor.ocr serializes the model's return value to JSON
-            # bytes, and both REST clients parse the body with
-            # response.json() — declaring text/plain here breaks aiohttp's
-            # content-type check on the async client.
-            return Response(content=text, media_type="application/json")
+            return Response(content=text, media_type="text/plain")
         except asyncio.CancelledError:
             err_str = f"The request has been cancelled: {request_id}"
             logger.error(err_str)
             await self._report_error_event(model_uid, err_str)
             raise HTTPException(status_code=409, detail=err_str)
-        except HTTPException:
-            raise
         except Exception as e:
             e = await self._get_model_last_error(model_ref.uid, e)
             logger.error(e, exc_info=True)

--- a/xinference/api/tests/test_replica_validation.py
+++ b/xinference/api/tests/test_replica_validation.py
@@ -12,14 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for the ``_validate_replica`` helper and its integration in REST endpoints."""
+"""Tests for REST launch payload validation helpers."""
 
 import math
 
 import pytest
 from fastapi import HTTPException
 
-from ..restful_api import _validate_replica
+from ..restful_api import _parse_replica_config, _validate_replica
 
 
 class TestValidateReplica:
@@ -117,3 +117,61 @@ class TestValidateReplica:
             _validate_replica(float("inf"))
         assert exc.value.status_code == 400
         assert "float" in exc.value.detail
+
+
+class TestParseReplicaConfig:
+    """Unit tests for ``_parse_replica_config``."""
+
+    def test_absent_config_returns_none(self):
+        assert _parse_replica_config({}) is None
+
+    def test_valid_config_is_parsed(self):
+        configs = _parse_replica_config(
+            {
+                "replica_config": [
+                    {
+                        "replica_uid": "replica-a",
+                        "devices": [
+                            {
+                                "worker_ip": "10.0.0.1:9978",
+                                "n_gpu": 1,
+                                "gpu_idx": [0],
+                            }
+                        ],
+                    }
+                ]
+            }
+        )
+
+        assert configs is not None
+        assert len(configs) == 1
+        assert configs[0].replica_uid == "replica-a"
+        assert configs[0].devices[0].worker_ip == "10.0.0.1:9978"
+
+    def test_empty_config_is_preserved(self):
+        assert _parse_replica_config({"replica_config": []}) == []
+
+    @pytest.mark.parametrize(
+        "legacy_placement",
+        [
+            {"worker_ip": "10.0.0.1:9978"},
+            {"gpu_idx": []},
+            {"n_gpu": 1},
+        ],
+    )
+    def test_rejects_legacy_placement_options(self, legacy_placement):
+        payload = {"replica_config": []}
+        payload.update(legacy_placement)
+
+        with pytest.raises(HTTPException) as exc:
+            _parse_replica_config(payload)
+
+        assert exc.value.status_code == 400
+        assert "together with replica_config" in exc.value.detail
+
+    def test_rejects_invalid_config(self):
+        with pytest.raises(HTTPException) as exc:
+            _parse_replica_config({"replica_config": [None]})
+
+        assert exc.value.status_code == 400
+        assert "Invalid replica_config" in exc.value.detail

--- a/xinference/client/restful/async_restful_client.py
+++ b/xinference/client/restful/async_restful_client.py
@@ -1307,6 +1307,7 @@ class AsyncClient:
         request_limits: Optional[int] = None,
         worker_ip: Optional[str] = None,
         gpu_idx: Optional[Union[int, List[int]]] = None,
+        replica_config: Optional[List[Dict]] = None,
         model_path: Optional[str] = None,
         enable_thinking: Optional[bool] = None,
         **kwargs,
@@ -1348,6 +1349,12 @@ class AsyncClient:
             Specify the worker ip where the model is located in a distributed scenario.
         gpu_idx: Optional[Union[int, List[int]]]
             Specify the GPU index where the model is located.
+        replica_config: Optional[List[Dict]]
+            Per-replica placement spec. Each item is ``{"replica_uid": str|None,
+            "devices": [{"worker_ip": "ip:port", "n_gpu": int|"auto",
+            "gpu_idx": [int]|None}]}``. When set, each replica is pinned to the
+            given worker/GPU and the legacy worker_ip/n_gpu/gpu_idx are ignored.
+            ``devices`` length must be 1 (no cross-worker sharding per replica).
         model_path: Optional[str]
             Model path, if gguf format, should be the file path, otherwise, should be directory of the model.
         enable_thinking: Optional[bool]
@@ -1384,6 +1391,7 @@ class AsyncClient:
             "request_limits": request_limits,
             "worker_ip": worker_ip,
             "gpu_idx": gpu_idx,
+            "replica_config": replica_config,
             "model_path": model_path,
             "enable_thinking": enable_thinking,
         }

--- a/xinference/client/restful/async_restful_client.py
+++ b/xinference/client/restful/async_restful_client.py
@@ -1354,6 +1354,7 @@ class AsyncClient:
             "devices": [{"worker_ip": "ip:port", "n_gpu": int|"auto",
             "gpu_idx": [int]|None}]}``. When set, each replica is pinned to the
             given worker/GPU and the legacy worker_ip/n_gpu/gpu_idx are ignored.
+            An omitted replica_uid defaults to ``{model_uid}-{replica_index}``.
             ``devices`` length must be 1 (no cross-worker sharding per replica).
         model_path: Optional[str]
             Model path, if gguf format, should be the file path, otherwise, should be directory of the model.

--- a/xinference/client/restful/restful_client.py
+++ b/xinference/client/restful/restful_client.py
@@ -1193,6 +1193,7 @@ class Client:
         request_limits: Optional[int] = None,
         worker_ip: Optional[str] = None,
         gpu_idx: Optional[Union[int, List[int]]] = None,
+        replica_config: Optional[List[Dict]] = None,
         model_path: Optional[str] = None,
         enable_thinking: Optional[bool] = None,
         enable_virtual_env: Optional[bool] = None,
@@ -1237,6 +1238,12 @@ class Client:
             Specify the worker ip where the model is located in a distributed scenario.
         gpu_idx: Optional[Union[int, List[int]]]
             Specify the GPU index where the model is located.
+        replica_config: Optional[List[Dict]]
+            Per-replica placement spec. Each item is ``{"replica_uid": str|None,
+            "devices": [{"worker_ip": "ip:port", "n_gpu": int|"auto",
+            "gpu_idx": [int]|None}]}``. When set, each replica is pinned to the
+            given worker/GPU and the legacy worker_ip/n_gpu/gpu_idx are ignored.
+            ``devices`` length must be 1 (no cross-worker sharding per replica).
         model_path: Optional[str]
             Model path, if gguf format, should be the file path, otherwise, should be directory of the model.
         enable_thinking: Optional[bool]
@@ -1280,6 +1287,7 @@ class Client:
             "request_limits": request_limits,
             "worker_ip": worker_ip,
             "gpu_idx": gpu_idx,
+            "replica_config": replica_config,
             "model_path": model_path,
             "enable_thinking": enable_thinking,
             "enable_virtual_env": enable_virtual_env,

--- a/xinference/client/restful/restful_client.py
+++ b/xinference/client/restful/restful_client.py
@@ -1243,6 +1243,7 @@ class Client:
             "devices": [{"worker_ip": "ip:port", "n_gpu": int|"auto",
             "gpu_idx": [int]|None}]}``. When set, each replica is pinned to the
             given worker/GPU and the legacy worker_ip/n_gpu/gpu_idx are ignored.
+            An omitted replica_uid defaults to ``{model_uid}-{replica_index}``.
             ``devices`` length must be 1 (no cross-worker sharding per replica).
         model_path: Optional[str]
             Model path, if gguf format, should be the file path, otherwise, should be directory of the model.

--- a/xinference/core/replica_config.py
+++ b/xinference/core/replica_config.py
@@ -1,0 +1,128 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Per-replica placement configuration for first-time model launch.
+
+``replica_config`` lets a caller pin each replica to a specific worker
+(full ``ip:port``) and GPU on launch, instead of relying on the supervisor's
+automatic load-balanced scheduling.
+
+This module only owns the *structural* data model and pure validation
+(lengths, uniqueness, ``n_gpu``/``gpu_idx`` consistency, ``replica_uid``
+naming). Stateful checks (worker registered in the cluster, GPU index legal,
+cross-replica GPU conflicts) live in the supervisor, which has access to the
+cluster topology.
+"""
+
+from typing import List, Optional, Union
+
+from .._compat import BaseModel
+from .utils import build_replica_model_uid, parse_replica_model_uid
+
+
+class DeviceConfig(BaseModel):
+    """Placement of one replica on a single worker.
+
+    Each replica is restricted to exactly one device for now (no cross-worker
+    sharding within a single replica); ``devices`` length is validated to be 1.
+    """
+
+    worker_ip: str  # full worker address "ip:port"
+    n_gpu: Union[int, str] = "auto"  # int count, or "auto" for worker auto-allocation
+    gpu_idx: Optional[List[int]] = None  # explicit GPU indexes; None/empty = auto
+
+
+class ReplicaConfig(BaseModel):
+    """Placement spec for a single replica."""
+
+    replica_uid: Optional[str] = None
+    devices: List[DeviceConfig] = []
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "ReplicaConfig":
+        return cls(**data)
+
+
+def _is_reserved_replica_uid(uid: str) -> bool:
+    """True if ``uid`` collides with an internal replica/rank identifier."""
+    _, rep = parse_replica_model_uid(uid)
+    return rep != -1 or uid.endswith("-rank0")
+
+
+def normalize_replica_configs(
+    model_uid: str,
+    replica: int,
+    configs: List[ReplicaConfig],
+) -> List[ReplicaConfig]:
+    """Validate structure and fill in default ``replica_uid``.
+
+    Returns a list aligned by replica index (length ``replica``). Raises
+    ``ValueError`` on any structural violation. Stateful validation (worker
+    existence, GPU legality, cross-replica GPU conflicts) is intentionally not
+    done here — it belongs to the supervisor which holds cluster topology.
+    """
+    if len(configs) != replica:
+        raise ValueError(
+            f"replica_config length ({len(configs)}) must equal replica ({replica})."
+        )
+
+    seen_uids: set = set()
+    resolved: List[ReplicaConfig] = []
+    for idx, cfg in enumerate(configs):
+        if len(cfg.devices) != 1:
+            raise ValueError(
+                "Each replica_config entry must have exactly one device "
+                f"(replica {idx} has {len(cfg.devices)}). "
+                "Cross-worker sharding per replica is not supported yet."
+            )
+        device = cfg.devices[0]
+
+        _validate_device_consistency(idx, device)
+
+        replica_uid = cfg.replica_uid
+        if replica_uid is None:
+            replica_uid = build_replica_model_uid(model_uid, idx)
+        elif _is_reserved_replica_uid(replica_uid):
+            raise ValueError(
+                f"replica_uid '{replica_uid}' collides with a reserved internal "
+                "replica/rank identifier; please choose another name."
+            )
+        if replica_uid in seen_uids:
+            raise ValueError(
+                f"Duplicate replica_uid '{replica_uid}' in replica_config."
+            )
+        seen_uids.add(replica_uid)
+
+        cfg.replica_uid = replica_uid
+        resolved.append(cfg)
+    return resolved
+
+
+def _validate_device_consistency(idx: int, device: DeviceConfig) -> None:
+    """Check n_gpu / gpu_idx consistency for one device."""
+    if not isinstance(device.n_gpu, int) and device.n_gpu != "auto":
+        raise ValueError(
+            f"replica_config[{idx}].devices[0].n_gpu must be an int or 'auto', "
+            f"got {device.n_gpu!r}."
+        )
+    gpu_idx = device.gpu_idx or []
+    if gpu_idx:
+        if device.n_gpu != "auto" and device.n_gpu != len(gpu_idx):
+            raise ValueError(
+                f"replica_config[{idx}].devices[0].n_gpu ({device.n_gpu}) must equal "
+                f"len(gpu_idx) ({len(gpu_idx)}), or be 'auto'."
+            )
+        if any(not isinstance(g, int) or g < 0 for g in gpu_idx):
+            raise ValueError(
+                f"replica_config[{idx}].devices[0].gpu_idx must be non-negative integers."
+            )

--- a/xinference/core/replica_config.py
+++ b/xinference/core/replica_config.py
@@ -26,8 +26,8 @@ cluster topology.
 
 from typing import List, Optional, Union
 
-from .._compat import BaseModel
-from .utils import build_replica_model_uid, parse_replica_model_uid
+from .._compat import BaseModel, Field
+from .utils import parse_replica_model_uid
 
 
 class DeviceConfig(BaseModel):
@@ -46,7 +46,7 @@ class ReplicaConfig(BaseModel):
     """Placement spec for a single replica."""
 
     replica_uid: Optional[str] = None
-    devices: List[DeviceConfig] = []
+    devices: List[DeviceConfig] = Field(default_factory=list)
 
     @classmethod
     def from_dict(cls, data: dict) -> "ReplicaConfig":
@@ -64,7 +64,7 @@ def normalize_replica_configs(
     replica: int,
     configs: List[ReplicaConfig],
 ) -> List[ReplicaConfig]:
-    """Validate structure and fill in default ``replica_uid``.
+    """Validate structure and preserve optional user-provided ``replica_uid``.
 
     Returns a list aligned by replica index (length ``replica``). Raises
     ``ValueError`` on any structural violation. Stateful validation (worker
@@ -90,20 +90,18 @@ def normalize_replica_configs(
         _validate_device_consistency(idx, device)
 
         replica_uid = cfg.replica_uid
-        if replica_uid is None:
-            replica_uid = build_replica_model_uid(model_uid, idx)
-        elif _is_reserved_replica_uid(replica_uid):
-            raise ValueError(
-                f"replica_uid '{replica_uid}' collides with a reserved internal "
-                "replica/rank identifier; please choose another name."
-            )
-        if replica_uid in seen_uids:
-            raise ValueError(
-                f"Duplicate replica_uid '{replica_uid}' in replica_config."
-            )
-        seen_uids.add(replica_uid)
+        if replica_uid is not None:
+            if _is_reserved_replica_uid(replica_uid):
+                raise ValueError(
+                    f"replica_uid '{replica_uid}' collides with a reserved internal "
+                    "replica/rank identifier; please choose another name."
+                )
+            if replica_uid in seen_uids:
+                raise ValueError(
+                    f"Duplicate replica_uid '{replica_uid}' in replica_config."
+                )
+            seen_uids.add(replica_uid)
 
-        cfg.replica_uid = replica_uid
         resolved.append(cfg)
     return resolved
 

--- a/xinference/core/replica_config.py
+++ b/xinference/core/replica_config.py
@@ -26,11 +26,16 @@ cluster topology.
 
 from typing import List, Optional, Union
 
-from .._compat import BaseModel, Field
+from .._compat import BaseModel, Field, validator
 from .utils import parse_replica_model_uid
 
 
-class DeviceConfig(BaseModel):
+class _PlacementConfigBase(BaseModel):
+    class Config:
+        extra = "forbid"
+
+
+class DeviceConfig(_PlacementConfigBase):
     """Placement of one replica on a single worker.
 
     Each replica is restricted to exactly one device for now (no cross-worker
@@ -41,8 +46,34 @@ class DeviceConfig(BaseModel):
     n_gpu: Union[int, str] = "auto"  # int count, or "auto" for worker auto-allocation
     gpu_idx: Optional[List[int]] = None  # explicit GPU indexes; None/empty = auto
 
+    @validator("worker_ip", pre=True)
+    def _validate_worker_ip(cls, value):
+        if not isinstance(value, str):
+            raise TypeError("worker_ip must be a string")
+        return value
 
-class ReplicaConfig(BaseModel):
+    @validator("n_gpu", pre=True)
+    def _validate_n_gpu(cls, value):
+        if value != "auto" and (isinstance(value, bool) or not isinstance(value, int)):
+            raise TypeError("n_gpu must be an integer or 'auto'")
+        return value
+
+    @validator("gpu_idx", pre=True)
+    def _validate_gpu_idx(cls, value):
+        if value is None:
+            return value
+        if not isinstance(value, list):
+            raise TypeError("gpu_idx must be a list of integers")
+        if any(
+            isinstance(index, bool) or not isinstance(index, int) for index in value
+        ):
+            raise TypeError("gpu_idx must contain only integers")
+        if len(set(value)) != len(value):
+            raise ValueError("gpu_idx must not contain duplicate indexes")
+        return value
+
+
+class ReplicaConfig(_PlacementConfigBase):
     """Placement spec for a single replica."""
 
     replica_uid: Optional[str] = None
@@ -64,12 +95,13 @@ def normalize_replica_configs(
     replica: int,
     configs: List[ReplicaConfig],
 ) -> List[ReplicaConfig]:
-    """Validate structure and preserve optional user-provided ``replica_uid``.
+    """Validate structure and resolve each replica's stable user-facing UID.
 
-    Returns a list aligned by replica index (length ``replica``). Raises
-    ``ValueError`` on any structural violation. Stateful validation (worker
-    existence, GPU legality, cross-replica GPU conflicts) is intentionally not
-    done here — it belongs to the supervisor which holds cluster topology.
+    Returns a list aligned by replica index (length ``replica``), assigning
+    ``{model_uid}-{index}`` when ``replica_uid`` is omitted. Raises ``ValueError``
+    on any structural violation. Stateful validation (worker existence, GPU
+    legality, cross-replica GPU conflicts) is intentionally not done here — it
+    belongs to the supervisor which holds cluster topology.
     """
     if len(configs) != replica:
         raise ValueError(
@@ -89,20 +121,20 @@ def normalize_replica_configs(
 
         _validate_device_consistency(idx, device)
 
-        replica_uid = cfg.replica_uid
-        if replica_uid is not None:
-            if _is_reserved_replica_uid(replica_uid):
-                raise ValueError(
-                    f"replica_uid '{replica_uid}' collides with a reserved internal "
-                    "replica/rank identifier; please choose another name."
-                )
-            if replica_uid in seen_uids:
-                raise ValueError(
-                    f"Duplicate replica_uid '{replica_uid}' in replica_config."
-                )
-            seen_uids.add(replica_uid)
-
-        resolved.append(cfg)
+        replica_uid = (
+            cfg.replica_uid if cfg.replica_uid is not None else f"{model_uid}-{idx}"
+        )
+        if _is_reserved_replica_uid(replica_uid):
+            raise ValueError(
+                f"replica_uid '{replica_uid}' collides with a reserved internal "
+                "replica/rank identifier; please choose another name."
+            )
+        if replica_uid in seen_uids:
+            raise ValueError(
+                f"Duplicate replica_uid '{replica_uid}' in replica_config."
+            )
+        seen_uids.add(replica_uid)
+        resolved.append(cfg.copy(update={"replica_uid": replica_uid}))
     return resolved
 
 

--- a/xinference/core/status_guard.py
+++ b/xinference/core/status_guard.py
@@ -45,6 +45,9 @@ class ReplicaStatus(BaseModel):
     # User-facing replica label (from replica_config.replica_uid). Purely
     # informational; not used for routing or as the internal replica_model_uid.
     replica_uid: Optional[str] = None
+    # GPU indexes this replica was pinned to at launch (only known for
+    # explicitly placed replicas; None for auto-scheduled). Informational.
+    gpu_idx: Optional[List[int]] = None
 
 
 class InstanceInfo(BaseModel):
@@ -141,6 +144,7 @@ class StatusGuardActor(xo.StatelessActor):
                     created_ts=status_update.get("created_ts", 0),
                     error_message=status_update.get("error_message", None),
                     replica_uid=status_update.get("replica_uid", None),
+                    gpu_idx=status_update.get("gpu_idx", None),
                 )
             )
 

--- a/xinference/core/status_guard.py
+++ b/xinference/core/status_guard.py
@@ -42,6 +42,9 @@ class ReplicaStatus(BaseModel):
     model_state: str = ""  # registering/loading/ready/error/stopping/stopped
     created_ts: int
     error_message: Optional[str] = None
+    # User-facing replica label (from replica_config.replica_uid). Purely
+    # informational; not used for routing or as the internal replica_model_uid.
+    replica_uid: Optional[str] = None
 
 
 class InstanceInfo(BaseModel):
@@ -137,6 +140,7 @@ class StatusGuardActor(xo.StatelessActor):
                     status=status_update.get("status", LaunchStatus.CREATING.name),
                     created_ts=status_update.get("created_ts", 0),
                     error_message=status_update.get("error_message", None),
+                    replica_uid=status_update.get("replica_uid", None),
                 )
             )
 

--- a/xinference/core/supervisor.py
+++ b/xinference/core/supervisor.py
@@ -2340,6 +2340,7 @@ class SupervisorActor(xo.StatelessActor):
                     "status": LaunchStatus.CREATING.name,
                     "created_ts": int(time.time()),
                     "replica_uid": replica_uid,
+                    "gpu_idx": target_gpu_idx,
                 },
             )
 

--- a/xinference/core/supervisor.py
+++ b/xinference/core/supervisor.py
@@ -61,6 +61,7 @@ from ..types import PeftModelConfig
 from .exceptions import ModelNotReadyError
 from .launch_strategy import IdleFirstLaunchStrategy
 from .metrics import record_metrics
+from .replica_config import ReplicaConfig, normalize_replica_configs
 from .resource import GPUStatus, ResourceStatus
 from .utils import (
     assign_replica_gpu,
@@ -1910,6 +1911,7 @@ class SupervisorActor(xo.StatelessActor):
         replica: int = 1,
         n_gpu: Optional[Union[int, str]] = "auto",
         wait_ready: bool = True,
+        replica_config: Optional[List[ReplicaConfig]] = None,
     ):
         parse_results = parse_model_version(model_version, model_type)
 
@@ -1930,6 +1932,7 @@ class SupervisorActor(xo.StatelessActor):
             n_gpu=n_gpu,
             wait_ready=wait_ready,
             model_version=model_version,
+            replica_config=replica_config,
             **kwargs,
         )
 
@@ -1945,6 +1948,126 @@ class SupervisorActor(xo.StatelessActor):
             f"Found {len(refs)} workers for IPs {ip_list}: {[r.address for r in refs]}"
         )
         return refs
+
+    def _get_worker_ref_by_address(
+        self, address: str
+    ) -> Optional[xo.ActorRefType["WorkerActor"]]:
+        """Resolve a worker by its full ``ip:port`` address (exact match).
+
+        Unlike ``_get_worker_refs_by_ip`` (which matches on the IP prefix and is
+        therefore ambiguous when one host runs several workers), this matches
+        the complete registered address key, which is what ``replica_config``
+        requires.
+        """
+        return self._worker_address_to_worker.get(address)
+
+    async def _resolve_replica_config(
+        self,
+        model_uid: str,
+        replica: int,
+        replica_config: List[ReplicaConfig],
+    ) -> Tuple[
+        List[Tuple[xo.ActorRefType["WorkerActor"], Optional[List[int]]]],
+        Dict[int, Optional[str]],
+    ]:
+        """Validate and resolve ``replica_config`` into per-replica targets.
+
+        Runs entirely before any replica is launched so that a bad config fails
+        cleanly (no partial deployment, no leaked actors). Returns, aligned by
+        replica index:
+          * a list of ``(worker_ref, gpu_idx_or_None)`` to dispatch to, and
+          * a map ``replica_id -> replica_uid`` label for status tracking.
+
+        Stateful checks performed here: worker registered in the cluster, GPU
+        index exists on the target worker, and (when the worker disallows
+        multi-replica-per-GPU) static cross-replica GPU conflicts.
+        """
+        # Structural validation + default replica_uid fill.
+        configs = normalize_replica_configs(model_uid, replica, replica_config)
+
+        is_local = self.is_local_deployment()
+        registered = list(self._worker_address_to_worker.keys())
+
+        # 1. Resolve worker ref per replica (exact ip:port; local short-circuit).
+        resolved_worker: List[Optional[xo.ActorRefType["WorkerActor"]]] = []
+        for idx, cfg in enumerate(configs):
+            address = cfg.devices[0].worker_ip
+            worker_ref = self._get_worker_ref_by_address(address)
+            if worker_ref is None:
+                if is_local:
+                    worker_ref = next(
+                        iter(self._worker_address_to_worker.values()), None
+                    )
+                    if worker_ref is None:
+                        raise RuntimeError("No available worker found")
+                    logger.warning(
+                        "Local deployment, ignore replica_config worker_ip %s.",
+                        address,
+                    )
+                else:
+                    raise ValueError(
+                        f"replica_config[{idx}].worker_ip '{address}' is not in the "
+                        f"cluster. Registered workers: {registered}"
+                    )
+            resolved_worker.append(worker_ref)
+
+        # 2. Fetch GPU allocation snapshots for the distinct target workers.
+        distinct: Dict[str, xo.ActorRefType["WorkerActor"]] = {}
+        for ref in resolved_worker:
+            assert ref is not None
+            distinct[ref.address] = ref
+        alloc_results: Dict[str, Any] = {}
+        if distinct:
+            addrs = list(distinct.keys())
+            snapshots = await asyncio.gather(
+                *[distinct[a].get_gpu_allocation_status() for a in addrs],
+                return_exceptions=True,
+            )
+            for a, snap in zip(addrs, snapshots):
+                if isinstance(snap, Exception):
+                    raise ValueError(
+                        f"Failed to query GPU status of worker {a} while "
+                        f"validating replica_config: {snap}"
+                    )
+                alloc_results[a] = snap
+
+        # 3. Validate GPU existence + static cross-replica conflicts per worker.
+        per_worker_used: Dict[str, Set[int]] = {}
+        resolved_targets: List[
+            Tuple[xo.ActorRefType["WorkerActor"], Optional[List[int]]]
+        ] = []
+        replica_uid_map: Dict[int, Optional[str]] = {}
+        for idx, cfg in enumerate(configs):
+            device = cfg.devices[0]
+            worker_ref = resolved_worker[idx]
+            assert worker_ref is not None
+            address = worker_ref.address
+            gpu_idx = list(device.gpu_idx) if device.gpu_idx else None
+            if gpu_idx:
+                total = set(alloc_results[address].get("total") or [])
+                invalid = set(gpu_idx) - total
+                if invalid:
+                    raise ValueError(
+                        f"replica_config[{idx}].gpu_idx {gpu_idx} is not visible on "
+                        f"worker {address}; visible GPU indexes: {sorted(total)}"
+                    )
+                allow_share = bool(
+                    alloc_results[address].get("allow_multi_replica_per_gpu", False)
+                )
+                if not allow_share:
+                    used = per_worker_used.setdefault(address, set())
+                    overlap = used.intersection(gpu_idx)
+                    if overlap:
+                        raise ValueError(
+                            f"replica_config GPU conflict on worker {address}: GPU "
+                            f"indexes {sorted(overlap)} requested by more than one "
+                            f"replica, and this worker disallows sharing a GPU."
+                        )
+                    used.update(gpu_idx)
+            resolved_targets.append((worker_ref, gpu_idx))
+            replica_uid_map[idx] = cfg.replica_uid
+
+        return resolved_targets, replica_uid_map
 
     @log_async(logger=logger)
     async def launch_builtin_model(
@@ -1965,6 +2088,7 @@ class SupervisorActor(xo.StatelessActor):
         peft_model_config: Optional[PeftModelConfig] = None,
         worker_ip: Optional[str] = None,
         gpu_idx: Optional[Union[int, List[int]]] = None,
+        replica_config: Optional[List[ReplicaConfig]] = None,
         download_hub: Optional[Literal["huggingface", "modelscope", "csghub"]] = None,
         model_path: Optional[str] = None,
         enable_virtual_env: Optional[bool] = None,
@@ -1976,6 +2100,20 @@ class SupervisorActor(xo.StatelessActor):
             # ignore n_worker > 1 if local deployment
             logger.warning("Local deployment, ignore n_worker(%s)", n_worker)
             n_worker = 1
+
+        if replica_config is not None:
+            # replica_config pins each replica to a single worker, so it is
+            # incompatible with sharded launch (n_worker>1) and with the legacy
+            # global worker_ip / n_gpu / gpu_idx parameters.
+            if n_worker > 1:  # type: ignore
+                raise ValueError(
+                    "replica_config is incompatible with n_worker>1 (sharded launch)."
+                )
+            if worker_ip is not None or gpu_idx is not None or n_gpu != "auto":
+                raise ValueError(
+                    "replica_config cannot be used together with the legacy "
+                    "worker_ip / n_gpu / gpu_idx parameters."
+                )
 
         if n_worker > 1:  # type: ignore
             # distributed inference
@@ -2040,6 +2178,19 @@ class SupervisorActor(xo.StatelessActor):
         if model_uid is None:
             model_uid = self._gen_model_uid(model_name)
 
+        # Resolve per-replica placement (replica_config) BEFORE any side effects
+        # below (xavier actor creation, replica_info, instance_info) so that a
+        # bad config fails cleanly with no leaked actors or partial state.
+        resolved_targets: Optional[
+            List[Tuple[xo.ActorRefType["WorkerActor"], Optional[List[int]]]]
+        ] = None
+        replica_uid_map: Dict[int, Optional[str]] = {}
+        if replica_config is not None:
+            (
+                resolved_targets,
+                replica_uid_map,
+            ) = await self._resolve_replica_config(model_uid, replica, replica_config)
+
         # Xavier-related
         enable_xavier: bool = (
             bool(kwargs.pop("enable_xavier", False))
@@ -2080,7 +2231,11 @@ class SupervisorActor(xo.StatelessActor):
         )
 
         async def _launch_one_model(
-            worker_ref, _replica_model_uid, rank: int, target_gpu_idx=None
+            worker_ref,
+            _replica_model_uid,
+            rank: int,
+            target_gpu_idx=None,
+            replica_uid=None,
         ):
             if _replica_model_uid in self._replica_model_uid_to_worker:
                 raise ValueError(
@@ -2104,6 +2259,7 @@ class SupervisorActor(xo.StatelessActor):
                     "worker_address": worker_ref.address,
                     "status": LaunchStatus.CREATING.name,
                     "created_ts": int(time.time()),
+                    "replica_uid": replica_uid,
                 },
             )
 
@@ -2212,57 +2368,59 @@ class SupervisorActor(xo.StatelessActor):
                             "Launch strategy %s not recognized, fallback to load-first",
                             strategy_name,
                         )
-                # Pre-fetch worker loads for balanced scheduling
-                worker_candidates = []
+                if resolved_targets is None:
+                    # Pre-fetch worker loads for balanced scheduling
+                    worker_candidates = []
 
-                if target_worker_refs:
-                    workers = target_worker_refs
-                else:
-                    workers = list(self._worker_address_to_worker.values())
+                    if target_worker_refs:
+                        workers = target_worker_refs
+                    else:
+                        workers = list(self._worker_address_to_worker.values())
 
-                if not workers:
-                    raise RuntimeError("No available worker found")
+                    if not workers:
+                        raise RuntimeError("No available worker found")
 
-                # Fetch loads in parallel to minimize latency
-                counts = await asyncio.gather(
-                    *[w.get_model_count() for w in workers], return_exceptions=True
-                )
-                # Fetch per-worker GPU allocation snapshots for visibility/scheduling.
-                allocations = await asyncio.gather(
-                    *[w.get_gpu_allocation_status() for w in workers],
-                    return_exceptions=True,
-                )
-
-                for w_ref, count, alloc in zip(workers, counts, allocations):
-                    if isinstance(count, Exception):
-                        logger.warning(
-                            f"Failed to get model count from worker: {count}"
-                        )
-                        continue
-                    if isinstance(alloc, Exception):
-                        logger.debug(
-                            "Failed to fetch GPU allocation snapshot from worker %s: %s",
-                            w_ref.address,
-                            alloc,
-                        )
-                        alloc = None
-                    worker_candidates.append(
-                        {"ref": w_ref, "count": count, "alloc": alloc}
+                    # Fetch loads in parallel to minimize latency
+                    counts = await asyncio.gather(
+                        *[w.get_model_count() for w in workers],
+                        return_exceptions=True,
+                    )
+                    # Fetch per-worker GPU allocation snapshots for visibility/scheduling.
+                    allocations = await asyncio.gather(
+                        *[w.get_gpu_allocation_status() for w in workers],
+                        return_exceptions=True,
                     )
 
-                if not worker_candidates:
-                    raise RuntimeError("No available worker found")
+                    for w_ref, count, alloc in zip(workers, counts, allocations):
+                        if isinstance(count, Exception):
+                            logger.warning(
+                                f"Failed to get model count from worker: {count}"
+                            )
+                            continue
+                        if isinstance(alloc, Exception):
+                            logger.debug(
+                                "Failed to fetch GPU allocation snapshot from worker %s: %s",
+                                w_ref.address,
+                                alloc,
+                            )
+                            alloc = None
+                        worker_candidates.append(
+                            {"ref": w_ref, "count": count, "alloc": alloc}
+                        )
 
-                logger.debug(
-                    f"Worker candidates for {model_uid}: {[{'addr': c['ref'].address, 'count': c['count']} for c in worker_candidates]}"
-                )
-                logger.debug(
-                    "GPU allocation snapshots: %s",
-                    [
-                        {"addr": c["ref"].address, "alloc": c.get("alloc")}
-                        for c in worker_candidates
-                    ],
-                )
+                    if not worker_candidates:
+                        raise RuntimeError("No available worker found")
+
+                    logger.debug(
+                        f"Worker candidates for {model_uid}: {[{'addr': c['ref'].address, 'count': c['count']} for c in worker_candidates]}"
+                    )
+                    logger.debug(
+                        "GPU allocation snapshots: %s",
+                        [
+                            {"addr": c["ref"].address, "alloc": c.get("alloc")}
+                            for c in worker_candidates
+                        ],
+                    )
 
                 # Pre-check: ensure no replica uid already exists before entering
                 # asyncio.gather, preventing partial-deploy-then-rollback.
@@ -2279,7 +2437,13 @@ class SupervisorActor(xo.StatelessActor):
                 for _idx, rep_model_uid in enumerate(
                     iter_replica_model_uid(model_uid, replica)
                 ):
-                    if strategy is not None:
+                    if resolved_targets is not None:
+                        worker_ref, target_gpu_idx = resolved_targets[_idx]
+                        logger.debug(
+                            f"Replica {_idx} pinned by replica_config to "
+                            f"{worker_ref.address} (gpu_idx: {target_gpu_idx})"
+                        )
+                    elif strategy is not None:
                         requested_gpu = n_gpu if isinstance(n_gpu, int) else None
                         worker_ref, target_gpu_idx = strategy.select_worker(
                             worker_candidates, n_gpu=requested_gpu
@@ -2325,7 +2489,11 @@ class SupervisorActor(xo.StatelessActor):
                     # Add regular replica launch task to parallel batch
                     launch_tasks.append(
                         _launch_one_model(
-                            worker_ref, rep_model_uid, _idx + 1, target_gpu_idx
+                            worker_ref,
+                            rep_model_uid,
+                            _idx + 1,
+                            target_gpu_idx,
+                            replica_uid=replica_uid_map.get(_idx),
                         )
                     )
                     task_metadata.append((worker_ref, rep_model_uid, False, _idx, None))

--- a/xinference/core/supervisor.py
+++ b/xinference/core/supervisor.py
@@ -2216,16 +2216,15 @@ class SupervisorActor(xo.StatelessActor):
                 **kwargs,
             )
 
+        is_local_deployment = self.is_local_deployment()
         target_worker_refs = (
-            self._get_worker_refs_by_ip(worker_ip) if worker_ip is not None else []
+            []
+            if worker_ip is None or is_local_deployment
+            else self._get_worker_refs_by_ip(worker_ip)
         )
-        if (
-            worker_ip is not None
-            and not self.is_local_deployment()
-            and not target_worker_refs
-        ):
+        if worker_ip is not None and not is_local_deployment and not target_worker_refs:
             raise ValueError(f"Worker ip address {worker_ip} is not in the cluster.")
-        if worker_ip is not None and self.is_local_deployment():
+        if worker_ip is not None and is_local_deployment:
             logger.warning(
                 f"You specified the worker ip: {worker_ip} in local mode, "
                 f"xinference will ignore this option."

--- a/xinference/core/supervisor.py
+++ b/xinference/core/supervisor.py
@@ -1936,16 +1936,62 @@ class SupervisorActor(xo.StatelessActor):
             **kwargs,
         )
 
-    def _get_worker_refs_by_ip(self, ip: str) -> List[xo.ActorRefType["WorkerActor"]]:
-        ip_list = [item.strip() for item in ip.split(",") if item.strip()]
-        refs_set = set()
-        for addr, ref in self._worker_address_to_worker.items():
-            existing_ip = addr.split(":")[0]
-            if existing_ip in ip_list:
-                refs_set.add(ref)
-        refs = list(refs_set)
+    @staticmethod
+    def _get_worker_host(address: str) -> str:
+        """Return the host portion of a registered worker address."""
+        if address.startswith("["):
+            closing_bracket = address.find("]")
+            if closing_bracket != -1:
+                return address[1:closing_bracket]
+
+        host, separator, port = address.rpartition(":")
+        if separator and port.isdigit():
+            return host
+        return address
+
+    def _resolve_worker_addresses(self, worker_ip: Union[str, List[str]]) -> List[str]:
+        """Resolve bare hosts and full worker addresses to registered addresses.
+
+        A full ``host:port`` value identifies one concrete worker. A bare host
+        keeps the legacy behavior and expands to every worker registered on
+        that host. The same resolver is used by regular and sharded launches so
+        both paths interpret ``worker_ip`` consistently.
+        """
+        raw_entries = worker_ip if isinstance(worker_ip, list) else [worker_ip]
+        requested = [
+            entry.strip()
+            for item in raw_entries
+            for entry in str(item).split(",")
+            if entry.strip()
+        ]
+
+        host_to_addresses: Dict[str, List[str]] = {}
+        for address in self._worker_address_to_worker:
+            host_to_addresses.setdefault(self._get_worker_host(address), []).append(
+                address
+            )
+
+        resolved_addresses: List[str] = []
+        for entry in requested:
+            if entry in self._worker_address_to_worker:
+                resolved_addresses.append(entry)
+                continue
+
+            matched_addresses = host_to_addresses.get(entry)
+            if not matched_addresses:
+                raise ValueError(f"Worker ip address {entry} is not in the cluster.")
+            resolved_addresses.extend(matched_addresses)
+
+        return list(dict.fromkeys(resolved_addresses))
+
+    def _get_worker_refs_by_ip(
+        self, ip: Union[str, List[str]]
+    ) -> List[xo.ActorRefType["WorkerActor"]]:
+        addresses = self._resolve_worker_addresses(ip)
+        refs = [self._worker_address_to_worker[address] for address in addresses]
         logger.debug(
-            f"Found {len(refs)} workers for IPs {ip_list}: {[r.address for r in refs]}"
+            f"Found {len(refs)} workers for worker addresses {addresses}: "
+            f"{[r.address for r in refs]}"
         )
         return refs
 
@@ -1967,7 +2013,13 @@ class SupervisorActor(xo.StatelessActor):
         replica: int,
         replica_config: List[ReplicaConfig],
     ) -> Tuple[
-        List[Tuple[xo.ActorRefType["WorkerActor"], Optional[List[int]]]],
+        List[
+            Tuple[
+                xo.ActorRefType["WorkerActor"],
+                Optional[List[int]],
+                Union[int, str],
+            ]
+        ],
         Dict[int, Optional[str]],
     ]:
         """Validate and resolve ``replica_config`` into per-replica targets.
@@ -1975,7 +2027,7 @@ class SupervisorActor(xo.StatelessActor):
         Runs entirely before any replica is launched so that a bad config fails
         cleanly (no partial deployment, no leaked actors). Returns, aligned by
         replica index:
-          * a list of ``(worker_ref, gpu_idx_or_None)`` to dispatch to, and
+          * a list of ``(worker_ref, gpu_idx_or_None, n_gpu)`` to dispatch to, and
           * a map ``replica_id -> replica_uid`` label for status tracking.
 
         Stateful checks performed here: worker registered in the cluster, GPU
@@ -2034,7 +2086,11 @@ class SupervisorActor(xo.StatelessActor):
         # 3. Validate GPU existence + static cross-replica conflicts per worker.
         per_worker_used: Dict[str, Set[int]] = {}
         resolved_targets: List[
-            Tuple[xo.ActorRefType["WorkerActor"], Optional[List[int]]]
+            Tuple[
+                xo.ActorRefType["WorkerActor"],
+                Optional[List[int]],
+                Union[int, str],
+            ]
         ] = []
         replica_uid_map: Dict[int, Optional[str]] = {}
         for idx, cfg in enumerate(configs):
@@ -2063,8 +2119,26 @@ class SupervisorActor(xo.StatelessActor):
                             f"indexes {sorted(overlap)} requested by more than one "
                             f"replica, and this worker disallows sharing a GPU."
                         )
+
+                    allocation = alloc_results[address]
+                    existing_models = allocation.get("models") or {}
+                    existing_user_specified = allocation.get("user_specified") or {}
+                    occupied = {
+                        gpu
+                        for gpu in gpu_idx
+                        if existing_models.get(gpu)
+                        or existing_models.get(str(gpu))
+                        or existing_user_specified.get(gpu)
+                        or existing_user_specified.get(str(gpu))
+                    }
+                    if occupied:
+                        raise ValueError(
+                            f"replica_config GPU conflict on worker {address}: GPU "
+                            f"indexes {sorted(occupied)} are already occupied, and "
+                            "this worker disallows sharing a GPU."
+                        )
                     used.update(gpu_idx)
-            resolved_targets.append((worker_ref, gpu_idx))
+            resolved_targets.append((worker_ref, gpu_idx, device.n_gpu))
             replica_uid_map[idx] = cfg.replica_uid
 
         return resolved_targets, replica_uid_map
@@ -2182,7 +2256,13 @@ class SupervisorActor(xo.StatelessActor):
         # below (xavier actor creation, replica_info, instance_info) so that a
         # bad config fails cleanly with no leaked actors or partial state.
         resolved_targets: Optional[
-            List[Tuple[xo.ActorRefType["WorkerActor"], Optional[List[int]]]]
+            List[
+                Tuple[
+                    xo.ActorRefType["WorkerActor"],
+                    Optional[List[int]],
+                    Union[int, str],
+                ]
+            ]
         ] = None
         replica_uid_map: Dict[int, Optional[str]] = {}
         if replica_config is not None:
@@ -2235,6 +2315,7 @@ class SupervisorActor(xo.StatelessActor):
             _replica_model_uid,
             rank: int,
             target_gpu_idx=None,
+            replica_n_gpu=None,
             replica_uid=None,
         ):
             if _replica_model_uid in self._replica_model_uid_to_worker:
@@ -2316,7 +2397,7 @@ class SupervisorActor(xo.StatelessActor):
                     quantization=quantization,
                     model_engine=model_engine,
                     model_type=model_type,
-                    n_gpu=n_gpu,
+                    n_gpu=replica_n_gpu if replica_n_gpu is not None else n_gpu,
                     request_limits=request_limits,
                     peft_model_config=peft_model_config,
                     gpu_idx=replica_gpu_idx,
@@ -2438,12 +2519,15 @@ class SupervisorActor(xo.StatelessActor):
                     iter_replica_model_uid(model_uid, replica)
                 ):
                     if resolved_targets is not None:
-                        worker_ref, target_gpu_idx = resolved_targets[_idx]
+                        worker_ref, target_gpu_idx, target_n_gpu = resolved_targets[
+                            _idx
+                        ]
                         logger.debug(
                             f"Replica {_idx} pinned by replica_config to "
                             f"{worker_ref.address} (gpu_idx: {target_gpu_idx})"
                         )
                     elif strategy is not None:
+                        target_n_gpu = n_gpu
                         requested_gpu = n_gpu if isinstance(n_gpu, int) else None
                         worker_ref, target_gpu_idx = strategy.select_worker(
                             worker_candidates, n_gpu=requested_gpu
@@ -2458,6 +2542,7 @@ class SupervisorActor(xo.StatelessActor):
                             f"Replica {_idx} assigned to {worker_ref.address} (count: {current_count})"
                         )
                     else:
+                        target_n_gpu = n_gpu
                         worker_candidates.sort(
                             key=lambda x: (x["count"], x["ref"].address)
                         )
@@ -2480,7 +2565,7 @@ class SupervisorActor(xo.StatelessActor):
                         _uid = model_uid + "-rank0"
                         # For Xavier, rank0 must be launched first, so we await it immediately
                         rank0_address = await _launch_one_model(
-                            worker_ref, _uid, 0, target_gpu_idx
+                            worker_ref, _uid, 0, target_gpu_idx, target_n_gpu
                         )
                         task_metadata.append(
                             (worker_ref, _uid, True, _idx, rank0_address)
@@ -2493,6 +2578,7 @@ class SupervisorActor(xo.StatelessActor):
                             rep_model_uid,
                             _idx + 1,
                             target_gpu_idx,
+                            replica_n_gpu=target_n_gpu,
                             replica_uid=replica_uid_map.get(_idx),
                         )
                     )
@@ -2647,35 +2733,7 @@ class SupervisorActor(xo.StatelessActor):
                 # no registration, use all workers
                 available_workers = all_workers
         else:
-            # ``worker_ip`` may arrive as a comma-separated string (from the
-            # REST API / web UI) or as a list (from the Python client). Normalize
-            # it to a list of entries, then resolve each entry to the concrete
-            # worker address(es) (``ip:port``) so the values match the keys used
-            # by ``_choose_worker`` and the ``n_worker`` count reflects real
-            # workers. An entry may be a bare IP or an already-qualified
-            # ``ip:port`` worker address; both are accepted.
-            raw_entries = worker_ip if isinstance(worker_ip, list) else [worker_ip]
-            requested = [
-                entry.strip()
-                for item in raw_entries
-                for entry in str(item).split(",")
-                if entry.strip()
-            ]
-            ip_to_addresses: Dict[str, List[str]] = {}
-            for addr in self._worker_address_to_worker:
-                ip_to_addresses.setdefault(addr.split(":")[0], []).append(addr)
-            for entry in requested:
-                if entry in self._worker_address_to_worker:
-                    # Already a concrete worker address (``ip:port``).
-                    available_workers.append(entry)
-                    continue
-                matched = ip_to_addresses.get(entry)
-                if not matched:
-                    raise ValueError(
-                        f"Worker ip address {entry} is not in the cluster."
-                    )
-                available_workers.extend(matched)
-            available_workers = list(dict.fromkeys(available_workers))
+            available_workers = self._resolve_worker_addresses(worker_ip)
 
         async def _launch_model():
             # Validation of n_worker, intercept if it is greater than the available workers.

--- a/xinference/core/tests/test_launch_strategy.py
+++ b/xinference/core/tests/test_launch_strategy.py
@@ -83,6 +83,13 @@ class DummySupervisor:
         self._launch_builtin_sharded_model = (
             SupervisorActor._launch_builtin_sharded_model.__get__(self)
         )
+        self._get_worker_host = SupervisorActor._get_worker_host
+        self._get_worker_refs_by_ip = SupervisorActor._get_worker_refs_by_ip.__get__(
+            self
+        )
+        self._resolve_worker_addresses = (
+            SupervisorActor._resolve_worker_addresses.__get__(self)
+        )
         # Fields used by _invalidate_list_models_debounce_cache (called from
         # _launch_builtin_sharded_model after model launch completes).
         self._list_models_result_cache = {}
@@ -95,6 +102,48 @@ class DummySupervisor:
 
     async def terminate_model(self, model_uid: str, suppress_exception: bool = False):
         return None
+
+
+def test_worker_address_resolution_prefers_exact_worker_address():
+    worker_1 = DummyRef("worker-1:30001")
+    worker_2 = DummyRef("worker-1:30002")
+    supervisor = DummySupervisor(
+        {
+            worker_1.address: worker_1,
+            worker_2.address: worker_2,
+        }
+    )
+
+    assert supervisor._get_worker_refs_by_ip("worker-1:30001") == [worker_1]
+    assert set(supervisor._get_worker_refs_by_ip("worker-1")) == {
+        worker_1,
+        worker_2,
+    }
+
+
+def test_worker_address_resolution_supports_multiple_addresses():
+    worker_1 = DummyRef("worker-1:30001")
+    worker_2 = DummyRef("worker-2:30001")
+    supervisor = DummySupervisor(
+        {
+            worker_1.address: worker_1,
+            worker_2.address: worker_2,
+        }
+    )
+
+    refs = supervisor._get_worker_refs_by_ip("worker-1:30001, worker-2:30001")
+
+    assert refs == [worker_1, worker_2]
+
+
+def test_worker_address_resolution_rejects_unknown_address():
+    worker = DummyRef("worker-1:30001")
+    supervisor = DummySupervisor({worker.address: worker})
+
+    with pytest.raises(
+        ValueError, match="Worker ip address worker-1:30002 is not in the cluster"
+    ):
+        supervisor._get_worker_refs_by_ip("worker-1:30002")
 
 
 def test_assign_replica_gpu_single_slot_reused():

--- a/xinference/core/tests/test_replica_config.py
+++ b/xinference/core/tests/test_replica_config.py
@@ -70,6 +70,31 @@ def test_from_dict_roundtrip():
     assert cfg.devices[0].gpu_idx == [0]
 
 
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("worker_ip", 9978),
+        ("n_gpu", 1.5),
+        ("n_gpu", True),
+        ("n_gpu", "1"),
+        ("gpu_idx", [0.9]),
+        ("gpu_idx", [True]),
+        ("gpu_idx", [0, 0]),
+    ],
+)
+def test_device_config_rejects_non_strict_placement_values(field, value):
+    data = {"worker_ip": "10.0.0.1:9978", field: value}
+    with pytest.raises(ValueError):
+        DeviceConfig(**data)
+
+
+def test_placement_config_rejects_unknown_fields():
+    with pytest.raises(ValueError):
+        DeviceConfig(worker_ip="10.0.0.1:9978", gpu_id=0)
+    with pytest.raises(ValueError):
+        ReplicaConfig(devices=[], replica_name="replica")
+
+
 def test_normalize_length_mismatch():
     with pytest.raises(ValueError, match="must equal replica"):
         normalize_replica_configs("m", replica=2, configs=[_cfg()])
@@ -91,12 +116,12 @@ def test_normalize_n_gpu_consistency():
     normalize_replica_configs("m", 1, [_cfg(n_gpu="auto", gpu_idx=[0])])
 
 
-def test_normalize_missing_replica_uid_stays_none():
+def test_normalize_missing_replica_uid_gets_stable_default():
     configs = normalize_replica_configs(
         "my-model", 2, [_cfg(), _cfg(worker_ip="10.0.0.2:9978")]
     )
-    assert configs[0].replica_uid is None
-    assert configs[1].replica_uid is None
+    assert configs[0].replica_uid == "my-model-0"
+    assert configs[1].replica_uid == "my-model-1"
 
 
 def test_normalize_replica_uid_uniqueness():
@@ -164,7 +189,7 @@ def test_resolve_valid():
     assert targets[0][2] == "auto"
     assert targets[1][0].address == "10.0.0.2:9978"
     assert targets[1][1] == [1]
-    assert uid_map == {0: None, 1: None}
+    assert uid_map == {0: "m-0", 1: "m-1"}
 
 
 def test_resolve_preserves_explicit_replica_uid():

--- a/xinference/core/tests/test_replica_config.py
+++ b/xinference/core/tests/test_replica_config.py
@@ -1,0 +1,253 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import asyncio
+
+import pytest
+
+from ..replica_config import DeviceConfig, ReplicaConfig, normalize_replica_configs
+from ..supervisor import SupervisorActor
+
+
+class _FakeWorker:
+    """Minimal stand-in for a WorkerActor ref used by _resolve_replica_config."""
+
+    def __init__(
+        self, address, total, allow_share=False, models=None, user_specified=None
+    ):
+        self.address = address
+        self._total = list(total)
+        self._allow_share = allow_share
+        self._models = models or {}
+        self._user_specified = user_specified or {}
+
+    async def get_gpu_allocation_status(self):
+        return {
+            "total": list(self._total),
+            "allow_multi_replica_per_gpu": self._allow_share,
+            "models": self._models,
+            "user_specified": self._user_specified,
+        }
+
+
+def _make_supervisor(workers, address="supervisor:9999"):
+    sup = SupervisorActor.__new__(SupervisorActor)
+    sup._worker_address_to_worker = {w.address: w for w in workers}
+    sup.address = address
+    return sup
+
+
+def _cfg(replica_uid=None, worker_ip="10.0.0.1:9978", n_gpu="auto", gpu_idx=None):
+    return ReplicaConfig(
+        replica_uid=replica_uid,
+        devices=[DeviceConfig(worker_ip=worker_ip, n_gpu=n_gpu, gpu_idx=gpu_idx)],
+    )
+
+
+# --------------------------- pure structural tests ---------------------------
+
+
+def test_from_dict_roundtrip():
+    cfg = ReplicaConfig.from_dict(
+        {
+            "replica_uid": "m-0",
+            "devices": [{"worker_ip": "1.2.3.4:9978", "n_gpu": 1, "gpu_idx": [0]}],
+        }
+    )
+    assert cfg.replica_uid == "m-0"
+    assert cfg.devices[0].worker_ip == "1.2.3.4:9978"
+    assert cfg.devices[0].n_gpu == 1
+    assert cfg.devices[0].gpu_idx == [0]
+
+
+def test_normalize_length_mismatch():
+    with pytest.raises(ValueError, match="must equal replica"):
+        normalize_replica_configs("m", replica=2, configs=[_cfg()])
+
+
+def test_normalize_devices_length_not_one():
+    cfg = ReplicaConfig(replica_uid=None, devices=[])
+    with pytest.raises(ValueError, match="exactly one device"):
+        normalize_replica_configs("m", replica=1, configs=[cfg])
+
+
+def test_normalize_n_gpu_consistency():
+    # n_gpu numeric must equal len(gpu_idx).
+    with pytest.raises(ValueError, match="must equal"):
+        normalize_replica_configs("m", 1, [_cfg(n_gpu=3, gpu_idx=[0, 1])])
+    # Consistent is fine.
+    normalize_replica_configs("m", 1, [_cfg(n_gpu=2, gpu_idx=[0, 1])])
+    # auto is fine with explicit gpu_idx.
+    normalize_replica_configs("m", 1, [_cfg(n_gpu="auto", gpu_idx=[0])])
+
+
+def test_normalize_missing_replica_uid_stays_none():
+    configs = normalize_replica_configs(
+        "my-model", 2, [_cfg(), _cfg(worker_ip="10.0.0.2:9978")]
+    )
+    assert configs[0].replica_uid is None
+    assert configs[1].replica_uid is None
+
+
+def test_normalize_replica_uid_uniqueness():
+    with pytest.raises(ValueError, match="Duplicate replica_uid"):
+        normalize_replica_configs(
+            "m", 2, [_cfg(replica_uid="same"), _cfg(replica_uid="same")]
+        )
+
+
+@pytest.mark.parametrize("uid", ["m-rep0", "my-model-rank0"])
+def test_normalize_reserved_replica_uid(uid):
+    with pytest.raises(ValueError, match="reserved"):
+        normalize_replica_configs("m", 1, [_cfg(replica_uid=uid)])
+
+
+def test_normalize_valid():
+    configs = normalize_replica_configs(
+        "m",
+        2,
+        [
+            _cfg(replica_uid="r0", worker_ip="10.0.0.1:9978", gpu_idx=[0]),
+            _cfg(replica_uid="r1", worker_ip="10.0.0.2:9978", gpu_idx=[1]),
+        ],
+    )
+    assert [c.replica_uid for c in configs] == ["r0", "r1"]
+
+
+def test_resolve_preserves_per_replica_n_gpu():
+    w1 = _FakeWorker("10.0.0.1:9978", total=[0, 1, 2, 3])
+    sup = _make_supervisor([w1])
+    targets, _ = asyncio.run(
+        sup._resolve_replica_config("m", 1, [_cfg(worker_ip=w1.address, n_gpu=2)])
+    )
+    assert targets[0][1] is None
+    assert targets[0][2] == 2
+
+
+def test_resolve_rejects_existing_gpu_occupancy():
+    w1 = _FakeWorker(
+        "10.0.0.1:9978", total=[0, 1], allow_share=False, models={0: ["existing"]}
+    )
+    sup = _make_supervisor([w1])
+    with pytest.raises(ValueError, match="already occupied"):
+        asyncio.run(
+            sup._resolve_replica_config(
+                "m", 1, [_cfg(worker_ip=w1.address, gpu_idx=[0])]
+            )
+        )
+
+
+# ------------------------- stateful resolve tests ----------------------------
+
+
+def test_resolve_valid():
+    w1 = _FakeWorker("10.0.0.1:9978", total=[0, 1])
+    w2 = _FakeWorker("10.0.0.2:9978", total=[0, 1])
+    sup = _make_supervisor([w1, w2])
+    configs = [
+        _cfg(worker_ip="10.0.0.1:9978", gpu_idx=[0]),
+        _cfg(worker_ip="10.0.0.2:9978", gpu_idx=[1]),
+    ]
+    targets, uid_map = asyncio.run(sup._resolve_replica_config("m", 2, configs))
+    assert targets[0][0].address == "10.0.0.1:9978"
+    assert targets[0][1] == [0]
+    assert targets[0][2] == "auto"
+    assert targets[1][0].address == "10.0.0.2:9978"
+    assert targets[1][1] == [1]
+    assert uid_map == {0: None, 1: None}
+
+
+def test_resolve_preserves_explicit_replica_uid():
+    w1 = _FakeWorker("10.0.0.1:9978", total=[0, 1])
+    w2 = _FakeWorker("10.0.0.2:9978", total=[0, 1])
+    sup = _make_supervisor([w1, w2])
+    configs = [
+        _cfg(replica_uid="primary", worker_ip=w1.address, gpu_idx=[0]),
+        _cfg(replica_uid="backup", worker_ip=w2.address, gpu_idx=[1]),
+    ]
+
+    _, uid_map = asyncio.run(sup._resolve_replica_config("m", 2, configs))
+
+    assert uid_map == {0: "primary", 1: "backup"}
+
+
+def test_resolve_unknown_worker():
+    w1 = _FakeWorker("10.0.0.1:9978", total=[0])
+    sup = _make_supervisor([w1])
+    with pytest.raises(ValueError, match="not in the cluster"):
+        asyncio.run(
+            sup._resolve_replica_config(
+                "m", 1, [_cfg(worker_ip="10.0.0.9:9978", gpu_idx=[0])]
+            )
+        )
+
+
+def test_resolve_gpu_not_visible():
+    w1 = _FakeWorker("10.0.0.1:9978", total=[0, 1])
+    sup = _make_supervisor([w1])
+    with pytest.raises(ValueError, match="not visible"):
+        asyncio.run(
+            sup._resolve_replica_config(
+                "m", 1, [_cfg(worker_ip="10.0.0.1:9978", gpu_idx=[9])]
+            )
+        )
+
+
+def test_resolve_static_conflict_disallowed():
+    # Same worker, overlapping gpu_idx, sharing disallowed -> rejected.
+    w1 = _FakeWorker("10.0.0.1:9978", total=[0, 1], allow_share=False)
+    sup = _make_supervisor([w1])
+    configs = [
+        _cfg(replica_uid="a", worker_ip="10.0.0.1:9978", gpu_idx=[0]),
+        _cfg(replica_uid="b", worker_ip="10.0.0.1:9978", gpu_idx=[0]),
+    ]
+    with pytest.raises(ValueError, match="conflict"):
+        asyncio.run(sup._resolve_replica_config("m", 2, configs))
+
+
+def test_resolve_allow_share_no_conflict():
+    # Same GPU on the same worker is allowed when the worker allows sharing.
+    w1 = _FakeWorker("10.0.0.1:9978", total=[0, 1], allow_share=True)
+    sup = _make_supervisor([w1])
+    configs = [
+        _cfg(replica_uid="a", worker_ip="10.0.0.1:9978", gpu_idx=[0]),
+        _cfg(replica_uid="b", worker_ip="10.0.0.1:9978", gpu_idx=[0]),
+    ]
+    targets, _ = asyncio.run(sup._resolve_replica_config("m", 2, configs))
+    assert targets[0][1] == [0] and targets[1][1] == [0]
+
+
+def test_resolve_local_mode_ignores_worker_ip():
+    # Local deployment: a single worker whose address == supervisor address.
+    local_addr = "127.0.0.1:9978"
+    w = _FakeWorker(local_addr, total=[0, 1])
+    sup = _make_supervisor([w], address=local_addr)
+    assert sup.is_local_deployment() is True
+    # worker_ip does not match, but local mode pins to the local worker anyway.
+    targets, _ = asyncio.run(
+        sup._resolve_replica_config(
+            "m", 1, [_cfg(worker_ip="9.9.9.9:9978", gpu_idx=[0])]
+        )
+    )
+    assert targets[0][0].address == local_addr
+    assert targets[0][1] == [0]
+
+
+def test_resolve_auto_gpu_skips_existence_check():
+    # gpu_idx omitted (auto) -> no existence check, worker will auto-allocate.
+    w1 = _FakeWorker("10.0.0.1:9978", total=[])
+    sup = _make_supervisor([w1])
+    targets, _ = asyncio.run(
+        sup._resolve_replica_config("m", 1, [_cfg(worker_ip="10.0.0.1:9978")])
+    )
+    assert targets[0][1] is None


### PR DESCRIPTION
## Summary

- add a typed `replica_config` launch option to the REST API and sync/async Python clients
- support selecting a worker, GPU indices, `n_gpu`, and an alias independently for every replica
- validate replica placement, resolve exact `host:port` worker addresses while retaining bare-host compatibility, and ignore worker pinning in local deployment
- preserve existing OCR request handling and propagate API validation errors without wrapping them as HTTP 500 responses
- document the launch option and add focused unit tests

## Stack

This is PR 1/6 and is the backend foundation for the replica-management stack.

## Validation

- 36 focused Python tests passed
- Black passed
- Ruff passed
- Python byte-compilation passed
- `git diff --check`

## Follow-up PRs

1. This PR: backend placement foundation (#5286)
2. Per-replica placement UI (#5287)
3. Replica scale API and clients (#5288)
4. Replica scale UI (#5289)
5. Worker recovery correctness (#5290)
6. Runtime resource reporting and display (#5291)

The independent launch-model stale-request fix is #5285.
