### PR TITLE
fix: make cancelling a model launch actually cancel it

### DIFF
--- a/frontend/src/lib/request.ts
+++ b/frontend/src/lib/request.ts
@@ -151,6 +151,10 @@ requestInstance.interceptors.response.use(
         }
         break;
       }
+      case 499: {
+        /** Client closed the request, e.g. the user cancelled a launch — not a server error. */
+        break;
+      }
       default: {
         eventBus.emit(RequestEvents.SERVER_ERROR, `Server error: ${status} - ${errorMessage}`);
       }

--- a/xinference/api/restful_api.py
+++ b/xinference/api/restful_api.py
@@ -966,10 +966,11 @@ class RESTfulAPI(CancelMixin):
         except RuntimeError as re:
             logger.error(str(re), exc_info=True)
             raise HTTPException(status_code=503, detail=str(re))
-        except asyncio.CancelledError as ce:
-            # cancelled by user
-            logger.error(str(ce), exc_info=True)
-            raise HTTPException(status_code=499, detail=str(ce))
+        except asyncio.CancelledError:
+            # Cancelled by the user. str() on a CancelledError is empty, so
+            # reporting it verbatim surfaces a blank error in the UI.
+            logger.info("Launch of %s was cancelled", model_uid)
+            raise HTTPException(status_code=499, detail="Launch cancelled")
         except Exception as e:
             logger.error(str(e), exc_info=True)
             raise HTTPException(status_code=500, detail=str(e))

--- a/xinference/constants.py
+++ b/xinference/constants.py
@@ -394,6 +394,12 @@ XINFERENCE_SUBPOOL_LAUNCH_TIMEOUT = int(
     os.environ.get("XINFERENCE_SUBPOOL_LAUNCH_TIMEOUT", "60")
 )
 
+# How long cancel_launch_model waits for the cancelled launch to unwind before
+# returning anyway, so an immediate relaunch is not rejected as still running.
+XINFERENCE_CANCEL_LAUNCH_TIMEOUT = int(
+    os.environ.get("XINFERENCE_CANCEL_LAUNCH_TIMEOUT", "60")
+)
+
 # Status gather timeout in seconds (for collecting GPU info, etc.)
 # Default: 10 seconds, increased from original 5 seconds
 XINFERENCE_STATUS_GATHER_TIMEOUT = int(

--- a/xinference/core/supervisor.py
+++ b/xinference/core/supervisor.py
@@ -2662,7 +2662,8 @@ class SupervisorActor(xo.StatelessActor):
                 for idx, (result, metadata) in enumerate(zip(results, task_metadata)):
                     worker_ref, rep_model_uid, is_rank0, _idx, _ = metadata
 
-                    if isinstance(result, Exception):
+                    # CancelledError is a BaseException, not an Exception.
+                    if isinstance(result, (Exception, asyncio.CancelledError)):
                         logger.error(
                             f"Failed to launch replica {rep_model_uid}: {result}"
                         )
@@ -2695,7 +2696,7 @@ class SupervisorActor(xo.StatelessActor):
                         )
 
                     logger.debug(f"Init transfer component for xavier done.")
-            except Exception:
+            except (Exception, asyncio.CancelledError):
                 # terminate_model will remove the replica info.
                 await self.terminate_model(model_uid, suppress_exception=True)
                 await self._status_guard_ref.update_instance_info(
@@ -2864,7 +2865,7 @@ class SupervisorActor(xo.StatelessActor):
                     # wait for load complete
                     for worker_ref in worker_refs:
                         await worker_ref.wait_for_load(rep_model_uid)
-            except Exception:
+            except (Exception, asyncio.CancelledError):
                 # terminate_model will remove the replica info.
                 await self.terminate_model(model_uid, suppress_exception=True)
                 await self._status_guard_ref.update_instance_info(
@@ -3230,6 +3231,8 @@ class SupervisorActor(xo.StatelessActor):
 
         replica_info = self._model_uid_to_replica_info.get(model_uid, None)
         if replica_info is None:
+            if suppress_exception:
+                return
             raise ValueError(f"Model not found in the model list, uid: {model_uid}")
 
         rep_model_uids = list(self._iter_active_replica_model_uids(model_uid))

--- a/xinference/core/tests/test_cancel_launch_cleanup.py
+++ b/xinference/core/tests/test_cancel_launch_cleanup.py
@@ -1,0 +1,115 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Cancelling a launch mid-download must not leak worker resources.
+
+Devices are reserved before the download starts and ``launch_info.sub_pools``
+is populated only afterwards, so a cancel that bypassed the launch cleanup
+handler would leave GPU capacity reserved and the launching guard occupied
+until the worker restarts — the next launch of the same uid then fails with
+"<uid> is running".
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+class _WorkerStub:
+    """Stand-in for WorkerActor; see test_subpool_hardening for the rationale
+    (xoscar forbids constructing a StatelessActor outside an actor pool)."""
+
+    pass
+
+
+def _make_worker():
+    from xinference.core.worker import LaunchInfo, WorkerActor
+
+    self = _WorkerStub()
+    self.address = "test:1"
+    self._main_pool = MagicMock()
+    self._main_pool.remove_sub_pool = AsyncMock()
+    self._model_uid_launching_guard = {}
+    self._model_uid_to_model = {}
+    self._launch_active = 0
+    self._launch_waiting = 0
+    self.release_devices = MagicMock()
+    self._update_model_state = AsyncMock()
+    self._get_progressor = AsyncMock(return_value=MagicMock())
+    self._launch_semaphore = asyncio.Semaphore(1)
+    self._check_model_is_valid = MagicMock()
+    self._create_virtual_env_manager = MagicMock(return_value=None)
+    self._spawn_subpool = AsyncMock(return_value="test:2")
+    self._allocate_subpool_devices = AsyncMock(return_value=({}, [0]))
+    self._upload_download_progress = MagicMock()
+    self._prepare_virtual_env = AsyncMock()
+    self.launch_builtin_model = WorkerActor.launch_builtin_model.__get__(self)
+    self.cancel_launch_model = WorkerActor.cancel_launch_model.__get__(self)
+    self.get_model_launch_status = WorkerActor.get_model_launch_status.__get__(self)
+    self._LaunchInfo = LaunchInfo
+    return self
+
+
+def _raise(exc):
+    def _fn(*args, **kwargs):
+        raise exc()
+
+    return _fn
+
+
+@pytest.mark.asyncio
+async def test_cancelled_download_releases_devices_and_guard(monkeypatch):
+    """A CancelledError from the download phase must run the same cleanup as
+    an ordinary failure, so devices and the launching guard are freed."""
+    worker = _make_worker()
+    monkeypatch.setattr(
+        "xinference.core.worker.create_model_instance", _raise(asyncio.CancelledError)
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await worker.launch_builtin_model(
+            model_uid="m-rep0",
+            model_name="m",
+            model_size_in_billions=None,
+            model_format=None,
+            quantization=None,
+            model_engine=None,
+        )
+
+    worker.release_devices.assert_called_once_with(model_uid="m-rep0")
+    assert "m-rep0" not in worker._model_uid_launching_guard
+    assert worker.get_model_launch_status("m-rep0") is None
+
+
+@pytest.mark.asyncio
+async def test_ordinary_failure_still_releases_devices(monkeypatch):
+    """Regression guard: widening the handler must not change the Exception path."""
+    worker = _make_worker()
+    monkeypatch.setattr(
+        "xinference.core.worker.create_model_instance", _raise(RuntimeError)
+    )
+
+    with pytest.raises(RuntimeError):
+        await worker.launch_builtin_model(
+            model_uid="m-rep0",
+            model_name="m",
+            model_size_in_billions=None,
+            model_format=None,
+            quantization=None,
+            model_engine=None,
+        )
+
+    worker.release_devices.assert_called_once_with(model_uid="m-rep0")
+    assert "m-rep0" not in worker._model_uid_launching_guard

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -51,6 +51,7 @@ from ..client.restful.restful_client import Client as RESTfulClient
 from ..constants import (
     XINFERENCE_ALLOW_MULTI_REPLICA_PER_GPU,
     XINFERENCE_CACHE_DIR,
+    XINFERENCE_CANCEL_LAUNCH_TIMEOUT,
     XINFERENCE_DISABLE_HEALTH_CHECK,
     XINFERENCE_ENABLE_VIRTUAL_ENV,
     XINFERENCE_HEALTH_CHECK_INTERVAL,
@@ -3851,6 +3852,22 @@ class WorkerActor(xo.StatelessActor):
             logger.error("Fail to cancel launching", exc_info=True)
             raise RuntimeError(
                 "Model is not launching, may have launched or not launched yet"
+            )
+
+        # The launch coroutine keeps the guard until it has finished unwinding
+        # (download abort, sub-pool teardown), so returning before that makes an
+        # immediate relaunch fail with "<uid> is running".
+        deadline = time.monotonic() + XINFERENCE_CANCEL_LAUNCH_TIMEOUT
+        while (
+            model_uid in self._model_uid_launching_guard and time.monotonic() < deadline
+        ):
+            await asyncio.sleep(0.1)
+        if model_uid in self._model_uid_launching_guard:
+            logger.warning(
+                "Launch of %s still unwinding after %ss; a relaunch may be "
+                "rejected as already running",
+                model_uid,
+                XINFERENCE_CANCEL_LAUNCH_TIMEOUT,
             )
 
     @log_async(logger=logger, level=logging.INFO)

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -3684,7 +3684,9 @@ class WorkerActor(xo.StatelessActor):
                             except xo.ServerClosed:
                                 check_cancel()
                                 raise
-                    except Exception:
+                    # CancelledError is a BaseException: skipping it leaks the
+                    # devices reserved before the download.
+                    except (Exception, asyncio.CancelledError):
                         logger.error(f"Failed to load model {model_uid}", exc_info=True)
                         await self._update_model_state(model_uid, "error")
                         self.release_devices(model_uid=model_uid)


### PR DESCRIPTION
Cancelling a model launch from the Web UI misbehaves in four separate ways, and they chain into each other. Reproduced end to end on a live deployment; each fix is one commit.

### 1. A cancelled launch is reported as a success, and leaks the replica info

`asyncio.CancelledError` subclasses `BaseException`, not `Exception`, so `supervisor.py` misses it twice:

```python
results = await asyncio.gather(*launch_tasks, return_exceptions=True)
...
if isinstance(result, Exception):        # False for CancelledError
    raise result
rank_addresses.append(result)            # the CancelledError object becomes a rank address
```

and the cleanup handlers, which are the only thing that undoes the replica info registered *before* launching:

```python
# Set replica info first for exception handler to terminate model.
self._model_uid_to_replica_info[model_uid] = self._build_replica_info(replica)
...
except Exception:                        # never sees CancelledError
    await self.terminate_model(model_uid, suppress_exception=True)
```

Result: `POST /v1/models` answers **200** for a launch that was cancelled, the uid stays in `_model_uid_to_replica_info` with no model actor behind it — so it is listed but absent from the running-models page — and every later attempt is rejected with `Model is already in the model list`. Only a restart clears it.

Observed, note the 200:

```
20:15:48.737  cancel_launch_model                        POST .../cancel  200
20:15:51.320  user clicks launch again                   POST /v1/models  400  "rep0 is running"
20:15:54.124  Launch finished: Qwen3-Reranker-8B-rep0    ← the cancelled launch
20:15:54.128                                             POST /v1/models  200  ← reported success
20:17:23.379  user clicks launch again                   POST /v1/models  400  "Model is already in the model list"
```

`restful_api.launch_model` already maps `CancelledError` to HTTP 499, so the intent is clearly that a cancel surfaces as a cancel — it just never gets there.

### 2. The cleanup itself then fails

Once those handlers actually run, they call `terminate_model(model_uid, suppress_exception=True)` — but `_terminate_model` ignores that flag for the "not in the list" case:

```python
replica_info = self._model_uid_to_replica_info.get(model_uid, None)
if replica_info is None:
    raise ValueError(f"Model not found in the model list, uid: {model_uid}")
```

`cancel_launch_builtin_model` has already popped the replica info, so cleanup raises on top of the failure it was cleaning up after, and *that* is what reaches the user. `suppress_exception` now covers this branch too; it already covered the per-replica teardown errors below it.

### 3. Relaunching right after a cancel is rejected as still running

`cancel_launch_model` sets the cancel event and returns immediately, but the launch coroutine holds `_model_uid_launching_guard` until it has unwound (download abort, sub-pool teardown) — about 3s in practice:

```
05:27:58.574  Launch started
05:28:10.568  cancel_launch_model → returns
05:28:13.655  user clicks launch → "Qwen3-Reranker-8B-rep0 is running"
05:28:13.763  Launch finished          ← guard released 0.1s too late
```

Cancel now waits for the guard to clear (bounded by `XINFERENCE_CANCEL_LAUNCH_TIMEOUT`, default 60s, warn-and-return on timeout), so when the call returns the model really is cancellable/relaunchable.

### 4. The cancel surfaces as a bogus error in the UI

Two independent bits:

- `str()` on a `CancelledError` is empty, so `detail=str(ce)` produced a blank error body — in practice just xoscar's `[address=..., pid=...]` prefix. The 499 now carries `Launch cancelled`, and the log line drops from ERROR to INFO because a user-initiated cancel is not an error.
- `frontend/src/lib/request.ts` funnels every non-401/403 status into `RequestEvents.SERVER_ERROR`, so 499 popped up as `Server error: 499 - ...`. 499 now breaks out of that switch; the rejection still reaches the caller, which already handles it (`stopPolling`, plus an existing `isCanceledLaunchRef` guard against a late success toast).

### Verification

On a live deployment, driving the SupervisorActor directly over xoscar (bypassing REST auth) and then through the Web UI:

- cancel mid-download → the launch call now raises instead of returning a uid, `list_models()` is empty afterwards, and relaunching the same uid is accepted
- the logs show the new path — neither line appears before this change:
  ```
  ERROR Failed to launch replica clean-test-rep0:      ← empty msg: str(CancelledError) is ""
  Enter terminate_model                                ← cleanup now runs
  ```
- an uncancelled launch is unaffected: still downloading past 25s, torn down normally
- from the UI: cancel, then immediately relaunch — no `is running`, no `Model not found in the model list`, no 499 popup

### Note on where those CancelledErrors came from

The deployment predates #5257, so its `CancellableDownloader.patch_tqdm` still scanned the whole heap and raised for *any* cancelled downloader ever created, which is why cancelling once poisoned every later download in that process until restart. #5257 replaced that with the bounded `_active_registry`, so this PR does not touch it.

It does mean the first bug is reachable far more easily than "the user pressed cancel": *anything* surfacing as `CancelledError` during a launch was silently reported as success.

One thing I did not verify: on current main, cancelling one download still calls `raise_error()` for every other downloader alive in `_active_registry` at that moment, so concurrent launches may still take each other down. Reading only — happy to file separately if that is worth pursuing.
