### PR TITLE
feat(video): add MiniMax-H3 support

### DIFF
--- a/doc/source/models/builtin/video/index.rst
+++ b/doc/source/models/builtin/video/index.rst
@@ -10,6 +10,7 @@ The following is a list of built-in video models in Xinference:
 .. toctree::
    :maxdepth: 1
 
+   minimax-h3
   
    cogvideox-2b
   
@@ -32,4 +33,3 @@ The following is a list of built-in video models in Xinference:
    wan2.2-i2v-a14b
   
    wan2.2-ti2v-5b
-  

--- a/doc/source/models/builtin/video/minimax-h3.rst
+++ b/doc/source/models/builtin/video/minimax-h3.rst
@@ -1,0 +1,18 @@
+.. _models_builtin_minimax-h3:
+
+==========
+MiniMax-H3
+==========
+
+- **Model Name:** MiniMax-H3
+- **Model Family:** MiniMax-H3
+- **Abilities:** text2video, image2video, firstlastframe2video
+
+Specifications
+^^^^^^^^^^^^^^
+
+- **Model ID:** MiniMaxAI/MiniMax-H3
+
+Execute the following command to launch the model::
+
+   xinference launch --model-name MiniMax-H3 --model-type video

--- a/doc/source/models/model_abilities/video.rst
+++ b/doc/source/models/model_abilities/video.rst
@@ -40,6 +40,7 @@ Supported models
 
 The text-to-video API is supported with the following models in Xinference:
 
+* :ref:`MiniMax-H3 <models_builtin_minimax-h3>`
 * :ref:`CogVideoX-2b <models_builtin_cogvideox-2b>`
 * :ref:`CogVideoX-5b <models_builtin_cogvideox-5b>`
 * :ref:`HunyuanVideo <models_builtin_hunyuanvideo>`
@@ -48,11 +49,13 @@ The text-to-video API is supported with the following models in Xinference:
 
 The image-to-video API is supported with the following models in Xinference:
 
+* :ref:`MiniMax-H3 <models_builtin_minimax-h3>`
 * :ref:`Wan2.1-i2v-14B-480p <models_builtin_wan2.1-i2v-14b-480p>`
 * :ref:`Wan2.1-i2v-14B-720p <models_builtin_wan2.1-i2v-14b-720p>`
 
 The firstlastframe-to-video API is supported with the following models in Xinference:
 
+* :ref:`MiniMax-H3 <models_builtin_minimax-h3>`
 * :ref:`Wan2.1-flf2v-14B-720p <models_builtin_wan2.1-flf2v-14b-720p>`
 
 Quickstart
@@ -153,6 +156,7 @@ Xinference supports several options to optimize video model memory (VRAM) usage.
 
 * CPU offloading or block level group offloading.
 * Layerwise casting.
+* Weight quantization.
 
 .. note::
 
@@ -195,6 +199,33 @@ add an additional option ``use_stream`` with the value set to ``True``.
 
     xinference launch --model-name Wan2.1-i2v-14B-480p --model-type video --group_offload True --use_stream True
 
+Weight quantization
+-------------------
+
+Some video models support weight-only quantization through the
+``--quantization`` option. Quantization lowers both GPU and host memory usage,
+with a possible quality and performance trade-off.
+
+MiniMax-H3 supports the following values for ``quantization``:
+
+* ``int4``: the default. Most large linear weights use TorchAO INT4, while a few
+  BF16 blocks remain on the CPU during loading. Together with block-level group
+  offloading, this allows the model to load on a 24GB consumer GPU without
+  additional launch options. CUDA streams are disabled on this path to avoid an
+  extra pinned host-memory copy.
+* ``int8``: use TorchAO INT8 weight-only quantization for higher weight precision.
+  This requires at least 75GB of available host RAM.
+* ``none`` or ``bf16``: disable weight quantization. With the default
+  ``torch_dtype``, weights are loaded in BF16 and require substantially more GPU
+  and host memory.
+* ``torchao``: a compatibility alias for ``int8``. Use ``int8`` in new launch
+  configurations.
+
+For example, select INT8 with::
+
+    xinference launch --model-name MiniMax-H3 --model-type video \
+        --quantization int8
+
 Applying Layerwise Casting to the Transformer
 ------------------------------------------------
 
@@ -210,4 +241,3 @@ This example will require 20GB of VRAM.
 .. code-block:: bash
 
     xinference launch --model-name Wan2.1-i2v-14B-480p --model-type video --layerwise_cast True --cpu_offload True
-

--- a/xinference/model/video/diffusers.py
+++ b/xinference/model/video/diffusers.py
@@ -319,7 +319,7 @@ class DiffusersVideoModel:
 
         manager = ComponentsManager()
         manager.enable_auto_cpu_offload(
-            device=kwargs.pop("offload_device", "cuda"),
+            device=kwargs.pop("onload_device", "cuda"),
             memory_reserve_margin=kwargs.pop("memory_reserve_margin", "12GB"),
         )
         pipeline = ModularPipeline.from_pretrained(
@@ -699,7 +699,7 @@ class DiffusersVideoModel:
         kwargs.pop("num_videos_per_prompt", None)
         kwargs.pop("fps", None)
 
-        generate_kwargs = self._model_spec.default_generate_config.copy()
+        generate_kwargs = (self._model_spec.default_generate_config or {}).copy()
         generate_kwargs.update(kwargs)
         if num_inference_steps is not None:
             generate_kwargs["num_inference_steps"] = num_inference_steps
@@ -766,7 +766,12 @@ class DiffusersVideoModel:
 
         missing = object()
         patched_blocks = []
-        for block in iter_blocks(pipeline._blocks):
+        blocks = getattr(pipeline, "_blocks", None)
+        if blocks is None:
+            yield
+            return
+
+        for block in iter_blocks(blocks):
             if getattr(block, "model_name", None) != "minimax-h3" or not hasattr(
                 block, "loop_step"
             ):

--- a/xinference/model/video/diffusers.py
+++ b/xinference/model/video/diffusers.py
@@ -830,18 +830,24 @@ class DiffusersVideoModel:
 
         sampling_rate = output.get("sampling_rate")
         urls = []
-        for index, video in enumerate(video_outputs):
-            path = os.path.join(XINFERENCE_VIDEO_DIR, uuid.uuid4().hex + ".mp4")
-            audio = audio_outputs[index] if index < len(audio_outputs) else None
-            encode_video(
-                video,
-                fps=24,
-                output_path=path,
-                audio=audio,
-                audio_sample_rate=sampling_rate,
-            )
-            urls.append(path)
-        return urls
+        try:
+            for index, video in enumerate(video_outputs):
+                path = os.path.join(XINFERENCE_VIDEO_DIR, uuid.uuid4().hex + ".mp4")
+                urls.append(path)
+                audio = audio_outputs[index] if index < len(audio_outputs) else None
+                encode_video(
+                    video,
+                    fps=24,
+                    output_path=path,
+                    audio=audio,
+                    audio_sample_rate=sampling_rate,
+                )
+            return urls
+        except BaseException:
+            for video_path in urls:
+                with suppress(OSError):
+                    os.remove(video_path)
+            raise
 
     def _process_image(self, image: PIL.Image.Image, max_area: int) -> PIL.Image.Image:
         assert self._model is not None

--- a/xinference/model/video/diffusers.py
+++ b/xinference/model/video/diffusers.py
@@ -22,7 +22,7 @@ import tempfile
 import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from functools import partial, reduce
 from typing import TYPE_CHECKING, Any, List, Optional, Union
 
@@ -709,23 +709,31 @@ class DiffusersVideoModel:
         pipeline = self._model
         assert callable(pipeline)
         videos = []
-        for video_index in range(n):
-            call_kwargs = generate_kwargs.copy()
-            if image is not None:
-                call_kwargs["image"] = image
-            if last_image is not None:
-                call_kwargs["last_image"] = last_image
-            with self._track_minimax_h3_progress(pipeline, progressor, video_index, n):
-                output = pipeline(
-                    prompt=prompt,
-                    output=["videos", "audio", "sampling_rate"],
-                    **call_kwargs,
-                )
-            videos.extend(self._encode_minimax_h3_output(output))
+        try:
+            for video_index in range(n):
+                call_kwargs = generate_kwargs.copy()
+                if image is not None:
+                    call_kwargs["image"] = image
+                if last_image is not None:
+                    call_kwargs["last_image"] = last_image
+                with self._track_minimax_h3_progress(
+                    pipeline, progressor, video_index, n
+                ):
+                    output = pipeline(
+                        prompt=prompt,
+                        output=["videos", "audio", "sampling_rate"],
+                        **call_kwargs,
+                    )
+                videos.extend(self._encode_minimax_h3_output(output))
 
-        if progressor and progressor.request_id:
-            progressor.set_progress(1.0)
-        return self._video_urls_to_response(videos, response_format)
+            if progressor and progressor.request_id:
+                progressor.set_progress(1.0)
+            return self._video_urls_to_response(videos, response_format)
+        except BaseException:
+            for video_path in videos:
+                with suppress(OSError):
+                    os.remove(video_path)
+            raise
 
     @staticmethod
     @contextmanager

--- a/xinference/model/video/diffusers.py
+++ b/xinference/model/video/diffusers.py
@@ -22,6 +22,7 @@ import tempfile
 import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
 from functools import partial, reduce
 from typing import TYPE_CHECKING, Any, List, Optional, Union
 
@@ -112,6 +113,229 @@ class DiffusersVideoModel:
         else:
             pipeline.transformer = transformer
 
+    @staticmethod
+    def _enable_minimax_h3_group_offload(pipeline, kwargs: dict):
+        import torch
+        from diffusers.hooks import apply_group_offloading
+
+        onload_device = torch.device(kwargs.pop("onload_device", "cuda"))
+        offload_device = torch.device(kwargs.pop("offload_device", "cpu"))
+        offload_kwargs = {
+            "onload_device": onload_device,
+            "offload_device": offload_device,
+            "use_stream": kwargs.pop("use_stream", True),
+        }
+        num_blocks_per_group = kwargs.pop("num_blocks_per_group", 1)
+
+        pipeline.transformer.requires_grad_(False)
+        pipeline.text_encoder.requires_grad_(False)
+        pipeline.transformer.enable_group_offload(
+            offload_type="block_level",
+            num_blocks_per_group=num_blocks_per_group,
+            **offload_kwargs,
+        )
+        text_encoder = getattr(pipeline.text_encoder, "model", pipeline.text_encoder)
+        apply_group_offloading(
+            text_encoder,
+            offload_type="leaf_level",
+            **offload_kwargs,
+        )
+        pipeline.vae.to(onload_device)
+        pipeline.audio_vae.to(onload_device)
+
+    def _load_minimax_h3_quantized(self, kwargs: dict, torch_dtype, quantization: str):
+        import torch
+        from diffusers import (
+            MiniMaxH3Transformer3DModel,
+            ModularPipeline,
+            TorchAoConfig,
+        )
+        from torchao.quantization import Int4WeightOnlyConfig, Int8WeightOnlyConfig
+        from transformers import Qwen3VLForConditionalGeneration
+        from transformers import TorchAoConfig as TransformersTorchAoConfig
+
+        @contextmanager
+        def skip_accelerate_dispatch(module, attribute):
+            # The mixed CUDA/CPU map is needed only while each weight is quantized.
+            # Installing runtime dispatch hooks afterwards briefly moves CPU weights
+            # back to CUDA and exceeds 24GB before we can hand off to group offload.
+            original = getattr(module, attribute)
+            setattr(module, attribute, lambda model, *args, **kwargs: model)
+            try:
+                yield
+            finally:
+                setattr(module, attribute, original)
+
+        def make_quant_type():
+            if quantization == "int4":
+                # The plain INT4 layout requires mslk, which is not published on
+                # PyPI. Use PyTorch's native CUDA packing instead.
+                return Int4WeightOnlyConfig(
+                    group_size=128,
+                    int4_packing_format="tile_packed_to_4d",
+                    version=2,
+                )
+            return Int8WeightOnlyConfig(version=2)
+
+        transformer_quantization_config = TorchAoConfig(
+            make_quant_type(),
+            modules_to_not_convert=[
+                "proj_in",
+                "audio_proj_in",
+                "context_embedder",
+                "time_embedder",
+                "time_proj",
+                "token_refiner",
+                "norm_out",
+                "proj_out",
+                "audio_proj_out",
+            ],
+        )
+        text_encoder_quantization_config = TransformersTorchAoConfig(
+            make_quant_type(),
+            modules_to_not_convert=[
+                "model.visual",
+                "model.language_model.embed_tokens",
+                "model.language_model.norm",
+                "lm_head",
+            ],
+        )
+
+        pipeline = ModularPipeline.from_pretrained(self._model_path)
+        onload_device = torch.device(kwargs.get("onload_device", "cuda"))
+        offload_device = torch.device(kwargs.get("offload_device", "cpu"))
+        transformer_load_kwargs = {}
+        text_encoder_load_kwargs = {}
+        if quantization == "int4":
+            # Native INT4 packing runs on CUDA. Keep modules that stay in BF16 on
+            # CPU, along with a few transformer blocks, so quantized weights never
+            # accumulate beyond the capacity of a 24GB card while loading.
+            transformer_device_map = {
+                "": onload_device,
+                "proj_in": "cpu",
+                "audio_proj_in": "cpu",
+                "context_embedder": "cpu",
+                "time_embedder": "cpu",
+                "time_proj": "cpu",
+                "token_refiner": "cpu",
+                "norm_out": "cpu",
+                "proj_out": "cpu",
+                "audio_proj_out": "cpu",
+            }
+            for block_index in range(46, 50):
+                transformer_device_map[f"transformer_blocks.{block_index}"] = "cpu"
+
+            transformer_load_kwargs["device_map"] = transformer_device_map
+            text_encoder_load_kwargs["device_map"] = {
+                "": onload_device,
+                "model.visual": "cpu",
+                "model.language_model.embed_tokens": "cpu",
+                "model.language_model.norm": "cpu",
+                "lm_head": "cpu",
+            }
+
+        if quantization == "int4":
+            from diffusers.models import modeling_utils as diffusers_modeling_utils
+
+            with skip_accelerate_dispatch(diffusers_modeling_utils, "dispatch_model"):
+                transformer = MiniMaxH3Transformer3DModel.from_pretrained(
+                    self._model_path,
+                    subfolder="transformer",
+                    dtype=torch_dtype,
+                    quantization_config=transformer_quantization_config,
+                    low_cpu_mem_usage=True,
+                    **transformer_load_kwargs,
+                )
+        else:
+            transformer = MiniMaxH3Transformer3DModel.from_pretrained(
+                self._model_path,
+                subfolder="transformer",
+                dtype=torch_dtype,
+                quantization_config=transformer_quantization_config,
+                low_cpu_mem_usage=True,
+            )
+        if quantization == "int4":
+            transformer.to(offload_device)
+
+        if quantization == "int4":
+            from transformers import modeling_utils as transformers_modeling_utils
+
+            with skip_accelerate_dispatch(
+                transformers_modeling_utils, "accelerate_dispatch"
+            ):
+                text_encoder = Qwen3VLForConditionalGeneration.from_pretrained(
+                    self._model_path,
+                    subfolder="text_encoder",
+                    dtype=torch_dtype,
+                    quantization_config=text_encoder_quantization_config,
+                    low_cpu_mem_usage=True,
+                    **text_encoder_load_kwargs,
+                )
+        else:
+            text_encoder = Qwen3VLForConditionalGeneration.from_pretrained(
+                self._model_path,
+                subfolder="text_encoder",
+                dtype=torch_dtype,
+                quantization_config=text_encoder_quantization_config,
+                low_cpu_mem_usage=True,
+            )
+        if quantization == "int4":
+            text_encoder.to(offload_device)
+
+        pipeline.update_components(transformer=transformer, text_encoder=text_encoder)
+        pipeline.load_components(
+            workflow="t2va",
+            dtype=torch_dtype,
+            pretrained_model_name_or_path=self._model_path,
+        )
+
+        if kwargs.pop("group_offload", False):
+            if quantization == "int4":
+                kwargs.setdefault("use_stream", False)
+            self._enable_minimax_h3_group_offload(pipeline, kwargs)
+        else:
+            device = torch.device(kwargs.pop("onload_device", "cuda"))
+            for component_name in ("transformer", "text_encoder", "vae", "audio_vae"):
+                getattr(pipeline, component_name).to(device)
+        self._model = pipeline
+
+    def _load_minimax_h3(self, kwargs: dict, torch_dtype):
+        quantization = kwargs.pop("quantization", None)
+        if quantization in ("int4", "int8", "torchao"):
+            self._load_minimax_h3_quantized(
+                kwargs,
+                torch_dtype,
+                "int8" if quantization == "torchao" else quantization,
+            )
+            return
+
+        if quantization not in (None, "none", "bf16"):
+            raise ValueError(
+                f"Unsupported MiniMax-H3 quantization: {quantization}. "
+                "Supported values are int4, int8, none, and bf16."
+            )
+
+        from diffusers import ComponentsManager, ModularPipeline
+
+        manager = ComponentsManager()
+        manager.enable_auto_cpu_offload(
+            device=kwargs.pop("offload_device", "cuda"),
+            memory_reserve_margin=kwargs.pop("memory_reserve_margin", "12GB"),
+        )
+        pipeline = ModularPipeline.from_pretrained(
+            self._model_path, components_manager=manager
+        )
+        pipeline.load_components(
+            workflow="t2va",
+            dtype=torch_dtype,
+            pretrained_model_name_or_path=self._model_path,
+        )
+        self._model = pipeline
+
+    @staticmethod
+    def _is_minimax_h3(model_spec) -> bool:
+        return model_spec.model_family == "MiniMax-H3"
+
     def load(self):
         import torch
 
@@ -125,6 +349,10 @@ class DiffusersVideoModel:
             kwargs["torch_dtype"] = getattr(torch, torch_dtype)
             torch_dtype = kwargs["torch_dtype"]
         logger.debug("Loading video model with kwargs: %s", kwargs)
+
+        if self._is_minimax_h3(self._model_spec):
+            self._load_minimax_h3(kwargs, torch_dtype)
+            return
 
         transformer = None
         if self._gguf_model_path and self._model_spec.model_family != "HunyuanVideo":
@@ -290,6 +518,14 @@ class DiffusersVideoModel:
     ) -> VideoList:
         assert self._model is not None
         assert callable(self._model)
+        if self._is_minimax_h3(self._model_spec):
+            return self._minimax_h3_generate(
+                prompt=prompt,
+                n=n,
+                num_inference_steps=num_inference_steps,
+                response_format=response_format,
+                **kwargs,
+            )
         generate_kwargs = self._model_spec.default_generate_config.copy()
         generate_kwargs.update(kwargs)
         generate_kwargs["num_videos_per_prompt"] = n
@@ -317,6 +553,15 @@ class DiffusersVideoModel:
     ):
         assert self._model is not None
         assert callable(self._model)
+        if self._is_minimax_h3(self._model_spec):
+            return self._minimax_h3_generate(
+                prompt=prompt,
+                image=image,
+                n=n,
+                num_inference_steps=num_inference_steps,
+                response_format=response_format,
+                **kwargs,
+            )
         generate_kwargs = self._model_spec.default_generate_config.copy()
         generate_kwargs.update(kwargs)
         if num_inference_steps:
@@ -393,6 +638,16 @@ class DiffusersVideoModel:
     ):
         assert self._model is not None
         assert callable(self._model)
+        if self._is_minimax_h3(self._model_spec):
+            return self._minimax_h3_generate(
+                prompt=prompt,
+                image=first_frame,
+                last_image=last_frame,
+                n=n,
+                num_inference_steps=num_inference_steps,
+                response_format=response_format,
+                **kwargs,
+            )
         generate_kwargs = self._model_spec.default_generate_config.copy()
         generate_kwargs.update(kwargs)
         generate_kwargs["num_videos_per_prompt"] = n
@@ -422,6 +677,158 @@ class DiffusersVideoModel:
             **generate_kwargs,
         )
         return self._output_to_video(output, fps, response_format)
+
+    def _minimax_h3_generate(
+        self,
+        prompt: str,
+        n: int,
+        num_inference_steps: Optional[int],
+        response_format: str,
+        image: Optional[PIL.Image.Image] = None,
+        last_image: Optional[PIL.Image.Image] = None,
+        **kwargs,
+    ) -> VideoList:
+        if n < 1:
+            raise ValueError("n must be at least 1")
+
+        progressor = kwargs.pop("progressor", None)
+        kwargs.pop("request_id", None)
+        # H3 is guidance-distilled and uses a fixed 24 fps output format.
+        kwargs.pop("negative_prompt", None)
+        kwargs.pop("guidance_scale", None)
+        kwargs.pop("num_videos_per_prompt", None)
+        kwargs.pop("fps", None)
+
+        generate_kwargs = self._model_spec.default_generate_config.copy()
+        generate_kwargs.update(kwargs)
+        if num_inference_steps is not None:
+            generate_kwargs["num_inference_steps"] = num_inference_steps
+        else:
+            generate_kwargs.setdefault("num_inference_steps", 50)
+
+        pipeline = self._model
+        assert callable(pipeline)
+        videos = []
+        for video_index in range(n):
+            call_kwargs = generate_kwargs.copy()
+            if image is not None:
+                call_kwargs["image"] = image
+            if last_image is not None:
+                call_kwargs["last_image"] = last_image
+            with self._track_minimax_h3_progress(pipeline, progressor, video_index, n):
+                output = pipeline(
+                    prompt=prompt,
+                    output=["videos", "audio", "sampling_rate"],
+                    **call_kwargs,
+                )
+            videos.extend(self._encode_minimax_h3_output(output))
+
+        if progressor and progressor.request_id:
+            progressor.set_progress(1.0)
+        return self._video_urls_to_response(videos, response_format)
+
+    @staticmethod
+    @contextmanager
+    def _track_minimax_h3_progress(pipeline, progressor, video_index: int, n: int):
+        if not progressor or not progressor.request_id:
+            yield
+            return
+
+        class ProgressBarWrapper:
+            def __init__(self, progress_bar):
+                self._progress_bar = progress_bar
+
+            def __enter__(self):
+                self._progress_bar.__enter__()
+                return self
+
+            def __exit__(self, exc_type, exc_val, exc_tb):
+                return self._progress_bar.__exit__(exc_type, exc_val, exc_tb)
+
+            def __getattr__(self, name):
+                return getattr(self._progress_bar, name)
+
+            def update(self, count=1):
+                result = self._progress_bar.update(count)
+                if self._progress_bar.total:
+                    step_progress = min(
+                        self._progress_bar.n / self._progress_bar.total, 1.0
+                    )
+                    progressor.set_progress((video_index + step_progress) / n)
+                return result
+
+        def iter_blocks(block):
+            yield block
+            sub_blocks = getattr(block, "sub_blocks", None)
+            if sub_blocks:
+                for sub_block in sub_blocks.values():
+                    yield from iter_blocks(sub_block)
+
+        missing = object()
+        patched_blocks = []
+        for block in iter_blocks(pipeline._blocks):
+            if getattr(block, "model_name", None) != "minimax-h3" or not hasattr(
+                block, "loop_step"
+            ):
+                continue
+            previous = block.__dict__.get("progress_bar", missing)
+            original = block.progress_bar
+
+            def tracked_progress_bar(*args, _original=original, **kwargs):
+                return ProgressBarWrapper(_original(*args, **kwargs))
+
+            block.progress_bar = tracked_progress_bar
+            patched_blocks.append((block, previous))
+
+        try:
+            yield
+        finally:
+            for block, previous in patched_blocks:
+                if previous is missing:
+                    del block.progress_bar
+                else:
+                    block.progress_bar = previous
+
+    @staticmethod
+    def _encode_minimax_h3_output(output: dict) -> List[str]:
+        from diffusers.utils import encode_video
+
+        os.makedirs(XINFERENCE_VIDEO_DIR, exist_ok=True)
+        video_outputs = output["videos"]
+        if hasattr(video_outputs, "ndim"):
+            video_outputs = (
+                list(video_outputs) if video_outputs.ndim == 5 else [video_outputs]
+            )
+        elif video_outputs and (
+            isinstance(video_outputs[0], (PIL.Image.Image, np.ndarray))
+            or getattr(video_outputs[0], "ndim", 0) == 3
+        ):
+            video_outputs = [video_outputs]
+
+        audio_outputs = output.get("audio")
+        if audio_outputs is None:
+            audio_outputs = [None] * len(video_outputs)
+        elif hasattr(audio_outputs, "ndim"):
+            audio_outputs = (
+                list(audio_outputs) if audio_outputs.ndim == 3 else [audio_outputs]
+            )
+        elif not isinstance(audio_outputs, list):
+            audio_outputs = [audio_outputs]
+
+        sampling_rate = output.get("sampling_rate")
+        urls = []
+        for index, video in enumerate(video_outputs):
+            path = os.path.join(XINFERENCE_VIDEO_DIR, uuid.uuid4().hex + ".mp4")
+            audio = audio_outputs[index] if index < len(audio_outputs) else None
+            encode_video(
+                video,
+                fps=24,
+                output_path=path,
+                audio=audio,
+                audio_sample_rate=sampling_rate,
+            )
+            urls.append(path)
+        return urls
 
     def _process_image(self, image: PIL.Image.Image, max_area: int) -> PIL.Image.Image:
         assert self._model is not None
@@ -475,6 +882,10 @@ class DiffusersVideoModel:
             )
             p = export(f, path, fps=fps)
             urls.append(p)
+        return self._video_urls_to_response(urls, response_format)
+
+    @staticmethod
+    def _video_urls_to_response(urls: List[str], response_format: str):
         if response_format == "url":
             return VideoList(
                 created=int(time.time()),

--- a/xinference/model/video/model_spec.json
+++ b/xinference/model/video/model_spec.json
@@ -530,7 +530,7 @@
     },
     "virtualenv": {
       "packages": [
-        "git+https://github.com/huggingface/diffusers",
+        "git+https://github.com/huggingface/diffusers@2da7040be1a2e5f2fcbc8b985083342a308f5a86",
         "transformers>=5.15.0,<6.0",
         "peft==0.18.0",
         "huggingface-hub>=1.23.0,<2.0",

--- a/xinference/model/video/model_spec.json
+++ b/xinference/model/video/model_spec.json
@@ -510,5 +510,53 @@
     },
     "updated_at": 1786492826,
     "featured": false
+  },
+  {
+    "version": 2,
+    "model_name": "MiniMax-H3",
+    "model_family": "MiniMax-H3",
+    "model_ability": [
+      "text2video",
+      "image2video",
+      "firstlastframe2video"
+    ],
+    "default_model_config": {
+      "quantization": "int4",
+      "group_offload": true,
+      "torch_dtype": "bfloat16"
+    },
+    "default_generate_config": {
+      "num_frames": 124
+    },
+    "virtualenv": {
+      "packages": [
+        "git+https://github.com/huggingface/diffusers",
+        "transformers>=5.15.0,<6.0",
+        "peft==0.18.0",
+        "huggingface-hub>=1.23.0,<2.0",
+        "safetensors>=0.8.0",
+        "torchao>=0.16.0",
+        "xformers>=0.0.34",
+        "av",
+        "imageio-ffmpeg",
+        "imageio",
+        "#system_torch#",
+        "#system_torchvision#",
+        "#system_numpy#"
+      ],
+      "no_build_isolation": true
+    },
+    "model_src": {
+      "huggingface": {
+        "model_id": "MiniMaxAI/MiniMax-H3",
+        "model_revision": "6818f6c32d12b210915e44ad56a4228c2608f160"
+      },
+      "modelscope": {
+        "model_id": "MiniMax/MiniMax-H3",
+        "model_revision": "master"
+      }
+    },
+    "updated_at": 1786685986,
+    "featured": false
   }
 ]

--- a/xinference/model/video/tests/test_minimax_h3_video.py
+++ b/xinference/model/video/tests/test_minimax_h3_video.py
@@ -16,6 +16,7 @@ import types
 from pathlib import Path
 
 import numpy as np
+import pytest
 from PIL import Image
 
 from .. import diffusers as diffusers_module
@@ -369,6 +370,33 @@ def test_minimax_h3_forwards_workflows_and_muxes_audio(monkeypatch, tmp_path):
     )
     assert calls[2]["image"] is image
     assert calls[2]["last_image"] is last_image
+    assert len(list(tmp_path.glob("*.mp4"))) == 2
+
+
+def test_minimax_h3_cleans_up_partial_outputs_on_failure(monkeypatch, tmp_path):
+    video_path = tmp_path / "partial.mp4"
+    video_path.write_bytes(b"partial")
+
+    class FailingPipeline:
+        def __init__(self):
+            self.call_count = 0
+
+        def __call__(self, **kwargs):
+            self.call_count += 1
+            if self.call_count == 2:
+                raise RuntimeError("generation failed")
+            return {}
+
+    model = DiffusersVideoModel("mock", "/tmp/minimax-h3", _model_spec())
+    model._model = FailingPipeline()
+    monkeypatch.setattr(
+        model, "_encode_minimax_h3_output", lambda output: [str(video_path)]
+    )
+
+    with pytest.raises(RuntimeError, match="generation failed"):
+        model.text_to_video("a red fox", n=2)
+
+    assert not video_path.exists()
 
 
 def test_minimax_h3_progress_tolerates_pipeline_without_blocks():

--- a/xinference/model/video/tests/test_minimax_h3_video.py
+++ b/xinference/model/video/tests/test_minimax_h3_video.py
@@ -80,12 +80,17 @@ def test_minimax_h3_loads_modular_pipeline(monkeypatch):
     fake_diffusers.ModularPipeline = FakePipeline
     monkeypatch.setitem(sys.modules, "diffusers", fake_diffusers)
 
-    model = DiffusersVideoModel("mock", "/tmp/minimax-h3", _model_spec())
-    model._kwargs["quantization"] = "none"
+    model = DiffusersVideoModel(
+        "mock",
+        "/tmp/minimax-h3",
+        _model_spec(),
+        quantization="none",
+        onload_device="cuda:1",
+    )
     model.load()
 
     assert calls["offload"] == {
-        "device": "cuda",
+        "device": "cuda:1",
         "memory_reserve_margin": "12GB",
     }
     model_path, from_pretrained_kwargs = calls["from_pretrained"]
@@ -364,3 +369,14 @@ def test_minimax_h3_forwards_workflows_and_muxes_audio(monkeypatch, tmp_path):
     )
     assert calls[2]["image"] is image
     assert calls[2]["last_image"] is last_image
+
+
+def test_minimax_h3_progress_tolerates_pipeline_without_blocks():
+    class FakeProgressor:
+        request_id = "request"
+
+    pipeline = types.SimpleNamespace()
+    with DiffusersVideoModel._track_minimax_h3_progress(
+        pipeline, FakeProgressor(), 0, 1
+    ):
+        pass

--- a/xinference/model/video/tests/test_minimax_h3_video.py
+++ b/xinference/model/video/tests/test_minimax_h3_video.py
@@ -399,6 +399,39 @@ def test_minimax_h3_cleans_up_partial_outputs_on_failure(monkeypatch, tmp_path):
     assert not video_path.exists()
 
 
+def test_minimax_h3_cleans_up_outputs_when_encoding_fails(monkeypatch, tmp_path):
+    call_count = 0
+
+    def failing_encode_video(video, *, output_path, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        Path(output_path).write_bytes(b"partial")
+        if call_count == 2:
+            raise RuntimeError("encoding failed")
+
+    fake_utils = types.ModuleType("diffusers.utils")
+    fake_utils.encode_video = failing_encode_video
+    fake_diffusers = types.ModuleType("diffusers")
+    fake_diffusers.utils = fake_utils
+    monkeypatch.setitem(sys.modules, "diffusers", fake_diffusers)
+    monkeypatch.setitem(sys.modules, "diffusers.utils", fake_utils)
+    monkeypatch.setattr(diffusers_module, "XINFERENCE_VIDEO_DIR", str(tmp_path))
+
+    output = {
+        "videos": [
+            [np.zeros((2, 2, 3), dtype=np.uint8)],
+            [np.zeros((2, 2, 3), dtype=np.uint8)],
+        ],
+        "audio": None,
+        "sampling_rate": 32000,
+    }
+    with pytest.raises(RuntimeError, match="encoding failed"):
+        DiffusersVideoModel._encode_minimax_h3_output(output)
+
+    assert call_count == 2
+    assert not list(tmp_path.glob("*.mp4"))
+
+
 def test_minimax_h3_progress_tolerates_pipeline_without_blocks():
     class FakeProgressor:
         request_id = "request"

--- a/xinference/model/video/tests/test_minimax_h3_video.py
+++ b/xinference/model/video/tests/test_minimax_h3_video.py
@@ -1,0 +1,366 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import sys
+import types
+from pathlib import Path
+
+import numpy as np
+from PIL import Image
+
+from .. import diffusers as diffusers_module
+from .. import load_model_family_from_json
+from ..core import VideoModelFamilyV2, match_diffusion
+from ..diffusers import DiffusersVideoModel
+
+
+def _model_spec():
+    return VideoModelFamilyV2(
+        version=2,
+        model_name="MiniMax-H3",
+        model_family="MiniMax-H3",
+        model_id="MiniMaxAI/MiniMax-H3",
+        model_revision="test-revision",
+        model_ability=["text2video", "image2video", "firstlastframe2video"],
+        default_model_config={
+            "quantization": "int4",
+            "group_offload": True,
+            "torch_dtype": "bfloat16",
+        },
+        default_generate_config={"num_frames": 124},
+        cache_config=None,
+        virtualenv={"packages": []},
+    )
+
+
+def test_minimax_h3_selects_modelscope_source(monkeypatch):
+    import xinference.model.video as video_module
+
+    model_families = {}
+    load_model_family_from_json("model_spec.json", model_families)
+    monkeypatch.setattr(video_module, "BUILTIN_VIDEO_MODELS", model_families)
+    monkeypatch.setenv("XINFERENCE_MODEL_SRC", "modelscope")
+
+    model_spec = match_diffusion("MiniMax-H3")
+
+    assert model_spec.model_hub == "modelscope"
+    assert model_spec.model_id == "MiniMax/MiniMax-H3"
+    assert model_spec.model_revision == "master"
+    assert model_spec.default_model_config["quantization"] == "int4"
+
+
+def test_minimax_h3_loads_modular_pipeline(monkeypatch):
+    calls = {}
+
+    class FakeComponentsManager:
+        def enable_auto_cpu_offload(self, **kwargs):
+            calls["offload"] = kwargs
+
+    class FakePipeline:
+        @classmethod
+        def from_pretrained(cls, model_path, **kwargs):
+            calls["from_pretrained"] = (model_path, kwargs)
+            return cls()
+
+        def load_components(self, **kwargs):
+            calls["load_components"] = kwargs
+
+    fake_diffusers = types.ModuleType("diffusers")
+    fake_diffusers.ComponentsManager = FakeComponentsManager
+    fake_diffusers.ModularPipeline = FakePipeline
+    monkeypatch.setitem(sys.modules, "diffusers", fake_diffusers)
+
+    model = DiffusersVideoModel("mock", "/tmp/minimax-h3", _model_spec())
+    model._kwargs["quantization"] = "none"
+    model.load()
+
+    assert calls["offload"] == {
+        "device": "cuda",
+        "memory_reserve_margin": "12GB",
+    }
+    model_path, from_pretrained_kwargs = calls["from_pretrained"]
+    assert model_path == "/tmp/minimax-h3"
+    assert list(from_pretrained_kwargs) == ["components_manager"]
+    assert isinstance(model._model, FakePipeline)
+    assert calls["load_components"]["workflow"] == "t2va"
+    assert (
+        calls["load_components"]["pretrained_model_name_or_path"] == "/tmp/minimax-h3"
+    )
+
+
+def test_minimax_h3_defaults_to_int4_and_group_offload(monkeypatch):
+    import torch
+
+    calls = {}
+
+    class FakeInt8WeightOnlyConfig:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    class FakeInt4WeightOnlyConfig(FakeInt8WeightOnlyConfig):
+        pass
+
+    class FakeQuantizationConfig:
+        def __init__(self, quant_type, modules_to_not_convert):
+            self.quant_type = quant_type
+            self.modules_to_not_convert = modules_to_not_convert
+
+    class FakeComponent:
+        def __init__(self, name):
+            self.name = name
+
+        def requires_grad_(self, value):
+            calls.setdefault("requires_grad", []).append((self.name, value))
+
+        def enable_group_offload(self, **kwargs):
+            calls["transformer_group_offload"] = kwargs
+
+        def to(self, device):
+            calls.setdefault("to", []).append((self.name, device))
+            return self
+
+    class FakeTextEncoder(FakeComponent):
+        def __init__(self):
+            super().__init__("text_encoder")
+            self.model = FakeComponent("text_encoder.model")
+
+    class FakeTransformer:
+        @classmethod
+        def from_pretrained(cls, model_path, **kwargs):
+            calls["transformer_from_pretrained"] = (model_path, kwargs)
+            return FakeComponent("transformer")
+
+    class FakeTextEncoderClass:
+        @classmethod
+        def from_pretrained(cls, model_path, **kwargs):
+            calls["text_encoder_from_pretrained"] = (model_path, kwargs)
+            return FakeTextEncoder()
+
+    class FakePipeline:
+        def __init__(self):
+            self.vae = FakeComponent("vae")
+            self.audio_vae = FakeComponent("audio_vae")
+
+        @classmethod
+        def from_pretrained(cls, model_path):
+            calls["from_pretrained"] = model_path
+            return cls()
+
+        def update_components(self, **kwargs):
+            calls["update_components"] = kwargs
+            self.transformer = kwargs["transformer"]
+            self.text_encoder = kwargs["text_encoder"]
+
+        def load_components(self, **kwargs):
+            calls["load_components"] = kwargs
+
+    def fake_apply_group_offloading(module, **kwargs):
+        calls["text_encoder_group_offload"] = (module, kwargs)
+
+    fake_hooks = types.ModuleType("diffusers.hooks")
+    fake_hooks.apply_group_offloading = fake_apply_group_offloading
+    fake_diffusers_modeling_utils = types.ModuleType("diffusers.models.modeling_utils")
+    original_diffusers_dispatch = object()
+    fake_diffusers_modeling_utils.dispatch_model = original_diffusers_dispatch
+    fake_diffusers_models = types.ModuleType("diffusers.models")
+    fake_diffusers_models.modeling_utils = fake_diffusers_modeling_utils
+    fake_diffusers = types.ModuleType("diffusers")
+    fake_diffusers.ModularPipeline = FakePipeline
+    fake_diffusers.MiniMaxH3Transformer3DModel = FakeTransformer
+    fake_diffusers.TorchAoConfig = FakeQuantizationConfig
+    fake_diffusers.hooks = fake_hooks
+    fake_transformers = types.ModuleType("transformers")
+    fake_transformers.Qwen3VLForConditionalGeneration = FakeTextEncoderClass
+    fake_transformers.TorchAoConfig = FakeQuantizationConfig
+    fake_transformers_modeling_utils = types.ModuleType("transformers.modeling_utils")
+    original_transformers_dispatch = object()
+    fake_transformers_modeling_utils.accelerate_dispatch = (
+        original_transformers_dispatch
+    )
+    fake_transformers.modeling_utils = fake_transformers_modeling_utils
+    fake_torchao = types.ModuleType("torchao")
+    fake_torchao_quantization = types.ModuleType("torchao.quantization")
+    fake_torchao_quantization.Int4WeightOnlyConfig = FakeInt4WeightOnlyConfig
+    fake_torchao_quantization.Int8WeightOnlyConfig = FakeInt8WeightOnlyConfig
+    fake_torchao.quantization = fake_torchao_quantization
+    monkeypatch.setitem(sys.modules, "diffusers", fake_diffusers)
+    monkeypatch.setitem(sys.modules, "diffusers.hooks", fake_hooks)
+    monkeypatch.setitem(sys.modules, "diffusers.models", fake_diffusers_models)
+    monkeypatch.setitem(
+        sys.modules, "diffusers.models.modeling_utils", fake_diffusers_modeling_utils
+    )
+    monkeypatch.setitem(sys.modules, "transformers", fake_transformers)
+    monkeypatch.setitem(
+        sys.modules, "transformers.modeling_utils", fake_transformers_modeling_utils
+    )
+    monkeypatch.setitem(sys.modules, "torchao", fake_torchao)
+    monkeypatch.setitem(sys.modules, "torchao.quantization", fake_torchao_quantization)
+
+    model = DiffusersVideoModel("mock", "/tmp/minimax-h3", _model_spec())
+    model.load()
+
+    transformer_path, transformer_kwargs = calls["transformer_from_pretrained"]
+    assert transformer_path == "/tmp/minimax-h3"
+    assert transformer_kwargs["dtype"] == torch.bfloat16
+    assert transformer_kwargs["low_cpu_mem_usage"] is True
+    assert transformer_kwargs["device_map"][""] == torch.device("cuda")
+    assert transformer_kwargs["device_map"]["token_refiner"] == "cpu"
+    assert transformer_kwargs["device_map"]["transformer_blocks.46"] == "cpu"
+    assert transformer_kwargs["device_map"]["transformer_blocks.49"] == "cpu"
+    assert "transformer_blocks.45" not in transformer_kwargs["device_map"]
+    assert transformer_kwargs["quantization_config"].quant_type.kwargs == {
+        "group_size": 128,
+        "int4_packing_format": "tile_packed_to_4d",
+        "version": 2,
+    }
+    assert "proj_in" in transformer_kwargs["quantization_config"].modules_to_not_convert
+
+    text_encoder_kwargs = calls["text_encoder_from_pretrained"][1]
+    assert text_encoder_kwargs["dtype"] == torch.bfloat16
+    assert text_encoder_kwargs["low_cpu_mem_usage"] is True
+    assert text_encoder_kwargs["device_map"] == {
+        "": torch.device("cuda"),
+        "model.visual": "cpu",
+        "model.language_model.embed_tokens": "cpu",
+        "model.language_model.norm": "cpu",
+        "lm_head": "cpu",
+    }
+    assert (
+        "model.visual"
+        in text_encoder_kwargs["quantization_config"].modules_to_not_convert
+    )
+    assert calls["load_components"]["workflow"] == "t2va"
+    assert (
+        calls["load_components"]["pretrained_model_name_or_path"] == "/tmp/minimax-h3"
+    )
+    assert calls["transformer_group_offload"]["offload_type"] == "block_level"
+    assert calls["transformer_group_offload"]["num_blocks_per_group"] == 1
+    assert calls["transformer_group_offload"]["use_stream"] is False
+    assert calls["text_encoder_group_offload"][0].name == "text_encoder.model"
+    assert fake_diffusers_modeling_utils.dispatch_model is original_diffusers_dispatch
+    assert (
+        fake_transformers_modeling_utils.accelerate_dispatch
+        is original_transformers_dispatch
+    )
+    assert [name for name, _ in calls["to"]].count("transformer") == 1
+    assert [name for name, _ in calls["to"]].count("text_encoder") == 1
+    assert {name for name, _ in calls["to"]} == {
+        "transformer",
+        "text_encoder",
+        "vae",
+        "audio_vae",
+    }
+
+
+def test_minimax_h3_forwards_workflows_and_muxes_audio(monkeypatch, tmp_path):
+    calls = []
+
+    class FakeProgressBar:
+        def __init__(self, total):
+            self.total = total
+            self.n = 0
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            return False
+
+        def update(self, count=1):
+            self.n += count
+
+    class MiniMaxH3DenoiseStep:
+        model_name = "minimax-h3"
+
+        def progress_bar(self, total):
+            return FakeProgressBar(total)
+
+        def loop_step(self):
+            pass
+
+    denoise = MiniMaxH3DenoiseStep()
+
+    class FakePipeline:
+        _blocks = types.SimpleNamespace(sub_blocks={"denoise": denoise})
+
+        def __call__(self, **kwargs):
+            calls.append(kwargs)
+            with denoise.progress_bar(total=kwargs["num_inference_steps"]) as bar:
+                for _ in range(kwargs["num_inference_steps"]):
+                    bar.update()
+            return {
+                "videos": [[np.zeros((2, 2, 3), dtype=np.uint8)]],
+                "audio": np.zeros((1, 2, 4), dtype=np.float32),
+                "sampling_rate": 32000,
+            }
+
+    def fake_encode_video(
+        video, *, fps, output_path, audio, audio_sample_rate, **kwargs
+    ):
+        assert fps == 24
+        assert audio is not None
+        assert audio_sample_rate == 32000
+        Path(output_path).write_bytes(b"mp4-with-audio")
+
+    fake_utils = types.ModuleType("diffusers.utils")
+    fake_utils.encode_video = fake_encode_video
+    fake_diffusers = types.ModuleType("diffusers")
+    fake_diffusers.utils = fake_utils
+    monkeypatch.setitem(sys.modules, "diffusers", fake_diffusers)
+    monkeypatch.setitem(sys.modules, "diffusers.utils", fake_utils)
+    monkeypatch.setattr(diffusers_module, "XINFERENCE_VIDEO_DIR", str(tmp_path))
+
+    model = DiffusersVideoModel("mock", "/tmp/minimax-h3", _model_spec())
+    model._model = FakePipeline()
+
+    class FakeProgressor:
+        request_id = "request"
+
+        def __init__(self):
+            self.progress = None
+            self.progress_updates = []
+
+        def set_progress(self, value):
+            self.progress = value
+            self.progress_updates.append(value)
+
+    progressor = FakeProgressor()
+    result = model.text_to_video(
+        "a red fox",
+        num_inference_steps=3,
+        negative_prompt="ignored",
+        guidance_scale=7,
+        response_format="b64_json",
+        progressor=progressor,
+    )
+
+    assert result["data"][0]["b64_json"] is not None
+    assert calls[0]["num_frames"] == 124
+    assert calls[0]["num_inference_steps"] == 3
+    assert calls[0]["output"] == ["videos", "audio", "sampling_rate"]
+    assert "negative_prompt" not in calls[0]
+    assert "guidance_scale" not in calls[0]
+    assert progressor.progress == 1.0
+    assert progressor.progress_updates[:3] == [1 / 3, 2 / 3, 1.0]
+    assert "progress_bar" not in denoise.__dict__
+
+    image = Image.new("RGB", (2, 2))
+    model.image_to_video(image, "animate it", response_format="url")
+    assert calls[1]["image"] is image
+
+    last_image = Image.new("RGB", (2, 2), color="white")
+    model.firstlastframe_to_video(
+        image, last_image, "transition", response_format="url"
+    )
+    assert calls[2]["image"] is image
+    assert calls[2]["last_image"] is last_image


### PR DESCRIPTION
## Summary

- register MiniMax-H3 for text-to-video, image-to-video, and first/last-frame-to-video workflows
- support Hugging Face and ModelScope model sources with an isolated virtual environment
- default to TorchAO INT4 plus group offload so the model can load on a 24 GB consumer GPU
- preserve INT8 and unquantized BF16 loading options, and document their memory trade-offs
- mux the generated 24 FPS video and audio output and report denoising progress to the Xinference progress API

## Why

MiniMax-H3 uses Diffusers' experimental ModularPipeline and has two very large model components. A normal BF16 load does not fit consumer hardware, while a straightforward INT4 load temporarily exceeds 24 GB during quantization and Accelerate redispatch. The implementation streams quantization across CUDA and CPU, keeps selected BF16 modules on CPU, suppresses the unnecessary load-time redispatch, and hands runtime movement to Diffusers group offload.

ModularPipeline's H3 denoiser also updates its own progress bar instead of invoking the standard `callback_on_step_end`. Xinference now wraps that request-local progress bar so `/v1/requests/{request_id}/progress` advances during generation.

## Validation

- `python -m pytest xinference/model/video/tests/test_minimax_h3_video.py -q` (4 passed locally and on the GPU host)
- `pre-commit run --files ...` for all six changed files (Black, Ruff, isort, mypy, codespell passed)
- full real-weight INT4 load from ModelScope on an RTX 3090 Ti completed successfully; peak CUDA allocation was about 19.4 GiB and peak process RSS was about 51.9 GiB
