### PR TITLE
fix(deploy): stop polling requests flooding the access log

### DIFF
--- a/xinference/constants.py
+++ b/xinference/constants.py
@@ -271,6 +271,13 @@ XINFERENCE_LOG_CONSOLE = (
     os.environ.get("XINFERENCE_LOG_CONSOLE", "true").lower() == "true"
 )
 
+# The Web UI polls /progress and /replicas about once a second per model and
+# metrics scrapers hit /metrics, so at info level those access lines bury
+# everything else. Set to true to log them anyway.
+XINFERENCE_LOG_POLLING_ACCESS = (
+    os.environ.get("XINFERENCE_LOG_POLLING_ACCESS", "false").lower() == "true"
+)
+
 # Download progress logging level (only effective when XINFERENCE_LOG_CONSOLE=false)
 # - "sampled": log 25/50/75/100% per shard + terminal state on exit (default)
 # - "full": log every tqdm frame

--- a/xinference/deploy/utils.py
+++ b/xinference/deploy/utils.py
@@ -36,6 +36,7 @@ from ..constants import (
     XINFERENCE_DEFAULT_LOG_FILE_NAME,
     XINFERENCE_LOG_DIR,
     XINFERENCE_LOG_DOWNLOAD_PROGRESS,
+    XINFERENCE_LOG_POLLING_ACCESS,
 )
 
 if TYPE_CHECKING:
@@ -422,6 +423,30 @@ class LoggerNameFilter(logging.Filter):
             record.name.startswith("uvicorn.error")
             and record.getMessage().startswith("Uvicorn running on")
         )
+
+
+# Hit continuously by the Web UI, health checks and metrics scrapers.
+_POLLING_ENDPOINTS = ("/progress", "/replicas", "/metrics", "/status")
+
+
+class PollingAccessFilter(logging.Filter):
+    """Drop successful polling requests from uvicorn's access log.
+
+    uvicorn logs each request with
+    ``args = (client_addr, method, full_path, http_version, status_code)``;
+    anything that does not match that shape is left alone.
+    """
+
+    def filter(self, record):
+        if XINFERENCE_LOG_POLLING_ACCESS:
+            return True
+        args = record.args
+        if not isinstance(args, tuple) or len(args) != 5:
+            return True
+        _, method, full_path, _, status = args
+        if method != "GET" or not isinstance(status, int) or status >= 400:
+            return True
+        return not full_path.split("?", 1)[0].endswith(_POLLING_ENDPOINTS)
 
 
 _PROGRESS_RE = re.compile(r"(\d+)%\|")
@@ -876,6 +901,9 @@ def get_config_dict(
             "logger_name_filter": {
                 "()": __name__ + ".LoggerNameFilter",
             },
+            "polling_access_filter": {
+                "()": __name__ + ".PollingAccessFilter",
+            },
         },
         "handlers": {
             "stream_handler": {
@@ -913,6 +941,7 @@ def get_config_dict(
                 "handlers": handlers_list,
                 "level": log_level,
                 "propagate": False,
+                "filters": ["polling_access_filter"],
             },
             "transformers": {
                 "handlers": (

--- a/xinference/tests/test_logging_filters.py
+++ b/xinference/tests/test_logging_filters.py
@@ -1,0 +1,74 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+import pytest
+
+from xinference.deploy import utils as deploy_utils
+from xinference.deploy.utils import PollingAccessFilter
+
+
+def _access_record(method: str, path: str, status: int) -> logging.LogRecord:
+    """Build the record uvicorn emits for one request."""
+    return logging.LogRecord(
+        "uvicorn.access",
+        logging.INFO,
+        "",
+        0,
+        '%s - "%s %s HTTP/%s" %d',
+        ("10.0.0.1:1234", method, path, "1.1", status),
+        None,
+    )
+
+
+@pytest.mark.parametrize(
+    "method,path,status",
+    [
+        ("GET", "/v1/models/my-model/progress", 200),
+        ("GET", "/v1/models/my-model/replicas", 200),
+        ("GET", "/v1/models/my-model/progress?request_id=abc", 200),
+        ("GET", "/metrics", 200),
+        ("GET", "/status", 200),
+    ],
+)
+def test_polling_is_dropped(method, path, status):
+    assert PollingAccessFilter().filter(_access_record(method, path, status)) is False
+
+
+@pytest.mark.parametrize(
+    "method,path,status",
+    [
+        ("GET", "/v1/models", 200),  # real query, not polling
+        ("POST", "/v1/models", 200),  # launching a model
+        ("DELETE", "/v1/models/my-model", 200),
+        ("GET", "/v1/models/my-model/progress", 500),  # failures stay visible
+        ("GET", "/v1/models/my-model/progress", 404),
+    ],
+)
+def test_everything_else_is_kept(method, path, status):
+    assert PollingAccessFilter().filter(_access_record(method, path, status)) is True
+
+
+def test_opt_in_keeps_polling(monkeypatch):
+    monkeypatch.setattr(deploy_utils, "XINFERENCE_LOG_POLLING_ACCESS", True)
+    assert PollingAccessFilter().filter(_access_record("GET", "/metrics", 200)) is True
+
+
+def test_unexpected_record_shape_is_kept():
+    """Records that are not uvicorn access lines must pass through untouched."""
+    record = logging.LogRecord(
+        "uvicorn.access", logging.INFO, "", 0, "something else %s", ("x",), None
+    )
+    assert PollingAccessFilter().filter(record) is True


### PR DESCRIPTION
### Problem

With the Web UI open, the access log is almost entirely polling:

```
INFO uvicorn.access ... "GET /v1/models/Qwen3-Reranker-8B/progress HTTP/1.1" 200
INFO uvicorn.access ... "GET /v1/models/SenseVoiceSmall/progress HTTP/1.1" 200
INFO uvicorn.access ... "GET /v1/models/SenseVoiceSmall/replicas HTTP/1.1" 200
```

The UI polls `/progress` and `/replicas` roughly once a second **per model**, and metrics scrapers hit `/metrics`, so at the default info level everything that actually matters is buried. There is currently no way to turn this off short of raising the whole log level and losing real messages with it.

This is not just cosmetic. While debugging a launch failure on a live deployment, every single log query had to start with `grep -v uvicorn.access` before anything could be read, and the useful lines were a handful among tens of thousands.

### Fix

Add a `PollingAccessFilter` on the `uvicorn.access` logger that drops **successful GETs to polling endpoints** (`/progress`, `/replicas`, `/metrics`, `/status`). Everything else is untouched:

- real API calls (`GET /v1/models`, `POST /v1/models`, `DELETE ...`) still logged
- **failures on polling endpoints still logged** — only 2xx/3xx are dropped, so a broken `/progress` stays visible
- records that are not uvicorn access lines pass through unchanged

Set `XINFERENCE_LOG_POLLING_ACCESS=true` to get the old behaviour back.

### Verification

`xinference/tests/test_logging_filters.py` covers the dropped set, the kept set (including non-2xx polling and non-GET), the opt-in env var, and a non-access record shape.
