### PR TITLE
fix(audio): correct IndexTTS-2.5 runtime dependencies

### DIFF
--- a/xinference/model/audio/model_spec.json
+++ b/xinference/model/audio/model_spec.json
@@ -2105,8 +2105,7 @@
         "openai-whisper>=20231117",
         "tiktoken",
         "safetensors>=0.5.2",
-        "huggingface-hub",
-        "requests>=2.28",
+        "huggingface-hub>=0.30,<1.0",
         "json5",
         "munch",
         "matplotlib",
@@ -2114,7 +2113,9 @@
         "julius",
         "tensorboard",
         "randomname",
-        "argbind"
+        "argbind",
+        "ffmpy",
+        "importlib-resources"
       ]
     },
     "model_src": {


### PR DESCRIPTION
## Summary

Fix the virtual environment dependencies required to launch IndexTTS-2.5.

The model files could be downloaded successfully, but model startup failed because of an incompatible `huggingface-hub` version and missing runtime packages.

## Changes

- Constrain `huggingface-hub` to `>=0.30,<1.0` to avoid incompatible 1.x releases.
- Remove the redundant direct `requests` constraint and allow the existing dependency stack to resolve a compatible version.
- Add `ffmpy`, which is required by the audio processing dependency chain.
- Add `importlib-resources`, which is imported during model initialization.

These changes are scoped to the IndexTTS-2.5 virtual environment and do not affect other model families.
