### PR TITLE
feat(webui): add IndexTTS emotion controls

### DIFF
--- a/frontend/src/components/pages/running-model-detail/capability-config.tsx
+++ b/frontend/src/components/pages/running-model-detail/capability-config.tsx
@@ -32,6 +32,11 @@ import {
   TextToVideoPanel,
 } from './panels/form-panels';
 import { ResultPanels } from './panels/result-panels';
+import {
+  EMPTY_INDEX_TTS_EMOTION_VECTOR,
+  isIndexTTSEmotionModel,
+  parseIndexTTSEmotionVector,
+} from './emotion-vector-utils.mjs';
 import type { CapabilityConfig, TransformContext } from './types';
 import {
   appendIfPresent,
@@ -673,17 +678,29 @@ export const CAPABILITY_CONFIGS: Partial<Record<ModelAbility, CapabilityConfig>>
       speed: 1,
       prompt_speech: [],
       prompt_text: '',
+      use_emo_vector: false,
+      emo_vector: [...EMPTY_INDEX_TTS_EMOTION_VECTOR],
     },
     formPanel: SpeechPanel,
     resultPanel: ResultPanels.Universal,
     responseType: 'blob',
-    transformValues: ({ modelUid, values }) => {
+    transformValues: ({ modelUid, model, values }) => {
       const promptSpeech = firstUpload(values, 'prompt_speech');
       const kwargs: Record<string, unknown> = {};
       const promptText = stringValue(values.prompt_text).trim();
 
       if (promptText) {
         kwargs.prompt_text = promptText;
+      }
+
+      if (
+        isIndexTTSEmotionModel(model.model_family, model.model_name) &&
+        booleanValue(values.use_emo_vector)
+      ) {
+        const emotionVector = parseIndexTTSEmotionVector(values.emo_vector);
+        if (emotionVector) {
+          kwargs.emo_vector = emotionVector;
+        }
       }
 
       if (promptSpeech) {

--- a/frontend/src/components/pages/running-model-detail/capability-config.tsx
+++ b/frontend/src/components/pages/running-model-detail/capability-config.tsx
@@ -36,7 +36,7 @@ import {
   EMPTY_INDEX_TTS_EMOTION_VECTOR,
   isIndexTTSEmotionModel,
   parseIndexTTSEmotionVector,
-} from './emotion-vector-utils.mjs';
+} from './emotion-vector-utils';
 import type { CapabilityConfig, TransformContext } from './types';
 import {
   appendIfPresent,

--- a/frontend/src/components/pages/running-model-detail/emotion-vector-utils.mjs
+++ b/frontend/src/components/pages/running-model-detail/emotion-vector-utils.mjs
@@ -1,0 +1,53 @@
+export const INDEX_TTS_EMOTION_DIMENSIONS = [
+  { key: 'happy', label: 'Happy' },
+  { key: 'angry', label: 'Angry' },
+  { key: 'sad', label: 'Sad' },
+  { key: 'afraid', label: 'Afraid' },
+  { key: 'disgusted', label: 'Disgusted' },
+  { key: 'melancholic', label: 'Melancholic' },
+  { key: 'surprised', label: 'Surprised' },
+  { key: 'calm', label: 'Calm' },
+];
+
+export const INDEX_TTS_EMOTION_MAX_TOTAL = 0.8;
+
+export const EMPTY_INDEX_TTS_EMOTION_VECTOR = INDEX_TTS_EMOTION_DIMENSIONS.map(() => 0);
+
+const EMOTION_TOTAL_EPSILON = 1e-9;
+
+/**
+ * IndexTTS-2 and IndexTTS-2.5 share the IndexTTS2 model family.
+ * Model-name checks keep the UI working if older runtime metadata omits the family.
+ *
+ * @param {unknown} modelFamily
+ * @param {unknown} modelName
+ */
+export function isIndexTTSEmotionModel(modelFamily, modelName) {
+  return modelFamily === 'IndexTTS2' || modelName === 'IndexTTS2' || modelName === 'IndexTTS-2.5';
+}
+
+/**
+ * Validate and copy the emotion vector accepted by the IndexTTS runtime.
+ *
+ * @param {unknown} value
+ * @returns {number[] | undefined}
+ */
+export function parseIndexTTSEmotionVector(value) {
+  if (!Array.isArray(value) || value.length !== INDEX_TTS_EMOTION_DIMENSIONS.length) {
+    return undefined;
+  }
+
+  if (
+    value.some((item) => typeof item !== 'number' || !Number.isFinite(item) || item < 0 || item > 1)
+  ) {
+    return undefined;
+  }
+
+  const vector = [...value];
+  const total = vector.reduce((sum, item) => sum + item, 0);
+  if (total > INDEX_TTS_EMOTION_MAX_TOTAL + EMOTION_TOTAL_EPSILON) {
+    return undefined;
+  }
+
+  return vector;
+}

--- a/frontend/src/components/pages/running-model-detail/emotion-vector-utils.ts
+++ b/frontend/src/components/pages/running-model-detail/emotion-vector-utils.ts
@@ -7,7 +7,7 @@ export const INDEX_TTS_EMOTION_DIMENSIONS = [
   { key: 'melancholic', label: 'Melancholic' },
   { key: 'surprised', label: 'Surprised' },
   { key: 'calm', label: 'Calm' },
-];
+] as const;
 
 export const INDEX_TTS_EMOTION_MAX_TOTAL = 0.8;
 
@@ -15,24 +15,17 @@ export const EMPTY_INDEX_TTS_EMOTION_VECTOR = INDEX_TTS_EMOTION_DIMENSIONS.map((
 
 const EMOTION_TOTAL_EPSILON = 1e-9;
 
-/**
- * IndexTTS-2 and IndexTTS-2.5 share the IndexTTS2 model family.
- * Model-name checks keep the UI working if older runtime metadata omits the family.
- *
- * @param {unknown} modelFamily
- * @param {unknown} modelName
- */
-export function isIndexTTSEmotionModel(modelFamily, modelName) {
+// IndexTTS-2 and IndexTTS-2.5 share the IndexTTS2 model family.
+// Model-name checks keep the UI working if older runtime metadata omits the family.
+export function isIndexTTSEmotionModel(
+  modelFamily: string | undefined,
+  modelName: string | undefined
+): boolean {
   return modelFamily === 'IndexTTS2' || modelName === 'IndexTTS2' || modelName === 'IndexTTS-2.5';
 }
 
-/**
- * Validate and copy the emotion vector accepted by the IndexTTS runtime.
- *
- * @param {unknown} value
- * @returns {number[] | undefined}
- */
-export function parseIndexTTSEmotionVector(value) {
+// Validate and copy the emotion vector accepted by the IndexTTS runtime.
+export function parseIndexTTSEmotionVector(value: unknown): number[] | undefined {
   if (!Array.isArray(value) || value.length !== INDEX_TTS_EMOTION_DIMENSIONS.length) {
     return undefined;
   }
@@ -43,7 +36,7 @@ export function parseIndexTTSEmotionVector(value) {
     return undefined;
   }
 
-  const vector = [...value];
+  const vector = [...value] as number[];
   const total = vector.reduce((sum, item) => sum + item, 0);
   if (total > INDEX_TTS_EMOTION_MAX_TOTAL + EMOTION_TOTAL_EPSILON) {
     return undefined;

--- a/frontend/src/components/pages/running-model-detail/panels/form-panels.tsx
+++ b/frontend/src/components/pages/running-model-detail/panels/form-panels.tsx
@@ -9,8 +9,10 @@ import { FormField } from '@/components/ui/form-field';
 import { FormList } from '@/components/ui/form-list';
 import { Input } from '@/components/ui/input';
 import { Select } from '@/components/ui/select';
+import { Slider } from '@/components/ui/slider';
 import { Switch } from '@/components/ui/switch';
 import { Textarea } from '@/components/ui/textarea';
+import { useWatch } from '@/hooks/use-form';
 import { ModelAbility } from '@/constants';
 import {
   SAMPLING_METHOD_OPTIONS,
@@ -18,8 +20,15 @@ import {
   OCR_MODEL_SIZE_OPTIONS,
 } from '@/constants/running';
 import type { FileUploadValue } from '@/types/common';
+import type { BaseFormFieldProps } from '@/types/form';
 
 import { ImageEditorCreateMask } from '../components/image-editor-create-mask';
+import {
+  INDEX_TTS_EMOTION_DIMENSIONS,
+  INDEX_TTS_EMOTION_MAX_TOTAL,
+  isIndexTTSEmotionModel,
+  parseIndexTTSEmotionVector,
+} from '../emotion-vector-utils.mjs';
 import type { CapabilityFormProps } from '../types';
 
 const DOCUMENT_BACKEND_OPTIONS = ['pipeline', 'vlm-auto-engine', 'hybrid-auto-engine'].map(
@@ -377,8 +386,73 @@ export function SpeakerEmbeddingPanel() {
   );
 }
 
-export function SpeechPanel({ model }: CapabilityFormProps) {
+function EmotionVectorInput({ value, onChange, disabled, error }: BaseFormFieldProps<number[]>) {
+  const vector = INDEX_TTS_EMOTION_DIMENSIONS.map((_, index) => {
+    const item = value?.[index];
+    return typeof item === 'number' && Number.isFinite(item) ? item : 0;
+  });
+  const total = vector.reduce((sum, item) => sum + item, 0);
+  const totalExceeded = parseIndexTTSEmotionVector(vector) === undefined;
+
+  const updateDimension = (index: number, nextValue: number | string) => {
+    const parsedValue = Number(nextValue);
+    if (!Number.isFinite(parsedValue)) return;
+
+    const nextVector = [...vector];
+    nextVector[index] =
+      Math.round(Math.min(INDEX_TTS_EMOTION_MAX_TOTAL, Math.max(0, parsedValue)) * 100) / 100;
+    onChange?.(nextVector);
+  };
+
+  return (
+    <div
+      className={`space-y-3 rounded-lg border p-3 ${
+        error ? 'border-destructive' : 'border-border'
+      } ${disabled ? 'opacity-60' : ''}`}
+    >
+      {INDEX_TTS_EMOTION_DIMENSIONS.map(({ key, label }, index) => (
+        <div key={key} className="grid grid-cols-[88px_minmax(0,1fr)_64px] items-center gap-3">
+          <span className="truncate text-xs font-medium text-muted-foreground">{label}</span>
+          <Slider
+            aria-label={`${label} emotion weight`}
+            disabled={disabled}
+            min={0}
+            max={INDEX_TTS_EMOTION_MAX_TOTAL}
+            step={0.01}
+            value={[vector[index]]}
+            onValueChange={([nextValue]) => updateDimension(index, nextValue)}
+          />
+          <Input
+            aria-label={`${label} emotion weight value`}
+            className="h-8 px-2 text-right font-mono text-xs"
+            disabled={disabled}
+            error={error}
+            type="number"
+            min={0}
+            max={INDEX_TTS_EMOTION_MAX_TOTAL}
+            step={0.01}
+            value={vector[index]}
+            onChange={(event) => updateDimension(index, event.target.value)}
+          />
+        </div>
+      ))}
+      <div
+        className={`flex justify-end text-xs font-medium ${
+          totalExceeded ? 'text-destructive' : 'text-muted-foreground'
+        }`}
+      >
+        Total: {total.toFixed(2)} / {INDEX_TTS_EMOTION_MAX_TOTAL.toFixed(2)}
+      </div>
+    </div>
+  );
+}
+
+export function SpeechPanel({ form, model }: CapabilityFormProps) {
   const supportsVoiceCloning = model.model_ability.includes(ModelAbility.Text2audioVoiceCloning);
+  const supportsEmotionVector =
+    isIndexTTSEmotionModel(model.model_family, model.model_name) &&
+    model.model_ability.includes(ModelAbility.Text2audioEmotionControl);
+  const emotionVectorEnabled = Boolean(useWatch('use_emo_vector', form));
 
   return (
     <>
@@ -406,6 +480,31 @@ export function SpeechPanel({ model }: CapabilityFormProps) {
             <Textarea placeholder="Text spoken in the prompt audio" />
           </FormField>
         </>
+      )}
+      {supportsEmotionVector && (
+        <div className="space-y-3 rounded-lg bg-muted/30 p-3">
+          <FormField
+            name="use_emo_vector"
+            label="Emotion control"
+            valuePropName="checked"
+            layout="horizontal"
+          >
+            <Switch />
+          </FormField>
+          <FormField
+            name="emo_vector"
+            disabled={!emotionVectorEnabled}
+            rules={[
+              {
+                validator: (value) =>
+                  !emotionVectorEnabled || parseIndexTTSEmotionVector(value) !== undefined,
+                message: 'Use non-negative emotion values with a total no greater than 0.8.',
+              },
+            ]}
+          >
+            <EmotionVectorInput />
+          </FormField>
+        </div>
       )}
     </>
   );

--- a/frontend/src/components/pages/running-model-detail/panels/form-panels.tsx
+++ b/frontend/src/components/pages/running-model-detail/panels/form-panels.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { Plus, Trash2 } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
@@ -28,7 +28,7 @@ import {
   INDEX_TTS_EMOTION_MAX_TOTAL,
   isIndexTTSEmotionModel,
   parseIndexTTSEmotionVector,
-} from '../emotion-vector-utils.mjs';
+} from '../emotion-vector-utils';
 import type { CapabilityFormProps } from '../types';
 
 const DOCUMENT_BACKEND_OPTIONS = ['pipeline', 'vlm-auto-engine', 'hybrid-auto-engine'].map(
@@ -391,10 +391,34 @@ function EmotionVectorInput({ value, onChange, disabled, error }: BaseFormFieldP
     const item = value?.[index];
     return typeof item === 'number' && Number.isFinite(item) ? item : 0;
   });
+  const [localValues, setLocalValues] = useState<string[]>(() =>
+    vector.map((item) => String(item))
+  );
+
+  useEffect(() => {
+    setLocalValues((previousValues) =>
+      INDEX_TTS_EMOTION_DIMENSIONS.map((_, index) => {
+        const item = value?.[index];
+        const nextValue = typeof item === 'number' && Number.isFinite(item) ? item : 0;
+        const previousValue = previousValues[index];
+
+        return previousValue !== undefined && Number(previousValue) === nextValue
+          ? previousValue
+          : String(nextValue);
+      })
+    );
+  }, [value]);
+
   const total = vector.reduce((sum, item) => sum + item, 0);
   const totalExceeded = parseIndexTTSEmotionVector(vector) === undefined;
 
   const updateDimension = (index: number, nextValue: number | string) => {
+    setLocalValues((previousValues) => {
+      const nextValues = [...previousValues];
+      nextValues[index] = String(nextValue);
+      return nextValues;
+    });
+
     const parsedValue = Number(nextValue);
     if (!Number.isFinite(parsedValue)) return;
 
@@ -402,6 +426,14 @@ function EmotionVectorInput({ value, onChange, disabled, error }: BaseFormFieldP
     nextVector[index] =
       Math.round(Math.min(INDEX_TTS_EMOTION_MAX_TOTAL, Math.max(0, parsedValue)) * 100) / 100;
     onChange?.(nextVector);
+  };
+
+  const normalizeDimension = (index: number) => {
+    setLocalValues((previousValues) => {
+      const nextValues = [...previousValues];
+      nextValues[index] = String(vector[index]);
+      return nextValues;
+    });
   };
 
   return (
@@ -431,8 +463,9 @@ function EmotionVectorInput({ value, onChange, disabled, error }: BaseFormFieldP
             min={0}
             max={INDEX_TTS_EMOTION_MAX_TOTAL}
             step={0.01}
-            value={vector[index]}
+            value={localValues[index] ?? ''}
             onChange={(event) => updateDimension(index, event.target.value)}
+            onBlur={() => normalizeDimension(index)}
           />
         </div>
       ))}


### PR DESCRIPTION
## Summary

This PR adds manual emotion control support to the Web UI for IndexTTS2 and IndexTTS-2.5.

Users can enable **Emotion control** in the speech generation panel and adjust the supported emotion weights: happy, angry, sad, afraid, disgusted, melancholic, surprised, and calm.

## Changes

- Show emotion controls only for IndexTTS models that advertise the `Text2audioEmotionControl` capability.
- Provide sliders and numeric inputs for each emotion weight.
- Display and validate the total weight, which must not exceed `0.8`.
- Send `emo_vector` to the speech API only when emotion control is enabled and the vector is valid.
- Keep the existing behavior unchanged for other audio models.

<img width="590" height="1627" alt="7bba8665d6c6577f456c71a1456ec9af" src="https://github.com/user-attachments/assets/1197d3c1-8663-4193-b6fa-7ab77ec36202" />
