### PR TITLE
fix(audio): return playable speech responses

### DIFF
--- a/frontend/src/components/pages/running-model-detail/panels/result-panels.tsx
+++ b/frontend/src/components/pages/running-model-detail/panels/result-panels.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo } from 'react';
+import { useEffect, useState } from 'react';
 import { Binary, ImageIcon, Sparkles } from 'lucide-react';
 
 import ReactMarkdown from '@/components/ui/markdown-renderer';
@@ -168,11 +168,19 @@ function BlobMediaPreview({
   type: MediaType;
   className: string;
 }) {
-  const url = useMemo(() => URL.createObjectURL(blob), [blob]);
+  const [url, setUrl] = useState<string>();
 
   useEffect(() => {
-    return () => URL.revokeObjectURL(url);
-  }, [url]);
+    const expectedMimeType = mediaMimeType(type);
+    const mediaBlob =
+      blob.type === expectedMimeType ? blob : new Blob([blob], { type: expectedMimeType });
+    const objectUrl = URL.createObjectURL(mediaBlob);
+
+    setUrl(objectUrl);
+    return () => URL.revokeObjectURL(objectUrl);
+  }, [blob, type]);
+
+  if (!url) return null;
 
   return <MediaPreview type={type} url={url} className={className} />;
 }

--- a/frontend/src/components/pages/running-model-detail/panels/result-panels.tsx
+++ b/frontend/src/components/pages/running-model-detail/panels/result-panels.tsx
@@ -173,7 +173,9 @@ function BlobMediaPreview({
   useEffect(() => {
     const expectedMimeType = mediaMimeType(type);
     const mediaBlob =
-      blob.type === expectedMimeType ? blob : new Blob([blob], { type: expectedMimeType });
+      blob.type && blob.type !== 'application/octet-stream'
+        ? blob
+        : new Blob([blob], { type: expectedMimeType });
     const objectUrl = URL.createObjectURL(mediaBlob);
 
     setUrl(objectUrl);

--- a/xinference/api/restful_api.py
+++ b/xinference/api/restful_api.py
@@ -106,6 +106,28 @@ from .utils import require_model
 logger = logging.getLogger(__name__)
 
 
+_AUDIO_RESPONSE_MEDIA_TYPES = {
+    "aac": "audio/aac",
+    "flac": "audio/flac",
+    "m4a": "audio/mp4",
+    "mp3": "audio/mpeg",
+    "mpeg": "audio/mpeg",
+    "ogg": "audio/ogg",
+    "opus": "audio/ogg",
+    "pcm": "audio/pcm",
+    "wav": "audio/wav",
+    "wave": "audio/wav",
+    "webm": "audio/webm",
+}
+
+
+def _audio_response_media_type(response_format: Optional[str]) -> str:
+    normalized_format = (response_format or "mp3").lower().lstrip(".")
+    return _AUDIO_RESPONSE_MEDIA_TYPES.get(
+        normalized_format, "application/octet-stream"
+    )
+
+
 def _validate_replica(value: Any) -> int:
     """Validate and convert the ``replica`` field from a JSON payload.
 
@@ -1813,7 +1835,10 @@ class RESTfulAPI(CancelMixin):
                     ping=XINFERENCE_SSE_PING_ATTEMPTS_SECONDS,
                 )
             else:
-                return Response(media_type="application/octet-stream", content=out)
+                return Response(
+                    media_type=_audio_response_media_type(body.response_format),
+                    content=out,
+                )
         except Exception as e:
             e = await self._get_model_last_error(model.uid, e)
             logger.error(e, exc_info=True)


### PR DESCRIPTION
## Summary

Fix generated speech responses being displayed as zero-duration or unplayable audio in the Web UI.

This is a generic audio response and media preview fix.

## Changes

### Backend

- Return the correct audio MIME type for non-streaming `/v1/audio/speech` responses.
- Map supported response formats such as MP3, WAV, FLAC, AAC, OGG, Opus, PCM, M4A, and WebM to their corresponding media types.
- Preserve `application/octet-stream` as the fallback for unknown formats.

### Web UI

- Create and revoke Blob object URLs within the same React effect lifecycle.
- Prevent React Strict Mode effect cleanup from leaving the media element with an already revoked object URL.
- Normalize the Blob MIME type before creating its object URL.

## Scope

The backend change applies to all models served through `/v1/audio/speech`.

The frontend change applies to the shared Blob media preview component used for generated audio, image, and video results.
