### PR TITLE
fix(worker): preserve Jina v3 allocator env for recovery

### DIFF
--- a/xinference/core/tests/test_worker.py
+++ b/xinference/core/tests/test_worker.py
@@ -598,6 +598,10 @@ def test_jina_v3_allocator_env_preserves_new_allocator_configuration():
         ("embedding", "jina-embeddings-v2"),
         ("embedding", "jina-embeddings-v4"),
         ("embedding", "bge-small-en-v1.5"),
+        (None, "jina-embeddings-v3"),
+        ("embedding", None),
+        ("", "jina-embeddings-v3"),
+        ("embedding", ""),
     ],
 )
 def test_jina_v3_allocator_env_does_not_affect_other_models(model_type, model_name):

--- a/xinference/core/tests/test_worker.py
+++ b/xinference/core/tests/test_worker.py
@@ -25,7 +25,7 @@ from ...model.core import VirtualEnvSettings
 from ..status_guard import InstanceInfo, LaunchStatus, ReplicaStatus
 from ..supervisor import ReplicaInfo, SupervisorActor
 from ..utils import merge_virtual_env_packages
-from ..worker import ModelStatus, WorkerActor
+from ..worker import ModelStatus, WorkerActor, _inject_jina_v3_allocator_env
 
 
 class MockWorkerActor(WorkerActor):
@@ -544,6 +544,74 @@ def test_prepare_virtual_env_injects_engine_vars():
     assert packages == ["pkgA==1.0.0", "pkgB==2.0.0"]
     assert kwargs["engine"] == "vllm"
     assert kwargs["model_engine"] == "vllm"
+
+
+def test_jina_v3_allocator_env_is_persisted_for_recovery():
+    launch_args = {"envs": None}
+
+    envs = _inject_jina_v3_allocator_env(
+        "embedding",
+        "jina-embeddings-v3",
+        None,
+        launch_args,
+    )
+
+    assert envs == {"PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True"}
+    assert launch_args["envs"] == envs
+
+
+def test_jina_v3_allocator_env_preserves_user_configuration():
+    launch_args = {"envs": None}
+    user_envs = {"PYTORCH_CUDA_ALLOC_CONF": "max_split_size_mb:128"}
+
+    envs = _inject_jina_v3_allocator_env(
+        "embedding",
+        "jina-embeddings-v3",
+        user_envs,
+        launch_args,
+    )
+
+    assert envs == user_envs
+    assert envs is not user_envs
+    assert launch_args["envs"] == user_envs
+
+
+def test_jina_v3_allocator_env_preserves_new_allocator_configuration():
+    launch_args = {"envs": None}
+    user_envs = {"PYTORCH_ALLOC_CONF": "backend:cudaMallocAsync"}
+
+    envs = _inject_jina_v3_allocator_env(
+        "embedding",
+        "jina-embeddings-v3",
+        user_envs,
+        launch_args,
+    )
+
+    assert envs == user_envs
+    assert launch_args["envs"] == user_envs
+
+
+@pytest.mark.parametrize(
+    "model_type,model_name",
+    [
+        ("LLM", "jina-embeddings-v3"),
+        ("embedding", "jina-embeddings-v2"),
+        ("embedding", "jina-embeddings-v4"),
+        ("embedding", "bge-small-en-v1.5"),
+    ],
+)
+def test_jina_v3_allocator_env_does_not_affect_other_models(model_type, model_name):
+    launch_args = {"envs": None}
+
+    envs = _inject_jina_v3_allocator_env(
+        model_type,
+        model_name,
+        None,
+        launch_args,
+    )
+
+    assert envs is None
+    assert launch_args["envs"] is None
 
 
 @pytest.mark.asyncio

--- a/xinference/core/tests/test_worker.py
+++ b/xinference/core/tests/test_worker.py
@@ -546,7 +546,9 @@ def test_prepare_virtual_env_injects_engine_vars():
     assert kwargs["model_engine"] == "vllm"
 
 
-def test_jina_v3_allocator_env_is_persisted_for_recovery():
+def test_jina_v3_allocator_env_is_persisted_for_recovery(monkeypatch):
+    monkeypatch.delenv("PYTORCH_CUDA_ALLOC_CONF", raising=False)
+    monkeypatch.delenv("PYTORCH_ALLOC_CONF", raising=False)
     launch_args = {"envs": None}
 
     envs = _inject_jina_v3_allocator_env(
@@ -573,6 +575,36 @@ def test_jina_v3_allocator_env_preserves_user_configuration():
 
     assert envs == user_envs
     assert envs is not user_envs
+    assert launch_args["envs"] == user_envs
+
+
+@pytest.mark.parametrize(
+    "allocator_key,allocator_value",
+    [
+        ("PYTORCH_CUDA_ALLOC_CONF", "max_split_size_mb:128"),
+        ("PYTORCH_ALLOC_CONF", "backend:cudaMallocAsync"),
+    ],
+)
+def test_jina_v3_allocator_env_preserves_inherited_worker_configuration(
+    monkeypatch, allocator_key, allocator_value
+):
+    monkeypatch.delenv("PYTORCH_CUDA_ALLOC_CONF", raising=False)
+    monkeypatch.delenv("PYTORCH_ALLOC_CONF", raising=False)
+    monkeypatch.setenv(allocator_key, allocator_value)
+    launch_args = {"envs": None}
+    user_envs = {"OTHER_ENV": "value"}
+
+    envs = _inject_jina_v3_allocator_env(
+        "embedding",
+        "jina-embeddings-v3",
+        user_envs,
+        launch_args,
+    )
+
+    assert envs == user_envs
+    assert envs is not user_envs
+    assert "PYTORCH_CUDA_ALLOC_CONF" not in envs
+    assert "PYTORCH_ALLOC_CONF" not in envs
     assert launch_args["envs"] == user_envs
 
 

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -285,6 +285,33 @@ _VRAM_READY_RATIO = 0.90
 _NVML_INIT_TIMEOUT = 10
 
 
+def _inject_jina_v3_allocator_env(
+    model_type: str,
+    model_name: str,
+    envs: Optional[Dict[str, str]],
+    launch_args: Dict[str, Any],
+) -> Optional[Dict[str, str]]:
+    """Add the Jina v3 allocator default and persist it for recovery.
+
+    The launch arguments are captured with ``locals()`` before this helper is
+    called.  Updating ``envs`` alone would therefore affect the current launch
+    but not the cached arguments used by worker restart recovery.
+    """
+    if model_type.lower() != "embedding" or model_name.lower() != "jina-embeddings-v3":
+        return envs
+
+    updated_envs = dict(envs or {})
+    if (
+        "PYTORCH_CUDA_ALLOC_CONF" not in updated_envs
+        and "PYTORCH_ALLOC_CONF" not in updated_envs
+    ):
+        updated_envs["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
+
+    # ``launch_args`` is the recovery snapshot, so update it explicitly.
+    launch_args["envs"] = updated_envs
+    return updated_envs
+
+
 def _strip_test_envs(launch_args: dict) -> Tuple[dict, Set[str]]:
     """Strip XINFERENCE_TEST_* envs from launch_args.
 
@@ -3238,6 +3265,7 @@ class WorkerActor(xo.StatelessActor):
         launch_args.pop("kwargs")
         launch_args.update(kwargs)
         launch_args["launch_ts"] = int(time.time())
+        envs = _inject_jina_v3_allocator_env(model_type, model_name, envs, launch_args)
 
         try:
             origin_uid, _ = parse_replica_model_uid(model_uid)

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -286,8 +286,8 @@ _NVML_INIT_TIMEOUT = 10
 
 
 def _inject_jina_v3_allocator_env(
-    model_type: str,
-    model_name: str,
+    model_type: Optional[str],
+    model_name: Optional[str],
     envs: Optional[Dict[str, str]],
     launch_args: Dict[str, Any],
 ) -> Optional[Dict[str, str]]:
@@ -297,7 +297,12 @@ def _inject_jina_v3_allocator_env(
     called.  Updating ``envs`` alone would therefore affect the current launch
     but not the cached arguments used by worker restart recovery.
     """
-    if model_type.lower() != "embedding" or model_name.lower() != "jina-embeddings-v3":
+    if (
+        not isinstance(model_type, str)
+        or not isinstance(model_name, str)
+        or model_type.lower() != "embedding"
+        or model_name.lower() != "jina-embeddings-v3"
+    ):
         return envs
 
     updated_envs = dict(envs or {})

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -295,7 +295,9 @@ def _inject_jina_v3_allocator_env(
 
     The launch arguments are captured with ``locals()`` before this helper is
     called.  Updating ``envs`` alone would therefore affect the current launch
-    but not the cached arguments used by worker restart recovery.
+    but not the cached arguments used by worker restart recovery. Allocator
+    settings inherited from the worker process count as explicit user
+    configuration because xoscar applies ``envs`` on top of ``os.environ``.
     """
     if (
         not isinstance(model_type, str)
@@ -306,10 +308,8 @@ def _inject_jina_v3_allocator_env(
         return envs
 
     updated_envs = dict(envs or {})
-    if (
-        "PYTORCH_CUDA_ALLOC_CONF" not in updated_envs
-        and "PYTORCH_ALLOC_CONF" not in updated_envs
-    ):
+    allocator_env_keys = ("PYTORCH_CUDA_ALLOC_CONF", "PYTORCH_ALLOC_CONF")
+    if not any(key in updated_envs or key in os.environ for key in allocator_env_keys):
         updated_envs["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
 
     # ``launch_args`` is the recovery snapshot, so update it explicitly.


### PR DESCRIPTION
## Summary

- apply `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True` only to `jina-embeddings-v3` embedding launches
- preserve user-provided `PYTORCH_CUDA_ALLOC_CONF` or `PYTORCH_ALLOC_CONF` values
- persist the resulting environment in recovery launch arguments
- add focused tests covering injection, user overrides, recovery persistence, and unaffected models

## Tests

- `pytest -q xinference/core/tests/test_worker.py --disable-warnings --maxfail=1` (59 passed)
- `pre-commit run --files xinference/core/worker.py xinference/core/tests/test_worker.py`