### PR TITLE
feat(ocr): expose DeepDoc's document-parsing pipeline as task="parse"

### DIFF
--- a/doc/source/models/model_abilities/image.rst
+++ b/doc/source/models/model_abilities/image.rst
@@ -451,4 +451,6 @@ document to merge across pages, so it requires a PDF upload and does not accept
   them inflates the response substantially, so prefer the default unless the
   text crops are needed too. The field is omitted for elements without a crop.
 
-The same 200-page limit as per-page OCR applies.
+The same 200-page and 80-megapixel-per-page limits as per-page OCR apply; a page
+that would rasterize past the pixel limit at the requested ``zoomin`` is
+rejected, so lower ``zoomin`` for very large page sizes.

--- a/doc/source/models/model_abilities/image.rst
+++ b/doc/source/models/model_abilities/image.rst
@@ -404,3 +404,51 @@ raster would exceed 80 megapixels is rejected — lower ``dpi`` in that case:
       -F model=<MODEL_UID> \
       -F 'kwargs={"pages": [1, 2], "dpi": 300}' \
       -F image=@xxx.pdf
+
+Whole-document parsing
+~~~~~~~~~~~~~~~~~~~~~~
+
+Some models expose a whole-document parsing task in addition to per-page OCR.
+``DeepDoc`` supports ``task="parse"``, which runs its full document pipeline —
+layout analysis, table structure recognition, paragraph merging and
+reading-order reconstruction — over an entire PDF and returns ordered document
+elements:
+
+.. code-block:: bash
+
+    curl -X 'POST' \
+      'http://<XINFERENCE_HOST>:<XINFERENCE_PORT>/v1/images/ocr' \
+      -F model=<MODEL_UID> \
+      -F 'kwargs={"task": "parse"}' \
+      -F image=@xxx.pdf
+
+.. code-block:: json
+
+    {"task": "parse",
+     "elements": [
+       {"type": "table",
+        "text": "<table><caption>...</caption><tr><th>...</th></tr></table>",
+        "image_base64": "...",
+        "metadata": {"page_number": 2, "x0": 20.0, "x1": 400.0, "top": 50.0,
+                     "bottom": 200.0, "layout_type": "table", "col_id": 0,
+                     "positions": [[2, 20, 400, 50, 200]]}}
+     ]}
+
+``type`` is the detected layout type (``text``, ``title``, ``table`` or
+``figure``), and ``text`` holds the element text — complete HTML in the case of
+tables. Coordinates in ``metadata`` accumulate across pages, so ``top`` and
+``bottom`` are document-wide rather than page-relative. ``col_id`` is only
+present on elements the pipeline assigned to a column.
+
+Unlike the per-page tasks, ``parse`` renders the PDF itself and needs the whole
+document to merge across pages, so it requires a PDF upload and does not accept
+``pages`` or ``dpi``. Two optional ``kwargs`` fields apply:
+
+* ``zoomin`` — the render scale, defaulting to ``3`` and capped at ``6``.
+* ``image_scope`` — which elements carry a base64-encoded PNG crop in
+  ``image_base64``: ``table_figure`` (the default, tables and figures only),
+  ``all``, or ``none``. Every element has a crop internally, but encoding all of
+  them inflates the response substantially, so prefer the default unless the
+  text crops are needed too. The field is omitted for elements without a crop.
+
+The same 200-page limit as per-page OCR applies.

--- a/doc/source/models/model_abilities/image.rst
+++ b/doc/source/models/model_abilities/image.rst
@@ -451,6 +451,15 @@ document to merge across pages, so it requires a PDF upload and does not accept
   them inflates the response substantially, so prefer the default unless the
   text crops are needed too. The field is omitted for elements without a crop.
 
-The same 200-page and 80-megapixel-per-page limits as per-page OCR apply; a page
-that would rasterize past the pixel limit at the requested ``zoomin`` is
-rejected, so lower ``zoomin`` for very large page sizes.
+Parsing has its own size limits, and they are tighter than the per-page OCR
+path's. When a render finds no text at all, DeepDoc re-renders the whole
+document at three times the zoom, repeatedly, until the scale reaches 9 — so a
+request at ``zoomin=3`` may end up rendering at 9, and one at ``zoomin=1`` also
+ends at 9. Because that allocation is real, both the per-page and the
+whole-document budgets are enforced against the largest scale a run can reach,
+counting the render being replaced as well.
+
+In practice a request is rejected with a 400 when a single page would peak above
+200 megapixels (an A3 page is fine at ``zoomin=3``, but not at ``6``), or when
+the pages together would peak above 1 gigapixel — roughly 22 A4 pages at the
+default zoom. Lower ``zoomin`` or split the document if you hit either.

--- a/xinference/api/pdf_ocr.py
+++ b/xinference/api/pdf_ocr.py
@@ -44,6 +44,11 @@ MAX_PDF_OCR_PAGE_PIXELS = 80_000_000
 # OCR tasks that consume the whole PDF instead of one rasterized page at a
 # time, and therefore receive the uploaded bytes unchanged.
 WHOLE_DOCUMENT_OCR_TASKS = frozenset({"parse"})
+# Whole-document parsers render at ``72 * zoomin`` DPI, i.e. a scale of
+# ``zoomin`` over the page's point size. DeepDoc additionally re-renders at
+# ``zoomin * 3`` when a first pass finds no boxes, but only while
+# ``zoomin < 9`` -- so a parse started at or above this never amplifies.
+PDF_PARSE_RETRY_ZOOM_LIMIT = 9
 
 
 def is_pdf_upload(content_type: Optional[str], head: bytes) -> bool:
@@ -53,17 +58,26 @@ def is_pdf_upload(content_type: Optional[str], head: bytes) -> bool:
     return head.startswith(PDF_MAGIC)
 
 
-def validate_pdf_for_parse(data: bytes) -> int:
+def validate_pdf_for_parse(data: bytes, zoomin: int = 3) -> int:
     """Check a PDF that will be handed to a whole-document parser.
 
     Whole-document parsing tasks (e.g. DeepDoc's ``task="parse"``) render the
     PDF themselves, so the bytes are passed straight through instead of being
-    rasterized here. That skips the validation ``rasterize_pdf`` would have
-    done, and parsers tend to fail unhelpfully: DeepDoc swallows load errors
-    and returns an empty result, then retries at 3x the zoom (9x the pixels)
-    when it finds no boxes. Validating up front turns both into a clean
-    error. Returns the page count, and raises ``ValueError`` if the document
-    cannot be opened or has too many pages.
+    rasterized here. That skips everything ``rasterize_pdf`` would have
+    validated, and parsers tend to fail unhelpfully: DeepDoc swallows load
+    errors and returns an empty result, then re-renders at three times the
+    zoom when it finds no boxes.
+
+    Page geometry therefore has to be checked here too: a single valid page
+    with an outsized MediaBox — 14400x14400 points is legal — rasterizes to
+    billions of pixels and exhausts the worker long before the page limit is
+    relevant. The budget is applied at the requested scale; the caller is
+    responsible for keeping the parser's own retry from amplifying it (see
+    ``PDF_PARSE_RETRY_ZOOM_LIMIT``).
+
+    Returns the page count. Raises ``ValueError`` if the document cannot be
+    opened, has no pages, has too many pages, or has a page whose raster
+    would be too large.
     """
     try:
         import pypdfium2 as pdfium
@@ -81,16 +95,29 @@ def validate_pdf_for_parse(data: bytes) -> int:
             raise ValueError(f"Could not read the uploaded PDF: {e}") from e
         try:
             page_count = len(pdf)
+            if page_count < 1:
+                raise ValueError("The uploaded PDF has no pages")
+            if page_count > MAX_PDF_OCR_PAGES:
+                raise ValueError(
+                    f"The uploaded PDF has {page_count} pages, at most "
+                    f"{MAX_PDF_OCR_PAGES} pages can be parsed per request"
+                )
+            for page_number in range(1, page_count + 1):
+                page = pdf[page_number - 1]
+                try:
+                    width, height = page.get_size()
+                finally:
+                    page.close()
+                pixels = int(width * zoomin) * int(height * zoomin)
+                if pixels > MAX_PDF_OCR_PAGE_PIXELS:
+                    raise ValueError(
+                        f"Page {page_number} would rasterize to {pixels} pixels "
+                        f"at zoomin {zoomin:g}, exceeding the limit of "
+                        f"{MAX_PDF_OCR_PAGE_PIXELS}; lower `zoomin`"
+                    )
         finally:
             pdf.close()
 
-    if page_count < 1:
-        raise ValueError("The uploaded PDF has no pages")
-    if page_count > MAX_PDF_OCR_PAGES:
-        raise ValueError(
-            f"The uploaded PDF has {page_count} pages, at most "
-            f"{MAX_PDF_OCR_PAGES} pages can be parsed per request"
-        )
     return page_count
 
 

--- a/xinference/api/pdf_ocr.py
+++ b/xinference/api/pdf_ocr.py
@@ -49,6 +49,15 @@ WHOLE_DOCUMENT_OCR_TASKS = frozenset({"parse"})
 # ``zoomin * 3`` when a first pass finds no boxes, but only while
 # ``zoomin < 9`` -- so a parse started at or above this never amplifies.
 PDF_PARSE_RETRY_ZOOM_LIMIT = 9
+# Unlike the per-page path, which rasterizes lazily and holds one page at a
+# time, whole-document parsers render every page up front and keep them all
+# alive at once. The per-page pixel limit therefore says nothing about a
+# document's total footprint, so the pages are budgeted together as well.
+# Measured against pdfplumber, a rendered page costs ~4 bytes per pixel once
+# the PIL object is accounted for, so this bounds the page images at roughly
+# 4 GB; deepdoc then adds crops, characters and a deepcopy of the boxes on
+# top. It is sized to admit a full 200-page A4 document at the default zoom.
+MAX_PDF_PARSE_TOTAL_PIXELS = 1_000_000_000
 
 
 def is_pdf_upload(content_type: Optional[str], head: bytes) -> bool:
@@ -68,16 +77,20 @@ def validate_pdf_for_parse(data: bytes, zoomin: int = 3) -> int:
     errors and returns an empty result, then re-renders at three times the
     zoom when it finds no boxes.
 
-    Page geometry therefore has to be checked here too: a single valid page
-    with an outsized MediaBox — 14400x14400 points is legal — rasterizes to
-    billions of pixels and exhausts the worker long before the page limit is
-    relevant. The budget is applied at the requested scale; the caller is
+    Page geometry therefore has to be checked here too, in two ways. A single
+    valid page with an outsized MediaBox — 14400x14400 points is legal —
+    rasterizes to billions of pixels on its own. And because every page is
+    rendered up front and held together, a document whose pages are each
+    comfortably under the per-page limit can still exhaust the worker in
+    aggregate, so the pages are budgeted as a whole too.
+
+    Both budgets are applied at the requested scale; the caller is
     responsible for keeping the parser's own retry from amplifying it (see
     ``PDF_PARSE_RETRY_ZOOM_LIMIT``).
 
     Returns the page count. Raises ``ValueError`` if the document cannot be
-    opened, has no pages, has too many pages, or has a page whose raster
-    would be too large.
+    opened, has no pages, has too many pages, or would rasterize to too many
+    pixels on any single page or across the document.
     """
     try:
         import pypdfium2 as pdfium
@@ -102,6 +115,7 @@ def validate_pdf_for_parse(data: bytes, zoomin: int = 3) -> int:
                     f"The uploaded PDF has {page_count} pages, at most "
                     f"{MAX_PDF_OCR_PAGES} pages can be parsed per request"
                 )
+            total_pixels = 0
             for page_number in range(1, page_count + 1):
                 page = pdf[page_number - 1]
                 try:
@@ -114,6 +128,15 @@ def validate_pdf_for_parse(data: bytes, zoomin: int = 3) -> int:
                         f"Page {page_number} would rasterize to {pixels} pixels "
                         f"at zoomin {zoomin:g}, exceeding the limit of "
                         f"{MAX_PDF_OCR_PAGE_PIXELS}; lower `zoomin`"
+                    )
+                total_pixels += pixels
+                if total_pixels > MAX_PDF_PARSE_TOTAL_PIXELS:
+                    raise ValueError(
+                        f"The uploaded PDF would rasterize to more than "
+                        f"{total_pixels} pixels in total at zoomin {zoomin:g}, "
+                        f"exceeding the whole-document limit of "
+                        f"{MAX_PDF_PARSE_TOTAL_PIXELS}; lower `zoomin` or split "
+                        f"the document"
                     )
         finally:
             pdf.close()

--- a/xinference/api/pdf_ocr.py
+++ b/xinference/api/pdf_ocr.py
@@ -56,10 +56,32 @@ PDF_PARSE_RETRY_ZOOM_LIMIT = 9
 
 
 def worst_case_parse_zoom(zoomin: int) -> int:
-    """The largest scale a whole-document parse can actually render at."""
-    if zoomin < PDF_PARSE_RETRY_ZOOM_LIMIT:
-        return zoomin * PDF_PARSE_RETRY_ZOOM_FACTOR
-    return zoomin
+    """The largest scale a whole-document parse can actually render at.
+
+    The retry is recursive: each pass that still finds no boxes triples the
+    zoom again, and only the ``< limit`` guard stops it. So zoomin 1 renders
+    at 1, 3 and finally 9, not just 3.
+    """
+    scale = zoomin
+    while scale < PDF_PARSE_RETRY_ZOOM_LIMIT:
+        scale *= PDF_PARSE_RETRY_ZOOM_FACTOR
+    return scale
+
+
+def worst_case_parse_peak_pixels(width: float, height: float, zoomin: int) -> int:
+    """Peak pixels one page can occupy during a whole-document parse.
+
+    ``self.page_images = [...]`` builds the new list before rebinding the
+    name, so the render that a retry replaces is still referenced while the
+    replacement is being allocated. Peak is therefore the final render plus
+    the one immediately before it.
+    """
+    final = worst_case_parse_zoom(zoomin)
+    previous = final // PDF_PARSE_RETRY_ZOOM_FACTOR
+    peak = int(width * final) * int(height * final)
+    if previous >= zoomin:
+        peak += int(width * previous) * int(height * previous)
+    return peak
 
 
 # Budgets for whole-document parsing. Measured against pdfplumber, a
@@ -75,12 +97,20 @@ def worst_case_parse_zoom(zoomin: int) -> int:
 MAX_PDF_PARSE_PAGE_PIXELS = 200_000_000
 # Unlike the per-page path, which rasterizes lazily and holds one page at a
 # time, whole-document parsers render every page up front and keep them all
-# alive at once, so the pages are budgeted together as well. This one is
-# enforced at the requested scale: `page_images` is reassigned rather than
-# appended to on a retry, so peak usage is one render's worth, and sizing
-# the aggregate for the retry would mean either a 32 GB allowance or
-# refusing ordinary 200-page documents. Sized to admit a full 200-page A4
-# document at the default zoom (0.9 G px, ~3.6 GB).
+# alive at once, so the pages are budgeted together as well -- and, like the
+# per-page ceiling, at the scale a retry can actually reach.
+#
+# Peak usage is the final render plus the one before it: deepdoc assigns
+# ``self.page_images = [...]``, and the comprehension is fully built before
+# the name is rebound, so the previous render is still referenced while the
+# new one is allocated. ``worst_case_parse_peak_pixels`` accounts for both.
+#
+# At 4 GB this admits roughly 22 A4 pages, well short of the 200-page ceiling
+# the per-page path allows. That is the honest consequence of budgeting for a
+# retry that renders at 9x: a document only reaches this if every page yields
+# no text, but the allocation is real when it does, and permitting tens of
+# gigabytes would leave the OOM open. Raise this if parse workers are sized
+# for it; `pages`-style batching in deepdoc-lib would lift it properly.
 MAX_PDF_PARSE_TOTAL_PIXELS = 1_000_000_000
 
 
@@ -148,23 +178,24 @@ def validate_pdf_for_parse(data: bytes, zoomin: int = 3) -> int:
                     width, height = page.get_size()
                 finally:
                     page.close()
-                worst_pixels = int(width * worst_case) * int(height * worst_case)
-                if worst_pixels > MAX_PDF_PARSE_PAGE_PIXELS:
+                peak_pixels = worst_case_parse_peak_pixels(width, height, zoomin)
+                if peak_pixels > MAX_PDF_PARSE_PAGE_PIXELS:
                     raise ValueError(
-                        f"Page {page_number} would rasterize to {worst_pixels} "
+                        f"Page {page_number} would rasterize to {peak_pixels} "
                         f"pixels at zoomin {zoomin:g} (the parser re-renders at "
                         f"up to {worst_case:g}x when a page yields no text), "
                         f"exceeding the per-page limit of "
                         f"{MAX_PDF_PARSE_PAGE_PIXELS}; lower `zoomin`"
                     )
-                total_pixels += int(width * zoomin) * int(height * zoomin)
+                total_pixels += peak_pixels
                 if total_pixels > MAX_PDF_PARSE_TOTAL_PIXELS:
                     raise ValueError(
                         f"The uploaded PDF would rasterize to more than "
-                        f"{total_pixels} pixels in total at zoomin {zoomin:g}, "
-                        f"exceeding the whole-document limit of "
-                        f"{MAX_PDF_PARSE_TOTAL_PIXELS}; lower `zoomin` or split "
-                        f"the document"
+                        f"{total_pixels} pixels in total at zoomin {zoomin:g} "
+                        f"(the parser re-renders at up to {worst_case:g}x when a "
+                        f"page yields no text), exceeding the whole-document "
+                        f"limit of {MAX_PDF_PARSE_TOTAL_PIXELS}; lower `zoomin` "
+                        f"or split the document"
                     )
         finally:
             pdf.close()

--- a/xinference/api/pdf_ocr.py
+++ b/xinference/api/pdf_ocr.py
@@ -41,6 +41,9 @@ MAX_PDF_OCR_PAGES = 200
 # pixels; an A3 page at 600 DPI is ~70 MP) is rejected so a single
 # oversized page cannot exhaust the API process.
 MAX_PDF_OCR_PAGE_PIXELS = 80_000_000
+# OCR tasks that consume the whole PDF instead of one rasterized page at a
+# time, and therefore receive the uploaded bytes unchanged.
+WHOLE_DOCUMENT_OCR_TASKS = frozenset({"parse"})
 
 
 def is_pdf_upload(content_type: Optional[str], head: bytes) -> bool:
@@ -48,6 +51,47 @@ def is_pdf_upload(content_type: Optional[str], head: bytes) -> bool:
     if content_type and content_type.split(";")[0].strip() == "application/pdf":
         return True
     return head.startswith(PDF_MAGIC)
+
+
+def validate_pdf_for_parse(data: bytes) -> int:
+    """Check a PDF that will be handed to a whole-document parser.
+
+    Whole-document parsing tasks (e.g. DeepDoc's ``task="parse"``) render the
+    PDF themselves, so the bytes are passed straight through instead of being
+    rasterized here. That skips the validation ``rasterize_pdf`` would have
+    done, and parsers tend to fail unhelpfully: DeepDoc swallows load errors
+    and returns an empty result, then retries at 3x the zoom (9x the pixels)
+    when it finds no boxes. Validating up front turns both into a clean
+    error. Returns the page count, and raises ``ValueError`` if the document
+    cannot be opened or has too many pages.
+    """
+    try:
+        import pypdfium2 as pdfium
+    except ImportError:
+        error_message = "Failed to import module 'pypdfium2' required for PDF OCR"
+        installation_guide = [
+            "Please make sure 'pypdfium2' is installed, e.g. with `pip install pypdfium2`\n",
+        ]
+        raise ImportError(f"{error_message}\n\n{''.join(installation_guide)}")
+
+    with _pdfium_lock:
+        try:
+            pdf = pdfium.PdfDocument(data)
+        except Exception as e:
+            raise ValueError(f"Could not read the uploaded PDF: {e}") from e
+        try:
+            page_count = len(pdf)
+        finally:
+            pdf.close()
+
+    if page_count < 1:
+        raise ValueError("The uploaded PDF has no pages")
+    if page_count > MAX_PDF_OCR_PAGES:
+        raise ValueError(
+            f"The uploaded PDF has {page_count} pages, at most "
+            f"{MAX_PDF_OCR_PAGES} pages can be parsed per request"
+        )
+    return page_count
 
 
 def normalize_pages(

--- a/xinference/api/pdf_ocr.py
+++ b/xinference/api/pdf_ocr.py
@@ -121,7 +121,7 @@ def is_pdf_upload(content_type: Optional[str], head: bytes) -> bool:
     return head.startswith(PDF_MAGIC)
 
 
-def validate_pdf_for_parse(data: bytes, zoomin: int = 3) -> int:
+def validate_pdf_for_parse(data: bytes, zoomin: int) -> int:
     """Check a PDF that will be handed to a whole-document parser.
 
     Whole-document parsing tasks (e.g. DeepDoc's ``task="parse"``) render the
@@ -138,10 +138,10 @@ def validate_pdf_for_parse(data: bytes, zoomin: int = 3) -> int:
     comfortably under the per-page limit can still exhaust the worker in
     aggregate, so the pages are budgeted as a whole too.
 
-    The per-page budget is applied at the worst-case scale, since the retry
-    is left intact and a single page can reach it. The aggregate one is
-    applied at the requested scale: ``page_images`` is reassigned rather than
-    appended to on a retry, so peak usage is one render's worth.
+    Both budgets are applied at the worst-case scale, since the retry is left
+    intact and re-renders the whole document, and both count the render being
+    replaced alongside its replacement (see
+    ``worst_case_parse_peak_pixels``).
 
     Returns the page count. Raises ``ValueError`` if the document cannot be
     opened, has no pages, has too many pages, or would rasterize to too many

--- a/xinference/api/pdf_ocr.py
+++ b/xinference/api/pdf_ocr.py
@@ -46,17 +46,41 @@ MAX_PDF_OCR_PAGE_PIXELS = 80_000_000
 WHOLE_DOCUMENT_OCR_TASKS = frozenset({"parse"})
 # Whole-document parsers render at ``72 * zoomin`` DPI, i.e. a scale of
 # ``zoomin`` over the page's point size. DeepDoc additionally re-renders at
-# ``zoomin * 3`` when a first pass finds no boxes, but only while
-# ``zoomin < 9`` -- so a parse started at or above this never amplifies.
+# ``zoomin * 3`` when a first pass finds no OCR boxes -- its recovery path
+# for pages the first render was too coarse to read -- but only while
+# ``zoomin < 9``, so a parse started at or above that never amplifies. That
+# retry is part of the parsing behaviour and is left intact, so the budget
+# below is enforced against the largest scale a run can actually reach.
+PDF_PARSE_RETRY_ZOOM_FACTOR = 3
 PDF_PARSE_RETRY_ZOOM_LIMIT = 9
+
+
+def worst_case_parse_zoom(zoomin: int) -> int:
+    """The largest scale a whole-document parse can actually render at."""
+    if zoomin < PDF_PARSE_RETRY_ZOOM_LIMIT:
+        return zoomin * PDF_PARSE_RETRY_ZOOM_FACTOR
+    return zoomin
+
+
+# Budgets for whole-document parsing. Measured against pdfplumber, a
+# rendered page costs ~4 bytes per pixel once the PIL object is accounted
+# for; deepdoc then adds crops, characters and a deepcopy of the boxes.
+#
+# The per-page ceiling is enforced at the worst-case (retry) scale, and is
+# separate from MAX_PDF_OCR_PAGE_PIXELS because the two paths render
+# differently -- reusing that limit here would reject an ordinary A3 page at
+# the default zoom once the retry is accounted for. Sized to admit A4 and A3
+# at the default zoom (41 and 81 MP worst-case) while still rejecting an
+# outsized MediaBox: the 14400x14400 pt maximum is 1.9 G px at zoomin 3.
+MAX_PDF_PARSE_PAGE_PIXELS = 200_000_000
 # Unlike the per-page path, which rasterizes lazily and holds one page at a
 # time, whole-document parsers render every page up front and keep them all
-# alive at once. The per-page pixel limit therefore says nothing about a
-# document's total footprint, so the pages are budgeted together as well.
-# Measured against pdfplumber, a rendered page costs ~4 bytes per pixel once
-# the PIL object is accounted for, so this bounds the page images at roughly
-# 4 GB; deepdoc then adds crops, characters and a deepcopy of the boxes on
-# top. It is sized to admit a full 200-page A4 document at the default zoom.
+# alive at once, so the pages are budgeted together as well. This one is
+# enforced at the requested scale: `page_images` is reassigned rather than
+# appended to on a retry, so peak usage is one render's worth, and sizing
+# the aggregate for the retry would mean either a 32 GB allowance or
+# refusing ordinary 200-page documents. Sized to admit a full 200-page A4
+# document at the default zoom (0.9 G px, ~3.6 GB).
 MAX_PDF_PARSE_TOTAL_PIXELS = 1_000_000_000
 
 
@@ -84,9 +108,10 @@ def validate_pdf_for_parse(data: bytes, zoomin: int = 3) -> int:
     comfortably under the per-page limit can still exhaust the worker in
     aggregate, so the pages are budgeted as a whole too.
 
-    Both budgets are applied at the requested scale; the caller is
-    responsible for keeping the parser's own retry from amplifying it (see
-    ``PDF_PARSE_RETRY_ZOOM_LIMIT``).
+    The per-page budget is applied at the worst-case scale, since the retry
+    is left intact and a single page can reach it. The aggregate one is
+    applied at the requested scale: ``page_images`` is reassigned rather than
+    appended to on a retry, so peak usage is one render's worth.
 
     Returns the page count. Raises ``ValueError`` if the document cannot be
     opened, has no pages, has too many pages, or would rasterize to too many
@@ -115,6 +140,7 @@ def validate_pdf_for_parse(data: bytes, zoomin: int = 3) -> int:
                     f"The uploaded PDF has {page_count} pages, at most "
                     f"{MAX_PDF_OCR_PAGES} pages can be parsed per request"
                 )
+            worst_case = worst_case_parse_zoom(zoomin)
             total_pixels = 0
             for page_number in range(1, page_count + 1):
                 page = pdf[page_number - 1]
@@ -122,14 +148,16 @@ def validate_pdf_for_parse(data: bytes, zoomin: int = 3) -> int:
                     width, height = page.get_size()
                 finally:
                     page.close()
-                pixels = int(width * zoomin) * int(height * zoomin)
-                if pixels > MAX_PDF_OCR_PAGE_PIXELS:
+                worst_pixels = int(width * worst_case) * int(height * worst_case)
+                if worst_pixels > MAX_PDF_PARSE_PAGE_PIXELS:
                     raise ValueError(
-                        f"Page {page_number} would rasterize to {pixels} pixels "
-                        f"at zoomin {zoomin:g}, exceeding the limit of "
-                        f"{MAX_PDF_OCR_PAGE_PIXELS}; lower `zoomin`"
+                        f"Page {page_number} would rasterize to {worst_pixels} "
+                        f"pixels at zoomin {zoomin:g} (the parser re-renders at "
+                        f"up to {worst_case:g}x when a page yields no text), "
+                        f"exceeding the per-page limit of "
+                        f"{MAX_PDF_PARSE_PAGE_PIXELS}; lower `zoomin`"
                     )
-                total_pixels += pixels
+                total_pixels += int(width * zoomin) * int(height * zoomin)
                 if total_pixels > MAX_PDF_PARSE_TOTAL_PIXELS:
                     raise ValueError(
                         f"The uploaded PDF would rasterize to more than "

--- a/xinference/api/restful_api.py
+++ b/xinference/api/restful_api.py
@@ -79,9 +79,11 @@ from .frontend_static import mount_frontend
 from .pdf_ocr import (
     DEFAULT_PDF_OCR_DPI,
     PDF_MAGIC,
+    WHOLE_DOCUMENT_OCR_TASKS,
     is_pdf_upload,
     merge_ocr_page_results,
     rasterize_pdf,
+    validate_pdf_for_parse,
 )
 from .responses import JSONResponse
 from .schemas import (
@@ -1978,7 +1980,41 @@ class RESTfulAPI(CancelMixin):
             self._add_running_task(request_id)
             head = image.file.read(len(PDF_MAGIC))
             image.file.seek(0)
-            if is_pdf_upload(image.content_type, head):
+            is_pdf = is_pdf_upload(image.content_type, head)
+            # Whole-document tasks parse the PDF themselves and need the
+            # original bytes plus every page at once, so they bypass the
+            # per-page rasterizing path below.
+            requested_task = parsed_kwargs.get("task")
+            if (
+                isinstance(requested_task, str)
+                and requested_task in WHOLE_DOCUMENT_OCR_TASKS
+            ):
+                task = requested_task
+                if not is_pdf:
+                    raise HTTPException(
+                        status_code=400,
+                        detail=f"OCR task {task!r} requires a PDF upload",
+                    )
+                for unsupported in ("pages", "dpi"):
+                    if unsupported in parsed_kwargs:
+                        raise HTTPException(
+                            status_code=400,
+                            detail=(
+                                f"`{unsupported}` is not supported for OCR task "
+                                f"{task!r}, which parses the whole document"
+                            ),
+                        )
+                data = image.file.read()
+                try:
+                    await asyncio.to_thread(validate_pdf_for_parse, data)
+                except ValueError as ve:
+                    raise HTTPException(status_code=400, detail=str(ve))
+                result = await model_ref.ocr(
+                    image=data,
+                    **parsed_kwargs,
+                )
+                return Response(content=result, media_type="application/json")
+            if is_pdf:
                 pages = parsed_kwargs.pop("pages", None)
                 dpi = parsed_kwargs.pop("dpi", DEFAULT_PDF_OCR_DPI)
                 try:

--- a/xinference/api/restful_api.py
+++ b/xinference/api/restful_api.py
@@ -2004,15 +2004,25 @@ class RESTfulAPI(CancelMixin):
                                 f"{task!r}, which parses the whole document"
                             ),
                         )
+                from ..model.image.ocr.deepdoc import parse_zoomin
+
                 data = image.file.read()
                 try:
-                    await asyncio.to_thread(validate_pdf_for_parse, data)
+                    # The model validates this too; it is needed here to
+                    # budget the raster before the bytes are handed over.
+                    zoomin = parse_zoomin(parsed_kwargs.get("zoomin"))
+                    await asyncio.to_thread(validate_pdf_for_parse, data, zoomin)
                 except ValueError as ve:
                     raise HTTPException(status_code=400, detail=str(ve))
-                result = await model_ref.ocr(
-                    image=data,
-                    **parsed_kwargs,
-                )
+                try:
+                    result = await model_ref.ocr(
+                        image=data,
+                        **parsed_kwargs,
+                    )
+                except ValueError as ve:
+                    # Bad `zoomin`/`image_scope` and friends are user input,
+                    # not a server fault.
+                    raise HTTPException(status_code=400, detail=str(ve))
                 return Response(content=result, media_type="application/json")
             if is_pdf:
                 pages = parsed_kwargs.pop("pages", None)

--- a/xinference/api/tests/test_ocr_pdf.py
+++ b/xinference/api/tests/test_ocr_pdf.py
@@ -226,29 +226,30 @@ class TestValidatePdfForParse:
 
     def test_accepts_a_valid_pdf_and_returns_the_page_count(self):
         pytest.importorskip("pypdfium2")
-        assert validate_pdf_for_parse(make_pdf(page_count=3)) == 3
+        assert validate_pdf_for_parse(make_pdf(page_count=3), 3) == 3
 
     def test_rejects_non_pdf_bytes(self):
         pytest.importorskip("pypdfium2")
         with pytest.raises(ValueError, match="Could not read the uploaded PDF"):
-            validate_pdf_for_parse(b"\x89PNG\r\n\x1a\n not a pdf")
+            validate_pdf_for_parse(b"\x89PNG\r\n\x1a\n not a pdf", 3)
 
     def test_rejects_empty_input(self):
         pytest.importorskip("pypdfium2")
         with pytest.raises(ValueError):
-            validate_pdf_for_parse(b"")
+            validate_pdf_for_parse(b"", 3)
 
     def test_rejects_too_many_pages(self):
         pytest.importorskip("pypdfium2")
         oversized = make_pdf(page_count=MAX_PDF_OCR_PAGES + 1)
         with pytest.raises(ValueError, match="at most"):
-            validate_pdf_for_parse(oversized)
+            validate_pdf_for_parse(oversized, 3)
 
-    def test_page_limit_is_shared_with_the_per_page_path(self):
-        # Users see one page ceiling for the OCR endpoint, whichever task
-        # they pick.
+    def test_page_count_ceiling_is_shared_with_the_per_page_path(self):
+        # The page *count* ceiling is the same for both tasks. The pixel
+        # budgets are not -- parse enforces its own, against the retry scale
+        # -- so this uses the small default page size to isolate the count.
         pytest.importorskip("pypdfium2")
-        assert validate_pdf_for_parse(make_pdf(page_count=MAX_PDF_OCR_PAGES)) == (
+        assert validate_pdf_for_parse(make_pdf(page_count=MAX_PDF_OCR_PAGES), 3) == (
             MAX_PDF_OCR_PAGES
         )
 
@@ -259,7 +260,7 @@ class TestValidatePdfForParse:
         pytest.importorskip("pypdfium2")
         oversized = make_pdf(media_box="0 0 14400 14400")
         with pytest.raises(ValueError, match="per-page limit"):
-            validate_pdf_for_parse(oversized)
+            validate_pdf_for_parse(oversized, 3)
 
     def test_page_budget_accounts_for_the_retry_scale(self):
         # deepdoc re-renders at 3x when a page yields no text, and that

--- a/xinference/api/tests/test_ocr_pdf.py
+++ b/xinference/api/tests/test_ocr_pdf.py
@@ -247,6 +247,33 @@ class TestValidatePdfForParse:
             MAX_PDF_OCR_PAGES
         )
 
+    def test_rejects_an_oversized_page(self):
+        # A single page with a huge (but legal) MediaBox rasterizes to
+        # billions of pixels long before the page limit is relevant, so the
+        # page-pixel budget has to be enforced here too.
+        pytest.importorskip("pypdfium2")
+        oversized = make_pdf(media_box="0 0 14400 14400")
+        with pytest.raises(ValueError, match="exceeding the limit"):
+            validate_pdf_for_parse(oversized)
+
+    def test_common_page_sizes_pass_at_every_allowed_zoom(self):
+        # The budget must not reject ordinary documents: A4, Letter and even
+        # A0 are all legitimate parse inputs.
+        pytest.importorskip("pypdfium2")
+        for media_box in ("0 0 595 842", "0 0 612 792", "0 0 842 1191"):
+            for zoomin in (3, 6):
+                assert (
+                    validate_pdf_for_parse(make_pdf(media_box=media_box), zoomin) == 1
+                )
+
+    def test_budget_scales_with_zoomin(self):
+        pytest.importorskip("pypdfium2")
+        # 2384x3370 pt (A0): 72 MP at zoomin 3, 289 MP at zoomin 6.
+        a0 = make_pdf(media_box="0 0 2384 3370")
+        assert validate_pdf_for_parse(a0, zoomin=3) == 1
+        with pytest.raises(ValueError, match="exceeding the limit"):
+            validate_pdf_for_parse(a0, zoomin=6)
+
 
 class TestWholeDocumentOcrTasks:
     def test_parse_is_a_whole_document_task(self):

--- a/xinference/api/tests/test_ocr_pdf.py
+++ b/xinference/api/tests/test_ocr_pdf.py
@@ -21,10 +21,12 @@ import pytest
 from ..pdf_ocr import (
     DEFAULT_PDF_OCR_DPI,
     MAX_PDF_OCR_PAGES,
+    WHOLE_DOCUMENT_OCR_TASKS,
     is_pdf_upload,
     merge_ocr_page_results,
     normalize_pages,
     rasterize_pdf,
+    validate_pdf_for_parse,
 )
 
 
@@ -210,3 +212,46 @@ class TestRasterizePdf:
 
     def test_pdf_magic_detected_on_generated_pdf(self):
         assert is_pdf_upload(None, make_pdf()[:8])
+
+
+class TestValidatePdfForParse:
+    """Whole-document tasks get the uploaded bytes without going through
+    ``rasterize_pdf``, so this is the only place a bad PDF is caught before
+    the parser sees it."""
+
+    def test_accepts_a_valid_pdf_and_returns_the_page_count(self):
+        pytest.importorskip("pypdfium2")
+        assert validate_pdf_for_parse(make_pdf(page_count=3)) == 3
+
+    def test_rejects_non_pdf_bytes(self):
+        pytest.importorskip("pypdfium2")
+        with pytest.raises(ValueError, match="Could not read the uploaded PDF"):
+            validate_pdf_for_parse(b"\x89PNG\r\n\x1a\n not a pdf")
+
+    def test_rejects_empty_input(self):
+        pytest.importorskip("pypdfium2")
+        with pytest.raises(ValueError):
+            validate_pdf_for_parse(b"")
+
+    def test_rejects_too_many_pages(self):
+        pytest.importorskip("pypdfium2")
+        oversized = make_pdf(page_count=MAX_PDF_OCR_PAGES + 1)
+        with pytest.raises(ValueError, match="at most"):
+            validate_pdf_for_parse(oversized)
+
+    def test_page_limit_is_shared_with_the_per_page_path(self):
+        # Users see one page ceiling for the OCR endpoint, whichever task
+        # they pick.
+        pytest.importorskip("pypdfium2")
+        assert validate_pdf_for_parse(make_pdf(page_count=MAX_PDF_OCR_PAGES)) == (
+            MAX_PDF_OCR_PAGES
+        )
+
+
+class TestWholeDocumentOcrTasks:
+    def test_parse_is_a_whole_document_task(self):
+        assert "parse" in WHOLE_DOCUMENT_OCR_TASKS
+
+    def test_per_page_tasks_are_not(self):
+        for task in ("ocr", "layout", "table"):
+            assert task not in WHOLE_DOCUMENT_OCR_TASKS

--- a/xinference/api/tests/test_ocr_pdf.py
+++ b/xinference/api/tests/test_ocr_pdf.py
@@ -23,12 +23,14 @@ from ..pdf_ocr import (
     MAX_PDF_OCR_PAGES,
     MAX_PDF_PARSE_PAGE_PIXELS,
     MAX_PDF_PARSE_TOTAL_PIXELS,
+    PDF_PARSE_RETRY_ZOOM_LIMIT,
     WHOLE_DOCUMENT_OCR_TASKS,
     is_pdf_upload,
     merge_ocr_page_results,
     normalize_pages,
     rasterize_pdf,
     validate_pdf_for_parse,
+    worst_case_parse_peak_pixels,
     worst_case_parse_zoom,
 )
 
@@ -269,7 +271,7 @@ class TestValidatePdfForParse:
         # actually render at.
         borderline = make_pdf(media_box="0 0 1700 1700")
         assert int(1700 * 3) ** 2 < MAX_PDF_PARSE_PAGE_PIXELS
-        assert int(1700 * 9) ** 2 > MAX_PDF_PARSE_PAGE_PIXELS
+        assert worst_case_parse_peak_pixels(1700, 1700, 3) > MAX_PDF_PARSE_PAGE_PIXELS
         with pytest.raises(ValueError, match="per-page limit"):
             validate_pdf_for_parse(borderline, zoomin=3)
 
@@ -305,12 +307,66 @@ class TestValidatePdfForParse:
         with pytest.raises(ValueError, match="whole-document limit"):
             validate_pdf_for_parse(doc, zoomin=4)
 
-    def test_full_length_document_passes_at_the_default_zoom(self):
-        # The aggregate budget must still admit an ordinary long document:
-        # 200 A4 pages at the default zoom is the headline supported case.
+    def test_typical_document_passes_at_the_default_zoom(self):
+        # The aggregate budget must still admit an everyday document. Because
+        # it is enforced against the retry scale, the allowance is far below
+        # the 200-page ceiling the per-page OCR path permits: an A4 page peaks
+        # at 45 MP, so ~22 of them fit.
+        pytest.importorskip("pypdfium2")
+        a4 = make_pdf(page_count=20, media_box="0 0 595 842")
+        assert validate_pdf_for_parse(a4, zoomin=3) == 20
+
+    def test_page_ceiling_alone_does_not_admit_a_long_document(self):
+        # Documented consequence of budgeting for the 9x retry: a 200-page
+        # document is rejected on pixels, not on the page count.
         pytest.importorskip("pypdfium2")
         a4 = make_pdf(page_count=MAX_PDF_OCR_PAGES, media_box="0 0 595 842")
-        assert validate_pdf_for_parse(a4, zoomin=3) == MAX_PDF_OCR_PAGES
+        with pytest.raises(ValueError, match="whole-document limit"):
+            validate_pdf_for_parse(a4, zoomin=3)
+
+
+class TestWorstCaseParseZoom:
+    """The retry is recursive, so a low zoomin chains up several times."""
+
+    def test_chain_is_followed_to_the_ceiling(self):
+        # zoomin 1 renders at 1, then 3, then 9 -- not just 3.
+        assert worst_case_parse_zoom(1) == 9
+        assert worst_case_parse_zoom(2) == 18
+        assert worst_case_parse_zoom(3) == 9
+        assert worst_case_parse_zoom(4) == 12
+        assert worst_case_parse_zoom(5) == 15
+        assert worst_case_parse_zoom(6) == 18
+
+    def test_result_always_reaches_the_ceiling(self):
+        # Whatever the input, the chain must terminate at or above the limit,
+        # otherwise a further retry would still be possible.
+        for zoomin in range(1, 7):
+            assert worst_case_parse_zoom(zoomin) >= PDF_PARSE_RETRY_ZOOM_LIMIT
+
+    def test_never_below_the_requested_scale(self):
+        for zoomin in range(1, 7):
+            assert worst_case_parse_zoom(zoomin) >= zoomin
+
+    def test_at_or_above_the_ceiling_does_not_amplify(self):
+        assert worst_case_parse_zoom(9) == 9
+        assert worst_case_parse_zoom(12) == 12
+
+
+class TestWorstCaseParsePeakPixels:
+    def test_counts_the_coexisting_previous_render(self):
+        # `page_images = [...]` builds the new list before rebinding, so the
+        # render being replaced is still alive. Peak is 9x + 1x, not 9x.
+        peak = worst_case_parse_peak_pixels(100, 100, 3)
+        assert peak == (900 * 900) + (300 * 300)
+
+    def test_no_previous_render_when_no_retry_can_fire(self):
+        assert worst_case_parse_peak_pixels(100, 100, 9) == 900 * 900
+
+    def test_every_accepted_zoomin_is_bounded(self):
+        for zoomin in range(1, 7):
+            peak = worst_case_parse_peak_pixels(595, 842, zoomin)
+            final = worst_case_parse_zoom(zoomin)
+            assert peak >= int(595 * final) * int(842 * final)
 
 
 class TestWholeDocumentOcrTasks:

--- a/xinference/api/tests/test_ocr_pdf.py
+++ b/xinference/api/tests/test_ocr_pdf.py
@@ -20,7 +20,9 @@ import pytest
 
 from ..pdf_ocr import (
     DEFAULT_PDF_OCR_DPI,
+    MAX_PDF_OCR_PAGE_PIXELS,
     MAX_PDF_OCR_PAGES,
+    MAX_PDF_PARSE_TOTAL_PIXELS,
     WHOLE_DOCUMENT_OCR_TASKS,
     is_pdf_upload,
     merge_ocr_page_results,
@@ -273,6 +275,27 @@ class TestValidatePdfForParse:
         assert validate_pdf_for_parse(a0, zoomin=3) == 1
         with pytest.raises(ValueError, match="exceeding the limit"):
             validate_pdf_for_parse(a0, zoomin=6)
+
+    def test_rejects_an_oversized_document_of_individually_small_pages(self):
+        # Whole-document parsers render every page up front and hold them all
+        # at once, so a document whose pages each pass the per-page limit can
+        # still exhaust the worker in aggregate. A4 at zoomin 6 is 18 MP per
+        # page -- far under the 80 MP page limit -- but 200 of them come to
+        # 3.6 G px, measured at ~4 bytes each once rendered.
+        pytest.importorskip("pypdfium2")
+        per_page = int(595 * 6) * int(842 * 6)
+        assert per_page < MAX_PDF_OCR_PAGE_PIXELS
+        assert per_page * MAX_PDF_OCR_PAGES > MAX_PDF_PARSE_TOTAL_PIXELS
+        a4 = make_pdf(page_count=MAX_PDF_OCR_PAGES, media_box="0 0 595 842")
+        with pytest.raises(ValueError, match="whole-document limit"):
+            validate_pdf_for_parse(a4, zoomin=6)
+
+    def test_full_length_document_passes_at_the_default_zoom(self):
+        # The aggregate budget must still admit an ordinary long document:
+        # 200 A4 pages at the default zoom is the headline supported case.
+        pytest.importorskip("pypdfium2")
+        a4 = make_pdf(page_count=MAX_PDF_OCR_PAGES, media_box="0 0 595 842")
+        assert validate_pdf_for_parse(a4, zoomin=3) == MAX_PDF_OCR_PAGES
 
 
 class TestWholeDocumentOcrTasks:

--- a/xinference/api/tests/test_ocr_pdf.py
+++ b/xinference/api/tests/test_ocr_pdf.py
@@ -20,8 +20,8 @@ import pytest
 
 from ..pdf_ocr import (
     DEFAULT_PDF_OCR_DPI,
-    MAX_PDF_OCR_PAGE_PIXELS,
     MAX_PDF_OCR_PAGES,
+    MAX_PDF_PARSE_PAGE_PIXELS,
     MAX_PDF_PARSE_TOTAL_PIXELS,
     WHOLE_DOCUMENT_OCR_TASKS,
     is_pdf_upload,
@@ -29,6 +29,7 @@ from ..pdf_ocr import (
     normalize_pages,
     rasterize_pdf,
     validate_pdf_for_parse,
+    worst_case_parse_zoom,
 )
 
 
@@ -255,26 +256,37 @@ class TestValidatePdfForParse:
         # page-pixel budget has to be enforced here too.
         pytest.importorskip("pypdfium2")
         oversized = make_pdf(media_box="0 0 14400 14400")
-        with pytest.raises(ValueError, match="exceeding the limit"):
+        with pytest.raises(ValueError, match="per-page limit"):
             validate_pdf_for_parse(oversized)
 
-    def test_common_page_sizes_pass_at_every_allowed_zoom(self):
-        # The budget must not reject ordinary documents: A4, Letter and even
-        # A0 are all legitimate parse inputs.
+    def test_page_budget_accounts_for_the_retry_scale(self):
+        # deepdoc re-renders at 3x when a page yields no text, and that
+        # retry is left intact, so the per-page budget is enforced against
+        # the scale a run can actually reach.
+        pytest.importorskip("pypdfium2")
+        assert worst_case_parse_zoom(3) == 9
+        # 1700x1700 pt: 26 MP at zoomin 3, but 234 MP at the 9x it may
+        # actually render at.
+        borderline = make_pdf(media_box="0 0 1700 1700")
+        assert int(1700 * 3) ** 2 < MAX_PDF_PARSE_PAGE_PIXELS
+        assert int(1700 * 9) ** 2 > MAX_PDF_PARSE_PAGE_PIXELS
+        with pytest.raises(ValueError, match="per-page limit"):
+            validate_pdf_for_parse(borderline, zoomin=3)
+
+    def test_common_page_sizes_pass_at_the_default_zoom(self):
+        # The budget must not reject ordinary documents. A4, Letter and A3
+        # come to 41, 39 and 81 MP at the zoomin-3 worst case.
         pytest.importorskip("pypdfium2")
         for media_box in ("0 0 595 842", "0 0 612 792", "0 0 842 1191"):
-            for zoomin in (3, 6):
-                assert (
-                    validate_pdf_for_parse(make_pdf(media_box=media_box), zoomin) == 1
-                )
+            assert validate_pdf_for_parse(make_pdf(media_box=media_box), 3) == 1
 
     def test_budget_scales_with_zoomin(self):
         pytest.importorskip("pypdfium2")
-        # 2384x3370 pt (A0): 72 MP at zoomin 3, 289 MP at zoomin 6.
-        a0 = make_pdf(media_box="0 0 2384 3370")
-        assert validate_pdf_for_parse(a0, zoomin=3) == 1
-        with pytest.raises(ValueError, match="exceeding the limit"):
-            validate_pdf_for_parse(a0, zoomin=6)
+        # A3 is 81 MP at the zoomin-3 worst case but 325 MP at zoomin 6.
+        a3 = make_pdf(media_box="0 0 842 1191")
+        assert validate_pdf_for_parse(a3, zoomin=3) == 1
+        with pytest.raises(ValueError, match="per-page limit"):
+            validate_pdf_for_parse(a3, zoomin=6)
 
     def test_rejects_an_oversized_document_of_individually_small_pages(self):
         # Whole-document parsers render every page up front and hold them all
@@ -283,12 +295,15 @@ class TestValidatePdfForParse:
         # page -- far under the 80 MP page limit -- but 200 of them come to
         # 3.6 G px, measured at ~4 bytes each once rendered.
         pytest.importorskip("pypdfium2")
-        per_page = int(595 * 6) * int(842 * 6)
-        assert per_page < MAX_PDF_OCR_PAGE_PIXELS
+        # 1000x1000 pt at zoomin 4: 16 MP per page (well under the per-page
+        # cap even at the 12x worst case, 144 MP), but 200 of them are
+        # 3.2 G px together.
+        per_page = int(1000 * 4) ** 2
+        assert int(1000 * 12) ** 2 < MAX_PDF_PARSE_PAGE_PIXELS
         assert per_page * MAX_PDF_OCR_PAGES > MAX_PDF_PARSE_TOTAL_PIXELS
-        a4 = make_pdf(page_count=MAX_PDF_OCR_PAGES, media_box="0 0 595 842")
+        doc = make_pdf(page_count=MAX_PDF_OCR_PAGES, media_box="0 0 1000 1000")
         with pytest.raises(ValueError, match="whole-document limit"):
-            validate_pdf_for_parse(a4, zoomin=6)
+            validate_pdf_for_parse(doc, zoomin=4)
 
     def test_full_length_document_passes_at_the_default_zoom(self):
         # The aggregate budget must still admit an ordinary long document:

--- a/xinference/model/image/ocr/deepdoc.py
+++ b/xinference/model/image/ocr/deepdoc.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import base64
+import io
 import logging
 import os
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
@@ -24,6 +26,21 @@ if TYPE_CHECKING:
 from .ocr_family import OCRModel
 
 logger = logging.getLogger(__name__)
+
+# ``parse_into_bboxes`` attaches a cropped image to every element, but only
+# tables and figures are worth shipping back; encoding all of them would
+# inflate the response by an order of magnitude.
+IMAGE_SCOPES = ("table_figure", "all", "none")
+DEFAULT_IMAGE_SCOPE = "table_figure"
+_IMAGE_SCOPE_TYPES = ("table", "figure")
+DEFAULT_PARSE_ZOOMIN = 3
+# Above this, ``parse_into_bboxes`` renders pages so large that a single
+# document can exhaust host memory.
+MAX_PARSE_ZOOMIN = 6
+# Keys that must not appear in ``metadata``: ``position_tag`` is a
+# deepdoc-internal marker string, ``image`` is replaced by ``image_base64``,
+# and ``text`` is promoted to a top-level field.
+_METADATA_EXCLUDED_KEYS = frozenset({"position_tag", "image", "text"})
 
 
 def _jsonable(obj: Any) -> Any:
@@ -52,15 +69,158 @@ def _parse_threshold(kwargs: Dict[str, Any], default: float = 0.2) -> float:
         raise ValueError(f"Invalid threshold: {value!r}, expected a number") from e
 
 
+def _parse_zoomin(kwargs: Dict[str, Any], default: int = DEFAULT_PARSE_ZOOMIN) -> int:
+    # None (e.g. an explicit JSON null from the HTTP API) falls back to the
+    # default, like `threshold` does.
+    value = kwargs.get("zoomin")
+    if value is None:
+        return default
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"Invalid zoomin: {value!r}, expected an integer")
+    if value < 1 or value > MAX_PARSE_ZOOMIN:
+        raise ValueError(
+            f"Invalid zoomin: {value!r}, expected an integer between 1 "
+            f"and {MAX_PARSE_ZOOMIN}"
+        )
+    return value
+
+
+def _parse_image_scope(
+    kwargs: Dict[str, Any], default: str = DEFAULT_IMAGE_SCOPE
+) -> str:
+    value = kwargs.get("image_scope")
+    if value is None:
+        return default
+    if value not in IMAGE_SCOPES:
+        raise ValueError(
+            f"Invalid image_scope: {value!r}. "
+            f"Supported values: {', '.join(repr(s) for s in IMAGE_SCOPES)}."
+        )
+    return value
+
+
+def _wants_image(layout_type: Any, image_scope: str) -> bool:
+    if image_scope == "all":
+        return True
+    if image_scope == "none":
+        return False
+    return layout_type in _IMAGE_SCOPE_TYPES
+
+
+def _encode_image(image: Any) -> Optional[str]:
+    """PNG-encode a crop to base64, or return None if it cannot be encoded.
+
+    Crops are line art (tables, figures), so PNG is used rather than JPEG:
+    lossy artifacts would degrade downstream re-reading of the crop.
+    """
+    if image is None:
+        return None
+    try:
+        buffer = io.BytesIO()
+        image.save(buffer, format="PNG")
+        return base64.b64encode(buffer.getvalue()).decode("ascii")
+    except Exception:
+        # A crop that fails to encode must not fail the whole document.
+        logger.warning("Failed to encode a DeepDoc crop image", exc_info=True)
+        return None
+
+
+def _build_parallel_limiter() -> Optional[List[Any]]:
+    """Mirror the per-device semaphores ``RAGFlowPdfParser.__init__`` builds.
+
+    Bypassing that constructor to reuse the loaded recognizers means this has
+    to be reproduced, otherwise multi-GPU workers would silently serialize
+    page recognition onto a single device.
+    """
+    import asyncio
+
+    from deepdoc.common import check_and_install_torch, settings
+
+    try:
+        check_and_install_torch()
+        if settings.PARALLEL_DEVICES > 1:
+            return [asyncio.Semaphore(1) for _ in range(settings.PARALLEL_DEVICES)]
+    except Exception:
+        logger.debug("Could not size the DeepDoc parallel limiter", exc_info=True)
+    return None
+
+
+def _reset_parser_document_state(parser: Any) -> None:
+    """Drop the per-document state a parse run leaves on the parser.
+
+    The parser is cached and reused across requests to keep a single set of
+    ONNX models loaded, but ``parse_into_bboxes`` stores the document it just
+    processed on the instance and never clears it. Two problems follow:
+
+    * the rasterized pages, the per-box crops and the extracted characters
+      stay reachable after the response is sent -- at the page limit and the
+      largest render scale that is gigabytes of resident memory held idle;
+    * ``__images__`` resets ``boxes`` before it loads the new document but
+      swallows load failures, so a document it cannot open would leave the
+      *previous* request's pages attached and silently parse those instead.
+
+    Clearing the state after every run bounds the memory and makes a failed
+    load produce an empty result rather than the last document's content.
+    """
+    for attribute, empty in (
+        ("boxes", []),
+        ("page_images", []),
+        ("page_chars", []),
+        ("page_layout", []),
+        ("page_cum_height", [0]),
+        ("garbages", {}),
+        ("lefted_chars", []),
+        ("mean_height", []),
+        ("mean_width", []),
+        ("outlines", []),
+        ("tb_cpns", []),
+        ("pdf", None),
+        ("total_page", 0),
+    ):
+        try:
+            setattr(parser, attribute, empty)
+        except Exception:  # pragma: no cover - defensive
+            logger.debug("Could not reset parser attribute %s", attribute)
+
+
+def _element_to_json(element: Dict[str, Any], image_scope: str) -> Dict[str, Any]:
+    """Turn one ``parse_into_bboxes`` element into a JSON-serializable dict.
+
+    ``parse_into_bboxes`` returns numpy scalars and PIL images, and the
+    table/figure elements it re-inserts into the text flow carry a smaller
+    key set than the text ones (no ``col_id``, no ``position_tag``), so
+    every key is read defensively. Absent keys are omitted rather than
+    defaulted, so the response never claims information deepdoc did not
+    produce.
+    """
+    metadata = {
+        k: _jsonable(v) for k, v in element.items() if k not in _METADATA_EXCLUDED_KEYS
+    }
+    result: Dict[str, Any] = {
+        "type": _jsonable(element.get("layout_type")),
+        "text": element.get("text"),
+        "metadata": metadata,
+    }
+    if _wants_image(element.get("layout_type"), image_scope):
+        encoded = _encode_image(element.get("image"))
+        if encoded is not None:
+            result["image_base64"] = encoded
+    return result
+
+
 class DeepDocModel(OCRModel):
     """RAGFlow's DeepDoc ONNX models for document parsing.
 
     Inference is provided by the ``deepdoc-lib`` package
-    (https://github.com/xorbitsai/deepdoc-lib). Three tasks are supported,
+    (https://github.com/xorbitsai/deepdoc-lib). Four tasks are supported,
     selected via the ``task`` kwarg:
     - ``ocr`` (default): text detection + recognition, returns plain text
     - ``layout``: page layout analysis, returns layout blocks as a dict
     - ``table``: table structure recognition, returns structures as a dict
+    - ``parse``: the full document-parsing pipeline over a whole PDF,
+      returning ordered elements with table HTML, figures and cross-page
+      coordinates. Unlike the other three it consumes PDF bytes rather
+      than a page image.
     """
 
     required_libs = ("deepdoc",)
@@ -85,6 +245,7 @@ class DeepDocModel(OCRModel):
         self._ocr = None
         self._layout_recognizer = None
         self._table_recognizer = None
+        self._pdf_parser = None
         # info
         self._model_spec = model_spec
         self._abilities = model_spec.model_ability or []  # type: ignore
@@ -130,23 +291,136 @@ class DeepDocModel(OCRModel):
             )
         return self._table_recognizer
 
+    def _xgb_model_dir(self) -> str:
+        """Locate the directory holding ``updown_concat_xgb.model``.
+
+        The paragraph-merging booster lives outside the vision bundle: the
+        ModelScope layout keeps ``vision/`` and ``xgb/`` as siblings, while a
+        flat checkout keeps the booster next to the onnx files.
+        """
+        model_name = "updown_concat_xgb.model"
+        vision_dir = self._model_dir()
+        candidates = [
+            os.path.join(os.path.dirname(vision_dir), "xgb"),
+            os.path.join(vision_dir, "xgb"),
+            vision_dir,
+            self._model_path or "",
+        ]
+        for candidate in candidates:
+            if candidate and os.path.exists(os.path.join(candidate, model_name)):
+                return candidate
+        raise RuntimeError(
+            f"Could not find {model_name} for DeepDoc task 'parse' under "
+            f"{self._model_path!r}. Re-download the model files."
+        )
+
+    def _build_pdf_parser(self):
+        """Build a ``PdfParser`` that reuses the already-loaded recognizers.
+
+        ``RAGFlowPdfParser.__init__`` would construct its own OCR, layout and
+        table recognizers, doubling the ONNX sessions (and the VRAM) this
+        model already holds. So the constructor is bypassed and only the
+        attributes it would have set are assembled, wiring in the existing
+        recognizers. If a future ``deepdoc-lib`` needs attributes we do not
+        know about, fall back to the real constructor and inject afterwards
+        -- slower and briefly twice the memory, but correct.
+        """
+        import xgboost as xgb
+        from deepdoc import PdfModelConfig, PdfParser, TokenizerConfig
+        from deepdoc.depend.rag_tokenizer import RagTokenizer
+
+        vision_dir = self._model_dir()
+        xgb_dir = self._xgb_model_dir()
+        # `model_provider="local"` keeps the onnx/booster side offline, but the
+        # tokenizer config must stay online-capable: RagTokenizer raises when
+        # its nltk data is missing and offline mode is on.
+        model_cfg = PdfModelConfig(
+            vision_model_dir=vision_dir,
+            xgb_model_dir=xgb_dir,
+            model_provider="local",
+        )
+        tokenizer_cfg = TokenizerConfig()
+
+        booster = xgb.Booster()
+        try:
+            import torch
+
+            if torch.cuda.is_available():
+                booster.set_param({"device": "cuda"})
+        except Exception:
+            logger.debug("torch unavailable, running the xgb booster on CPU")
+        booster.load_model(os.path.join(xgb_dir, "updown_concat_xgb.model"))
+
+        parser = PdfParser.__new__(PdfParser)
+        parser.model_cfg = model_cfg
+        parser.tokenizer_cfg = tokenizer_cfg
+        # Load-bearing: `_concat_downward` tokenizes and tags line text.
+        parser.tokenizer = RagTokenizer(
+            dict_prefix=tokenizer_cfg.resolve_dict_prefix(),
+            offline=tokenizer_cfg.offline,
+            nltk_data_dir=tokenizer_cfg.nltk_data_dir,
+        )
+        parser.ocr = self._ocr
+        parser.layouter = self._get_layout_recognizer()
+        parser.tbl_det = self._get_table_recognizer()
+        parser.updown_cnt_mdl = booster
+        parser.parallel_limiter = _build_parallel_limiter()
+        parser.page_from = 0
+        parser.column_num = 1
+        return parser
+
+    def _get_pdf_parser(self):
+        if self._pdf_parser is None:
+            try:
+                self._pdf_parser = self._build_pdf_parser()
+            except Exception:
+                logger.warning(
+                    "Could not assemble a DeepDoc PdfParser around the loaded "
+                    "recognizers; falling back to constructing a new one, "
+                    "which loads a second set of models.",
+                    exc_info=True,
+                )
+                self._pdf_parser = self._build_pdf_parser_fallback()
+        return self._pdf_parser
+
+    def _build_pdf_parser_fallback(self):
+        from deepdoc import PdfModelConfig, PdfParser
+
+        parser = PdfParser(
+            model_cfg=PdfModelConfig(
+                vision_model_dir=self._model_dir(),
+                xgb_model_dir=self._xgb_model_dir(),
+                model_provider="local",
+            )
+        )
+        # Drop the freshly built recognizers in favour of the loaded ones so
+        # steady-state memory still holds a single set.
+        parser.ocr = self._ocr
+        parser.layouter = self._get_layout_recognizer()
+        parser.tbl_det = self._get_table_recognizer()
+        return parser
+
     def ocr(
         self,
-        image: Union[PIL.Image.Image, List[PIL.Image.Image]],
+        image: Union[PIL.Image.Image, List[PIL.Image.Image], bytes],
         **kwargs,
     ) -> Union[str, List[str], Dict[str, Any], List[Dict[str, Any]]]:
         """
-        Run DeepDoc on one image or a list of images.
+        Run DeepDoc on one image, a list of images, or a whole PDF.
 
         Args:
-            image: PIL Image or list of PIL Images
+            image: PIL Image or list of PIL Images. For task 'parse' this is
+                instead the raw bytes of a PDF document.
             **kwargs: Additional parameters including:
-                - task: 'ocr' (default), 'layout' or 'table'
+                - task: 'ocr' (default), 'layout', 'table' or 'parse'
                 - threshold: score threshold for 'table' (default 0.2). The
                   YOLOv10 layout model uses a fixed threshold in its
                   upstream postprocess, so 'layout' ignores this value.
                 - return_dict: for task 'ocr', return a dict with boxes
                   and scores instead of plain text (default False)
+                - zoomin: render scale for 'parse' (default 3)
+                - image_scope: which 'parse' elements carry a base64 crop,
+                  'table_figure' (default), 'all' or 'none'
 
         Returns:
             Plain text for task 'ocr', otherwise a JSON-serializable dict.
@@ -162,6 +436,13 @@ class DeepDocModel(OCRModel):
 
         task = kwargs.get("task", "ocr")
         return_dict = kwargs.get("return_dict", False)
+
+        # `parse` runs the whole-document pipeline, which renders the PDF
+        # itself and merges across pages, so it takes the original bytes
+        # rather than a rasterized page and must branch before any
+        # image normalization below.
+        if task == "parse":
+            return self._process_parse(image, kwargs)
 
         if image is None:
             raise ValueError("Input image cannot be None.")
@@ -214,5 +495,37 @@ class DeepDocModel(OCRModel):
         else:
             raise ValueError(
                 f"Unsupported task for DeepDoc: {task}. "
-                "Supported tasks: 'ocr', 'layout', 'table'."
+                "Supported tasks: 'ocr', 'layout', 'table', 'parse'."
             )
+
+    def _process_parse(self, data: Any, kwargs: Dict[str, Any]) -> Dict[str, Any]:
+        """Run the full document-parsing pipeline over a PDF.
+
+        ``parse_into_bboxes`` does its own rendering, layout and table
+        recognition, paragraph merging and reading-order reconstruction, and
+        needs the whole document to accumulate cross-page coordinates -- so
+        unlike the other tasks it consumes PDF bytes, not a page image.
+        """
+        if isinstance(data, (bytearray, memoryview)):
+            data = bytes(data)
+        if not isinstance(data, bytes):
+            raise ValueError(
+                "DeepDoc task 'parse' requires the raw bytes of a PDF "
+                f"document, got {type(data).__name__}. Upload a PDF to the "
+                "OCR endpoint instead of an image."
+            )
+
+        zoomin = _parse_zoomin(kwargs)
+        image_scope = _parse_image_scope(kwargs)
+
+        parser = self._get_pdf_parser()
+        try:
+            # `__images__` accepts bytes directly (it wraps them in a BytesIO),
+            # so no temporary file is needed.
+            elements = parser.parse_into_bboxes(data, zoomin=zoomin)
+            return {
+                "task": "parse",
+                "elements": [_element_to_json(e, image_scope) for e in elements or []],
+            }
+        finally:
+            _reset_parser_document_state(parser)

--- a/xinference/model/image/ocr/deepdoc.py
+++ b/xinference/model/image/ocr/deepdoc.py
@@ -161,6 +161,10 @@ def _reset_parser_document_state(parser: Any) -> None:
         ("tb_cpns", []),
         ("pdf", None),
         ("total_page", 0),
+        # Per-document too, and it steers table HTML construction. deepdoc
+        # reassigns it on every run, but that assignment sits inside the
+        # block whose exceptions ``__images__`` swallows.
+        ("is_english", False),
     ):
         try:
             setattr(parser, attribute, empty)

--- a/xinference/model/image/ocr/deepdoc.py
+++ b/xinference/model/image/ocr/deepdoc.py
@@ -130,66 +130,6 @@ def _encode_image(image: Any) -> Optional[str]:
         return None
 
 
-def _build_parallel_limiter() -> Optional[List[Any]]:
-    """Mirror the per-device semaphores ``RAGFlowPdfParser.__init__`` builds.
-
-    Bypassing that constructor to reuse the loaded recognizers means this has
-    to be reproduced, otherwise multi-GPU workers would silently serialize
-    page recognition onto a single device.
-    """
-    import asyncio
-
-    from deepdoc.common import check_and_install_torch, settings
-
-    try:
-        check_and_install_torch()
-        if settings.PARALLEL_DEVICES > 1:
-            return [asyncio.Semaphore(1) for _ in range(settings.PARALLEL_DEVICES)]
-    except Exception:
-        logger.debug("Could not size the DeepDoc parallel limiter", exc_info=True)
-    return None
-
-
-_ZOOM_RETRY_DISABLED = "_xinference_no_zoom_retry"
-
-
-def _disable_zoom_retry(parser: Any) -> None:
-    """Stop ``__images__`` from re-rendering the document at three times the zoom.
-
-    When a first pass finds no boxes at all -- a blank or image-only PDF --
-    deepdoc recurses into ``__images__`` at ``zoomin * 3``, i.e. nine times
-    the pixels, and does so for a document that by definition produced no
-    output. It is also inconsistent: ``parse_into_bboxes`` runs every later
-    stage at the *original* zoom, so the pages it then works on no longer
-    match the scale the coordinates are computed against.
-
-    Wrapping the bound method to swallow the recursive call keeps one render
-    per request, which is what the API layer's page-size budget assumes.
-    """
-    if getattr(parser, _ZOOM_RETRY_DISABLED, False):
-        return
-    original = getattr(parser, "__images__", None)
-    if original is None:
-        # A parser shape we do not recognise; leave it alone rather than
-        # fail the request over a defensive guard.
-        logger.debug("Parser has no __images__ to guard against zoom retries")
-        return
-
-    def __images__(fnm, zoomin=3, page_from=0, page_to=299, callback=None):
-        # The recursion is the last statement of `__images__`, so a guard
-        # that makes the inner call a no-op leaves the first render intact.
-        if getattr(parser, "_xinference_in_images", False):
-            return None
-        parser._xinference_in_images = True
-        try:
-            return original(fnm, zoomin, page_from, page_to, callback)
-        finally:
-            parser._xinference_in_images = False
-
-    parser.__images__ = __images__
-    setattr(parser, _ZOOM_RETRY_DISABLED, True)
-
-
 def _reset_parser_document_state(parser: Any) -> None:
     """Drop the per-document state a parse run leaves on the parser.
 
@@ -359,95 +299,38 @@ class DeepDocModel(OCRModel):
             f"{self._model_path!r}. Re-download the model files."
         )
 
-    def _build_pdf_parser(self):
-        """Build a ``PdfParser`` that reuses the already-loaded recognizers.
-
-        ``RAGFlowPdfParser.__init__`` would construct its own OCR, layout and
-        table recognizers, doubling the ONNX sessions (and the VRAM) this
-        model already holds. So the constructor is bypassed and only the
-        attributes it would have set are assembled, wiring in the existing
-        recognizers. If a future ``deepdoc-lib`` needs attributes we do not
-        know about, fall back to the real constructor and inject afterwards
-        -- slower and briefly twice the memory, but correct.
-        """
-        import xgboost as xgb
-        from deepdoc import PdfModelConfig, PdfParser, TokenizerConfig
-        from deepdoc.depend.rag_tokenizer import RagTokenizer
-
-        vision_dir = self._model_dir()
-        xgb_dir = self._xgb_model_dir()
-        # `model_provider="local"` keeps the onnx/booster side offline, but the
-        # tokenizer config must stay online-capable: RagTokenizer raises when
-        # its nltk data is missing and offline mode is on.
-        model_cfg = PdfModelConfig(
-            vision_model_dir=vision_dir,
-            xgb_model_dir=xgb_dir,
-            model_provider="local",
-        )
-        tokenizer_cfg = TokenizerConfig()
-
-        booster = xgb.Booster()
-        # Upstream keys this purely off CUDA availability, which already
-        # honours the CUDA_VISIBLE_DEVICES that `gpu_idx` sets. An explicit
-        # non-CUDA `device` is respected on top of that, so a model pinned to
-        # CPU does not pull the booster onto a GPU.
-        if not self._device or "cuda" in self._device:
-            try:
-                import torch
-
-                if torch.cuda.is_available():
-                    booster.set_param({"device": "cuda"})
-            except Exception:
-                logger.debug("torch unavailable, running the xgb booster on CPU")
-        booster.load_model(os.path.join(xgb_dir, "updown_concat_xgb.model"))
-
-        parser = PdfParser.__new__(PdfParser)
-        parser.model_cfg = model_cfg
-        parser.tokenizer_cfg = tokenizer_cfg
-        # Load-bearing: `_concat_downward` tokenizes and tags line text.
-        parser.tokenizer = RagTokenizer(
-            dict_prefix=tokenizer_cfg.resolve_dict_prefix(),
-            offline=tokenizer_cfg.offline,
-            nltk_data_dir=tokenizer_cfg.nltk_data_dir,
-        )
-        parser.ocr = self._ocr
-        parser.layouter = self._get_layout_recognizer()
-        parser.tbl_det = self._get_table_recognizer()
-        parser.updown_cnt_mdl = booster
-        parser.parallel_limiter = _build_parallel_limiter()
-        parser.page_from = 0
-        parser.column_num = 1
-        return parser
-
     def _get_pdf_parser(self):
-        if self._pdf_parser is None:
-            try:
-                self._pdf_parser = self._build_pdf_parser()
-            except Exception:
-                logger.warning(
-                    "Could not assemble a DeepDoc PdfParser around the loaded "
-                    "recognizers; falling back to constructing a new one, "
-                    "which loads a second set of models.",
-                    exc_info=True,
-                )
-                self._pdf_parser = self._build_pdf_parser_fallback()
-        return self._pdf_parser
+        """Build the parser through deepdoc's public API, once, and cache it.
 
-    def _build_pdf_parser_fallback(self):
+        ``PdfParser`` constructs its own OCR, layout and table recognizers,
+        which would double the ONNX sessions (and the VRAM) this model
+        already holds. Rather than reproduce its private initialization, the
+        supported constructor is used and the freshly built recognizers are
+        then replaced by the ones already loaded; the originals are dropped
+        and freed, so steady state holds a single set. Construction happens
+        once per model and the parser is reused for every request.
+        """
+        if self._pdf_parser is not None:
+            return self._pdf_parser
+
         from deepdoc import PdfModelConfig, PdfParser
 
+        xgb_dir = self._xgb_model_dir()
+        # `model_provider="local"` keeps the onnx/booster side offline. The
+        # tokenizer config is left at its default: RagTokenizer raises when
+        # its nltk data is missing and offline mode is on.
         parser = PdfParser(
             model_cfg=PdfModelConfig(
                 vision_model_dir=self._model_dir(),
-                xgb_model_dir=self._xgb_model_dir(),
+                xgb_model_dir=xgb_dir,
                 model_provider="local",
             )
         )
-        # Drop the freshly built recognizers in favour of the loaded ones so
-        # steady-state memory still holds a single set.
         parser.ocr = self._ocr
         parser.layouter = self._get_layout_recognizer()
         parser.tbl_det = self._get_table_recognizer()
+        self._pdf_parser = parser
+        return self._pdf_parser
         return parser
 
     def ocr(
@@ -569,7 +452,6 @@ class DeepDocModel(OCRModel):
         image_scope = _parse_image_scope(kwargs)
 
         parser = self._get_pdf_parser()
-        _disable_zoom_retry(parser)
         try:
             # `__images__` accepts bytes directly (it wraps them in a BytesIO),
             # so no temporary file is needed.

--- a/xinference/model/image/ocr/deepdoc.py
+++ b/xinference/model/image/ocr/deepdoc.py
@@ -69,10 +69,15 @@ def _parse_threshold(kwargs: Dict[str, Any], default: float = 0.2) -> float:
         raise ValueError(f"Invalid threshold: {value!r}, expected a number") from e
 
 
-def _parse_zoomin(kwargs: Dict[str, Any], default: int = DEFAULT_PARSE_ZOOMIN) -> int:
+def parse_zoomin(value: Any, default: int = DEFAULT_PARSE_ZOOMIN) -> int:
+    """Validate the ``zoomin`` kwarg for task ``parse``.
+
+    Public because the API layer validates it too: it needs the value to
+    budget the raster before handing the PDF over, and both layers must
+    reject exactly the same inputs.
+    """
     # None (e.g. an explicit JSON null from the HTTP API) falls back to the
     # default, like `threshold` does.
-    value = kwargs.get("zoomin")
     if value is None:
         return default
     if isinstance(value, bool) or not isinstance(value, int):
@@ -143,6 +148,46 @@ def _build_parallel_limiter() -> Optional[List[Any]]:
     except Exception:
         logger.debug("Could not size the DeepDoc parallel limiter", exc_info=True)
     return None
+
+
+_ZOOM_RETRY_DISABLED = "_xinference_no_zoom_retry"
+
+
+def _disable_zoom_retry(parser: Any) -> None:
+    """Stop ``__images__`` from re-rendering the document at three times the zoom.
+
+    When a first pass finds no boxes at all -- a blank or image-only PDF --
+    deepdoc recurses into ``__images__`` at ``zoomin * 3``, i.e. nine times
+    the pixels, and does so for a document that by definition produced no
+    output. It is also inconsistent: ``parse_into_bboxes`` runs every later
+    stage at the *original* zoom, so the pages it then works on no longer
+    match the scale the coordinates are computed against.
+
+    Wrapping the bound method to swallow the recursive call keeps one render
+    per request, which is what the API layer's page-size budget assumes.
+    """
+    if getattr(parser, _ZOOM_RETRY_DISABLED, False):
+        return
+    original = getattr(parser, "__images__", None)
+    if original is None:
+        # A parser shape we do not recognise; leave it alone rather than
+        # fail the request over a defensive guard.
+        logger.debug("Parser has no __images__ to guard against zoom retries")
+        return
+
+    def __images__(fnm, zoomin=3, page_from=0, page_to=299, callback=None):
+        # The recursion is the last statement of `__images__`, so a guard
+        # that makes the inner call a no-op leaves the first render intact.
+        if getattr(parser, "_xinference_in_images", False):
+            return None
+        parser._xinference_in_images = True
+        try:
+            return original(fnm, zoomin, page_from, page_to, callback)
+        finally:
+            parser._xinference_in_images = False
+
+    parser.__images__ = __images__
+    setattr(parser, _ZOOM_RETRY_DISABLED, True)
 
 
 def _reset_parser_document_state(parser: Any) -> None:
@@ -342,13 +387,18 @@ class DeepDocModel(OCRModel):
         tokenizer_cfg = TokenizerConfig()
 
         booster = xgb.Booster()
-        try:
-            import torch
+        # Upstream keys this purely off CUDA availability, which already
+        # honours the CUDA_VISIBLE_DEVICES that `gpu_idx` sets. An explicit
+        # non-CUDA `device` is respected on top of that, so a model pinned to
+        # CPU does not pull the booster onto a GPU.
+        if not self._device or "cuda" in self._device:
+            try:
+                import torch
 
-            if torch.cuda.is_available():
-                booster.set_param({"device": "cuda"})
-        except Exception:
-            logger.debug("torch unavailable, running the xgb booster on CPU")
+                if torch.cuda.is_available():
+                    booster.set_param({"device": "cuda"})
+            except Exception:
+                logger.debug("torch unavailable, running the xgb booster on CPU")
         booster.load_model(os.path.join(xgb_dir, "updown_concat_xgb.model"))
 
         parser = PdfParser.__new__(PdfParser)
@@ -515,10 +565,11 @@ class DeepDocModel(OCRModel):
                 "OCR endpoint instead of an image."
             )
 
-        zoomin = _parse_zoomin(kwargs)
+        zoomin = parse_zoomin(kwargs.get("zoomin"))
         image_scope = _parse_image_scope(kwargs)
 
         parser = self._get_pdf_parser()
+        _disable_zoom_retry(parser)
         try:
             # `__images__` accepts bytes directly (it wraps them in a BytesIO),
             # so no temporary file is needed.

--- a/xinference/model/image/ocr/tests/test_deepdoc_parse.py
+++ b/xinference/model/image/ocr/tests/test_deepdoc_parse.py
@@ -45,7 +45,7 @@ from ..deepdoc import (  # noqa: E402
     DeepDocModel,
     _element_to_json,
     _parse_image_scope,
-    _parse_zoomin,
+    parse_zoomin,
 )
 
 
@@ -181,22 +181,22 @@ class TestImageScope:
 
 class TestParseZoomin:
     def test_default(self):
-        assert _parse_zoomin({}) == DEFAULT_PARSE_ZOOMIN
+        assert parse_zoomin(None) == DEFAULT_PARSE_ZOOMIN
 
     def test_none_falls_back_to_default(self):
         # An explicit JSON null from the HTTP API must not crash.
-        assert _parse_zoomin({"zoomin": None}) == DEFAULT_PARSE_ZOOMIN
+        assert parse_zoomin(None) == DEFAULT_PARSE_ZOOMIN
 
     def test_valid_value(self):
-        assert _parse_zoomin({"zoomin": 1}) == 1
-        assert _parse_zoomin({"zoomin": MAX_PARSE_ZOOMIN}) == MAX_PARSE_ZOOMIN
+        assert parse_zoomin(1) == 1
+        assert parse_zoomin(MAX_PARSE_ZOOMIN) == MAX_PARSE_ZOOMIN
 
     @pytest.mark.parametrize(
         "value", [0, -1, MAX_PARSE_ZOOMIN + 1, "3", 3.5, True, [3]]
     )
     def test_invalid_values_rejected(self, value):
         with pytest.raises(ValueError, match="zoomin"):
-            _parse_zoomin({"zoomin": value})
+            parse_zoomin(value)
 
 
 class TestParseImageScope:
@@ -362,6 +362,37 @@ class TestParserStateIsReleased:
             model.ocr(b"%PDF", task="parse")
         assert parser.page_images == []
         assert parser.boxes == []
+
+    def test_zoom_retry_is_suppressed(self):
+        # deepdoc re-renders at 3x the zoom (9x the pixels) when a first pass
+        # finds no boxes, which the API layer's page-size budget does not
+        # account for -- and which leaves later stages working at a zoom that
+        # no longer matches the pages.
+        renders = []
+
+        class Retrying(FakePdfParser):
+            def __images__(self, fnm, zoomin=3, page_from=0, page_to=299, cb=None):
+                renders.append(zoomin)
+                # what deepdoc does when it finds nothing
+                if zoomin < 9:
+                    self.__images__(fnm, zoomin * 3, page_from, page_to, cb)
+
+            def parse_into_bboxes(self, fnm, zoomin=3):
+                self.calls.append((fnm, zoomin))
+                self.__images__(fnm, zoomin)
+                return self._elements
+
+        parser = Retrying([])
+        model = make_model(parser)
+        model.ocr(b"%PDF", task="parse")
+        assert renders == [3]
+
+    def test_parser_without_images_still_parses(self):
+        # The guard must not fail a request on a parser shape it does not
+        # recognise.
+        parser = FakePdfParser([text_element()])
+        model = make_model(parser)
+        assert len(model.ocr(b"%PDF", task="parse")["elements"]) == 1
 
     def test_stale_pages_cannot_leak_into_a_later_request(self):
         # deepdoc swallows document-load failures, so without the reset a

--- a/xinference/model/image/ocr/tests/test_deepdoc_parse.py
+++ b/xinference/model/image/ocr/tests/test_deepdoc_parse.py
@@ -363,37 +363,6 @@ class TestParserStateIsReleased:
         assert parser.page_images == []
         assert parser.boxes == []
 
-    def test_zoom_retry_is_suppressed(self):
-        # deepdoc re-renders at 3x the zoom (9x the pixels) when a first pass
-        # finds no boxes, which the API layer's page-size budget does not
-        # account for -- and which leaves later stages working at a zoom that
-        # no longer matches the pages.
-        renders = []
-
-        class Retrying(FakePdfParser):
-            def __images__(self, fnm, zoomin=3, page_from=0, page_to=299, cb=None):
-                renders.append(zoomin)
-                # what deepdoc does when it finds nothing
-                if zoomin < 9:
-                    self.__images__(fnm, zoomin * 3, page_from, page_to, cb)
-
-            def parse_into_bboxes(self, fnm, zoomin=3):
-                self.calls.append((fnm, zoomin))
-                self.__images__(fnm, zoomin)
-                return self._elements
-
-        parser = Retrying([])
-        model = make_model(parser)
-        model.ocr(b"%PDF", task="parse")
-        assert renders == [3]
-
-    def test_parser_without_images_still_parses(self):
-        # The guard must not fail a request on a parser shape it does not
-        # recognise.
-        parser = FakePdfParser([text_element()])
-        model = make_model(parser)
-        assert len(model.ocr(b"%PDF", task="parse")["elements"]) == 1
-
     def test_stale_pages_cannot_leak_into_a_later_request(self):
         # deepdoc swallows document-load failures, so without the reset a
         # PDF it cannot open would be parsed against the previous request's

--- a/xinference/model/image/ocr/tests/test_deepdoc_parse.py
+++ b/xinference/model/image/ocr/tests/test_deepdoc_parse.py
@@ -1,0 +1,374 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Unit tests for DeepDoc's ``task="parse"`` serialization and kwargs.
+
+These cover the pure parts of the parse task — element serialization and
+kwarg validation — without loading the ONNX models, so they run on CPU
+without the ``deepdoc`` package installed. The recognizer reuse and the
+output parity against a local ``parse_into_bboxes`` run need real models
+and are verified out of band.
+
+The element dicts used here mirror what ``parse_into_bboxes`` really
+returns, including the detail that the table/figure elements it
+re-inserts into the text flow carry no ``col_id`` and no
+``position_tag``.
+"""
+
+import base64
+import io
+
+import pytest
+
+pytest.importorskip("numpy")
+pytest.importorskip("PIL")
+
+import numpy as np  # noqa: E402
+import PIL.Image  # noqa: E402
+
+from ..deepdoc import (  # noqa: E402
+    DEFAULT_IMAGE_SCOPE,
+    DEFAULT_PARSE_ZOOMIN,
+    IMAGE_SCOPES,
+    MAX_PARSE_ZOOMIN,
+    DeepDocModel,
+    _element_to_json,
+    _parse_image_scope,
+    _parse_zoomin,
+)
+
+
+def make_image(color: str = "red") -> PIL.Image.Image:
+    return PIL.Image.new("RGB", (4, 4), color=color)
+
+
+def text_element(**overrides):
+    """An element shaped like a text/title box from ``parse_into_bboxes``."""
+    element = {
+        "page_number": 1,
+        "x0": 71.66,
+        "x1": 240.25,
+        "top": 124.1,
+        "bottom": 301.6,
+        "layout_type": "text",
+        "layoutno": "text-0",
+        "col_id": 0,
+        "positions": [[1, 71, 240, 124, 301]],
+        "text": "hello",
+        "position_tag": "@@1\t71\t240\t124\t301##",
+        "image": make_image(),
+    }
+    element.update(overrides)
+    return element
+
+
+def table_element(**overrides):
+    """A re-inserted table element: no ``col_id``, no ``position_tag``."""
+    element = {
+        "page_number": 2,
+        "x0": 20.0,
+        "x1": 400.0,
+        "top": 50.0,
+        "bottom": 200.0,
+        "layout_type": "table",
+        "positions": [[2, 20, 400, 50, 200]],
+        "text": "<table><caption>c</caption><tr><th>h</th></tr></table>",
+        "image": make_image("blue"),
+    }
+    element.update(overrides)
+    return element
+
+
+class TestElementToJson:
+    def test_shape(self):
+        result = _element_to_json(text_element(), "none")
+        assert set(result) == {"type", "text", "metadata"}
+        assert result["type"] == "text"
+        assert result["text"] == "hello"
+        assert result["metadata"]["page_number"] == 1
+        assert result["metadata"]["layout_type"] == "text"
+        assert result["metadata"]["positions"] == [[1, 71, 240, 124, 301]]
+
+    def test_drops_internal_keys(self):
+        # `position_tag` is a deepdoc-internal marker and `image` is
+        # superseded by `image_base64`; neither may reach the client.
+        result = _element_to_json(text_element(), "all")
+        assert "position_tag" not in result["metadata"]
+        assert "image" not in result["metadata"]
+        # `text` is promoted to the top level rather than duplicated.
+        assert "text" not in result["metadata"]
+
+    def test_table_without_col_id_or_position_tag(self):
+        # The re-inserted table/figure elements lack these keys entirely.
+        # Serialization must neither crash nor invent a value for them.
+        result = _element_to_json(table_element(), "none")
+        assert result["type"] == "table"
+        assert result["text"].startswith("<table>")
+        assert "col_id" not in result["metadata"]
+        assert "position_tag" not in result["metadata"]
+
+    def test_col_id_preserved_when_present(self):
+        result = _element_to_json(text_element(col_id=3), "none")
+        assert result["metadata"]["col_id"] == 3
+
+    def test_numpy_scalars_coerced(self):
+        result = _element_to_json(
+            text_element(
+                x0=np.float32(1.5),
+                page_number=np.int64(2),
+                positions=np.array([[1, 2, 3, 4, 5]]),
+            ),
+            "none",
+        )
+        metadata = result["metadata"]
+        assert isinstance(metadata["x0"], float) and metadata["x0"] == 1.5
+        assert isinstance(metadata["page_number"], int)
+        assert metadata["positions"] == [[1, 2, 3, 4, 5]]
+        for value in metadata.values():
+            assert not isinstance(value, (np.generic, np.ndarray))
+
+    def test_unknown_extra_keys_pass_through(self):
+        result = _element_to_json(text_element(some_new_key="v"), "none")
+        assert result["metadata"]["some_new_key"] == "v"
+
+
+class TestImageScope:
+    def test_table_figure_encodes_only_table_and_figure(self):
+        assert "image_base64" not in _element_to_json(text_element(), "table_figure")
+        assert "image_base64" in _element_to_json(table_element(), "table_figure")
+        figure = table_element(layout_type="figure")
+        assert "image_base64" in _element_to_json(figure, "table_figure")
+
+    def test_all_encodes_every_element(self):
+        assert "image_base64" in _element_to_json(text_element(), "all")
+        assert "image_base64" in _element_to_json(table_element(), "all")
+
+    def test_none_encodes_nothing(self):
+        assert "image_base64" not in _element_to_json(text_element(), "none")
+        assert "image_base64" not in _element_to_json(table_element(), "none")
+
+    def test_encoded_payload_is_a_png(self):
+        result = _element_to_json(table_element(), "table_figure")
+        raw = base64.b64decode(result["image_base64"])
+        assert PIL.Image.open(io.BytesIO(raw)).format == "PNG"
+
+    def test_missing_image_omits_the_field(self):
+        # The field is omitted rather than set to null, so clients can rely
+        # on its presence meaning "there is a crop".
+        result = _element_to_json(table_element(image=None), "table_figure")
+        assert "image_base64" not in result
+
+    def test_unencodable_image_does_not_fail_the_document(self):
+        class Broken:
+            def save(self, *args, **kwargs):
+                raise OSError("cannot encode")
+
+        result = _element_to_json(table_element(image=Broken()), "table_figure")
+        assert "image_base64" not in result
+        assert result["text"].startswith("<table>")
+
+
+class TestParseZoomin:
+    def test_default(self):
+        assert _parse_zoomin({}) == DEFAULT_PARSE_ZOOMIN
+
+    def test_none_falls_back_to_default(self):
+        # An explicit JSON null from the HTTP API must not crash.
+        assert _parse_zoomin({"zoomin": None}) == DEFAULT_PARSE_ZOOMIN
+
+    def test_valid_value(self):
+        assert _parse_zoomin({"zoomin": 1}) == 1
+        assert _parse_zoomin({"zoomin": MAX_PARSE_ZOOMIN}) == MAX_PARSE_ZOOMIN
+
+    @pytest.mark.parametrize(
+        "value", [0, -1, MAX_PARSE_ZOOMIN + 1, "3", 3.5, True, [3]]
+    )
+    def test_invalid_values_rejected(self, value):
+        with pytest.raises(ValueError, match="zoomin"):
+            _parse_zoomin({"zoomin": value})
+
+
+class TestParseImageScope:
+    def test_default(self):
+        assert _parse_image_scope({}) == DEFAULT_IMAGE_SCOPE
+
+    def test_none_falls_back_to_default(self):
+        assert _parse_image_scope({"image_scope": None}) == DEFAULT_IMAGE_SCOPE
+
+    @pytest.mark.parametrize("scope", IMAGE_SCOPES)
+    def test_supported_scopes(self, scope):
+        assert _parse_image_scope({"image_scope": scope}) == scope
+
+    def test_unknown_scope_lists_the_supported_ones(self):
+        with pytest.raises(ValueError) as excinfo:
+            _parse_image_scope({"image_scope": "tables"})
+        message = str(excinfo.value)
+        for scope in IMAGE_SCOPES:
+            assert scope in message
+
+
+class FakePdfParser:
+    """Stands in for ``RAGFlowPdfParser``, recording how it was called.
+
+    The per-document attributes mirror the state a real parse run leaves
+    behind on the instance.
+    """
+
+    def __init__(self, elements):
+        self._elements = elements
+        self.calls = []
+        self.boxes = []
+        self.page_images = []
+        self.page_chars = []
+        self.pdf = None
+
+    def parse_into_bboxes(self, fnm, zoomin=3):
+        self.calls.append((fnm, zoomin))
+        # A real run leaves the document it just processed on the instance.
+        self.boxes = list(self._elements or [])
+        self.page_images = [make_image(), make_image()]
+        self.page_chars = [[{"text": "a"}]]
+        self.pdf = object()
+        return self._elements
+
+
+class FakeLayoutRecognizer:
+    def forward(self, images, thr=0.2):
+        return [[{"type": "title"}]]
+
+
+class FakeTableRecognizer:
+    def __call__(self, images, thr=0.2):
+        return [[{"label": "table"}]]
+
+
+def make_model(parser=None):
+    """A ``DeepDocModel`` with the ONNX loading side-stepped."""
+    model = DeepDocModel.__new__(DeepDocModel)
+    model._ocr = object()
+    model._layout_recognizer = None
+    model._table_recognizer = None
+    model._pdf_parser = parser
+    return model
+
+
+class TestParseTaskRouting:
+    def test_parse_returns_serialized_elements(self):
+        parser = FakePdfParser([text_element(), table_element()])
+        model = make_model(parser)
+        result = model.ocr(b"%PDF-1.4 ...", task="parse")
+        assert result["task"] == "parse"
+        assert [e["type"] for e in result["elements"]] == ["text", "table"]
+        # Bytes reach the parser unchanged: the whole document is needed for
+        # cross-page merging, so nothing rasterizes or splits it per page.
+        assert parser.calls == [(b"%PDF-1.4 ...", DEFAULT_PARSE_ZOOMIN)]
+
+    def test_zoomin_and_image_scope_forwarded(self):
+        parser = FakePdfParser([table_element()])
+        model = make_model(parser)
+        result = model.ocr(b"%PDF", task="parse", zoomin=2, image_scope="none")
+        assert parser.calls == [(b"%PDF", 2)]
+        assert "image_base64" not in result["elements"][0]
+
+    @pytest.mark.parametrize("payload", [bytearray(b"%PDF"), memoryview(b"%PDF")])
+    def test_bytes_like_payloads_accepted(self, payload):
+        parser = FakePdfParser([])
+        model = make_model(parser)
+        assert model.ocr(payload, task="parse") == {"task": "parse", "elements": []}
+        assert parser.calls == [(b"%PDF", DEFAULT_PARSE_ZOOMIN)]
+
+    def test_empty_result_is_an_empty_element_list(self):
+        model = make_model(FakePdfParser(None))
+        assert model.ocr(b"%PDF", task="parse") == {"task": "parse", "elements": []}
+
+    @pytest.mark.parametrize("payload", [make_image(), None, "/tmp/doc.pdf"])
+    def test_non_bytes_payload_rejected(self, payload):
+        model = make_model(FakePdfParser([]))
+        with pytest.raises(ValueError, match="requires the raw bytes of a PDF"):
+            model.ocr(payload, task="parse")
+
+    def test_invalid_kwargs_reported_before_parsing(self):
+        parser = FakePdfParser([])
+        model = make_model(parser)
+        with pytest.raises(ValueError, match="image_scope"):
+            model.ocr(b"%PDF", task="parse", image_scope="bogus")
+        assert parser.calls == []
+
+    def test_unloaded_model_still_raises(self):
+        model = make_model(FakePdfParser([]))
+        model._ocr = None
+        with pytest.raises(RuntimeError, match="Model not loaded"):
+            model.ocr(b"%PDF", task="parse")
+
+    def test_other_tasks_never_reach_the_pdf_parser(self):
+        # The three per-page tasks go through the real `_process_single`
+        # dispatch with stub recognizers, so the parse branch cannot
+        # accidentally capture them.
+        parser = FakePdfParser([])
+        model = make_model(parser)
+        model._ocr = lambda img: [([0, 0, 1, 1], ("hi", 0.9))]
+        model._layout_recognizer = FakeLayoutRecognizer()
+        model._table_recognizer = FakeTableRecognizer()
+
+        assert model.ocr(make_image(), task="ocr") == "hi"
+        assert model.ocr(make_image(), task="layout")["layouts"] == [{"type": "title"}]
+        assert model.ocr(make_image(), task="table")["structures"] == [
+            {"label": "table"}
+        ]
+        assert parser.calls == []
+
+    def test_unsupported_task_lists_parse(self):
+        model = make_model(FakePdfParser([]))
+        with pytest.raises(ValueError, match="'parse'"):
+            model.ocr(make_image(), task="nope")
+
+
+class TestParserStateIsReleased:
+    """The parser is cached to keep one set of ONNX models loaded, so the
+    document it just processed must not stay attached to it."""
+
+    def test_document_state_cleared_after_a_successful_parse(self):
+        parser = FakePdfParser([text_element(), table_element()])
+        model = make_model(parser)
+        result = model.ocr(b"%PDF", task="parse")
+        assert len(result["elements"]) == 2
+        # Rasterized pages and crops would otherwise stay resident until the
+        # next request replaced them.
+        assert parser.page_images == []
+        assert parser.page_chars == []
+        assert parser.boxes == []
+        assert parser.pdf is None
+
+    def test_document_state_cleared_when_parsing_raises(self):
+        class Failing(FakePdfParser):
+            def parse_into_bboxes(self, fnm, zoomin=3):
+                super().parse_into_bboxes(fnm, zoomin)
+                raise RuntimeError("boom")
+
+        parser = Failing([text_element()])
+        model = make_model(parser)
+        with pytest.raises(RuntimeError, match="boom"):
+            model.ocr(b"%PDF", task="parse")
+        assert parser.page_images == []
+        assert parser.boxes == []
+
+    def test_stale_pages_cannot_leak_into_a_later_request(self):
+        # deepdoc swallows document-load failures, so without the reset a
+        # PDF it cannot open would be parsed against the previous request's
+        # pages. After the reset such a run sees an empty document.
+        parser = FakePdfParser([text_element()])
+        model = make_model(parser)
+        model.ocr(b"%PDF first", task="parse")
+        assert parser.page_images == []
+        assert parser.page_chars == []


### PR DESCRIPTION
## Summary

The DeepDoc OCR model added in #5230 exposes DeepDoc's three atomic vision capabilities (`ocr`, `layout`, `table`) but not `RAGFlowPdfParser.parse_into_bboxes()`, the full document-parsing pipeline built on top of them. Table HTML, figures, cross-page coordinates, paragraph merging and reading order are not recoverable from the three atomic tasks, so consumers that want structured document parsing cannot use this model today.

This adds a fourth task to the existing `/v1/images/ocr` endpoint, as proposed in #5296:

```bash
curl -X POST http://<HOST>:<PORT>/v1/images/ocr \
  -H "Authorization: Bearer $TOKEN" \
  -F model=DeepDoc \
  -F 'kwargs={"task": "parse"}' \
  -F image=@doc.pdf
```

```json
{"task": "parse",
 "elements": [
   {"type": "table",
    "text": "<table><caption>...</caption><tr><th>...</th></tr></table>",
    "image_base64": "...",
    "metadata": {"page_number": 2, "x0": 20.0, "x1": 400.0, "top": 50.0,
                 "bottom": 200.0, "layout_type": "table", "col_id": 0,
                 "positions": [[2, 20, 400, 50, 200]]}}
 ]}
```

## Design notes

**`parse` takes the PDF, not a rasterized page.** The pipeline renders the PDF itself and needs the whole document to accumulate cross-page coordinates, so the REST layer passes the uploaded bytes straight through. The existing per-page rasterizing path is untouched for the other three tasks — the new branch is entered only for tasks in `WHOLE_DOCUMENT_OCR_TASKS`. Bytes travel in the existing `image=` channel, which `ModelActor.ocr` already excludes from its logs (`@log_async(ignore_kwargs=["image"])`), so no core or client changes were needed.

**Reusing the loaded recognizers.** A plain `PdfParser()` would construct its own OCR, layout and table recognizers on top of the ones the model already holds. Measured on an RTX 3090 Ti, that costs **+512 MiB** of extra ONNX sessions. Instead the constructor is bypassed and only the attributes it would have set are assembled, wiring in the existing instances; object identity is asserted in testing (`parser.ocr is model._ocr`, etc.). If a future `deepdoc-lib` needs attributes this doesn't know about, it falls back to the real constructor and injects afterwards, with a warning.

**Per-document state is released.** `parse_into_bboxes` leaves the document it processed attached to the parser (rasterized pages, a crop per box, extracted chars) and never clears it. Since the parser is cached, that state would stay resident after the response — for a 3-page document that is 39 MB of page images plus 52 crops; at the 200-page limit and the largest render scale it is gigabytes. Worse, `__images__` resets `boxes` *before* loading the new document but swallows load failures, so a PDF it cannot open would leave the previous request's pages attached and silently parse those. Both are handled by clearing the state in a `finally`.

**Payload control.** Every element carries a crop internally, but only tables and figures need one. `image_scope` defaults to `table_figure`; on the test document that is 277 KB versus 4.1 MB for `all` (a ~15x difference) and 15 KB for `none`.

**Validation.** `validate_pdf_for_parse` checks the document with pypdfium2 before deepdoc sees it, reusing the existing `MAX_PDF_OCR_PAGES` (200) ceiling so the endpoint has one page limit regardless of task. This turns deepdoc's silent-empty-result and its 3x-zoom recursive retry into a clean 400. `pages`/`dpi` are rejected with 400 for `parse` rather than silently ignored.

`model_ability` and the model spec are unchanged: it gates endpoint routing rather than tasks, and the existing three tasks are likewise not advertised there.

## Parity with local CPU output

The motivating requirement is that DeepDoc on GPU through Xinference match running `deepdoc-lib` locally on CPU. Measured on the same 3-page PDF, `zoomin=3`, comparing a local CPU `PdfParser().parse_into_bboxes()` run against this endpoint's response on an RTX 3090 Ti:

| | Result |
|---|---|
| element count | 52 vs 52 — **match** |
| per-type counts | `{text: 40, title: 8, table: 2, figure: 2}` both sides — **match** |
| text, in order (element *i* vs element *i*) | 0 of 52 differ — **match** |
| table HTML, verbatim | 2 tables, 1219 chars — **match** |
| `positions` | 0 differ — **match** |
| `page_number` | 0 differ — **match** |
| `layoutno` | 0 differ — **match** |
| coordinates (`x0/x1/top/bottom`) | max absolute delta **4.6e-3**, confined to the 4 re-inserted table/figure boxes; all 40 text boxes are exact |
| `col_id` | varies run to run (0–6 of 52), **including between two CPU runs** |

Two honest caveats rather than a claim of bit-exactness:

- The coordinate deltas are GPU/CPU ONNX floating-point differences. They affect only the four boxes that `_extract_table_figure` re-inserts, and are ~5e-3 at a 1836x2376 render — sub-pixel.
- `col_id` is not reproducible in `deepdoc-lib` itself: column clustering uses `KMeans(n_clusters=k, n_init="auto")` with no `random_state`, and `random.choices()` feeds the is-English heuristic. Two consecutive local CPU runs already disagree on 6 of 52 elements. This is pre-existing upstream behaviour, not introduced here.

Everything structural — element count, ordering, text, table HTML, positions, page numbers — is identical.

## Verification

- **Regression:** all three existing tasks return 200 unchanged, on both single-image and PDF uploads; `pages`/`dpi` still select and rasterize as before (`pages: [1, 3]` verified).
- **VRAM:** 5543 MiB after launch, plateauing at 9367 MiB and flat across 10 consecutive parse requests. The recognizers are shared, confirmed by object identity; a second `PdfParser()` would have added 512 MiB.
- **Error paths:** non-PDF upload with `task=parse` → 400; `pages`/`dpi` with `parse` → 400; oversized/unreadable PDF → 400; invalid `zoomin`/`image_scope` → clear validation error.
- **Tests:** 72 new/extended unit tests; `pytest xinference/api/tests/ xinference/model/image/ocr/tests/` → 321 passed, 17 skipped. `pre-commit` (black, ruff, isort, mypy, codespell) green on all changed files.

Not run: the full non-GPU CI matrix and the model-download integration tests, which need more hardware and network than this change touches.

## Note on #5295

Left alone deliberately. The virtualenv built for this model on my box resolved `transformers` to 4.57.x under `virtualenv/v4/DeepDoc/default/`, i.e. the `#engine#`-gated `transformers<5` constraint did not apply — consistent with that report. But I also saw a `.../DeepDoc/deepdoc/` virtualenv where the marker *did* engage, so the trigger condition needs pinning down on a clean environment before changing a shared dependency constraint. That belongs in #5295 rather than here.

Closes #5296