### PR TITLE
fix: mirror sdists with broken metadata builds

### DIFF
--- a/xinference/deploy/docker/pypiserver/download_packages.py
+++ b/xinference/deploy/docker/pypiserver/download_packages.py
@@ -35,6 +35,7 @@ Writes ``report.json`` with size/version statistics next to the manifest.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import subprocess
@@ -42,13 +43,18 @@ import sys
 from collections import defaultdict
 from pathlib import Path
 from typing import Dict, List, Optional, Set, Tuple
+from urllib.parse import urljoin
+from urllib.request import Request, urlopen
 
 from packaging.requirements import InvalidRequirement, Requirement
 from packaging.utils import (
+    InvalidSdistFilename,
     InvalidWheelFilename,
     canonicalize_name,
+    parse_sdist_filename,
     parse_wheel_filename,
 )
+from packaging.version import InvalidVersion, Version
 
 TORCH_FAMILY = ("torch", "torchvision", "torchaudio", "torchcodec")
 
@@ -199,6 +205,108 @@ def pip_download(
     return run(cmd + args, env=env)
 
 
+def download_sdist_without_metadata(
+    spec: str,
+    dest: Path,
+    *,
+    index_url: str,
+    python_version: str,
+) -> Optional[Path]:
+    """Fetch the newest compatible sdist without invoking its build backend.
+
+    ``pip download`` prepares package metadata even when the requested artifact
+    is an sdist. Some valid source distributions import runtime-only packages
+    from ``setup.py`` while doing that (``flash-attn`` imports torch), which
+    makes mirroring fail before pip can save the archive. The Simple API already
+    exposes filenames, Python requirements and hashes, so use it as a last
+    resort after normal constrained and unconstrained pip downloads fail.
+
+    Only sdists from a PEP 691 JSON response are accepted, and their SHA-256
+    digest is verified before the archive is added to the mirror.
+    """
+
+    try:
+        requirement = Requirement(spec)
+        target_python = Version(python_version)
+    except (InvalidRequirement, InvalidVersion):
+        return None
+    if requirement.url is not None:
+        return None
+
+    project = canonicalize_name(requirement.name)
+    project_url = f"{index_url.rstrip('/')}/{project}/"
+    request = Request(
+        project_url,
+        headers={"Accept": "application/vnd.pypi.simple.v1+json"},
+    )
+    try:
+        with urlopen(request, timeout=30) as response:
+            payload = json.load(response)
+    except (OSError, ValueError):
+        return None
+
+    candidates: Dict[Version, List[Dict[str, object]]] = defaultdict(list)
+    for file_info in payload.get("files", []):
+        if not isinstance(file_info, dict) or file_info.get("yanked"):
+            continue
+        filename = file_info.get("filename")
+        if not isinstance(filename, str) or Path(filename).name != filename:
+            continue
+        try:
+            name, version = parse_sdist_filename(filename)
+        except InvalidSdistFilename:
+            continue
+        if canonicalize_name(name) != project:
+            continue
+        requires_python = file_info.get("requires-python")
+        if isinstance(requires_python, str):
+            try:
+                if not Requirement(f"python{requires_python}").specifier.contains(
+                    target_python, prereleases=True
+                ):
+                    continue
+            except InvalidRequirement:
+                continue
+        hashes = file_info.get("hashes")
+        if not isinstance(hashes, dict) or not isinstance(hashes.get("sha256"), str):
+            continue
+        if not isinstance(file_info.get("url"), str):
+            continue
+        candidates[version].append(file_info)
+
+    allowed_versions = list(requirement.specifier.filter(candidates))
+    if not allowed_versions:
+        return None
+    selected_version = max(allowed_versions)
+    selected = sorted(
+        candidates[selected_version], key=lambda item: str(item["filename"])
+    )[0]
+    filename = str(selected["filename"])
+    expected_sha256 = str(selected["hashes"]["sha256"])  # type: ignore[index]
+    artifact_url = urljoin(project_url, str(selected["url"]))
+    target = dest / filename
+    partial = dest / (filename + ".part")
+    digest = hashlib.sha256()
+    try:
+        with urlopen(artifact_url, timeout=60) as response, partial.open("wb") as f:
+            while chunk := response.read(1024 * 1024):
+                digest.update(chunk)
+                f.write(chunk)
+        if digest.hexdigest() != expected_sha256:
+            partial.unlink(missing_ok=True)
+            return None
+        partial.replace(target)
+    except OSError:
+        partial.unlink(missing_ok=True)
+        return None
+    print(
+        f"WARN: downloaded sdist '{filename}' directly from the Simple API "
+        "because its metadata build failed",
+        flush=True,
+    )
+    return target
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--manifest-dir", type=Path, required=True)
@@ -240,6 +348,7 @@ def main() -> None:
     # (manylinux_2_17) would hide e.g. recent sglang releases.
     python_platform = f"{machine}-manylinux_2_34"
     unconstrained_fallbacks: List[str] = []
+    raw_sdist_fallbacks: List[str] = []
     sdist_left: List[str] = []
 
     # ------------------------------------------------------------------
@@ -372,7 +481,15 @@ def main() -> None:
                 env=package_build_env,
             )
             if proc.returncode != 0:
-                sys.exit(f"FATAL: pin '{spec}' cannot be downloaded")
+                sdist = download_sdist_without_metadata(
+                    spec,
+                    dest,
+                    index_url=args.index_url,
+                    python_version=args.python_version,
+                )
+                if sdist is None:
+                    sys.exit(f"FATAL: pin '{spec}' cannot be downloaded")
+                raw_sdist_fallbacks.append(spec)
             unconstrained_fallbacks.append(spec)
 
     # ------------------------------------------------------------------
@@ -499,6 +616,7 @@ def main() -> None:
     report: Dict[str, object] = {
         "runtime_constraints": list(runtime_pins.values()),
         "unconstrained_fallbacks": unconstrained_fallbacks,
+        "raw_sdist_fallbacks": raw_sdist_fallbacks,
         "sdist_left": sdist_left,
         "file_count": len(files),
         "total_size_bytes": total_size,

--- a/xinference/deploy/docker/pypiserver/download_packages.py
+++ b/xinference/deploy/docker/pypiserver/download_packages.py
@@ -41,6 +41,7 @@ import os
 import subprocess
 import sys
 from collections import defaultdict
+from http.client import HTTPException
 from pathlib import Path
 from typing import Dict, List, Optional, Set, Tuple
 from urllib.parse import urljoin
@@ -242,7 +243,9 @@ def download_sdist_without_metadata(
     try:
         with urlopen(request, timeout=30) as response:
             payload = json.load(response)
-    except (OSError, ValueError):
+        if not isinstance(payload, dict) or not isinstance(payload.get("files"), list):
+            return None
+    except (HTTPException, OSError, ValueError):
         return None
 
     candidates: Dict[Version, List[Dict[str, object]]] = defaultdict(list)
@@ -282,7 +285,7 @@ def download_sdist_without_metadata(
         candidates[selected_version], key=lambda item: str(item["filename"])
     )[0]
     filename = str(selected["filename"])
-    expected_sha256 = str(selected["hashes"]["sha256"])  # type: ignore[index]
+    expected_sha256 = str(selected["hashes"]["sha256"]).lower()  # type: ignore[index]
     artifact_url = urljoin(project_url, str(selected["url"]))
     target = dest / filename
     partial = dest / (filename + ".part")
@@ -296,7 +299,7 @@ def download_sdist_without_metadata(
             partial.unlink(missing_ok=True)
             return None
         partial.replace(target)
-    except OSError:
+    except (HTTPException, OSError):
         partial.unlink(missing_ok=True)
         return None
     print(

--- a/xinference/deploy/docker/pypiserver/tests/test_scripts.py
+++ b/xinference/deploy/docker/pypiserver/tests/test_scripts.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import hashlib
 import importlib.util
+import io
 import json
 import subprocess
 import sys
@@ -174,6 +176,65 @@ def test_pip_download_forwards_package_build_environment(monkeypatch, tmp_path):
     )
 
     assert calls[0][1]["env"] is build_env
+
+
+def test_download_sdist_without_metadata_uses_simple_api(monkeypatch, tmp_path):
+    downloader = _load_script("download_packages")
+    content = b"source distribution"
+    digest = hashlib.sha256(content).hexdigest()
+    simple_payload = json.dumps(
+        {
+            "files": [
+                {
+                    "filename": "flash_attn-2.8.3.tar.gz",
+                    "url": "../../files/flash_attn-2.8.3.tar.gz",
+                    "hashes": {"sha256": digest},
+                    "requires-python": ">=3.9",
+                    "yanked": False,
+                },
+                {
+                    "filename": "flash_attn-2.8.3.post1.tar.gz",
+                    "url": "../../files/flash_attn-2.8.3.post1.tar.gz",
+                    "hashes": {"sha256": digest},
+                    "requires-python": ">=3.9",
+                    "yanked": False,
+                },
+                {
+                    "filename": "flash_attn-2.9.0.tar.gz",
+                    "url": "../../files/flash_attn-2.9.0.tar.gz",
+                    "hashes": {"sha256": digest},
+                    "requires-python": ">=3.13",
+                    "yanked": False,
+                },
+            ]
+        }
+    ).encode()
+    urls = []
+
+    def fake_urlopen(request, timeout):
+        url = request.full_url if hasattr(request, "full_url") else request
+        urls.append((url, timeout))
+        if url.endswith("/simple/flash-attn/"):
+            assert "application/vnd.pypi.simple.v1+json" in request.headers["Accept"]
+            return io.BytesIO(simple_payload)
+        assert url.endswith("/files/flash_attn-2.8.3.post1.tar.gz")
+        return io.BytesIO(content)
+
+    monkeypatch.setattr(downloader, "urlopen", fake_urlopen)
+
+    result = downloader.download_sdist_without_metadata(
+        "flash-attn<2.9",
+        tmp_path,
+        index_url="https://example.invalid/simple",
+        python_version="3.12",
+    )
+
+    assert result == tmp_path / "flash_attn-2.8.3.post1.tar.gz"
+    assert result.read_bytes() == content
+    assert urls == [
+        ("https://example.invalid/simple/flash-attn/", 30),
+        ("https://example.invalid/files/flash_attn-2.8.3.post1.tar.gz", 60),
+    ]
 
 
 def test_runtime_constraints_require_exact_pins(tmp_path):

--- a/xinference/deploy/docker/pypiserver/tests/test_scripts.py
+++ b/xinference/deploy/docker/pypiserver/tests/test_scripts.py
@@ -18,6 +18,7 @@ import io
 import json
 import subprocess
 import sys
+from http.client import IncompleteRead
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
 
@@ -181,7 +182,7 @@ def test_pip_download_forwards_package_build_environment(monkeypatch, tmp_path):
 def test_download_sdist_without_metadata_uses_simple_api(monkeypatch, tmp_path):
     downloader = _load_script("download_packages")
     content = b"source distribution"
-    digest = hashlib.sha256(content).hexdigest()
+    digest = hashlib.sha256(content).hexdigest().upper()
     simple_payload = json.dumps(
         {
             "files": [
@@ -235,6 +236,65 @@ def test_download_sdist_without_metadata_uses_simple_api(monkeypatch, tmp_path):
         ("https://example.invalid/simple/flash-attn/", 30),
         ("https://example.invalid/files/flash_attn-2.8.3.post1.tar.gz", 60),
     ]
+
+
+def test_download_sdist_without_metadata_rejects_malformed_simple_api(
+    monkeypatch, tmp_path
+):
+    downloader = _load_script("download_packages")
+    monkeypatch.setattr(
+        downloader, "urlopen", lambda *_args, **_kwargs: io.BytesIO(b"[]")
+    )
+
+    assert (
+        downloader.download_sdist_without_metadata(
+            "flash-attn",
+            tmp_path,
+            index_url="https://example.invalid/simple",
+            python_version="3.12",
+        )
+        is None
+    )
+
+
+def test_download_sdist_without_metadata_cleans_up_incomplete_download(
+    monkeypatch, tmp_path
+):
+    downloader = _load_script("download_packages")
+    content = b"source distribution"
+    simple_payload = json.dumps(
+        {
+            "files": [
+                {
+                    "filename": "flash_attn-2.8.3.post1.tar.gz",
+                    "url": "../../files/flash_attn-2.8.3.post1.tar.gz",
+                    "hashes": {"sha256": hashlib.sha256(content).hexdigest()},
+                    "requires-python": ">=3.9",
+                    "yanked": False,
+                }
+            ]
+        }
+    ).encode()
+
+    class BrokenResponse(io.BytesIO):
+        def read(self, *_args, **_kwargs):
+            raise IncompleteRead(b"partial")
+
+    responses = iter((io.BytesIO(simple_payload), BrokenResponse(content)))
+    monkeypatch.setattr(
+        downloader, "urlopen", lambda *_args, **_kwargs: next(responses)
+    )
+
+    assert (
+        downloader.download_sdist_without_metadata(
+            "flash-attn",
+            tmp_path,
+            index_url="https://example.invalid/simple",
+            python_version="3.12",
+        )
+        is None
+    )
+    assert not list(tmp_path.iterdir())
 
 
 def test_runtime_constraints_require_exact_pins(tmp_path):


### PR DESCRIPTION
## Summary

- fall back to the PEP 691 Simple API when both constrained and unconstrained `pip download` fail during sdist metadata preparation
- select the newest non-yanked sdist compatible with the requested spec and Python version
- verify the advertised SHA-256 before adding the archive to the offline mirror
- record raw-sdist fallbacks in the build report

## Root cause

The v3.2.0 pypiserver build reaches the new Wan Animate `flash-attn` dependency. PyPI publishes `flash-attn` only as an sdist, and its `setup.py` imports torch while pip prepares metadata. The mirror stage downloads but intentionally does not install the runtime torch wheel, so every available `flash-attn` version fails before pip saves the sdist on both amd64 and arm64.

## Validation

- `pytest -q xinference/deploy/docker/pypiserver/tests/test_scripts.py` (14 passed)
- `pre-commit run --files xinference/deploy/docker/pypiserver/download_packages.py xinference/deploy/docker/pypiserver/tests/test_scripts.py`
- live PyPI fallback fetched and hash-verified `flash_attn-2.8.3.post1.tar.gz`

A no-push run of the exact multi-architecture pypiserver workflow will be dispatched from this branch.