### PR TITLE
fix: normalize replica during autostart recovery

### DIFF
--- a/xinference/core/autostart.py
+++ b/xinference/core/autostart.py
@@ -65,9 +65,7 @@ def normalize_launch_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
                 "Autostart launch config replica must be an integer."
             ) from None
         if replica < 1:
-            raise ValueError(
-                "Autostart launch config replica must be greater than 0."
-            )
+            raise ValueError("Autostart launch config replica must be greater than 0.")
         launch["replica"] = replica
     launch.pop("wait_ready", None)
     return launch

--- a/xinference/core/autostart.py
+++ b/xinference/core/autostart.py
@@ -54,6 +54,21 @@ def normalize_launch_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
     launch["model_name"] = model_name.strip()
     launch["model_uid"] = model_uid.strip()
     launch.setdefault("model_type", "LLM")
+    if "replica" in launch:
+        replica = launch["replica"]
+        if isinstance(replica, (bool, float)):
+            raise ValueError("Autostart launch config replica must be an integer.")
+        try:
+            replica = int(replica)
+        except (TypeError, ValueError, OverflowError):
+            raise ValueError(
+                "Autostart launch config replica must be an integer."
+            ) from None
+        if replica < 1:
+            raise ValueError(
+                "Autostart launch config replica must be greater than 0."
+            )
+        launch["replica"] = replica
     launch.pop("wait_ready", None)
     return launch
 

--- a/xinference/core/tests/test_autostart.py
+++ b/xinference/core/tests/test_autostart.py
@@ -40,7 +40,11 @@ async def test_load_autostart_entries_reads_sqlite_store_and_normalizes():
                 "priority": "5",
                 "max_retries": "2",
                 "retry_interval_seconds": "9",
-                "launch": {"model_name": "llama", "model_uid": "uid-1"},
+                "launch": {
+                    "model_name": "llama",
+                    "model_uid": "uid-1",
+                    "replica": "2",
+                },
             }
         ]
     )
@@ -57,6 +61,7 @@ async def test_load_autostart_entries_reads_sqlite_store_and_normalizes():
                 "model_name": "llama",
                 "model_uid": "uid-1",
                 "model_type": "LLM",
+                "replica": 2,
             },
         }
     ]


### PR DESCRIPTION
## What

Normalize a persisted autostart `replica` value to an integer while loading the launch payload, and cover the UI-produced string form in the autostart regression test.

## Why

The REST launch path accepts values such as `replica="2"`, but launch history can retain that string. On restart, the autostart path previously forwarded it to replica scheduling, where `range("2")` raises a `TypeError` and prevents model recovery.

## Impact

Existing autostart records with integer strings recover correctly. Invalid boolean, float, non-numeric, zero, and negative values are rejected during normalization instead of failing later in model launch.

Fixes #5305.

## Checks

- Isolated normalization regression checks (valid string and invalid values)
- `python3 -m compileall -q xinference/core/autostart.py xinference/core/tests/test_autostart.py`
- `git diff --check`

The focused pytest file could not run in this environment because the optional `xoscar` dependency is not installed.