### PR TITLE
fix(vllm): keep WorkerActor importable without vllm for multi-GPU launch

### DIFF
--- a/xinference/model/llm/vllm/distributed_executor_v1.py
+++ b/xinference/model/llm/vllm/distributed_executor_v1.py
@@ -30,10 +30,10 @@ from typing import (
 
 import xoscar as xo
 from vllm.v1.executor.abstract import Executor
-from vllm.v1.worker.worker_base import WorkerWrapperBase
 from xoscar.utils import get_next_port
 
 from ....isolation import Isolation
+from .distributed_worker_actor import WorkerActor
 from .utils import get_distributed_init_method
 
 if TYPE_CHECKING:
@@ -42,62 +42,6 @@ if TYPE_CHECKING:
     from vllm.v1.outputs import ModelRunnerOutput
 
 logger = logging.getLogger(__name__)
-
-DEBUG_EXECUTOR = bool(int(os.getenv("XINFERENCE_DEBUG_VLLM_EXECUTOR", "0")))
-
-
-class WorkerActor(xo.StatelessActor):
-    def __init__(self, vllm_config: "VllmConfig", rpc_rank: int = 0, **kwargs):
-        super().__init__(**kwargs)
-        self._worker = WorkerWrapperBase(rpc_rank=rpc_rank)
-
-    async def __post_create__(self):
-        try:
-            # Change process title for model
-            import setproctitle
-
-            _uid = os.environ.get("XINFERENCE_MODEL_UID", "")
-            setproctitle.setproctitle(
-                f"Xinf vLLM worker: {self._worker.rpc_rank} [{_uid}]"
-            )
-        except ImportError:
-            pass
-
-    def __getattr__(self, item):
-        from xoscar.core import NO_LOCK_ATTRIBUTE_HINT
-
-        if item == NO_LOCK_ATTRIBUTE_HINT:
-            return True
-        return getattr(self._worker, item)
-
-    @classmethod
-    def gen_uid(cls, rank):
-        return f"VllmWorker_{rank}"
-
-    def execute_method(self, method: Union[str, Callable], *args, **kwargs):
-        if DEBUG_EXECUTOR:
-            # NOTE: too many logs, but useful for debug
-            logger.debug(
-                "Calling method %s in vllm worker %s, args: %s, kwargs: %s",
-                method,
-                self.uid,
-                args,
-                kwargs,
-            )
-        if isinstance(method, str):
-            if method != "sample_tokens":
-                return getattr(self._worker, method)(*args, **kwargs)
-            else:
-                result = getattr(self._worker, method)(*args, **kwargs)
-                return self._sanitize_result(result)
-        else:
-            return method(self._worker, *args, **kwargs)
-
-    def _sanitize_result(self, obj):
-        if obj is None:
-            return obj
-        output = obj.get_output()
-        return output
 
 
 class WorkerWrapper:
@@ -166,7 +110,6 @@ class XinferenceDistributedExecutorV1(Executor):
         for rank in range(world_size):
             coro = xo.create_actor(
                 WorkerActor,
-                self.vllm_config,
                 rpc_rank=rank,
                 address=self._pool_addresses[rank],
                 uid=WorkerActor.gen_uid(rank),

--- a/xinference/model/llm/vllm/distributed_worker_actor.py
+++ b/xinference/model/llm/vllm/distributed_worker_actor.py
@@ -1,0 +1,83 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import os
+from typing import Callable, Union
+
+import xoscar as xo
+
+logger = logging.getLogger(__name__)
+
+DEBUG_EXECUTOR = bool(int(os.getenv("XINFERENCE_DEBUG_VLLM_EXECUTOR", "0")))
+
+
+# Lives apart from distributed_executor_v1 because the worker main pool
+# deserializes this class when a sub-pool registers it, and that process may
+# have no vllm installed (per-model virtualenv). Nothing here may import vllm
+# at module level.
+class WorkerActor(xo.StatelessActor):
+    def __init__(self, rpc_rank: int = 0, **kwargs):
+        super().__init__(**kwargs)
+        from vllm.v1.worker.worker_base import WorkerWrapperBase
+
+        self._worker = WorkerWrapperBase(rpc_rank=rpc_rank)
+
+    async def __post_create__(self):
+        try:
+            # Change process title for model
+            import setproctitle
+
+            _uid = os.environ.get("XINFERENCE_MODEL_UID", "")
+            setproctitle.setproctitle(
+                f"Xinf vLLM worker: {self._worker.rpc_rank} [{_uid}]"
+            )
+        except ImportError:
+            pass
+
+    def __getattr__(self, item):
+        from xoscar.core import NO_LOCK_ATTRIBUTE_HINT
+
+        if item == NO_LOCK_ATTRIBUTE_HINT:
+            return True
+        return getattr(self._worker, item)
+
+    @classmethod
+    def gen_uid(cls, rank):
+        return f"VllmWorker_{rank}"
+
+    def execute_method(self, method: Union[str, Callable], *args, **kwargs):
+        if DEBUG_EXECUTOR:
+            # NOTE: too many logs, but useful for debug
+            logger.debug(
+                "Calling method %s in vllm worker %s, args: %s, kwargs: %s",
+                method,
+                self.uid,
+                args,
+                kwargs,
+            )
+        if isinstance(method, str):
+            if method != "sample_tokens":
+                return getattr(self._worker, method)(*args, **kwargs)
+            else:
+                result = getattr(self._worker, method)(*args, **kwargs)
+                return self._sanitize_result(result)
+        else:
+            return method(self._worker, *args, **kwargs)
+
+    def _sanitize_result(self, obj):
+        if obj is None:
+            return obj
+        output = obj.get_output()
+        return output


### PR DESCRIPTION
### Problem

Every multi-GPU vLLM launch fails on the official Docker image. Reproduced 100% of the time with 2 GPUs on `xprobe/xinference:latest`, and it is not model- or hardware-specific.

What the user sees is misleading — the surfaced error mentions neither vllm nor an import:

```
RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {}
  ← xoscar.errors.ServerClosed: Remote server unixsocket:///9699328 closed:
      0 bytes read on a total of 11 expected bytes
```

The real exception is only in `$XINFERENCE_HOME/logs/xinference.log`, never on stderr, because the root logger's `stream_handler` carries `LoggerNameFilter` and drops non-`xinference` loggers:

```
ERROR asyncio  Unhandled exception in client_connected_cb
  File ".../xinference/model/llm/vllm/distributed_executor_v1.py", line 32, in <module>
    from vllm.v1.executor.abstract import Executor
ModuleNotFoundError: No module named 'vllm'
→ xoscar.backends.message.DeserializeMessageFailed
```

### Root cause

1. With more than one GPU, `vllm/core.py` replaces vLLM's own mp executor with `XinferenceDistributedExecutorV1`, so each rank's `WorkerActor` gets registered through xoscar.
2. `xo.create_actor(WorkerActor, ...)` runs in a sub-pool, but the registration message is forwarded to the worker **main pool**, which deserializes it — that means unpickling the `WorkerActor` class ref, which imports its defining module.
3. With per-model virtualenv enabled (the default), the sub-pools run the model venv's python (has vllm) while the main pool runs the base env's python. On the official image the base env has **no vllm at all** (`pip show vllm` → not found; the image drops it because the per-model venv owns the engine, and the base torch is `2.11.0+cu130`, incompatible with the base image's vllm anyway).
4. So the main pool hits `ModuleNotFoundError` while deserializing. The exception escapes `client_connected_cb`, xoscar closes the connection, and the sub-pool reports the confusing `ServerClosed ... 0 bytes read`.

Single GPU never creates a `WorkerActor`, so it is unaffected. Anyone running xinference and vllm in the *same* Python environment is also unaffected — the main pool imports vllm successfully and the latent module-level coupling stays hidden. That is why this survived CI.

### Fix

Move `WorkerActor` into `distributed_worker_actor.py`, a module that does not import vllm at module level (`WorkerWrapperBase` is only needed inside `__init__`, so it becomes a local import). Since pickle resolves a class by `module.qualname`, the main pool now imports only this vllm-free module.

`XinferenceDistributedExecutorV1` itself cannot be made lazy — it subclasses vLLM's `Executor` — which is why splitting the actor out is the fix rather than reordering imports.

Also drop the `vllm_config` argument from the `create_actor` call. It was never used by `WorkerActor.__init__` (`WorkerWrapperBase.__init__` takes only `rpc_rank`/`global_rank`), but it was pickled into the same registration message, so the main pool would need vllm to deserialize a `VllmConfig` even after the class was moved.

`DEBUG_EXECUTOR` moves along with its only consumer; `distributed_executor.py` (the v0 path) keeps its own copy.

### Verification

Applied to a running container on the affected host, both copies of the package (`dist-packages` and `/opt/inference`):

- base env python (no vllm) can now import the actor module — this is exactly what the main pool does:
  `import xinference.model.llm.vllm.distributed_worker_actor` → OK
- model venv python (with vllm) still imports the executor, and `WorkerActor.__module__` is the new module, i.e. the path pickle records:
  `from ...distributed_executor_v1 import XinferenceDistributedExecutorV1, WorkerActor` → OK
- after restart, the previously 100%-failing 2-GPU launch of a 27B FP8 model starts successfully.

`black` and `isort` clean; the one `flake8` E501 in the touched file is pre-existing (only its line number shifted).
