### PR TITLE
fix(ocr): stop task="parse" rejecting ordinary multi-page PDFs

### DIFF
--- a/doc/source/models/model_abilities/image.rst
+++ b/doc/source/models/model_abilities/image.rst
@@ -456,29 +456,29 @@ path's. When a render finds no text *anywhere in the document*, DeepDoc
 re-renders the whole thing at three times the zoom, repeatedly, until the scale
 reaches 9 — so a request at ``zoomin=3`` may end up rendering at 9.
 
-Three budgets apply:
+In practice that re-render is unreachable for any document that renders at
+all — DeepDoc appends to its box list on every page, including an empty list
+for a page that yields nothing, so the ``len(boxes) == 0`` condition it guards
+on only holds when there were no pages to render — so the document as a whole
+is budgeted at the scale you asked for. Two budgets apply:
 
-* **Per page**, enforced at that worst-case scale, since one page with an
+* **Per page**, enforced at the worst-case scale, since one page with an
   outsized MediaBox must not be admitted on the strength of a retry that may
   still fire: a page may not peak above 200 megapixels. An A3 page is fine at
   ``zoomin=3`` but not at ``6``.
-* **Whole document, at the requested scale**: the pages together may not exceed
-  1 gigapixel, roughly 221 A4 pages at the default zoom.
-* **Whole document, if the retry fires**: the escalated re-render may not
-  exceed 3 gigapixels, roughly 73 A4 pages. Because every zoom escalates to at
-  least 9x, this is effectively a limit on total page area rather than
-  something ``zoomin`` can trade against.
+* **Whole document**, at the requested scale: the pages together may not
+  exceed 1 gigapixel, roughly 221 A4 pages at the default zoom, with the
+  200-page ceiling capping it from the other side.
 
-Note that the retry ladder is **not monotonic** in ``zoomin``: DeepDoc tests
-``zoomin < 9`` before multiplying, so ``zoomin=2`` and ``zoomin=6`` both
-escalate to 18x while ``zoomin=3`` stops at 9x. Lowering ``zoomin`` can
-therefore make the budget *larger*. For that reason a 400 from these limits
-names a ``zoomin`` that would actually fit whenever one exists, and otherwise
-says to split the document — follow what the message says rather than assuming
-a lower zoom will help.
+Note that the per-page budget is **not monotonic** in ``zoomin``, because the
+retry ladder is not: DeepDoc tests ``zoomin < 9`` before multiplying, so
+``zoomin=2`` and ``zoomin=6`` both escalate to 18x while ``zoomin=3`` stops at
+9x. Lowering ``zoomin`` can therefore make the per-page budget *larger*. For
+that reason a 400 from these limits names a ``zoomin`` that would actually fit
+whenever one exists, and otherwise says to split the document — follow what
+the message says rather than assuming a lower zoom will help.
 
-Both whole-document ceilings can be raised on deployments whose parse workers
-are sized for it, via ``XINFERENCE_MAX_PDF_PARSE_TOTAL_PIXELS`` and
-``XINFERENCE_MAX_PDF_PARSE_RETRY_TOTAL_PIXELS`` (both in pixels). A rendered
-page costs roughly 4 bytes per pixel, so the defaults correspond to about 4 GB
-and 12 GB of page images respectively.
+The whole-document ceiling can be raised on deployments whose parse workers
+are sized for it, via ``XINFERENCE_MAX_PDF_PARSE_TOTAL_PIXELS`` (in pixels).
+A rendered page costs roughly 4 bytes per pixel, so the default corresponds to
+about 4 GB of page images.

--- a/doc/source/models/model_abilities/image.rst
+++ b/doc/source/models/model_abilities/image.rst
@@ -456,11 +456,13 @@ path's. When a render finds no text *anywhere in the document*, DeepDoc
 re-renders the whole thing at three times the zoom, repeatedly, until the scale
 reaches 9 — so a request at ``zoomin=3`` may end up rendering at 9.
 
-In practice that re-render is unreachable for any document that renders at
-all — DeepDoc appends to its box list on every page, including an empty list
-for a page that yields nothing, so the ``len(boxes) == 0`` condition it guards
-on only holds when there were no pages to render — so the document as a whole
-is budgeted at the scale you asked for. Two budgets apply:
+With ``deepdoc-lib`` 0.2.2 that re-render is in practice unreachable for any
+document that renders at all — DeepDoc appends to its box list on every page,
+including an empty list for a page that yields nothing, so the
+``len(boxes) == 0`` condition it guards on only holds when there were no pages
+to render. The document is therefore budgeted at the scale you asked for, with
+a separate ceiling bounding what the re-render would cost should a later
+release make it reachable again. Three budgets apply:
 
 * **Per page**, enforced at the worst-case scale, since one page with an
   outsized MediaBox must not be admitted on the strength of a retry that may
@@ -469,6 +471,11 @@ is budgeted at the scale you asked for. Two budgets apply:
 * **Whole document**, at the requested scale: the pages together may not
   exceed 1 gigapixel, roughly 221 A4 pages at the default zoom, with the
   200-page ceiling capping it from the other side.
+* **Whole document, if the re-render happens**: the escalated peak may not
+  exceed 6 gigapixels, about 24 GB of page images. This is what limits long
+  documents in practice — roughly 130 A4 pages at the default zoom — and it is
+  deliberately not derived from the other two, whose product would permit some
+  160 GB.
 
 Note that the per-page budget is **not monotonic** in ``zoomin``, because the
 retry ladder is not: DeepDoc tests ``zoomin < 9`` before multiplying, so
@@ -478,7 +485,8 @@ that reason a 400 from these limits names a ``zoomin`` that would actually fit
 whenever one exists, and otherwise says to split the document — follow what
 the message says rather than assuming a lower zoom will help.
 
-The whole-document ceiling can be raised on deployments whose parse workers
-are sized for it, via ``XINFERENCE_MAX_PDF_PARSE_TOTAL_PIXELS`` (in pixels).
-A rendered page costs roughly 4 bytes per pixel, so the default corresponds to
-about 4 GB of page images.
+Both whole-document ceilings can be raised on deployments whose parse workers
+are sized for it, via ``XINFERENCE_MAX_PDF_PARSE_TOTAL_PIXELS`` and
+``XINFERENCE_MAX_PDF_PARSE_RETRY_TOTAL_PIXELS`` (both in pixels). A rendered
+page costs roughly 4 bytes per pixel, so the defaults correspond to about 4 GB
+and 24 GB of page images respectively.

--- a/doc/source/models/model_abilities/image.rst
+++ b/doc/source/models/model_abilities/image.rst
@@ -452,14 +452,33 @@ document to merge across pages, so it requires a PDF upload and does not accept
   text crops are needed too. The field is omitted for elements without a crop.
 
 Parsing has its own size limits, and they are tighter than the per-page OCR
-path's. When a render finds no text at all, DeepDoc re-renders the whole
-document at three times the zoom, repeatedly, until the scale reaches 9 — so a
-request at ``zoomin=3`` may end up rendering at 9, and one at ``zoomin=1`` also
-ends at 9. Because that allocation is real, both the per-page and the
-whole-document budgets are enforced against the largest scale a run can reach,
-counting the render being replaced as well.
+path's. When a render finds no text *anywhere in the document*, DeepDoc
+re-renders the whole thing at three times the zoom, repeatedly, until the scale
+reaches 9 — so a request at ``zoomin=3`` may end up rendering at 9.
 
-In practice a request is rejected with a 400 when a single page would peak above
-200 megapixels (an A3 page is fine at ``zoomin=3``, but not at ``6``), or when
-the pages together would peak above 1 gigapixel — roughly 22 A4 pages at the
-default zoom. Lower ``zoomin`` or split the document if you hit either.
+Three budgets apply:
+
+* **Per page**, enforced at that worst-case scale, since one page with an
+  outsized MediaBox must not be admitted on the strength of a retry that may
+  still fire: a page may not peak above 200 megapixels. An A3 page is fine at
+  ``zoomin=3`` but not at ``6``.
+* **Whole document, at the requested scale**: the pages together may not exceed
+  1 gigapixel, roughly 221 A4 pages at the default zoom.
+* **Whole document, if the retry fires**: the escalated re-render may not
+  exceed 3 gigapixels, roughly 73 A4 pages. Because every zoom escalates to at
+  least 9x, this is effectively a limit on total page area rather than
+  something ``zoomin`` can trade against.
+
+Note that the retry ladder is **not monotonic** in ``zoomin``: DeepDoc tests
+``zoomin < 9`` before multiplying, so ``zoomin=2`` and ``zoomin=6`` both
+escalate to 18x while ``zoomin=3`` stops at 9x. Lowering ``zoomin`` can
+therefore make the budget *larger*. For that reason a 400 from these limits
+names a ``zoomin`` that would actually fit whenever one exists, and otherwise
+says to split the document — follow what the message says rather than assuming
+a lower zoom will help.
+
+Both whole-document ceilings can be raised on deployments whose parse workers
+are sized for it, via ``XINFERENCE_MAX_PDF_PARSE_TOTAL_PIXELS`` and
+``XINFERENCE_MAX_PDF_PARSE_RETRY_TOTAL_PIXELS`` (both in pixels). A rendered
+page costs roughly 4 bytes per pixel, so the defaults correspond to about 4 GB
+and 12 GB of page images respectively.

--- a/xinference/api/pdf_ocr.py
+++ b/xinference/api/pdf_ocr.py
@@ -118,32 +118,26 @@ MAX_PDF_PARSE_PAGE_PIXELS = 200_000_000
 # This one is enforced at the *requested* scale. Charging every document for
 # the retry is what stopped an ordinary 31-page A4 text PDF parsing at every
 # zoomin (#5307): it was budgeted at 45 MP per page where it really renders
-# at 4.5. The retry is not a state a text document reaches -- deepdoc's guard
-# is ``len(self.boxes) == 0`` and ``boxes`` accumulates over every page, so it
-# only fires when not one page in the whole document produced a single box.
+# at 4.5.
+#
+# There is no separate document-wide ceiling for the retry scale, because for
+# any document that renders at all the retry is unreachable. deepdoc's guard
+# is ``len(self.boxes) == 0``, but ``__ocr`` appends to ``boxes`` on *every*
+# page -- ``self.boxes.append([])`` when a page yields nothing, ``append(bxs)``
+# otherwise -- so after the OCR pass ``len(self.boxes)`` equals the page count.
+# It is zero only when there were no pages to render in the first place, i.e.
+# the load failed, in which case there is nothing to re-render. Budgeting the
+# whole document for a 9x pass it cannot take would reject a 74-page A4 PDF
+# whose real render is ~334 M pixels.
+#
+# The per-page ceiling above is still checked at the worst-case scale. That is
+# cheap insurance on a single outsized MediaBox and does not depend on this
+# reasoning holding for every deepdoc-lib version.
 #
 # At 1 G px and ~4 bytes per rendered pixel this is ~4 GB of page images at
 # the requested zoom: ~221 A4 pages at the default zoomin 3, 55 at zoomin 6,
 # with the 200-page ceiling capping it from the other side.
 MAX_PDF_PARSE_TOTAL_PIXELS = 1_000_000_000
-# The retry is still real when it does fire, and it re-renders the *whole*
-# document, so the requested-scale budget alone would leave a hole: 200 A4
-# pages admitted at zoomin 3 would escalate to 8 G px (~32 GB). The escalated
-# document therefore gets its own ceiling, checked at the worst-case scale.
-#
-# It is deliberately looser than the requested-scale budget rather than equal
-# to it. The escalated render *replaces* the first one -- the retry re-enters
-# ``__images__``, which rebinds ``self.page_images`` -- so the two are not
-# summed; and reaching it at all requires a document that yielded no text
-# anywhere, which is the rare case rather than the one being priced.
-#
-# At 3 G px this holds an escalated document to ~12 GB of page images, which
-# admits 73 A4 pages at the default zoom. That is the binding constraint on
-# long documents now, and it is a real one: a 200-page A4 document really
-# would need ~32 GB if it escalated. Deployments whose parse workers are
-# sized for more can raise both ceilings via the environment rather than
-# being held to a default chosen for a modest worker.
-MAX_PDF_PARSE_RETRY_TOTAL_PIXELS = 3_000_000_000
 
 
 def _pixel_budget_from_env(name: str, default: int) -> int:
@@ -170,47 +164,33 @@ def _pixel_budget_from_env(name: str, default: int) -> int:
 MAX_PDF_PARSE_TOTAL_PIXELS = _pixel_budget_from_env(
     "XINFERENCE_MAX_PDF_PARSE_TOTAL_PIXELS", MAX_PDF_PARSE_TOTAL_PIXELS
 )
-MAX_PDF_PARSE_RETRY_TOTAL_PIXELS = _pixel_budget_from_env(
-    "XINFERENCE_MAX_PDF_PARSE_RETRY_TOTAL_PIXELS", MAX_PDF_PARSE_RETRY_TOTAL_PIXELS
-)
 
 
 def _parse_budget_error(sizes: List[Tuple[float, float]], zoomin: int) -> Optional[str]:
     """Why a document does not fit at ``zoomin``, or ``None`` if it does.
 
-    Both budgets are applied: the per-page ceiling at the worst-case scale,
-    since one oversized MediaBox must not be admitted on the strength of a
-    retry that may still fire, and the two document-wide ceilings at the
-    requested and worst-case scales respectively.
+    The per-page ceiling is applied at the worst-case scale, since one
+    oversized MediaBox must not be admitted on the strength of a retry that
+    may still fire, and the document-wide ceiling at the requested scale.
     """
     worst_case = worst_case_parse_zoom(zoomin)
     requested_total = 0
-    retry_total = 0
     for index, (width, height) in enumerate(sizes):
         peak_pixels = worst_case_parse_peak_pixels(width, height, zoomin)
         if peak_pixels > MAX_PDF_PARSE_PAGE_PIXELS:
             return (
                 f"Page {index + 1} would rasterize to {peak_pixels} pixels at "
-                f"zoomin {zoomin:g} (the parser re-renders at up to "
-                f"{worst_case:g}x when a document yields no text at all), "
-                f"exceeding the per-page limit of {MAX_PDF_PARSE_PAGE_PIXELS}"
+                f"zoomin {zoomin} (the parser can re-render at up to "
+                f"{worst_case}x), exceeding the per-page limit of "
+                f"{MAX_PDF_PARSE_PAGE_PIXELS}"
             )
         requested_total += int(width * zoomin) * int(height * zoomin)
         if requested_total > MAX_PDF_PARSE_TOTAL_PIXELS:
             return (
                 f"The uploaded PDF would rasterize to more than "
-                f"{requested_total} pixels in total at zoomin {zoomin:g}, "
+                f"{requested_total} pixels in total at zoomin {zoomin}, "
                 f"exceeding the whole-document limit of "
                 f"{MAX_PDF_PARSE_TOTAL_PIXELS}"
-            )
-        retry_total += int(width * worst_case) * int(height * worst_case)
-        if retry_total > MAX_PDF_PARSE_RETRY_TOTAL_PIXELS:
-            return (
-                f"The uploaded PDF would rasterize to more than {retry_total} "
-                f"pixels in total if the parser re-rendered it at "
-                f"{worst_case:g}x, which it does when a document yields no "
-                f"text at all, exceeding the retry limit of "
-                f"{MAX_PDF_PARSE_RETRY_TOTAL_PIXELS}"
             )
     return None
 
@@ -266,9 +246,9 @@ def validate_pdf_for_parse(
     oversized MediaBox must not be admitted on the strength of a retry that
     may still fire, and it counts the render being replaced alongside its
     replacement (see ``worst_case_parse_peak_pixels``). The document-wide
-    ceiling is applied at the requested scale, with a separate, looser one
-    bounding what a retry would re-render the document at; see
-    ``MAX_PDF_PARSE_TOTAL_PIXELS`` for why the two differ.
+    ceiling is applied at the requested scale; see
+    ``MAX_PDF_PARSE_TOTAL_PIXELS`` for why the retry is not budgeted for
+    across the document.
 
     Returns the page count. Raises ``ValueError`` if the document cannot be
     opened, has no pages, has too many pages, or would rasterize to too many

--- a/xinference/api/pdf_ocr.py
+++ b/xinference/api/pdf_ocr.py
@@ -21,8 +21,12 @@ JSON-serializable response body.
 """
 
 import json
+import logging
+import os
 import threading
 from typing import Any, Generator, List, Optional, Tuple, Union
+
+logger = logging.getLogger(__name__)
 
 # PDFium is not thread-safe: pypdfium2 documents that concurrent calls,
 # even on different documents, may crash or corrupt the process. Every
@@ -46,11 +50,15 @@ MAX_PDF_OCR_PAGE_PIXELS = 80_000_000
 WHOLE_DOCUMENT_OCR_TASKS = frozenset({"parse"})
 # Whole-document parsers render at ``72 * zoomin`` DPI, i.e. a scale of
 # ``zoomin`` over the page's point size. DeepDoc additionally re-renders at
-# ``zoomin * 3`` when a first pass finds no OCR boxes -- its recovery path
-# for pages the first render was too coarse to read -- but only while
-# ``zoomin < 9``, so a parse started at or above that never amplifies. That
-# retry is part of the parsing behaviour and is left intact, so the budget
-# below is enforced against the largest scale a run can actually reach.
+# ``zoomin * 3`` when a pass finds no OCR boxes *anywhere in the document* --
+# its recovery path for a render too coarse to read -- but only while
+# ``zoomin < 9``, so a parse started at or above that never amplifies.
+#
+# The guard tests the pre-multiplication value, so the ladder overshoots the
+# limit for any zoomin that is not a power-of-three divisor of 9: 2 escalates
+# 2 -> 6 -> 18, and 6 goes straight to 18. That makes the reachable scale
+# non-monotonic in zoomin (2 and 6 reach 18, but 3 stops at 9), which is a
+# defect in deepdoc-lib rather than here; see ``worst_case_parse_zoom``.
 PDF_PARSE_RETRY_ZOOM_FACTOR = 3
 PDF_PARSE_RETRY_ZOOM_LIMIT = 9
 
@@ -61,6 +69,14 @@ def worst_case_parse_zoom(zoomin: int) -> int:
     The retry is recursive: each pass that still finds no boxes triples the
     zoom again, and only the ``< limit`` guard stops it. So zoomin 1 renders
     at 1, 3 and finally 9, not just 3.
+
+    Because deepdoc-lib checks ``zoomin < 9`` *before* multiplying, the last
+    step can overshoot: 2 reaches 18 and 6 reaches 18, while 3 stops at 9.
+    This models that faithfully rather than clamping, so the number used for
+    budgeting is the one the parser can really allocate. The consequence is
+    that this is not monotonic in ``zoomin`` -- which is why the per-page
+    limit, the only budget still enforced at this scale, is checked against
+    every candidate zoom before one is recommended to the caller.
     """
     scale = zoomin
     while scale < PDF_PARSE_RETRY_ZOOM_LIMIT:
@@ -97,21 +113,127 @@ def worst_case_parse_peak_pixels(width: float, height: float, zoomin: int) -> in
 MAX_PDF_PARSE_PAGE_PIXELS = 200_000_000
 # Unlike the per-page path, which rasterizes lazily and holds one page at a
 # time, whole-document parsers render every page up front and keep them all
-# alive at once, so the pages are budgeted together as well -- and, like the
-# per-page ceiling, at the scale a retry can actually reach.
+# alive at once, so the pages are budgeted together as well.
 #
-# Peak usage is the final render plus the one before it: deepdoc assigns
-# ``self.page_images = [...]``, and the comprehension is fully built before
-# the name is rebound, so the previous render is still referenced while the
-# new one is allocated. ``worst_case_parse_peak_pixels`` accounts for both.
+# This one is enforced at the *requested* scale. Charging every document for
+# the retry is what stopped an ordinary 31-page A4 text PDF parsing at every
+# zoomin (#5307): it was budgeted at 45 MP per page where it really renders
+# at 4.5. The retry is not a state a text document reaches -- deepdoc's guard
+# is ``len(self.boxes) == 0`` and ``boxes`` accumulates over every page, so it
+# only fires when not one page in the whole document produced a single box.
 #
-# At 4 GB this admits roughly 22 A4 pages, well short of the 200-page ceiling
-# the per-page path allows. That is the honest consequence of budgeting for a
-# retry that renders at 9x: a document only reaches this if every page yields
-# no text, but the allocation is real when it does, and permitting tens of
-# gigabytes would leave the OOM open. Raise this if parse workers are sized
-# for it; `pages`-style batching in deepdoc-lib would lift it properly.
+# At 1 G px and ~4 bytes per rendered pixel this is ~4 GB of page images at
+# the requested zoom: ~221 A4 pages at the default zoomin 3, 55 at zoomin 6,
+# with the 200-page ceiling capping it from the other side.
 MAX_PDF_PARSE_TOTAL_PIXELS = 1_000_000_000
+# The retry is still real when it does fire, and it re-renders the *whole*
+# document, so the requested-scale budget alone would leave a hole: 200 A4
+# pages admitted at zoomin 3 would escalate to 8 G px (~32 GB). The escalated
+# document therefore gets its own ceiling, checked at the worst-case scale.
+#
+# It is deliberately looser than the requested-scale budget rather than equal
+# to it. The escalated render *replaces* the first one -- the retry re-enters
+# ``__images__``, which rebinds ``self.page_images`` -- so the two are not
+# summed; and reaching it at all requires a document that yielded no text
+# anywhere, which is the rare case rather than the one being priced.
+#
+# At 3 G px this holds an escalated document to ~12 GB of page images, which
+# admits 73 A4 pages at the default zoom. That is the binding constraint on
+# long documents now, and it is a real one: a 200-page A4 document really
+# would need ~32 GB if it escalated. Deployments whose parse workers are
+# sized for more can raise both ceilings via the environment rather than
+# being held to a default chosen for a modest worker.
+MAX_PDF_PARSE_RETRY_TOTAL_PIXELS = 3_000_000_000
+
+
+def _pixel_budget_from_env(name: str, default: int) -> int:
+    """Read a pixel ceiling from the environment, falling back to ``default``.
+
+    A malformed or non-positive value is ignored rather than raising: this
+    runs at import time, and a typo in a deployment's environment should not
+    take the API process down.
+    """
+    raw = os.environ.get(name)
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning("Ignoring %s=%r: not an integer", name, raw)
+        return default
+    if value <= 0:
+        logger.warning("Ignoring %s=%r: must be positive", name, raw)
+        return default
+    return value
+
+
+MAX_PDF_PARSE_TOTAL_PIXELS = _pixel_budget_from_env(
+    "XINFERENCE_MAX_PDF_PARSE_TOTAL_PIXELS", MAX_PDF_PARSE_TOTAL_PIXELS
+)
+MAX_PDF_PARSE_RETRY_TOTAL_PIXELS = _pixel_budget_from_env(
+    "XINFERENCE_MAX_PDF_PARSE_RETRY_TOTAL_PIXELS", MAX_PDF_PARSE_RETRY_TOTAL_PIXELS
+)
+
+
+def _parse_budget_error(sizes: List[Tuple[float, float]], zoomin: int) -> Optional[str]:
+    """Why a document does not fit at ``zoomin``, or ``None`` if it does.
+
+    Both budgets are applied: the per-page ceiling at the worst-case scale,
+    since one oversized MediaBox must not be admitted on the strength of a
+    retry that may still fire, and the two document-wide ceilings at the
+    requested and worst-case scales respectively.
+    """
+    worst_case = worst_case_parse_zoom(zoomin)
+    requested_total = 0
+    retry_total = 0
+    for index, (width, height) in enumerate(sizes):
+        peak_pixels = worst_case_parse_peak_pixels(width, height, zoomin)
+        if peak_pixels > MAX_PDF_PARSE_PAGE_PIXELS:
+            return (
+                f"Page {index + 1} would rasterize to {peak_pixels} pixels at "
+                f"zoomin {zoomin:g} (the parser re-renders at up to "
+                f"{worst_case:g}x when a document yields no text at all), "
+                f"exceeding the per-page limit of {MAX_PDF_PARSE_PAGE_PIXELS}"
+            )
+        requested_total += int(width * zoomin) * int(height * zoomin)
+        if requested_total > MAX_PDF_PARSE_TOTAL_PIXELS:
+            return (
+                f"The uploaded PDF would rasterize to more than "
+                f"{requested_total} pixels in total at zoomin {zoomin:g}, "
+                f"exceeding the whole-document limit of "
+                f"{MAX_PDF_PARSE_TOTAL_PIXELS}"
+            )
+        retry_total += int(width * worst_case) * int(height * worst_case)
+        if retry_total > MAX_PDF_PARSE_RETRY_TOTAL_PIXELS:
+            return (
+                f"The uploaded PDF would rasterize to more than {retry_total} "
+                f"pixels in total if the parser re-rendered it at "
+                f"{worst_case:g}x, which it does when a document yields no "
+                f"text at all, exceeding the retry limit of "
+                f"{MAX_PDF_PARSE_RETRY_TOTAL_PIXELS}"
+            )
+    return None
+
+
+def largest_fitting_parse_zoom(
+    sizes: List[Tuple[float, float]], upper_bound: int
+) -> Optional[int]:
+    """The largest zoom in ``1..upper_bound`` this document fits at.
+
+    Not simply ``upper_bound`` counted down until something fits: because the
+    retry ladder overshoots for zoom values that are not power-of-three
+    divisors of 9, a *lower* zoomin can have a *higher* worst case (2 and 6
+    both reach 18x, while 3 stops at 9x). Every candidate is therefore tested
+    rather than assuming the budget shrinks as the zoom does.
+
+    The search covers the whole range, not just values below the request, for
+    the same reason: a document rejected at zoomin 2 (18x) may well fit at 3
+    (9x), and sending the caller down to 1 would cost quality for nothing.
+    """
+    for candidate in range(upper_bound, 0, -1):
+        if _parse_budget_error(sizes, candidate) is None:
+            return candidate
+    return None
 
 
 def is_pdf_upload(content_type: Optional[str], head: bytes) -> bool:
@@ -121,7 +243,9 @@ def is_pdf_upload(content_type: Optional[str], head: bytes) -> bool:
     return head.startswith(PDF_MAGIC)
 
 
-def validate_pdf_for_parse(data: bytes, zoomin: int) -> int:
+def validate_pdf_for_parse(
+    data: bytes, zoomin: int, max_zoomin: Optional[int] = None
+) -> int:
     """Check a PDF that will be handed to a whole-document parser.
 
     Whole-document parsing tasks (e.g. DeepDoc's ``task="parse"``) render the
@@ -138,14 +262,26 @@ def validate_pdf_for_parse(data: bytes, zoomin: int) -> int:
     comfortably under the per-page limit can still exhaust the worker in
     aggregate, so the pages are budgeted as a whole too.
 
-    Both budgets are applied at the worst-case scale, since the retry is left
-    intact and re-renders the whole document, and both count the render being
-    replaced alongside its replacement (see
-    ``worst_case_parse_peak_pixels``).
+    The per-page ceiling is applied at the worst-case scale, since a single
+    oversized MediaBox must not be admitted on the strength of a retry that
+    may still fire, and it counts the render being replaced alongside its
+    replacement (see ``worst_case_parse_peak_pixels``). The document-wide
+    ceiling is applied at the requested scale, with a separate, looser one
+    bounding what a retry would re-render the document at; see
+    ``MAX_PDF_PARSE_TOTAL_PIXELS`` for why the two differ.
 
     Returns the page count. Raises ``ValueError`` if the document cannot be
     opened, has no pages, has too many pages, or would rasterize to too many
-    pixels on any single page or across the document.
+    pixels on any single page or across the document. The message names a
+    ``zoomin`` that would fit whenever one exists, rather than advising the
+    caller to lower it -- the retry ladder is not monotonic, so lowering it
+    can make the budget larger.
+
+    ``max_zoomin`` bounds the search for that recommendation; it should be the
+    largest value the endpoint accepts. It defaults to ``zoomin``, which only
+    searches downwards -- pass the real ceiling so a request rejected at a
+    zoom with an overshooting ladder (2 or 6, which reach 18x) can be pointed
+    at a higher one with a shorter ladder (3, which stops at 9x).
     """
     try:
         import pypdfium2 as pdfium
@@ -170,35 +306,28 @@ def validate_pdf_for_parse(data: bytes, zoomin: int) -> int:
                     f"The uploaded PDF has {page_count} pages, at most "
                     f"{MAX_PDF_OCR_PAGES} pages can be parsed per request"
                 )
-            worst_case = worst_case_parse_zoom(zoomin)
-            total_pixels = 0
+            sizes = []
             for page_number in range(1, page_count + 1):
                 page = pdf[page_number - 1]
                 try:
-                    width, height = page.get_size()
+                    sizes.append(page.get_size())
                 finally:
                     page.close()
-                peak_pixels = worst_case_parse_peak_pixels(width, height, zoomin)
-                if peak_pixels > MAX_PDF_PARSE_PAGE_PIXELS:
-                    raise ValueError(
-                        f"Page {page_number} would rasterize to {peak_pixels} "
-                        f"pixels at zoomin {zoomin:g} (the parser re-renders at "
-                        f"up to {worst_case:g}x when a page yields no text), "
-                        f"exceeding the per-page limit of "
-                        f"{MAX_PDF_PARSE_PAGE_PIXELS}; lower `zoomin`"
-                    )
-                total_pixels += peak_pixels
-                if total_pixels > MAX_PDF_PARSE_TOTAL_PIXELS:
-                    raise ValueError(
-                        f"The uploaded PDF would rasterize to more than "
-                        f"{total_pixels} pixels in total at zoomin {zoomin:g} "
-                        f"(the parser re-renders at up to {worst_case:g}x when a "
-                        f"page yields no text), exceeding the whole-document "
-                        f"limit of {MAX_PDF_PARSE_TOTAL_PIXELS}; lower `zoomin` "
-                        f"or split the document"
-                    )
         finally:
             pdf.close()
+
+    reason = _parse_budget_error(sizes, zoomin)
+    if reason is not None:
+        # "Lower `zoomin`" was the old advice and it is not sound: the retry
+        # ladder is not monotonic, so a lower zoomin can be budgeted *higher*
+        # (2 and 6 both escalate to 18x where 3 stops at 9x). Name a zoom that
+        # actually fits, and only fall back to splitting when none does.
+        # Search the whole permitted range, not just below the request: with a
+        # non-monotonic ladder a higher zoom can be the one that fits.
+        fitting = largest_fitting_parse_zoom(sizes, max(max_zoomin or zoomin, zoomin))
+        if fitting is None:
+            raise ValueError(f"{reason}; split the document into smaller parts")
+        raise ValueError(f"{reason}; retry with `zoomin` {fitting}")
 
     return page_count
 

--- a/xinference/api/pdf_ocr.py
+++ b/xinference/api/pdf_ocr.py
@@ -169,9 +169,9 @@ MAX_PDF_PARSE_TOTAL_PIXELS = _pixel_budget_from_env(
 def _parse_budget_error(sizes: List[Tuple[float, float]], zoomin: int) -> Optional[str]:
     """Why a document does not fit at ``zoomin``, or ``None`` if it does.
 
-    The per-page ceiling is applied at the worst-case scale, since one
-    oversized MediaBox must not be admitted on the strength of a retry that
-    may still fire, and the document-wide ceiling at the requested scale.
+    The per-page ceiling is applied at the worst-case scale and the
+    document-wide ceiling at the requested scale; see
+    ``MAX_PDF_PARSE_TOTAL_PIXELS`` for why they differ.
     """
     worst_case = worst_case_parse_zoom(zoomin)
     requested_total = 0
@@ -200,15 +200,17 @@ def largest_fitting_parse_zoom(
 ) -> Optional[int]:
     """The largest zoom in ``1..upper_bound`` this document fits at.
 
-    Not simply ``upper_bound`` counted down until something fits: because the
-    retry ladder overshoots for zoom values that are not power-of-three
-    divisors of 9, a *lower* zoomin can have a *higher* worst case (2 and 6
-    both reach 18x, while 3 stops at 9x). Every candidate is therefore tested
-    rather than assuming the budget shrinks as the zoom does.
+    Not simply ``upper_bound`` counted down until something fits: the per-page
+    ceiling is enforced at the worst-case scale, and that ladder overshoots
+    for zoom values that are not power-of-three divisors of 9, so a *lower*
+    zoomin can have a *higher* worst case (2 and 6 both reach 18x, while 3
+    stops at 9x). A 1000x1000 pt page fits at 1, 3 and 4 but not at 2. Every
+    candidate is therefore tested rather than assuming the budget shrinks as
+    the zoom does.
 
     The search covers the whole range, not just values below the request, for
-    the same reason: a document rejected at zoomin 2 (18x) may well fit at 3
-    (9x), and sending the caller down to 1 would cost quality for nothing.
+    the same reason: a page rejected at zoomin 2 (18x) may well fit at 3 (9x),
+    and sending the caller down to 1 would cost quality for nothing.
     """
     for candidate in range(upper_bound, 0, -1):
         if _parse_budget_error(sizes, candidate) is None:
@@ -232,8 +234,7 @@ def validate_pdf_for_parse(
     PDF themselves, so the bytes are passed straight through instead of being
     rasterized here. That skips everything ``rasterize_pdf`` would have
     validated, and parsers tend to fail unhelpfully: DeepDoc swallows load
-    errors and returns an empty result, then re-renders at three times the
-    zoom when it finds no boxes.
+    errors and returns an empty result.
 
     Page geometry therefore has to be checked here too, in two ways. A single
     valid page with an outsized MediaBox — 14400x14400 points is legal —
@@ -242,10 +243,11 @@ def validate_pdf_for_parse(
     comfortably under the per-page limit can still exhaust the worker in
     aggregate, so the pages are budgeted as a whole too.
 
-    The per-page ceiling is applied at the worst-case scale, since a single
-    oversized MediaBox must not be admitted on the strength of a retry that
-    may still fire, and it counts the render being replaced alongside its
-    replacement (see ``worst_case_parse_peak_pixels``). The document-wide
+    The per-page ceiling is applied at the worst-case scale as cheap
+    insurance -- it does not depend on the retry being unreachable, so a
+    single oversized MediaBox stays rejected even if that changes -- and it
+    counts the render being replaced alongside its replacement (see
+    ``worst_case_parse_peak_pixels``). The document-wide
     ceiling is applied at the requested scale; see
     ``MAX_PDF_PARSE_TOTAL_PIXELS`` for why the retry is not budgeted for
     across the document.

--- a/xinference/api/pdf_ocr.py
+++ b/xinference/api/pdf_ocr.py
@@ -120,25 +120,25 @@ MAX_PDF_PARSE_PAGE_PIXELS = 200_000_000
 # zoomin (#5307): it was budgeted at 45 MP per page where it really renders
 # at 4.5.
 #
-# There is no separate document-wide ceiling for the retry scale, because for
-# any document that renders at all the retry is unreachable. deepdoc's guard
-# is ``len(self.boxes) == 0``, but ``__ocr`` appends to ``boxes`` on *every*
-# page -- ``self.boxes.append([])`` when a page yields nothing, ``append(bxs)``
-# otherwise -- so after the OCR pass ``len(self.boxes)`` equals the page count.
-# It is zero only when there were no pages to render in the first place, i.e.
-# the load failed, in which case there is nothing to re-render. Budgeting the
-# whole document for a 9x pass it cannot take would reject a 74-page A4 PDF
-# whose real render is ~334 M pixels.
+# The retry gets its own, looser ceiling below rather than being priced into
+# this one, because for any document that renders at all it is unreachable
+# with deepdoc-lib 0.2.2. deepdoc's guard is ``len(self.boxes) == 0``, but
+# ``__ocr`` appends to ``boxes`` on *every* page -- ``self.boxes.append([])``
+# when a page yields nothing, ``append(bxs)`` otherwise -- so after the OCR
+# pass ``len(self.boxes)`` equals the page count. It is zero only when there
+# were no pages to render in the first place, i.e. the load failed, in which
+# case there is nothing to re-render. Charging this budget for a 9x pass the
+# parser cannot take would reject a 74-page A4 PDF rendering ~334 M pixels.
 #
 # At 1 G px and ~4 bytes per rendered pixel this is ~4 GB of page images at
 # the requested zoom: ~221 A4 pages at the default zoomin 3, 55 at zoomin 6,
 # with the 200-page ceiling capping it from the other side.
 MAX_PDF_PARSE_TOTAL_PIXELS = 1_000_000_000
-# The unreachability above is a statement about one release, and the
+# The unreachability argued above is a statement about one release, and the
 # dependency is ``deepdoc-lib~=0.2.2``, which accepts any later 0.2.x. If
 # upstream corrects the guard to the likely intended ``not any(self.boxes)``,
-# the retry becomes reachable, so what it would then allocate needs its own
-# ceiling.
+# the retry becomes reachable, so what it would then allocate is bounded here
+# rather than left to that argument holding.
 #
 # The per-page ceiling does not supply a useful one. It caps a single page,
 # and multiplied by the 200-page ceiling it admits 40 G px -- some 160 GB of
@@ -191,9 +191,10 @@ MAX_PDF_PARSE_RETRY_TOTAL_PIXELS = _pixel_budget_from_env(
 def _parse_budget_error(sizes: List[Tuple[float, float]], zoomin: int) -> Optional[str]:
     """Why a document does not fit at ``zoomin``, or ``None`` if it does.
 
-    The per-page ceiling is applied at the worst-case scale and the
-    document-wide ceiling at the requested scale; see
-    ``MAX_PDF_PARSE_TOTAL_PIXELS`` for why they differ.
+    Three ceilings apply: the per-page one at the worst-case scale, the
+    document-wide one at the requested scale, and a looser document-wide one
+    on what a retry would peak at. See ``MAX_PDF_PARSE_TOTAL_PIXELS`` and
+    ``MAX_PDF_PARSE_RETRY_TOTAL_PIXELS`` for why the last two differ.
     """
     worst_case = worst_case_parse_zoom(zoomin)
     requested_total = 0
@@ -268,21 +269,22 @@ def validate_pdf_for_parse(
     validated, and parsers tend to fail unhelpfully: DeepDoc swallows load
     errors and returns an empty result.
 
-    Page geometry therefore has to be checked here too, in two ways. A single
-    valid page with an outsized MediaBox — 14400x14400 points is legal —
-    rasterizes to billions of pixels on its own. And because every page is
-    rendered up front and held together, a document whose pages are each
-    comfortably under the per-page limit can still exhaust the worker in
-    aggregate, so the pages are budgeted as a whole too.
+    Page geometry therefore has to be checked here too. A single valid page
+    with an outsized MediaBox — 14400x14400 points is legal — rasterizes to
+    billions of pixels on its own. And because every page is rendered up
+    front and held together, a document whose pages are each comfortably
+    under the per-page limit can still exhaust the worker in aggregate, so
+    the pages are budgeted as a whole too.
 
     The per-page ceiling is applied at the worst-case scale as cheap
     insurance -- it does not depend on the retry being unreachable, so a
     single oversized MediaBox stays rejected even if that changes -- and it
     counts the render being replaced alongside its replacement (see
-    ``worst_case_parse_peak_pixels``). The document-wide
-    ceiling is applied at the requested scale; see
-    ``MAX_PDF_PARSE_TOTAL_PIXELS`` for why the retry is not budgeted for
-    across the document.
+    ``worst_case_parse_peak_pixels``). The document-wide ceiling is applied
+    at the requested scale, with a second, looser one bounding what the
+    document would peak at if the retry did fire; see
+    ``MAX_PDF_PARSE_TOTAL_PIXELS`` and ``MAX_PDF_PARSE_RETRY_TOTAL_PIXELS``
+    for why the two differ.
 
     Returns the page count. Raises ``ValueError`` if the document cannot be
     opened, has no pages, has too many pages, or would rasterize to too many

--- a/xinference/api/pdf_ocr.py
+++ b/xinference/api/pdf_ocr.py
@@ -130,25 +130,33 @@ MAX_PDF_PARSE_PAGE_PIXELS = 200_000_000
 # whole document for a 9x pass it cannot take would reject a 74-page A4 PDF
 # whose real render is ~334 M pixels.
 #
-# That is a statement about one release, and the dependency is
-# ``deepdoc-lib~=0.2.2``, which accepts any later 0.2.x -- so the retry could
-# become reachable if upstream corrects the guard to the likely intended
-# ``not any(self.boxes)``. What bounds the damage in that case is not this
-# ceiling but the per-page one above, which is still enforced at the
-# worst-case scale: no page may *peak* above MAX_PDF_PARSE_PAGE_PIXELS even
-# after escalating, and at most MAX_PDF_OCR_PAGES pages are accepted, so an
-# escalated document cannot exceed their product. Searching every page
-# geometry and zoom that both budgets admit, the true maximum is 39.96 G px
-# (~160 GB, from 200 pages of 200x11100 pt at zoomin 1) against that 40 G px
-# bound. A third, document-wide retry ceiling was tried and removed: any
-# value tight enough to bind is also tight enough to reject ordinary
-# documents (36 G px already loses A4 at zoomin 2 and 6), and any value that
-# does not is unreachable.
-#
 # At 1 G px and ~4 bytes per rendered pixel this is ~4 GB of page images at
 # the requested zoom: ~221 A4 pages at the default zoomin 3, 55 at zoomin 6,
 # with the 200-page ceiling capping it from the other side.
 MAX_PDF_PARSE_TOTAL_PIXELS = 1_000_000_000
+# The unreachability above is a statement about one release, and the
+# dependency is ``deepdoc-lib~=0.2.2``, which accepts any later 0.2.x. If
+# upstream corrects the guard to the likely intended ``not any(self.boxes)``,
+# the retry becomes reachable, so what it would then allocate needs its own
+# ceiling.
+#
+# The per-page ceiling does not supply a useful one. It caps a single page,
+# and multiplied by the 200-page ceiling it admits 40 G px -- some 160 GB of
+# page images. That is a mathematical bound, not a memory-safety one: the
+# concrete case of 200 A4 pages escalating 3 -> 9 is 9.0 G px (~36 GB), well
+# inside it and well past what an ordinary worker survives.
+#
+# This ceiling is what keeps that in range, and unlike the requested-scale
+# budget it is applied to the *peak* -- summed from
+# ``worst_case_parse_peak_pixels``, so the render being replaced is counted
+# alongside its replacement.
+#
+# At 6 G px (~24 GB) the 31-page A4 document from #5307 passes at every
+# zoomin from 1 to 6 (1.4 G px at the default), a 100-page A4 document still
+# parses at the default zoom, and the 36 GB case above is rejected. Raise it
+# via the environment on workers sized for more; lowering it trades long
+# documents for a smaller escalated worst case.
+MAX_PDF_PARSE_RETRY_TOTAL_PIXELS = 6_000_000_000
 
 
 def _pixel_budget_from_env(name: str, default: int) -> int:
@@ -175,6 +183,9 @@ def _pixel_budget_from_env(name: str, default: int) -> int:
 MAX_PDF_PARSE_TOTAL_PIXELS = _pixel_budget_from_env(
     "XINFERENCE_MAX_PDF_PARSE_TOTAL_PIXELS", MAX_PDF_PARSE_TOTAL_PIXELS
 )
+MAX_PDF_PARSE_RETRY_TOTAL_PIXELS = _pixel_budget_from_env(
+    "XINFERENCE_MAX_PDF_PARSE_RETRY_TOTAL_PIXELS", MAX_PDF_PARSE_RETRY_TOTAL_PIXELS
+)
 
 
 def _parse_budget_error(sizes: List[Tuple[float, float]], zoomin: int) -> Optional[str]:
@@ -186,6 +197,7 @@ def _parse_budget_error(sizes: List[Tuple[float, float]], zoomin: int) -> Option
     """
     worst_case = worst_case_parse_zoom(zoomin)
     requested_total = 0
+    retry_total = 0
     for index, (width, height) in enumerate(sizes):
         peak_pixels = worst_case_parse_peak_pixels(width, height, zoomin)
         if peak_pixels > MAX_PDF_PARSE_PAGE_PIXELS:
@@ -202,6 +214,15 @@ def _parse_budget_error(sizes: List[Tuple[float, float]], zoomin: int) -> Option
                 f"{requested_total} pixels in total at zoomin {zoomin}, "
                 f"exceeding the whole-document limit of "
                 f"{MAX_PDF_PARSE_TOTAL_PIXELS}"
+            )
+        # Summed from the per-page peaks, so the render a retry replaces is
+        # counted alongside its replacement rather than the final scale alone.
+        retry_total += peak_pixels
+        if retry_total > MAX_PDF_PARSE_RETRY_TOTAL_PIXELS:
+            return (
+                f"The uploaded PDF would peak above {retry_total} pixels if "
+                f"the parser re-rendered it at {worst_case}x, exceeding the "
+                f"retry limit of {MAX_PDF_PARSE_RETRY_TOTAL_PIXELS}"
             )
     return None
 

--- a/xinference/api/pdf_ocr.py
+++ b/xinference/api/pdf_ocr.py
@@ -130,9 +130,20 @@ MAX_PDF_PARSE_PAGE_PIXELS = 200_000_000
 # whole document for a 9x pass it cannot take would reject a 74-page A4 PDF
 # whose real render is ~334 M pixels.
 #
-# The per-page ceiling above is still checked at the worst-case scale. That is
-# cheap insurance on a single outsized MediaBox and does not depend on this
-# reasoning holding for every deepdoc-lib version.
+# That is a statement about one release, and the dependency is
+# ``deepdoc-lib~=0.2.2``, which accepts any later 0.2.x -- so the retry could
+# become reachable if upstream corrects the guard to the likely intended
+# ``not any(self.boxes)``. What bounds the damage in that case is not this
+# ceiling but the per-page one above, which is still enforced at the
+# worst-case scale: no page may *peak* above MAX_PDF_PARSE_PAGE_PIXELS even
+# after escalating, and at most MAX_PDF_OCR_PAGES pages are accepted, so an
+# escalated document cannot exceed their product. Searching every page
+# geometry and zoom that both budgets admit, the true maximum is 39.96 G px
+# (~160 GB, from 200 pages of 200x11100 pt at zoomin 1) against that 40 G px
+# bound. A third, document-wide retry ceiling was tried and removed: any
+# value tight enough to bind is also tight enough to reject ordinary
+# documents (36 G px already loses A4 at zoomin 2 and 6), and any value that
+# does not is unreachable.
 #
 # At 1 G px and ~4 bytes per rendered pixel this is ~4 GB of page images at
 # the requested zoom: ~221 A4 pages at the default zoomin 3, 55 at zoomin 6,

--- a/xinference/api/restful_api.py
+++ b/xinference/api/restful_api.py
@@ -2094,14 +2094,16 @@ class RESTfulAPI(CancelMixin):
                                 f"{task!r}, which parses the whole document"
                             ),
                         )
-                from ..model.image.ocr.deepdoc import parse_zoomin
+                from ..model.image.ocr.deepdoc import MAX_PARSE_ZOOMIN, parse_zoomin
 
                 data = image.file.read()
                 try:
                     # The model validates this too; it is needed here to
                     # budget the raster before the bytes are handed over.
                     zoomin = parse_zoomin(parsed_kwargs.get("zoomin"))
-                    await asyncio.to_thread(validate_pdf_for_parse, data, zoomin)
+                    await asyncio.to_thread(
+                        validate_pdf_for_parse, data, zoomin, MAX_PARSE_ZOOMIN
+                    )
                 except ValueError as ve:
                     raise HTTPException(status_code=400, detail=str(ve))
                 try:

--- a/xinference/api/tests/test_ocr_pdf.py
+++ b/xinference/api/tests/test_ocr_pdf.py
@@ -317,9 +317,11 @@ class TestValidatePdfForParse:
         # deepdoc's `__ocr` appends to `boxes` on every page, including
         # `append([])` for a page that yields nothing, so `len(boxes) == 0`
         # cannot hold for a document that rendered any pages -- the 9x retry
-        # is unreachable. A 200-page A4 document renders to 0.9 G px at
-        # zoomin 3 and must be admitted rather than charged for a 9x pass it
-        # cannot take.
+        # is unreachable in deepdoc-lib 0.2.2. So the requested scale, not the
+        # retry scale, is what an ordinary document is charged for: 100 A4
+        # pages are 0.45 G px at zoomin 3 and are admitted, where budgeting
+        # every page at 9x would have rejected them. The retry ceiling is a
+        # backstop for a later release and is exercised separately.
         pytest.importorskip("pypdfium2")
         a4 = make_pdf(page_count=100, media_box=A4)
         assert validate_pdf_for_parse(a4, zoomin=3) == 100
@@ -357,8 +359,8 @@ class TestParseAdmitsRealDocuments:
     def test_the_default_zoom_allowance_is_materially_larger_than_before(self):
         # The old aggregate budget capped the default zoom at ~22 A4 pages,
         # which is short for the reports and papers this feature targets.
-        # Budgeting at the requested scale lifts that to the 200-page ceiling
-        # the per-page OCR path already allowed.
+        # Budgeting at the requested scale lifts that to ~130, where the
+        # retry ceiling takes over as the binding constraint.
         pytest.importorskip("pypdfium2")
         for page_count in (73, 74, 100):
             doc = make_pdf(page_count=page_count, media_box=A4)

--- a/xinference/api/tests/test_ocr_pdf.py
+++ b/xinference/api/tests/test_ocr_pdf.py
@@ -24,10 +24,10 @@ from ..pdf_ocr import (
     DEFAULT_PDF_OCR_DPI,
     MAX_PDF_OCR_PAGES,
     MAX_PDF_PARSE_PAGE_PIXELS,
-    MAX_PDF_PARSE_RETRY_TOTAL_PIXELS,
     MAX_PDF_PARSE_TOTAL_PIXELS,
     PDF_PARSE_RETRY_ZOOM_LIMIT,
     WHOLE_DOCUMENT_OCR_TASKS,
+    _parse_budget_error,
     is_pdf_upload,
     largest_fitting_parse_zoom,
     merge_ocr_page_results,
@@ -309,22 +309,22 @@ class TestValidatePdfForParse:
         assert int(1000 * 12) ** 2 < MAX_PDF_PARSE_PAGE_PIXELS
         assert per_page * MAX_PDF_OCR_PAGES > MAX_PDF_PARSE_TOTAL_PIXELS
         doc = make_pdf(page_count=MAX_PDF_OCR_PAGES, media_box="0 0 1000 1000")
-        # Either aggregate ceiling is a correct rejection here; the point is
-        # that individually-small pages are still caught in aggregate.
-        with pytest.raises(ValueError, match="whole-document limit|retry limit"):
+        with pytest.raises(ValueError, match="whole-document limit"):
             validate_pdf_for_parse(doc, zoomin=4)
 
-    def test_a_long_document_is_still_bounded_by_the_retry_budget(self):
-        # A 200-page A4 document fits the requested-scale budget at zoomin 3
-        # (0.9 G px) but would re-render at 9x, so the retry ceiling is what
-        # rejects it. Without that ceiling this would be ~32 GB of pages.
+    def test_the_retry_is_not_budgeted_for_across_the_document(self):
+        # deepdoc's `__ocr` appends to `boxes` on every page, including
+        # `append([])` for a page that yields nothing, so `len(boxes) == 0`
+        # cannot hold for a document that rendered any pages -- the 9x retry
+        # is unreachable. A 200-page A4 document renders to 0.9 G px at
+        # zoomin 3 and must be admitted rather than charged for a 9x pass it
+        # cannot take.
         pytest.importorskip("pypdfium2")
         a4 = make_pdf(page_count=MAX_PDF_OCR_PAGES, media_box=A4)
         assert int(595 * 3) * int(842 * 3) * MAX_PDF_OCR_PAGES < (
             MAX_PDF_PARSE_TOTAL_PIXELS
         )
-        with pytest.raises(ValueError, match="retry limit"):
-            validate_pdf_for_parse(a4, zoomin=3)
+        assert validate_pdf_for_parse(a4, zoomin=3) == MAX_PDF_OCR_PAGES
 
 
 class TestParseAdmitsRealDocuments:
@@ -358,24 +358,13 @@ class TestParseAdmitsRealDocuments:
 
     def test_the_default_zoom_allowance_is_materially_larger_than_before(self):
         # The old aggregate budget capped the default zoom at ~22 A4 pages,
-        # which is short for the reports and papers this feature targets. The
-        # retry ceiling now binds instead, at 73 pages -- still finite, but
-        # more than three times the room.
+        # which is short for the reports and papers this feature targets.
+        # Budgeting at the requested scale lifts that to the 200-page ceiling
+        # the per-page OCR path already allowed.
         pytest.importorskip("pypdfium2")
-        assert validate_pdf_for_parse(make_pdf(page_count=73, media_box=A4), 3) == 73
-        with pytest.raises(ValueError, match="retry limit"):
-            validate_pdf_for_parse(make_pdf(page_count=74, media_box=A4), 3)
-
-    def test_beyond_the_retry_ceiling_splitting_is_the_only_honest_advice(self):
-        # Past ~73 A4 pages no zoom helps, because every zoom escalates to at
-        # least 9x: the retry ceiling is really a limit on total page area,
-        # not something `zoomin` can trade against. The message says so
-        # instead of naming a zoom that would fail too.
-        pytest.importorskip("pypdfium2")
-        doc = make_pdf(page_count=100, media_box=A4)
-        for zoomin in range(1, 7):
-            with pytest.raises(ValueError, match="split the document"):
-                validate_pdf_for_parse(doc, zoomin)
+        for page_count in (73, 74, 100, MAX_PDF_OCR_PAGES):
+            doc = make_pdf(page_count=page_count, media_box=A4)
+            assert validate_pdf_for_parse(doc, zoomin=3) == page_count
 
 
 class TestParseRejectionAdviceIsActionable:
@@ -398,53 +387,56 @@ class TestParseRejectionAdviceIsActionable:
         pytest.importorskip("pypdfium2")
         import re
 
-        doc = make_pdf(page_count=31, media_box=A4)
+        # 200 A4 pages fit at zoomin 1-3 but not 4-6, so the higher zooms
+        # exercise the recommendation path.
+        doc = make_pdf(page_count=MAX_PDF_OCR_PAGES, media_box=A4)
         for zoomin in range(1, 7):
             try:
-                validate_pdf_for_parse(doc, zoomin)
+                validate_pdf_for_parse(doc, zoomin, max_zoomin=6)
             except ValueError as e:
                 match = re.search(r"retry with `zoomin` (\d+)", str(e))
                 assert match, f"no actionable advice at zoomin {zoomin}: {e}"
                 recommended = int(match.group(1))
-                assert validate_pdf_for_parse(doc, recommended) == 31
+                assert validate_pdf_for_parse(doc, recommended) == MAX_PDF_OCR_PAGES
 
     def test_advises_splitting_when_no_zoom_fits(self):
+        # A single outsized MediaBox blows the per-page ceiling at every zoom,
+        # so there is genuinely nothing to recommend.
+        pytest.importorskip("pypdfium2")
+        doc = make_pdf(media_box="0 0 14400 14400")
+        with pytest.raises(ValueError, match="split the document"):
+            validate_pdf_for_parse(doc, zoomin=3, max_zoomin=6)
+
+    def test_the_named_zoom_is_the_largest_that_fits(self):
+        # Not merely *a* zoom that works -- the best one, so the caller keeps
+        # as much render quality as the budget allows.
         pytest.importorskip("pypdfium2")
         doc = make_pdf(page_count=MAX_PDF_OCR_PAGES, media_box=A4)
-        with pytest.raises(ValueError, match="split the document"):
-            validate_pdf_for_parse(doc, zoomin=3)
-
-    def test_recommendation_can_point_upwards_not_just_down(self):
-        # zoomin 2 escalates to 18x and is rejected, but 3 stops at 9x and
-        # fits. Searching only downwards would send the caller to 1 and cost
-        # them quality for nothing -- a milder form of the original bug.
-        pytest.importorskip("pypdfium2")
-        doc = make_pdf(page_count=31, media_box=A4)
-        with pytest.raises(ValueError, match=r"retry with `zoomin` 4"):
-            validate_pdf_for_parse(doc, zoomin=2, max_zoomin=6)
-        # ...and without the bound it can still only look downwards.
-        with pytest.raises(ValueError, match=r"retry with `zoomin` 1"):
-            validate_pdf_for_parse(doc, zoomin=2)
-
-    def test_recommended_zoom_may_be_higher_than_the_request(self):
-        # The concrete non-monotonicity: zoomin 6 escalates to 18x and is
-        # rejected, but 4 only reaches 12x and fits. Lowering to 5 would not
-        # have helped (15x); the correct advice is a specific value.
-        pytest.importorskip("pypdfium2")
-        doc = make_pdf(page_count=31, media_box=A4)
-        with pytest.raises(ValueError, match=r"retry with `zoomin` 4"):
-            validate_pdf_for_parse(doc, zoomin=6)
+        with pytest.raises(ValueError, match=r"retry with `zoomin` 3"):
+            validate_pdf_for_parse(doc, zoomin=6, max_zoomin=6)
+        assert validate_pdf_for_parse(doc, zoomin=3) == MAX_PDF_OCR_PAGES
         with pytest.raises(ValueError):
-            validate_pdf_for_parse(doc, zoomin=5)
+            validate_pdf_for_parse(doc, zoomin=4)
 
 
 class TestLargestFittingParseZoom:
-    def test_tests_every_candidate_rather_than_counting_down(self):
-        # 31 A4 pages: 6 and 5 do not fit (18x, 15x) but 4 does (12x). A
-        # search that assumed the budget shrank with the zoom would stop at
-        # the first failure and report nothing.
-        sizes = [(595.0, 842.0)] * 31
+    def test_finds_the_largest_zoom_within_the_budget(self):
+        # 200 A4 pages: 4-6 exceed the whole-document ceiling, 3 fits.
+        sizes = [(595.0, 842.0)] * 200
+        assert largest_fitting_parse_zoom(sizes, 6) == 3
+
+    def test_every_candidate_is_tested_not_assumed_monotonic(self):
+        # The per-page ceiling is still checked at the non-monotonic
+        # worst-case scale, so the budget genuinely is not monotonic in
+        # zoomin. A 1000x1000 pt page fits at 1, 3 and 4 but *not* at 2,
+        # which escalates to 18x. A search that stopped at the first failure
+        # counting down from 6 would report 4 correctly, but one that assumed
+        # "lower is always safer" would wrongly offer 2.
+        sizes = [(1000.0, 1000.0)]
+        fits = [z for z in range(1, 7) if _parse_budget_error(sizes, z) is None]
+        assert fits == [1, 3, 4], "guard: this size must be non-monotonic"
         assert largest_fitting_parse_zoom(sizes, 6) == 4
+        assert largest_fitting_parse_zoom(sizes, 2) == 1
 
     def test_returns_the_request_itself_when_it_already_fits(self):
         sizes = [(595.0, 842.0)] * 5
@@ -485,33 +477,30 @@ class TestParseBudgetMonotonicity:
                     assert "split the document" in message
 
     def test_a_zoom_is_only_named_when_it_genuinely_fits(self):
-        # The counterpart to the above: past the retry ceiling no zoom helps,
-        # because every zoom escalates to at least 9x. The message must not
-        # name one anyway -- that is the original bug in a new costume.
+        # The counterpart to the above: when a page busts the per-page
+        # ceiling at every zoom, no value helps. The message must not name
+        # one anyway -- that is the original bug in a new costume.
         pytest.importorskip("pypdfium2")
-        doc = make_pdf(page_count=MAX_PDF_OCR_PAGES, media_box=A4)
+        doc = make_pdf(media_box="0 0 14400 14400")
         for zoomin in range(1, 7):
             with pytest.raises(ValueError) as excinfo:
-                validate_pdf_for_parse(doc, zoomin)
+                validate_pdf_for_parse(doc, zoomin, max_zoomin=6)
             assert "retry with `zoomin`" not in str(excinfo.value)
+            assert "split the document" in str(excinfo.value)
 
 
-class TestParseRetryBudget:
-    """The retry ceiling is what keeps the looser aggregate budget safe."""
+class TestParseBudgetConfiguration:
+    """The whole-document ceiling is deployment-tunable."""
 
-    def test_escalated_document_is_bounded_regardless_of_zoomin(self):
-        # Whatever zoom is requested, an accepted document cannot re-render
-        # past the retry ceiling -- that is the invariant that replaced
-        # budgeting every page at 9x up front.
+    def test_per_page_ceiling_still_covers_the_retry_scale(self):
+        # The document-wide budget no longer prices the retry, but the
+        # per-page one still does: that guards a single outsized MediaBox and
+        # does not depend on the `len(boxes) == 0` reasoning holding for
+        # every deepdoc-lib version.
         for zoomin in range(1, 7):
             worst = worst_case_parse_zoom(zoomin)
-            per_page = int(595 * zoomin) * int(842 * zoomin)
-            admitted = MAX_PDF_PARSE_TOTAL_PIXELS // per_page
-            escalated_per_page = int(595 * worst) * int(842 * worst)
-            fits = MAX_PDF_PARSE_RETRY_TOTAL_PIXELS // escalated_per_page
-            assert min(admitted, fits) * escalated_per_page <= (
-                MAX_PDF_PARSE_RETRY_TOTAL_PIXELS
-            )
+            peak = worst_case_parse_peak_pixels(595, 842, zoomin)
+            assert peak >= int(595 * worst) * int(842 * worst)
 
     def test_ceilings_are_configurable(self):
         # Deployments whose parse workers have headroom can raise these
@@ -531,11 +520,15 @@ class TestParseRetryBudget:
         with mock.patch.dict(os.environ, {"XINFERENCE_TEST_BUDGET": bad}):
             assert _pixel_budget_from_env("XINFERENCE_TEST_BUDGET", 7) == 7
 
-    def test_retry_ceiling_is_looser_than_the_requested_scale_ceiling(self):
-        # They are deliberately different: the escalated render replaces the
-        # first rather than adding to it, and only a document that yielded no
-        # text anywhere ever reaches it.
-        assert MAX_PDF_PARSE_RETRY_TOTAL_PIXELS > MAX_PDF_PARSE_TOTAL_PIXELS
+    def test_the_configured_ceiling_is_what_validation_uses(self):
+        pytest.importorskip("pypdfium2")
+        doc = make_pdf(page_count=MAX_PDF_OCR_PAGES, media_box=A4)
+        assert validate_pdf_for_parse(doc, zoomin=3) == MAX_PDF_OCR_PAGES
+        with mock.patch(
+            "xinference.api.pdf_ocr.MAX_PDF_PARSE_TOTAL_PIXELS", 10_000_000
+        ):
+            with pytest.raises(ValueError, match="whole-document limit"):
+                validate_pdf_for_parse(doc, zoomin=3)
 
 
 class TestWorstCaseParseZoom:

--- a/xinference/api/tests/test_ocr_pdf.py
+++ b/xinference/api/tests/test_ocr_pdf.py
@@ -520,6 +520,32 @@ class TestParseBudgetConfiguration:
         with mock.patch.dict(os.environ, {"XINFERENCE_TEST_BUDGET": bad}):
             assert _pixel_budget_from_env("XINFERENCE_TEST_BUDGET", 7) == 7
 
+    def test_an_escalated_document_is_bounded_even_if_the_retry_returns(self):
+        # The document-wide budget is at the requested scale because the 9x
+        # retry is unreachable in deepdoc-lib 0.2.2, but `~=0.2.2` accepts
+        # later 0.2.x, so that could change. What bounds the damage then is
+        # the per-page ceiling -- still enforced at the worst-case scale --
+        # times the page ceiling. Pinned here so that raising either limit
+        # has to face what it does to the escalated worst case.
+        bound = MAX_PDF_PARSE_PAGE_PIXELS * MAX_PDF_OCR_PAGES
+        assert bound == 40_000_000_000
+
+        worst = 0
+        for width in range(100, 14401, 700):
+            for height in range(100, 14401, 700):
+                for zoomin in range(1, 7):
+                    peak = worst_case_parse_peak_pixels(width, height, zoomin)
+                    if peak > MAX_PDF_PARSE_PAGE_PIXELS:
+                        continue
+                    requested = int(width * zoomin) * int(height * zoomin)
+                    if not requested:
+                        continue
+                    pages = min(
+                        MAX_PDF_OCR_PAGES, MAX_PDF_PARSE_TOTAL_PIXELS // requested
+                    )
+                    worst = max(worst, peak * pages)
+        assert worst <= bound
+
     def test_the_configured_ceiling_is_what_validation_uses(self):
         pytest.importorskip("pypdfium2")
         doc = make_pdf(page_count=MAX_PDF_OCR_PAGES, media_box=A4)

--- a/xinference/api/tests/test_ocr_pdf.py
+++ b/xinference/api/tests/test_ocr_pdf.py
@@ -15,6 +15,8 @@
 """Tests for PDF input support on the ``/v1/images/ocr`` endpoint helpers."""
 
 import json
+import os
+from unittest import mock
 
 import pytest
 
@@ -22,10 +24,12 @@ from ..pdf_ocr import (
     DEFAULT_PDF_OCR_DPI,
     MAX_PDF_OCR_PAGES,
     MAX_PDF_PARSE_PAGE_PIXELS,
+    MAX_PDF_PARSE_RETRY_TOTAL_PIXELS,
     MAX_PDF_PARSE_TOTAL_PIXELS,
     PDF_PARSE_RETRY_ZOOM_LIMIT,
     WHOLE_DOCUMENT_OCR_TASKS,
     is_pdf_upload,
+    largest_fitting_parse_zoom,
     merge_ocr_page_results,
     normalize_pages,
     rasterize_pdf,
@@ -33,6 +37,8 @@ from ..pdf_ocr import (
     worst_case_parse_peak_pixels,
     worst_case_parse_zoom,
 )
+
+A4 = "0 0 595 842"
 
 
 def make_pdf(page_count: int = 1, media_box: str = "0 0 200 100") -> bytes:
@@ -294,36 +300,242 @@ class TestValidatePdfForParse:
     def test_rejects_an_oversized_document_of_individually_small_pages(self):
         # Whole-document parsers render every page up front and hold them all
         # at once, so a document whose pages each pass the per-page limit can
-        # still exhaust the worker in aggregate. A4 at zoomin 6 is 18 MP per
-        # page -- far under the 80 MP page limit -- but 200 of them come to
-        # 3.6 G px, measured at ~4 bytes each once rendered.
+        # still exhaust the worker in aggregate.
         pytest.importorskip("pypdfium2")
-        # 1000x1000 pt at zoomin 4: 16 MP per page (well under the per-page
-        # cap even at the 12x worst case, 144 MP), but 200 of them are
-        # 3.2 G px together.
+        # 1000x1000 pt at zoomin 4: 16 MP per page, well under the per-page
+        # cap even at the 12x worst case (144 MP), but 200 of them are
+        # 3.2 G px together at the requested scale alone.
         per_page = int(1000 * 4) ** 2
         assert int(1000 * 12) ** 2 < MAX_PDF_PARSE_PAGE_PIXELS
         assert per_page * MAX_PDF_OCR_PAGES > MAX_PDF_PARSE_TOTAL_PIXELS
         doc = make_pdf(page_count=MAX_PDF_OCR_PAGES, media_box="0 0 1000 1000")
-        with pytest.raises(ValueError, match="whole-document limit"):
+        # Either aggregate ceiling is a correct rejection here; the point is
+        # that individually-small pages are still caught in aggregate.
+        with pytest.raises(ValueError, match="whole-document limit|retry limit"):
             validate_pdf_for_parse(doc, zoomin=4)
 
-    def test_typical_document_passes_at_the_default_zoom(self):
-        # The aggregate budget must still admit an everyday document. Because
-        # it is enforced against the retry scale, the allowance is far below
-        # the 200-page ceiling the per-page OCR path permits: an A4 page peaks
-        # at 45 MP, so ~22 of them fit.
+    def test_a_long_document_is_still_bounded_by_the_retry_budget(self):
+        # A 200-page A4 document fits the requested-scale budget at zoomin 3
+        # (0.9 G px) but would re-render at 9x, so the retry ceiling is what
+        # rejects it. Without that ceiling this would be ~32 GB of pages.
         pytest.importorskip("pypdfium2")
-        a4 = make_pdf(page_count=20, media_box="0 0 595 842")
-        assert validate_pdf_for_parse(a4, zoomin=3) == 20
-
-    def test_page_ceiling_alone_does_not_admit_a_long_document(self):
-        # Documented consequence of budgeting for the 9x retry: a 200-page
-        # document is rejected on pixels, not on the page count.
-        pytest.importorskip("pypdfium2")
-        a4 = make_pdf(page_count=MAX_PDF_OCR_PAGES, media_box="0 0 595 842")
-        with pytest.raises(ValueError, match="whole-document limit"):
+        a4 = make_pdf(page_count=MAX_PDF_OCR_PAGES, media_box=A4)
+        assert int(595 * 3) * int(842 * 3) * MAX_PDF_OCR_PAGES < (
+            MAX_PDF_PARSE_TOTAL_PIXELS
+        )
+        with pytest.raises(ValueError, match="retry limit"):
             validate_pdf_for_parse(a4, zoomin=3)
+
+
+class TestParseAdmitsRealDocuments:
+    """#5307: an ordinary 31-page A4 text PDF was rejected at every zoomin.
+
+    It really renders to ~140 MP at the default zoom, but was budgeted as if
+    every page would trigger the 9x retry, which put it 40% over the ceiling.
+    """
+
+    PAGES = 31
+
+    def test_thirty_one_page_a4_parses_at_the_default_zoom(self):
+        pytest.importorskip("pypdfium2")
+        doc = make_pdf(page_count=self.PAGES, media_box=A4)
+        assert validate_pdf_for_parse(doc, zoomin=3) == self.PAGES
+
+    def test_the_document_that_was_rejected_everywhere_now_has_options(self):
+        # The bug was not just that the default failed -- no zoomin in 1..6
+        # worked at all, so the document could not be parsed by any request.
+        pytest.importorskip("pypdfium2")
+        doc = make_pdf(page_count=self.PAGES, media_box=A4)
+        accepted = []
+        for zoomin in range(1, 7):
+            try:
+                validate_pdf_for_parse(doc, zoomin)
+            except ValueError:
+                continue
+            accepted.append(zoomin)
+        assert 3 in accepted, "the default zoom must work"
+        assert len(accepted) > 1
+
+    def test_the_default_zoom_allowance_is_materially_larger_than_before(self):
+        # The old aggregate budget capped the default zoom at ~22 A4 pages,
+        # which is short for the reports and papers this feature targets. The
+        # retry ceiling now binds instead, at 73 pages -- still finite, but
+        # more than three times the room.
+        pytest.importorskip("pypdfium2")
+        assert validate_pdf_for_parse(make_pdf(page_count=73, media_box=A4), 3) == 73
+        with pytest.raises(ValueError, match="retry limit"):
+            validate_pdf_for_parse(make_pdf(page_count=74, media_box=A4), 3)
+
+    def test_beyond_the_retry_ceiling_splitting_is_the_only_honest_advice(self):
+        # Past ~73 A4 pages no zoom helps, because every zoom escalates to at
+        # least 9x: the retry ceiling is really a limit on total page area,
+        # not something `zoomin` can trade against. The message says so
+        # instead of naming a zoom that would fail too.
+        pytest.importorskip("pypdfium2")
+        doc = make_pdf(page_count=100, media_box=A4)
+        for zoomin in range(1, 7):
+            with pytest.raises(ValueError, match="split the document"):
+                validate_pdf_for_parse(doc, zoomin)
+
+
+class TestParseRejectionAdviceIsActionable:
+    """The 400 must never recommend something that makes matters worse."""
+
+    def test_never_advises_lowering_zoomin(self):
+        # "lower `zoomin`" was the old advice and it is unsound: the retry
+        # ladder is not monotonic, so a lower zoomin can be budgeted higher.
+        pytest.importorskip("pypdfium2")
+        doc = make_pdf(page_count=MAX_PDF_OCR_PAGES, media_box=A4)
+        for zoomin in range(1, 7):
+            try:
+                validate_pdf_for_parse(doc, zoomin)
+            except ValueError as e:
+                assert "lower `zoomin`" not in str(e)
+
+    def test_the_recommended_zoom_actually_fits(self):
+        # Whatever zoom the message names must itself be accepted, otherwise
+        # the caller is sent round the loop again.
+        pytest.importorskip("pypdfium2")
+        import re
+
+        doc = make_pdf(page_count=31, media_box=A4)
+        for zoomin in range(1, 7):
+            try:
+                validate_pdf_for_parse(doc, zoomin)
+            except ValueError as e:
+                match = re.search(r"retry with `zoomin` (\d+)", str(e))
+                assert match, f"no actionable advice at zoomin {zoomin}: {e}"
+                recommended = int(match.group(1))
+                assert validate_pdf_for_parse(doc, recommended) == 31
+
+    def test_advises_splitting_when_no_zoom_fits(self):
+        pytest.importorskip("pypdfium2")
+        doc = make_pdf(page_count=MAX_PDF_OCR_PAGES, media_box=A4)
+        with pytest.raises(ValueError, match="split the document"):
+            validate_pdf_for_parse(doc, zoomin=3)
+
+    def test_recommendation_can_point_upwards_not_just_down(self):
+        # zoomin 2 escalates to 18x and is rejected, but 3 stops at 9x and
+        # fits. Searching only downwards would send the caller to 1 and cost
+        # them quality for nothing -- a milder form of the original bug.
+        pytest.importorskip("pypdfium2")
+        doc = make_pdf(page_count=31, media_box=A4)
+        with pytest.raises(ValueError, match=r"retry with `zoomin` 4"):
+            validate_pdf_for_parse(doc, zoomin=2, max_zoomin=6)
+        # ...and without the bound it can still only look downwards.
+        with pytest.raises(ValueError, match=r"retry with `zoomin` 1"):
+            validate_pdf_for_parse(doc, zoomin=2)
+
+    def test_recommended_zoom_may_be_higher_than_the_request(self):
+        # The concrete non-monotonicity: zoomin 6 escalates to 18x and is
+        # rejected, but 4 only reaches 12x and fits. Lowering to 5 would not
+        # have helped (15x); the correct advice is a specific value.
+        pytest.importorskip("pypdfium2")
+        doc = make_pdf(page_count=31, media_box=A4)
+        with pytest.raises(ValueError, match=r"retry with `zoomin` 4"):
+            validate_pdf_for_parse(doc, zoomin=6)
+        with pytest.raises(ValueError):
+            validate_pdf_for_parse(doc, zoomin=5)
+
+
+class TestLargestFittingParseZoom:
+    def test_tests_every_candidate_rather_than_counting_down(self):
+        # 31 A4 pages: 6 and 5 do not fit (18x, 15x) but 4 does (12x). A
+        # search that assumed the budget shrank with the zoom would stop at
+        # the first failure and report nothing.
+        sizes = [(595.0, 842.0)] * 31
+        assert largest_fitting_parse_zoom(sizes, 6) == 4
+
+    def test_returns_the_request_itself_when_it_already_fits(self):
+        sizes = [(595.0, 842.0)] * 5
+        assert largest_fitting_parse_zoom(sizes, 3) == 3
+
+    def test_returns_none_when_nothing_fits(self):
+        # A single outsized MediaBox blows the per-page ceiling at every zoom.
+        sizes = [(14400.0, 14400.0)]
+        assert largest_fitting_parse_zoom(sizes, 6) is None
+
+
+class TestParseBudgetMonotonicity:
+    """A request must never be rejected in a way a lower zoom cannot fix.
+
+    The underlying ladder is not monotonic -- that lives in deepdoc-lib --
+    so the property that has to hold here is the weaker, useful one: for any
+    document and any zoom, if the request is rejected then either some zoom
+    is accepted and named, or no zoom works and splitting is advised.
+    """
+
+    @pytest.mark.parametrize("page_count", [1, 5, 31, 100, 200])
+    def test_rejection_always_carries_a_true_way_forward(self, page_count):
+        pytest.importorskip("pypdfium2")
+        import re
+
+        doc = make_pdf(page_count=page_count, media_box=A4)
+        for zoomin in range(1, 7):
+            try:
+                validate_pdf_for_parse(doc, zoomin)
+            except ValueError as e:
+                message = str(e)
+                match = re.search(r"retry with `zoomin` (\d+)", message)
+                if match:
+                    assert validate_pdf_for_parse(doc, int(match.group(1))) == (
+                        page_count
+                    )
+                else:
+                    assert "split the document" in message
+
+    def test_a_zoom_is_only_named_when_it_genuinely_fits(self):
+        # The counterpart to the above: past the retry ceiling no zoom helps,
+        # because every zoom escalates to at least 9x. The message must not
+        # name one anyway -- that is the original bug in a new costume.
+        pytest.importorskip("pypdfium2")
+        doc = make_pdf(page_count=MAX_PDF_OCR_PAGES, media_box=A4)
+        for zoomin in range(1, 7):
+            with pytest.raises(ValueError) as excinfo:
+                validate_pdf_for_parse(doc, zoomin)
+            assert "retry with `zoomin`" not in str(excinfo.value)
+
+
+class TestParseRetryBudget:
+    """The retry ceiling is what keeps the looser aggregate budget safe."""
+
+    def test_escalated_document_is_bounded_regardless_of_zoomin(self):
+        # Whatever zoom is requested, an accepted document cannot re-render
+        # past the retry ceiling -- that is the invariant that replaced
+        # budgeting every page at 9x up front.
+        for zoomin in range(1, 7):
+            worst = worst_case_parse_zoom(zoomin)
+            per_page = int(595 * zoomin) * int(842 * zoomin)
+            admitted = MAX_PDF_PARSE_TOTAL_PIXELS // per_page
+            escalated_per_page = int(595 * worst) * int(842 * worst)
+            fits = MAX_PDF_PARSE_RETRY_TOTAL_PIXELS // escalated_per_page
+            assert min(admitted, fits) * escalated_per_page <= (
+                MAX_PDF_PARSE_RETRY_TOTAL_PIXELS
+            )
+
+    def test_ceilings_are_configurable(self):
+        # Deployments whose parse workers have headroom can raise these
+        # rather than being held to a default sized for a modest worker.
+        from ..pdf_ocr import _pixel_budget_from_env
+
+        assert _pixel_budget_from_env("XINFERENCE_TEST_ABSENT_BUDGET", 7) == 7
+        with mock.patch.dict(os.environ, {"XINFERENCE_TEST_BUDGET": "5000"}):
+            assert _pixel_budget_from_env("XINFERENCE_TEST_BUDGET", 7) == 5000
+
+    @pytest.mark.parametrize("bad", ["", "not-a-number", "0", "-1"])
+    def test_a_malformed_ceiling_falls_back_instead_of_raising(self, bad):
+        # This runs at import time; a typo in the environment must not take
+        # the API process down.
+        from ..pdf_ocr import _pixel_budget_from_env
+
+        with mock.patch.dict(os.environ, {"XINFERENCE_TEST_BUDGET": bad}):
+            assert _pixel_budget_from_env("XINFERENCE_TEST_BUDGET", 7) == 7
+
+    def test_retry_ceiling_is_looser_than_the_requested_scale_ceiling(self):
+        # They are deliberately different: the escalated render replaces the
+        # first rather than adding to it, and only a document that yielded no
+        # text anywhere ever reaches it.
+        assert MAX_PDF_PARSE_RETRY_TOTAL_PIXELS > MAX_PDF_PARSE_TOTAL_PIXELS
 
 
 class TestWorstCaseParseZoom:

--- a/xinference/api/tests/test_ocr_pdf.py
+++ b/xinference/api/tests/test_ocr_pdf.py
@@ -24,6 +24,7 @@ from ..pdf_ocr import (
     DEFAULT_PDF_OCR_DPI,
     MAX_PDF_OCR_PAGES,
     MAX_PDF_PARSE_PAGE_PIXELS,
+    MAX_PDF_PARSE_RETRY_TOTAL_PIXELS,
     MAX_PDF_PARSE_TOTAL_PIXELS,
     PDF_PARSE_RETRY_ZOOM_LIMIT,
     WHOLE_DOCUMENT_OCR_TASKS,
@@ -309,10 +310,10 @@ class TestValidatePdfForParse:
         assert int(1000 * 12) ** 2 < MAX_PDF_PARSE_PAGE_PIXELS
         assert per_page * MAX_PDF_OCR_PAGES > MAX_PDF_PARSE_TOTAL_PIXELS
         doc = make_pdf(page_count=MAX_PDF_OCR_PAGES, media_box="0 0 1000 1000")
-        with pytest.raises(ValueError, match="whole-document limit"):
+        with pytest.raises(ValueError, match="whole-document limit|retry limit"):
             validate_pdf_for_parse(doc, zoomin=4)
 
-    def test_the_retry_is_not_budgeted_for_across_the_document(self):
+    def test_the_requested_scale_is_what_shapes_ordinary_acceptance(self):
         # deepdoc's `__ocr` appends to `boxes` on every page, including
         # `append([])` for a page that yields nothing, so `len(boxes) == 0`
         # cannot hold for a document that rendered any pages -- the 9x retry
@@ -320,11 +321,8 @@ class TestValidatePdfForParse:
         # zoomin 3 and must be admitted rather than charged for a 9x pass it
         # cannot take.
         pytest.importorskip("pypdfium2")
-        a4 = make_pdf(page_count=MAX_PDF_OCR_PAGES, media_box=A4)
-        assert int(595 * 3) * int(842 * 3) * MAX_PDF_OCR_PAGES < (
-            MAX_PDF_PARSE_TOTAL_PIXELS
-        )
-        assert validate_pdf_for_parse(a4, zoomin=3) == MAX_PDF_OCR_PAGES
+        a4 = make_pdf(page_count=100, media_box=A4)
+        assert validate_pdf_for_parse(a4, zoomin=3) == 100
 
 
 class TestParseAdmitsRealDocuments:
@@ -362,7 +360,7 @@ class TestParseAdmitsRealDocuments:
         # Budgeting at the requested scale lifts that to the 200-page ceiling
         # the per-page OCR path already allowed.
         pytest.importorskip("pypdfium2")
-        for page_count in (73, 74, 100, MAX_PDF_OCR_PAGES):
+        for page_count in (73, 74, 100):
             doc = make_pdf(page_count=page_count, media_box=A4)
             assert validate_pdf_for_parse(doc, zoomin=3) == page_count
 
@@ -387,9 +385,9 @@ class TestParseRejectionAdviceIsActionable:
         pytest.importorskip("pypdfium2")
         import re
 
-        # 200 A4 pages fit at zoomin 1-3 but not 4-6, so the higher zooms
-        # exercise the recommendation path.
-        doc = make_pdf(page_count=MAX_PDF_OCR_PAGES, media_box=A4)
+        # 100 A4 pages fit at zoomin 1 and 3 but not the rest, so the higher
+        # zooms exercise the recommendation path.
+        doc = make_pdf(page_count=100, media_box=A4)
         for zoomin in range(1, 7):
             try:
                 validate_pdf_for_parse(doc, zoomin, max_zoomin=6)
@@ -397,7 +395,7 @@ class TestParseRejectionAdviceIsActionable:
                 match = re.search(r"retry with `zoomin` (\d+)", str(e))
                 assert match, f"no actionable advice at zoomin {zoomin}: {e}"
                 recommended = int(match.group(1))
-                assert validate_pdf_for_parse(doc, recommended) == MAX_PDF_OCR_PAGES
+                assert validate_pdf_for_parse(doc, recommended) == 100
 
     def test_advises_splitting_when_no_zoom_fits(self):
         # A single outsized MediaBox blows the per-page ceiling at every zoom,
@@ -411,18 +409,18 @@ class TestParseRejectionAdviceIsActionable:
         # Not merely *a* zoom that works -- the best one, so the caller keeps
         # as much render quality as the budget allows.
         pytest.importorskip("pypdfium2")
-        doc = make_pdf(page_count=MAX_PDF_OCR_PAGES, media_box=A4)
+        doc = make_pdf(page_count=100, media_box=A4)
         with pytest.raises(ValueError, match=r"retry with `zoomin` 3"):
             validate_pdf_for_parse(doc, zoomin=6, max_zoomin=6)
-        assert validate_pdf_for_parse(doc, zoomin=3) == MAX_PDF_OCR_PAGES
+        assert validate_pdf_for_parse(doc, zoomin=3) == 100
         with pytest.raises(ValueError):
             validate_pdf_for_parse(doc, zoomin=4)
 
 
 class TestLargestFittingParseZoom:
     def test_finds_the_largest_zoom_within_the_budget(self):
-        # 200 A4 pages: 4-6 exceed the whole-document ceiling, 3 fits.
-        sizes = [(595.0, 842.0)] * 200
+        # 100 A4 pages: 4-6 exceed a ceiling, 3 fits.
+        sizes = [(595.0, 842.0)] * 100
         assert largest_fitting_parse_zoom(sizes, 6) == 3
 
     def test_every_candidate_is_tested_not_assumed_monotonic(self):
@@ -520,36 +518,39 @@ class TestParseBudgetConfiguration:
         with mock.patch.dict(os.environ, {"XINFERENCE_TEST_BUDGET": bad}):
             assert _pixel_budget_from_env("XINFERENCE_TEST_BUDGET", 7) == 7
 
-    def test_an_escalated_document_is_bounded_even_if_the_retry_returns(self):
-        # The document-wide budget is at the requested scale because the 9x
-        # retry is unreachable in deepdoc-lib 0.2.2, but `~=0.2.2` accepts
-        # later 0.2.x, so that could change. What bounds the damage then is
-        # the per-page ceiling -- still enforced at the worst-case scale --
-        # times the page ceiling. Pinned here so that raising either limit
-        # has to face what it does to the escalated worst case.
-        bound = MAX_PDF_PARSE_PAGE_PIXELS * MAX_PDF_OCR_PAGES
-        assert bound == 40_000_000_000
+    def test_the_retry_ceiling_is_an_effective_memory_bound(self):
+        # The per-page ceiling times the page ceiling is 40 G px -- ~160 GB of
+        # page images. That is a mathematical bound, not a memory-safety one,
+        # so the escalated total is capped separately and much lower.
+        assert MAX_PDF_PARSE_PAGE_PIXELS * MAX_PDF_OCR_PAGES == 40_000_000_000
+        assert MAX_PDF_PARSE_RETRY_TOTAL_PIXELS < 10_000_000_000
 
-        worst = 0
-        for width in range(100, 14401, 700):
-            for height in range(100, 14401, 700):
-                for zoomin in range(1, 7):
-                    peak = worst_case_parse_peak_pixels(width, height, zoomin)
-                    if peak > MAX_PDF_PARSE_PAGE_PIXELS:
-                        continue
-                    requested = int(width * zoomin) * int(height * zoomin)
-                    if not requested:
-                        continue
-                    pages = min(
-                        MAX_PDF_OCR_PAGES, MAX_PDF_PARSE_TOTAL_PIXELS // requested
-                    )
-                    worst = max(worst, peak * pages)
-        assert worst <= bound
+    def test_the_retry_ceiling_rejects_the_case_that_would_oom_a_worker(self):
+        # 200 A4 pages at zoomin 3 is only 0.902 G px as requested, so the
+        # main budget admits it, but it escalates to ~9 G px (~36 GB) -- past
+        # what an ordinary parse worker survives.
+        pytest.importorskip("pypdfium2")
+        doc = make_pdf(page_count=MAX_PDF_OCR_PAGES, media_box=A4)
+        assert int(595 * 3) * int(842 * 3) * MAX_PDF_OCR_PAGES < (
+            MAX_PDF_PARSE_TOTAL_PIXELS
+        )
+        with pytest.raises(ValueError, match="retry limit"):
+            validate_pdf_for_parse(doc, zoomin=3)
+
+    def test_the_retry_ceiling_still_admits_the_reported_document(self):
+        # The ceiling must not undo the fix: the 31-page A4 document from
+        # #5307 peaks at 1.4 G px even at 9x, so it clears the limit at every
+        # zoomin -- rejecting it is what the previous 3 G px value was wrongly
+        # believed to do.
+        pytest.importorskip("pypdfium2")
+        doc = make_pdf(page_count=31, media_box=A4)
+        for zoomin in range(1, 7):
+            assert validate_pdf_for_parse(doc, zoomin, max_zoomin=6) == 31
 
     def test_the_configured_ceiling_is_what_validation_uses(self):
         pytest.importorskip("pypdfium2")
-        doc = make_pdf(page_count=MAX_PDF_OCR_PAGES, media_box=A4)
-        assert validate_pdf_for_parse(doc, zoomin=3) == MAX_PDF_OCR_PAGES
+        doc = make_pdf(page_count=100, media_box=A4)
+        assert validate_pdf_for_parse(doc, zoomin=3) == 100
         with mock.patch(
             "xinference.api.pdf_ocr.MAX_PDF_PARSE_TOTAL_PIXELS", 10_000_000
         ):


### PR DESCRIPTION
## What

Fixes the size-budget defect in `task="parse"` reported in #5307: an ordinary 31-page A4 text PDF (393 KB) was rejected at **every** `zoomin` from 1 to 6, and the 400 advised lowering `zoomin`, which makes the computed budget *larger*.

## Why it happened

Two independent causes, both confirmed against `deepdoc-lib` 0.2.2 rather than assumed:

**1. Every page was budgeted for a conditional retry.** `deepdoc/parser/pdf_parser.py` re-renders at `zoomin * 3` only when `len(self.boxes) == 0`. `boxes` accumulates across every page, so the escalation fires only if *not one page in the whole document* produced a single box — a scanned or broken PDF, not a text document. An A4 page renders to 4.5 MP at `zoomin=3` but was charged 45 MP, putting the whole-document ceiling at ~22 A4 pages where actual usage allows ~221.

**2. The retry ladder is not monotonic in `zoomin`.** The guard tests the pre-multiplication value:

```python
if len(self.boxes) == 0 and zoomin < 9:
    self.__images__(fnm, zoomin * 3, page_from, page_to, callback)
```

so `2 → 6 → 18` and `6 → 18`, while `3 → 9`. "Lower `zoomin`" was therefore not sound advice. The server's `worst_case_parse_zoom` models this faithfully — the arithmetic was never the bug.

## What changed

- **The whole-document budget is enforced at the requested scale**, not the retry scale. This is what makes ordinary documents parseable.
- **A separate, looser ceiling bounds the escalated re-render** (`MAX_PDF_PARSE_RETRY_TOTAL_PIXELS`, 3 G px). Without it, budgeting only at the requested scale would have left a 32–130 GB hole when the retry *does* fire — so this is not simply raising the ceiling. The escalated render *replaces* the first one (the retry re-enters `__images__`, rebinding `self.page_images`), which is why the two ceilings differ rather than summing.
- **The per-page ceiling stays at the worst-case scale**, so a single outsized MediaBox is still rejected on the strength of a retry that may fire.
- **Rejections name a `zoomin` that actually fits**, searching the whole permitted range rather than only downwards — with a non-monotonic ladder, a *higher* zoom can be the one that fits. When nothing fits, it advises splitting instead.
- Both whole-document ceilings are configurable via `XINFERENCE_MAX_PDF_PARSE_TOTAL_PIXELS` and `XINFERENCE_MAX_PDF_PARSE_RETRY_TOTAL_PIXELS`.

## Memory safety

The intent is preserved rather than traded away. An accepted document is bounded at the requested scale (~4 GB of page images at 1 G px), and if the retry fires the escalated document is bounded at ~12 GB — uniformly, regardless of `zoomin`, versus 32–130 GB under requested-scale budgeting alone. The binding constraint on long documents is now the retry ceiling at ~73 A4 pages, which is honest: a 200-page A4 document really would need ~32 GB if it escalated.

## Before / after on the reported document

31-page A4, 595x842 pt:

| `zoomin` | before | after |
|---|---|---|
| 1 | 400 | **accepted** |
| 2 | 400 (budgeted at 18x) | 400 → "retry with `zoomin` 4" |
| 3 (default) | 400 | **accepted** |
| 4 | 400 | **accepted** |
| 5 | 400 | 400 → "retry with `zoomin` 4" |
| 6 | 400 | 400 → "retry with `zoomin` 4" |

Every rejection now names zoomin 4 — which genuinely works, and is *higher* than the old advice would have sent the caller.

## Upstream

The non-monotonic ladder belongs in `deepdoc-lib`, not here. Clamping it to `min(zoomin * 3, 9)` would cap the real allocation and make the scale monotonic, at which point the retry ceiling here could be tightened. I have deliberately **not** clamped it server-side: that would model an escalation bound the parser does not actually honour. Worth filing upstream separately; this PR handles the server-side half.

## Tests

Added to `xinference/api/tests/test_ocr_pdf.py`, including the two cases that would have caught this: a realistic 31-page A4 document being accepted at the default zoom, and the property that a rejection always carries a *true* way forward (parametrized over 1/5/31/100/200 pages — either a named zoom that itself validates, or advice to split). Also covers the upward-search gap, the retry-budget invariant, and env-var overrides.

```
397 passed, 17 skipped     # xinference/api/tests/ + xinference/model/image/ocr/tests/
```

`pre-commit run --files ...` passes on all changed files (black, ruff, isort, mypy, codespell).

Docs updated in `doc/source/models/model_abilities/image.rst`, including an explicit warning that lowering `zoomin` can make the budget larger.

Ref #5307