### PR TITLE
feat(model): support qwen3.8-27B

### DIFF
--- a/doc/source/models/builtin/llm/index.rst
+++ b/doc/source/models/builtin/llm/index.rst
@@ -721,6 +721,11 @@ The following is a list of built-in LLM in Xinference:
      - 262144
      - Following the February release of the Qwen3.5 series, we're pleased to share the first open-weight variant of Qwen3.6. Built on direct feedback from the community, Qwen3.6 prioritizes stability and real-world utility, offering developers a more intuitive, responsive, and genuinely productive coding experience.
 
+   * - :ref:`qwen3.8 <models_llm_qwen3.8>`
+     - chat, vision, tools, reasoning, hybrid
+     - 262144
+     - Built on the architectural foundation of Qwen3.5, Qwen3.8 delivers substantial gains across coding, professional work, research, and long-horizon agentic tasks. Qwen3.8-27B brings these advances to a compact, deployment-friendly dense model: a native vision-language model that understands images and videos, with flexible thinking control.
+
    * - :ref:`qwenlong-l1 <models_llm_qwenlong-l1>`
      - chat
      - 32768
@@ -1132,6 +1137,8 @@ The following is a list of built-in LLM in Xinference:
    qwen3.5
   
    qwen3.6
+  
+   qwen3.8
   
    qwenlong-l1
   

--- a/doc/source/models/builtin/llm/qwen3.8.rst
+++ b/doc/source/models/builtin/llm/qwen3.8.rst
@@ -1,0 +1,79 @@
+.. _models_llm_qwen3.8:
+
+========================================
+qwen3.8
+========================================
+
+- **Context Length:** 262144
+- **Model Name:** qwen3.8
+- **Languages:** en, zh
+- **Abilities:** chat, vision, tools, reasoning, hybrid
+- **Description:** Built on the architectural foundation of Qwen3.5, Qwen3.8 delivers substantial gains across coding, professional work, research, and long-horizon agentic tasks. Qwen3.8-27B brings these advances to a compact, deployment-friendly dense model: a native vision-language model that understands images and videos, with flexible thinking control.
+
+Specifications
+^^^^^^^^^^^^^^
+
+
+Model Spec 1 (pytorch, 27 Billion)
+++++++++++++++++++++++++++++++++++++++++
+
+- **Model Format:** pytorch
+- **Model Size (in billions):** 27
+- **Quantizations:** none
+- **Engines**: vLLM, Transformers, SGLang
+- **Model ID:** Qwen/Qwen3.8-27B
+- **Model Hubs**:  `Hugging Face <https://huggingface.co/Qwen/Qwen3.8-27B>`__, `ModelScope <https://modelscope.cn/models/Qwen/Qwen3.8-27B>`__
+
+Execute the following command to launch the model, remember to replace ``${quantization}`` with your
+chosen quantization method from the options listed above::
+
+   xinference launch --model-engine ${engine} --model-name qwen3.8 --size-in-billions 27 --model-format pytorch --quantization ${quantization}
+
+
+Model Spec 2 (fp8, 27 Billion)
+++++++++++++++++++++++++++++++++++++++++
+
+- **Model Format:** fp8
+- **Model Size (in billions):** 27
+- **Quantizations:** FP8
+- **Engines**: vLLM, Transformers, SGLang
+- **Model ID:** Qwen/Qwen3.8-27B-FP8
+- **Model Hubs**:  `Hugging Face <https://huggingface.co/Qwen/Qwen3.8-27B-FP8>`__, `ModelScope <https://modelscope.cn/models/Qwen/Qwen3.8-27B-FP8>`__
+
+Execute the following command to launch the model, remember to replace ``${quantization}`` with your
+chosen quantization method from the options listed above::
+
+   xinference launch --model-engine ${engine} --model-name qwen3.8 --size-in-billions 27 --model-format fp8 --quantization ${quantization}
+
+
+Model Spec 3 (ggufv2, 27 Billion)
+++++++++++++++++++++++++++++++++++++++++
+
+- **Model Format:** ggufv2
+- **Model Size (in billions):** 27
+- **Quantizations:** IQ4_NL, IQ4_XS, Q3_K_M, Q3_K_S, Q4_0, Q4_1, Q4_K_M, Q4_K_S, Q5_K_M, Q5_K_S, Q6_K, Q8_0, UD-IQ2_M, UD-IQ2_XXS, UD-IQ3_XXS, UD-Q2_K_XL, UD-Q3_K_XL, UD-Q4_K_XL, UD-Q5_K_XL, UD-Q6_K_XL, UD-Q8_K_XL
+- **Engines**: llama.cpp
+- **Model ID:** unsloth/Qwen3.8-27B-GGUF
+- **Model Hubs**:  `Hugging Face <https://huggingface.co/unsloth/Qwen3.8-27B-GGUF>`__, `ModelScope <https://modelscope.cn/models/unsloth/Qwen3.8-27B-GGUF>`__
+
+Execute the following command to launch the model, remember to replace ``${quantization}`` with your
+chosen quantization method from the options listed above::
+
+   xinference launch --model-engine ${engine} --model-name qwen3.8 --size-in-billions 27 --model-format ggufv2 --quantization ${quantization}
+
+
+Model Spec 4 (mlx, 27 Billion)
+++++++++++++++++++++++++++++++++++++++++
+
+- **Model Format:** mlx
+- **Model Size (in billions):** 27
+- **Quantizations:** 4bit, 8bit, bf16
+- **Engines**: MLX
+- **Model ID:** mlx-community/Qwen3.8-27B-{quantization}
+- **Model Hubs**:  `Hugging Face <https://huggingface.co/mlx-community/Qwen3.8-27B-{quantization}>`__, `ModelScope <https://modelscope.cn/models/mlx-community/Qwen3.8-27B-{quantization}>`__
+
+Execute the following command to launch the model, remember to replace ``${quantization}`` with your
+chosen quantization method from the options listed above::
+
+   xinference launch --model-engine ${engine} --model-name qwen3.8 --size-in-billions 27 --model-format mlx --quantization ${quantization}
+

--- a/xinference/model/llm/llm_family.json
+++ b/xinference/model/llm/llm_family.json
@@ -31208,6 +31208,195 @@
     "updated_at": 1786693269
   },
   {
+    "model_name": "qwen3.8",
+    "model_description": "Built on the architectural foundation of Qwen3.5, Qwen3.8 delivers substantial gains across coding, professional work, research, and long-horizon agentic tasks. Qwen3.8-27B brings these advances to a compact, deployment-friendly dense model: a native vision-language model that understands images and videos, with flexible thinking control.",
+    "context_length": 262144,
+    "model_lang": [
+      "en",
+      "zh"
+    ],
+    "model_ability": [
+      "chat",
+      "vision",
+      "tools",
+      "reasoning",
+      "hybrid"
+    ],
+    "model_specs": [
+      {
+        "model_size_in_billions": 27,
+        "model_format": "pytorch",
+        "model_src": {
+          "huggingface": {
+            "model_id": "Qwen/Qwen3.8-27B",
+            "quantizations": [
+              "none"
+            ]
+          },
+          "modelscope": {
+            "model_id": "Qwen/Qwen3.8-27B",
+            "quantizations": [
+              "none"
+            ]
+          }
+        }
+      },
+      {
+        "model_size_in_billions": 27,
+        "model_format": "fp8",
+        "model_src": {
+          "huggingface": {
+            "model_id": "Qwen/Qwen3.8-27B-FP8",
+            "quantizations": [
+              "FP8"
+            ]
+          },
+          "modelscope": {
+            "model_id": "Qwen/Qwen3.8-27B-FP8",
+            "quantizations": [
+              "FP8"
+            ]
+          }
+        }
+      },
+      {
+        "model_size_in_billions": 27,
+        "model_format": "ggufv2",
+        "model_src": {
+          "huggingface": {
+            "model_id": "unsloth/Qwen3.8-27B-GGUF",
+            "model_file_name_template": "Qwen3.8-27B-{quantization}.gguf",
+            "model_file_name_split_template": "Qwen3.8-27B-{quantization}-{part}.gguf",
+            "quantizations": [
+              "IQ4_NL",
+              "IQ4_XS",
+              "Q3_K_M",
+              "Q3_K_S",
+              "Q4_0",
+              "Q4_1",
+              "Q4_K_M",
+              "Q4_K_S",
+              "Q5_K_M",
+              "Q5_K_S",
+              "Q6_K",
+              "Q8_0",
+              "UD-IQ2_M",
+              "UD-IQ2_XXS",
+              "UD-IQ3_XXS",
+              "UD-Q2_K_XL",
+              "UD-Q3_K_XL",
+              "UD-Q4_K_XL",
+              "UD-Q5_K_XL",
+              "UD-Q6_K_XL",
+              "UD-Q8_K_XL"
+            ],
+            "quantization_parts": {
+              "BF16": [
+                "00001-of-00002",
+                "00002-of-00002"
+              ]
+            },
+            "multimodal_projectors": [
+              "mmproj-BF16.gguf",
+              "mmproj-F16.gguf"
+            ]
+          },
+          "modelscope": {
+            "model_id": "unsloth/Qwen3.8-27B-GGUF",
+            "model_file_name_template": "Qwen3.8-27B-{quantization}.gguf",
+            "model_file_name_split_template": "Qwen3.8-27B-{quantization}-{part}.gguf",
+            "quantizations": [
+              "IQ4_NL",
+              "IQ4_XS",
+              "Q3_K_M",
+              "Q3_K_S",
+              "Q4_0",
+              "Q4_1",
+              "Q4_K_M",
+              "Q4_K_S",
+              "Q5_K_M",
+              "Q5_K_S",
+              "Q6_K",
+              "Q8_0",
+              "UD-IQ2_M",
+              "UD-IQ2_XXS",
+              "UD-IQ3_XXS",
+              "UD-Q2_K_XL",
+              "UD-Q3_K_XL",
+              "UD-Q4_K_XL",
+              "UD-Q5_K_XL",
+              "UD-Q6_K_XL",
+              "UD-Q8_K_XL"
+            ],
+            "quantization_parts": {
+              "BF16": [
+                "00001-of-00002",
+                "00002-of-00002"
+              ]
+            },
+            "multimodal_projectors": [
+              "mmproj-BF16.gguf",
+              "mmproj-F16.gguf"
+            ]
+          }
+        }
+      },
+      {
+        "model_size_in_billions": 27,
+        "model_format": "mlx",
+        "model_src": {
+          "huggingface": {
+            "model_id": "mlx-community/Qwen3.8-27B-{quantization}",
+            "quantizations": [
+              "4bit",
+              "8bit",
+              "bf16"
+            ]
+          },
+          "modelscope": {
+            "model_id": "mlx-community/Qwen3.8-27B-{quantization}",
+            "quantizations": [
+              "4bit",
+              "8bit",
+              "bf16"
+            ]
+          }
+        }
+      }
+    ],
+    "version": 2,
+    "virtualenv": {
+      "packages": [
+        "sglang_dependencies ; #engine# == \"sglang\"",
+        "transformers>=5.2.0 ; #engine# == \"Transformers\"",
+        "qwen-vl-utils!=0.0.9 ; #engine# == \"Transformers\"",
+        "qwen_omni_utils ; #engine# == \"vllm\"",
+        "audioread ; #engine# == \"vllm\"",
+        "#system_numpy# ; #engine# == \"vllm\"",
+        "vllm==0.21.0 ; #engine# == \"vllm\"",
+        "ninja ; #engine# == \"vllm\"",
+        "#llama_cpp_dependencies# ; #engine# == \"llama.cpp\""
+      ]
+    },
+    "architectures": [
+      "Qwen3_5ForConditionalGeneration"
+    ],
+    "chat_template": "{%- set image_count = namespace(value=0) %}\n{%- set video_count = namespace(value=0) %}\n{%- macro render_content(content, do_vision_count, is_system_content=false) %}\n    {%- if content is string %}\n        {{- content }}\n    {%- elif content is iterable and content is not mapping %}\n        {%- for item in content %}\n            {%- if 'image' in item or 'image_url' in item or item.type == 'image' %}\n                {%- if is_system_content %}\n                    {{- raise_exception('System message cannot contain images.') }}\n                {%- endif %}\n                {%- if do_vision_count %}\n                    {%- set image_count.value = image_count.value + 1 %}\n                {%- endif %}\n                {%- if add_vision_id %}\n                    {{- 'Picture ' ~ image_count.value ~ ': ' }}\n                {%- endif %}\n                {{- '<|vision_start|><|image_pad|><|vision_end|>' }}\n            {%- elif 'video' in item or item.type == 'video' %}\n                {%- if is_system_content %}\n                    {{- raise_exception('System message cannot contain videos.') }}\n                {%- endif %}\n                {%- if do_vision_count %}\n                    {%- set video_count.value = video_count.value + 1 %}\n                {%- endif %}\n                {%- if add_vision_id %}\n                    {{- 'Video ' ~ video_count.value ~ ': ' }}\n                {%- endif %}\n                {{- '<|vision_start|><|video_pad|><|vision_end|>' }}\n            {%- elif 'text' in item %}\n                {{- item.text }}\n            {%- else %}\n                {{- raise_exception('Unexpected item type in content.') }}\n            {%- endif %}\n        {%- endfor %}\n    {%- elif content is none or content is undefined %}\n        {{- '' }}\n    {%- else %}\n        {{- raise_exception('Unexpected content type.') }}\n    {%- endif %}\n{%- endmacro %}\n{%- if not messages %}\n    {{- raise_exception('No messages provided.') }}\n{%- endif %}\n{%- set reasoning_instructions = '' %}\n{%- if enable_thinking is undefined or enable_thinking is true %}\n    {%- set resolved_reasoning_effort = reasoning_effort|default('xhigh') %}\n    {%- if resolved_reasoning_effort not in ('xhigh', 'medium', 'low') %}\n        {{- raise_exception('Unexpected reasoning effort ' ~ reasoning_effort ~ '. Supported types are xhigh (default), medium, and low.') }}\n    {%- endif %}\n    {%- if resolved_reasoning_effort == 'xhigh' %}\n        {%- set reasoning_instructions = 'Reasoning effort is set to xhigh. Please think carefully through the task, validate key assumptions, consider plausible alternatives, and prioritize correctness, consistency, and clarity in the final answer.' %}\n    {%- elif resolved_reasoning_effort == 'low' %}\n        {%- set reasoning_instructions = 'Reasoning effort is set to low. Keep your thinking brief and focused, moving directly to the conclusion without unnecessary elaboration.' %}\n    {%- endif %}\n{%- endif %}\n{%- if tools and tools is iterable and tools is not mapping %}\n    {{- '<|im_start|>system\\n' }}\n    {%- if reasoning_instructions %}\n        {{- reasoning_instructions + '\\n\\n' }}\n    {%- endif %}\n    {{- \"# Tools\\n\\nYou have access to the following functions:\\n\\n<tools>\" }}\n    {%- for tool in tools %}\n        {{- \"\\n\" }}\n        {{- tool | tojson }}\n    {%- endfor %}\n    {{- \"\\n</tools>\" }}\n    {{- '\\n\\nIf you choose to call a function ONLY reply in the following format with NO suffix:\\n\\n<tool_call>\\n<function=example_function_name>\\n<parameter=example_parameter_1>\\nvalue_1\\n</parameter>\\n<parameter=example_parameter_2>\\nThis is the value for the second parameter\\nthat can span\\nmultiple lines\\n</parameter>\\n</function>\\n</tool_call>\\n\\n<IMPORTANT>\\nReminder:\\n- Function calls MUST follow the specified format: an inner <function=...></function> block must be nested within <tool_call></tool_call> XML tags\\n- Required parameters MUST be specified\\n- You may provide optional reasoning for your function call in natural language BEFORE the function call, but NOT after\\n- If there is no function call available, answer the question like normal with your current knowledge and do not tell the user about function calls\\n</IMPORTANT>' }}\n    {%- if messages[0].role == 'system' %}\n        {%- set content = render_content(messages[0].content, false, true)|trim %}\n        {%- if content %}\n            {{- '\\n\\n' + content }}\n        {%- endif %}\n    {%- endif %}\n    {{- '<|im_end|>\\n' }}\n{%- else %}\n    {%- if messages[0].role == 'system' %}\n        {%- set content = render_content(messages[0].content, false, true)|trim %}\n        {%- if content %}\n            {{- '<|im_start|>system\\n' + (reasoning_instructions + '\\n\\n' if reasoning_instructions else '')  + content + '<|im_end|>\\n' }}\n        {%- elif reasoning_instructions %}\n            {{- '<|im_start|>system\\n' + reasoning_instructions + '<|im_end|>\\n' }}\n        {%- endif %}\n    {%- elif reasoning_instructions %}\n        {{- '<|im_start|>system\\n' + reasoning_instructions + '<|im_end|>\\n' }}\n    {%- endif %}\n{%- endif %}\n{%- set ns = namespace(multi_step_tool=true, last_query_index=messages|length - 1) %}\n{%- for message in messages[::-1] %}\n    {%- set index = (messages|length - 1) - loop.index0 %}\n    {%- if ns.multi_step_tool and message.role == \"user\" %}\n        {%- set content = render_content(message.content, false)|trim %}\n        {%- if not(content.startswith('<tool_response>') and content.endswith('</tool_response>')) %}\n            {%- set ns.multi_step_tool = false %}\n            {%- set ns.last_query_index = index %}\n        {%- endif %}\n    {%- endif %}\n{%- endfor %}\n{%- if ns.multi_step_tool %}\n    {{- raise_exception('No user query found in messages.') }}\n{%- endif %}\n{%- for message in messages %}\n    {%- set content = render_content(message.content, true)|trim %}\n    {%- if message.role == \"system\" %}\n        {%- if not loop.first %}\n            {{- raise_exception('System message must be at the beginning.') }}\n        {%- endif %}\n    {%- elif message.role == \"user\" %}\n        {{- '<|im_start|>' + message.role + '\\n' + content + '<|im_end|>' + '\\n' }}\n    {%- elif message.role == \"assistant\" %}\n        {%- set reasoning_content = '' %}\n        {%- if message.reasoning_content is string %}\n            {%- set reasoning_content = message.reasoning_content %}\n        {%- endif %}\n        {%- set reasoning_content = reasoning_content|trim %}\n        {%- if preserve_thinking is undefined or preserve_thinking is true or loop.index0 > ns.last_query_index %}\n            {{- '<|im_start|>' + message.role + '\\n<think>\\n' + reasoning_content + '\\n</think>\\n\\n' + content }}\n        {%- else %}\n            {{- '<|im_start|>' + message.role + '\\n' + content }}\n        {%- endif %}\n        {%- if message.tool_calls and message.tool_calls is iterable and message.tool_calls is not mapping %}\n            {%- for tool_call in message.tool_calls %}\n                {%- if tool_call.function is defined %}\n                    {%- set tool_call = tool_call.function %}\n                {%- endif %}\n                {%- if loop.first %}\n                    {%- if content|trim %}\n                        {{- '\\n\\n<tool_call>\\n<function=' + tool_call.name + '>\\n' }}\n                    {%- else %}\n                        {{- '<tool_call>\\n<function=' + tool_call.name + '>\\n' }}\n                    {%- endif %}\n                {%- else %}\n                    {{- '\\n<tool_call>\\n<function=' + tool_call.name + '>\\n' }}\n                {%- endif %}\n                {%- if tool_call.arguments is defined and tool_call.arguments != '' %}\n                    {%- for args_name, args_value in tool_call.arguments|items %}\n                        {{- '<parameter=' + args_name + '>\\n' }}\n                        {%- set args_value = args_value | string if args_value is string else args_value | tojson | safe %}\n                        {{- args_value }}\n                        {{- '\\n</parameter>\\n' }}\n                    {%- endfor %}\n                {%- endif %}\n                {{- '</function>\\n</tool_call>' }}\n            {%- endfor %}\n        {%- endif %}\n        {{- '<|im_end|>\\n' }}\n    {%- elif message.role == \"tool\" %}\n        {%- if loop.previtem and loop.previtem.role != \"tool\" %}\n            {{- '<|im_start|>user' }}\n        {%- endif %}\n        {{- '\\n<tool_response>\\n' }}\n        {{- content }}\n        {{- '\\n</tool_response>' }}\n        {%- if not loop.last and loop.nextitem.role != \"tool\" %}\n            {{- '<|im_end|>\\n' }}\n        {%- elif loop.last %}\n            {{- '<|im_end|>\\n' }}\n        {%- endif %}\n    {%- else %}\n        {{- raise_exception('Unexpected message role.') }}\n    {%- endif %}\n{%- endfor %}\n{%- if add_generation_prompt %}\n    {{- '<|im_start|>assistant\\n' }}\n    {%- if enable_thinking is defined and enable_thinking is false %}\n        {{- '<think>\\n\\n</think>\\n\\n' }}\n    {%- else %}\n        {{- '<think>\\n' }}\n    {%- endif %}\n{%- endif %}",
+    "stop_token_ids": [
+      248044,
+      248046
+    ],
+    "reasoning_start_tag": "<think>",
+    "reasoning_end_tag": "</think>",
+    "stop": [
+      "<|endoftext|>",
+      "<|im_end|>"
+    ],
+    "tool_parser": "qwen",
+    "featured": false,
+    "updated_at": 1786815199
+  },
+  {
     "model_name": "MiniMax-M2.7",
     "model_description": "MiniMax-M2.7 is our first model deeply participating in its own evolution. M2.7 is capable of building complex agent harnesses and completing highly elaborate productivity tasks, leveraging Agent Teams, complex Skills, and dynamic tool search",
     "context_length": 204800,

--- a/xinference/model/llm/tests/test_utils.py
+++ b/xinference/model/llm/tests/test_utils.py
@@ -2640,7 +2640,7 @@ def test_qwen3_family_get_full_context_handles_string_arguments():
     # string.
     from .. import BUILTIN_LLM_FAMILIES
 
-    targets = {"Qwen3-Coder", "qwen3.5", "qwen3.6"}
+    targets = {"Qwen3-Coder", "qwen3.5", "qwen3.6", "qwen3.8"}
     families = {
         f.model_name: f for f in BUILTIN_LLM_FAMILIES if f.model_name in targets
     }

--- a/xinference/model/llm/transformers/multimodal/qwen2_vl.py
+++ b/xinference/model/llm/transformers/multimodal/qwen2_vl.py
@@ -34,6 +34,7 @@ logger = logging.getLogger(__name__)
     "Qwen3-VL-Thinking",
     "qwen3.5",
     "qwen3.6",
+    "qwen3.8",
     "Nex-N2",
 )
 @register_transformer


### PR DESCRIPTION
Adds the `qwen3.8` built-in family (27B dense).

### Why this is a data-only change

`Qwen/Qwen3.8-27B` reports `architectures: ["Qwen3_5ForConditionalGeneration"]` and `model_type: qwen3_5`. I diffed its `config.json` against `Qwen/Qwen3.6-27B` key by key (flattened, including `text_config` and `vision_config`) — the key sets are **identical**. So every engine path that already handles the Qwen3.5 architecture handles this one, and no engine code needed touching:

- `vllm/core.py`, `vllm/patches/hybrid_kv_cache_page_size.py`, `sglang/core.py` already list `Qwen3_5ForConditionalGeneration`.
- `transformers/multimodal/qwen2_vl.py` already registers the architecture; only the **name-keyed** `register_batching_multimodal_models` list needed the new entry, which is the one code line here.

### Specs

Every repo below was verified to exist on both hubs (`huggingface.co/api/models/...` and `modelscope.cn/api/v1/models/...` both return 200):

| Format | Model ID |
| --- | --- |
| pytorch | `Qwen/Qwen3.8-27B` |
| fp8 | `Qwen/Qwen3.8-27B-FP8` |
| ggufv2 | `unsloth/Qwen3.8-27B-GGUF` — 21 single-file quants, `BF16` split into 2 parts, `mmproj-BF16/F16` |
| mlx | `mlx-community/Qwen3.8-27B-{4bit,8bit,bf16}` |

`context_length` 262144 (`max_position_embeddings`), `stop_token_ids [248044, 248046]` (from `generation_config.json` `eos_token_id`, mapping to `<|endoftext|>` / `<|im_end|>` in `added_tokens_decoder`), `tool_parser: qwen`, `<think>`/`</think>` reasoning tags, and the `virtualenv` package list mirrors `qwen3.6`.

**No AWQ spec.** `QuantTrio`/`tclf90` have not published a Qwen3.8 AWQ yet. The only Int4 repo present on both hubs (`cyankiwi/Qwen3.8-27B-AWQ-INT4`) is actually compressed-tensors `pack-quantized`, not classic AWQ, so filing it under `model_format: awq` would mislead the vLLM quantization path. Worth adding as a follow-up once a real AWQ build lands.

`mlx-community` has no `5bit`/`6bit` for this model (both 401), so unlike `qwen3.6` those two are omitted rather than copied over.

### Notes

- The chat template contains both the system-first guard and `tool_call.arguments|items`, so `is_strict_system_first_template()` returns True for it and the Coder-style string-arguments path applies. I extended the existing `test_qwen3_family_get_full_context_handles_string_arguments` targets to cover `qwen3.8` — it passes.
- `llm_family.json` was edited programmatically and round-trip verified (`json.dumps(..., indent=2, ensure_ascii=False)` reproduces the original file byte for byte), so the diff is purely the 189 added lines with no reformatting noise.
- Docs regenerated with `doc/source/gen_docs.py`; unrelated drift the generator produced in the rerank pages was reverted to keep the diff scoped.

### Verification

- `pytest xinference/model/llm/tests/test_utils.py -k qwen3_family` — passes.
- `pytest xinference/model/llm/tests/test_llm_family.py xinference/deploy/docker/pypiserver/tests/test_scripts.py` — passes except `test_query_engine_general`, which fails identically on an unmodified checkout in my environment (no `llama.cpp` installed) and is unrelated to this change.
- `pre-commit run --files <changed files>` — all hooks pass.
- Family loads correctly at runtime: 4 specs resolve across both hubs, abilities `chat, vision, tools, reasoning, hybrid`, `strict_system_first` True.
- Deployed to a live server and ran the model end to end: `Qwen/Qwen3.8-27B-FP8` on vLLM, tensor parallel across 2x L20, weights pulled from ModelScope. Launch finished cleanly, and chat completions return correct output.
- Reasoning parsing behaves as expected for this family: the template pre-fills `<think>\n` into the generation prompt, so the model emits only the closing tag; with `reasoning_content=True` the parser splits `reasoning_content` from `content` correctly.

Not run: the gguf, mlx and pytorch specs — only the FP8 spec was exercised on real hardware.
