### PR TITLE
FIX: use Xorbits/deepdoc mirror for the DeepDoc huggingface source

### DIFF
--- a/xinference/model/image/model_spec.json
+++ b/xinference/model/image/model_spec.json
@@ -1797,8 +1797,8 @@
     },
     "model_src": {
       "huggingface": {
-        "model_id": "InfiniFlow/deepdoc",
-        "model_revision": "de0e793dc6d744406c96dabd688ccc969f41b443"
+        "model_id": "Xorbits/deepdoc",
+        "model_revision": "e18026ac948f64836a47aea7715502518ea04106"
       },
       "modelscope": {
         "model_id": "Xorbits/deepdoc",


### PR DESCRIPTION
## Summary
- Point the DeepDoc OCR model's huggingface source at `Xorbits/deepdoc` (pinned to the current HEAD revision `e18026ac948f64836a47aea7715502518ea04106`) instead of the upstream `InfiniFlow/deepdoc` repo, matching the modelscope source which already uses the `Xorbits/deepdoc` mirror.
- No code changes needed: `DeepDocModel._model_dir()` (xinference/model/image/ocr/deepdoc.py) already probes for a `vision/` subdirectory layout, which is how the `Xorbits/deepdoc` mirror lays out its ONNX files (vs. flat layout on `InfiniFlow/deepdoc`), since that fallback was added to support the modelscope mirror.

## Test plan
- [x] `pytest xinference/model/image/tests/test_deepdoc.py` — 8 passed
- [x] `pre-commit run --files xinference/model/image/model_spec.json` — passed