### PR TITLE
fix(llm): declare audioread for qwen_omni_utils virtualenvs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,6 +150,7 @@ transformers = [
     "jj-pytorchvideo",  # For CogVLM2-video
     "qwen-vl-utils!=0.0.9",  # For qwen2-vl
     "qwen_omni_utils",  # For qwen2.5-omni
+    "audioread",  # Undeclared runtime dependency of qwen_omni_utils
     "datamodel_code_generator",  # for minicpm-4B
     "jsonschema",  # for minicpm-4B
     "blobfile",  # for moonlight-16b-a3b

--- a/xinference/model/llm/llm_family.json
+++ b/xinference/model/llm/llm_family.json
@@ -17373,6 +17373,7 @@
         "#sglang_dependencies# ; #engine# == \"sglang\"",
         "#system_numpy# ; #engine# == \"vllm\"",
         "qwen_omni_utils",
+        "audioread",
         "soundfile"
       ]
     },
@@ -25680,6 +25681,7 @@
         "#sglang_dependencies# ; #engine# == \"sglang\"",
         "#system_numpy# ; #engine# == \"vllm\"",
         "qwen_omni_utils",
+        "audioread",
         "soundfile"
       ]
     },
@@ -25766,6 +25768,7 @@
         "#sglang_dependencies# ; #engine# == \"sglang\"",
         "#system_numpy# ; #engine# == \"vllm\"",
         "qwen_omni_utils",
+        "audioread",
         "soundfile"
       ]
     },
@@ -26460,7 +26463,8 @@
         "qwen-vl-utils",
         "#system_torch#",
         "#system_numpy#",
-        "qwen_omni_utils"
+        "qwen_omni_utils",
+        "audioread"
       ]
     },
     "featured": false,
@@ -30168,6 +30172,7 @@
         "transformers>=5.2.0 ; #engine# == \"Transformers\"",
         "qwen-vl-utils!=0.0.9 ; #engine# == \"Transformers\"",
         "qwen_omni_utils==0.0.9 ; #engine# == \"vllm\"",
+        "audioread ; #engine# == \"vllm\"",
         "#system_numpy# ; #engine# == \"vllm\"",
         "vllm==0.21.0 ; #engine# == \"vllm\"",
         "transformers==4.57.6 ; #engine# == \"vllm\"",
@@ -30906,6 +30911,7 @@
         "vllm>=0.22.0 ; #engine# == \"vllm\"",
         "transformers>=5.8.0 ; #engine# == \"vllm\"",
         "qwen_omni_utils ; #engine# == \"vllm\"",
+        "audioread ; #engine# == \"vllm\"",
         "#sglang_dependencies# ; #engine# == \"sglang\"",
         "sglang==0.5.13.post1 ; #engine# == \"sglang\"",
         "transformers==5.8.1 ; #engine# == \"sglang\"",
@@ -31176,6 +31182,7 @@
         "transformers>=5.2.0 ; #engine# == \"Transformers\"",
         "qwen-vl-utils!=0.0.9 ; #engine# == \"Transformers\"",
         "qwen_omni_utils ; #engine# == \"vllm\"",
+        "audioread ; #engine# == \"vllm\"",
         "#system_numpy# ; #engine# == \"vllm\"",
         "vllm==0.21.0 ; #engine# == \"vllm\"",
         "ninja ; #engine# == \"vllm\"",
@@ -33029,6 +33036,7 @@
         "sglang_dependencies ; #engine# == \"sglang\"",
         "transformers>=5.2.0 ; #engine# == \"Transformers\"",
         "qwen_omni_utils ; #engine# == \"vllm\"",
+        "audioread ; #engine# == \"vllm\"",
         "#system_numpy# ; #engine# == \"vllm\"",
         "vllm==0.21.0 ; #engine# == \"vllm\"",
         "transformers==4.57.6 ; #engine# == \"vllm\"",


### PR DESCRIPTION
### Problem

Chat against any qwen-omni model fails immediately with:

```
ModuleNotFoundError: No module named 'audioread'
```

The model launches fine — it only breaks on the first request, so it looks like a runtime bug rather than a missing dependency:

```
File ".../xinference/model/llm/vllm/core.py", line 2313, in async_chat
    from qwen_omni_utils import (
File ".../site-packages/qwen_omni_utils/__init__.py", line 1, in <module>
    from .v2_5 import *
File ".../site-packages/qwen_omni_utils/v2_5/audio_process.py", line 4, in <module>
    import audioread
ModuleNotFoundError: No module named 'audioread'
```

### Root cause

`qwen_omni_utils` imports `audioread` at module level, but never declares it:

```
$ grep -E '^(Requires-Dist|Provides-Extra)' qwen_omni_utils-0.0.9.dist-info/METADATA
Requires-Dist: av
Requires-Dist: librosa
Requires-Dist: packaging
Requires-Dist: pillow
Requires-Dist: requests
Provides-Extra: decord
Requires-Dist: decord; extra == 'decord'
```

It used to arrive transitively through `librosa`. librosa deprecated `audioread` in 0.11 and removed the dependency in 1.0, so a virtualenv that resolves librosa 1.0 no longer gets it. There is no extra to opt into either, so the only fix on our side is to declare it explicitly.

Affected virtualenv in the wild: `librosa 1.0.0`, `soundfile 0.14.0`, `qwen_omni_utils 0.0.9`, no `audioread`.

### Fix

Add `audioread` next to every `qwen_omni_utils` declaration in `llm_family.json`, carrying over the same `#engine#` marker where one is present. All 8 entries that declare `qwen_omni_utils` were missing it:

`qwen2.5-omni`, `Qwen3-Omni-Thinking`, `Qwen3-Omni-Instruct`, `MinerU2.5-2509-1.2B`, `qwen3.5`, `gemma-4`, `qwen3.6`, `Ornith-1.0-35B`

### Verification

Confirmed end to end on `qwen3.6` (vLLM engine): installing `audioread` into the model's virtualenv makes `from qwen_omni_utils import process_audio_info` succeed, and chat then works — no model restart needed, since the import happens per request. The same JSON change was applied to the running deployment so a rebuilt virtualenv keeps the dependency.

The remaining 7 entries are the identical declaration pattern and the same import path, but I have not launched each of them individually.
