### PR TITLE
feat: support MiniMax-H3 Lightning LoRA

### DIFF
--- a/doc/source/gen_docs.py
+++ b/doc/source/gen_docs.py
@@ -542,11 +542,14 @@ def main():
             # Process model_src for template compatibility
             model_src = _extract_primary_model_src(model)
             if model_src:
-                if 'huggingface' in model_src:
-                    model['model_id'] = model_src['huggingface']['model_id']
-                elif 'modelscope' in model_src:
-                    model['model_id'] = model_src['modelscope']['model_id']
+                primary_src = model_src.get('huggingface') or model_src.get('modelscope')
+                if primary_src:
+                    model['model_id'] = primary_src['model_id']
+                    if primary_src.get('lightning_model_id'):
+                        model['lightning_model_id'] = primary_src['lightning_model_id']
 
+            if model.get('lightning_versions'):
+                model['lightning_versions'] = ", ".join(model['lightning_versions'])
             model["model_ability"] = ', '.join(model.get("model_ability"))
             rendered = env.get_template('video.rst.jinja').render(model)
             output_file_path = os.path.join(output_dir, f"{model['model_name'].lower()}.rst")

--- a/doc/source/models/builtin/video/minimax-h3.rst
+++ b/doc/source/models/builtin/video/minimax-h3.rst
@@ -12,7 +12,13 @@ Specifications
 ^^^^^^^^^^^^^^
 
 - **Model ID:** MiniMaxAI/MiniMax-H3
+- **Lightning Model ID:** lightx2v/Minimax-h3-Turbo
+- **Lightning Versions:** 4step_v0.1, 8step_v1.0_bf16, 4step_v1.0_768p_bf16
 
 Execute the following command to launch the model::
 
    xinference launch --model-name MiniMax-H3 --model-type video
+
+For Lightning LoRA acceleration, use::
+
+   xinference launch --model-name MiniMax-H3 --model-type video --lightning_version ${lightning_version}

--- a/doc/source/models/model_abilities/video.rst
+++ b/doc/source/models/model_abilities/video.rst
@@ -152,7 +152,8 @@ Lightning LoRA acceleration
 Lightning LoRA checkpoints distill a video model into fewer denoising steps.
 Select a supported version with ``--lightning_version`` when launching the model;
 Xinference downloads the LoRA, applies its training alpha and scheduler shifts,
-and uses the version's recommended inference-step count by default.
+and uses the version's recommended inference-step count when the request does not
+override ``num_inference_steps``.
 Lightning reduces denoising time, but does not reduce model size or peak memory;
 MiniMax-H3's default INT4 quantization and group offload remain enabled.
 
@@ -181,10 +182,34 @@ MiniMax-H3's default INT4 quantization and group offload remain enabled.
      - 6
      - 1344x768
 
-For example::
+In the Web UI, open the MiniMax-H3 launch dialog, expand **Advanced
+Configuration**, and select a value under **Lightning Versions**. Leave
+**Lightning Model Path** empty to download the selected checkpoint
+automatically. After the model starts, set **Inference Steps** on the video
+generation page to the evaluation count in the table. The generation page
+currently starts with 25 steps, which overrides the Lightning default if left
+unchanged.
+
+For example, launch the 768p four-step version from the command line::
 
     xinference launch --model-name MiniMax-H3 --model-type video \
-        --lightning_version 4step_v0.1
+        --lightning_version 4step_v1.0_768p_bf16
+
+Then generate with four inference steps. MiniMax-H3 outputs at a fixed 24 FPS;
+124 frames produce a video of about five seconds::
+
+    from xinference.client import Client
+
+    client = Client("http://<XINFERENCE_HOST>:<XINFERENCE_PORT>")
+    model = client.get_model("<MODEL_UID>")
+    model.text_to_video(
+        prompt="A running cat",
+        width=1344,
+        height=768,
+        num_frames=124,
+        fps=24,
+        num_inference_steps=4,
+    )
 
 Xinference downloads the Lightning checkpoint from the same hub selected for
 the base model. Both Hugging Face and ModelScope are supported. To use an already
@@ -194,9 +219,11 @@ downloaded checkpoint, pass both its path and version::
         --lightning_version 4step_v0.1 \
         --lightning_model_path /path/to/minimax_h3_fl2v_turbo_4step_v0.1.safetensors
 
-``num_inference_steps`` remains a per-request override and represents actual
-transformer evaluations. MiniMax-H3's scheduler internally adds the terminal
-sigma grid point required to run that number of evaluations.
+``num_inference_steps`` represents actual transformer evaluations and remains a
+per-request override. Match it to the selected Lightning version: use 4 for a
+``4step`` checkpoint and 8 for an ``8step`` checkpoint. MiniMax-H3's scheduler
+internally adds the terminal sigma grid point required to run that number of
+evaluations.
 
 
 Memory optimization

--- a/doc/source/models/model_abilities/video.rst
+++ b/doc/source/models/model_abilities/video.rst
@@ -146,6 +146,59 @@ You can try firstlastframe-to-video API out either via cURL, or Xinference's pyt
         model.flf_to_video(first_frame=f1.read(), last_frame=f2.read(), prompt=prompt)
 
 
+Lightning LoRA acceleration
+===========================
+
+Lightning LoRA checkpoints distill a video model into fewer denoising steps.
+Select a supported version with ``--lightning_version`` when launching the model;
+Xinference downloads the LoRA, applies its training alpha and scheduler shifts,
+and uses the version's recommended inference-step count by default.
+Lightning reduces denoising time, but does not reduce model size or peak memory;
+MiniMax-H3's default INT4 quantization and group offload remain enabled.
+
+.. list-table::
+   :widths: 25 30 15 15 15
+   :header-rows: 1
+
+   * - Model
+     - Lightning version
+     - Evaluations
+     - Video shift
+     - Recommended canvas
+   * - MiniMax-H3
+     - ``4step_v0.1``
+     - 4
+     - 12
+     - 544p mixed aspect ratios
+   * - MiniMax-H3
+     - ``8step_v1.0_bf16``
+     - 8
+     - 12
+     - 544p mixed aspect ratios
+   * - MiniMax-H3
+     - ``4step_v1.0_768p_bf16``
+     - 4
+     - 6
+     - 1344x768
+
+For example::
+
+    xinference launch --model-name MiniMax-H3 --model-type video \
+        --lightning_version 4step_v0.1
+
+Xinference downloads the Lightning checkpoint from the same hub selected for
+the base model. Both Hugging Face and ModelScope are supported. To use an already
+downloaded checkpoint, pass both its path and version::
+
+    xinference launch --model-name MiniMax-H3 --model-type video \
+        --lightning_version 4step_v0.1 \
+        --lightning_model_path /path/to/minimax_h3_fl2v_turbo_4step_v0.1.safetensors
+
+``num_inference_steps`` remains a per-request override and represents actual
+transformer evaluations. MiniMax-H3's scheduler internally adds the terminal
+sigma grid point required to run that number of evaluations.
+
+
 Memory optimization
 ===================
 

--- a/doc/source/models/model_abilities/video.rst
+++ b/doc/source/models/model_abilities/video.rst
@@ -225,6 +225,14 @@ per-request override. Match it to the selected Lightning version: use 4 for a
 internally adds the terminal sigma grid point required to run that number of
 evaluations.
 
+.. note::
+
+   The evaluation-count semantics apply to MiniMax-H3 with or without Lightning.
+   A request for N evaluations now passes N + 1 scheduler grid points so the
+   terminal sigma does not consume one of the requested evaluations. Therefore,
+   non-Lightning output may differ from earlier Xinference versions for the same
+   ``num_inference_steps`` value.
+
 
 Memory optimization
 ===================

--- a/doc/templates/video.rst.jinja
+++ b/doc/templates/video.rst.jinja
@@ -11,8 +11,14 @@
 Specifications
 ^^^^^^^^^^^^^^
 
-- **Model ID:** {{ model_id }}
+- **Model ID:** {{ model_id }}{% if lightning_model_id %}
+- **Lightning Model ID:** {{ lightning_model_id }}
+- **Lightning Versions:** {{ lightning_versions }}{% endif %}
 
 Execute the following command to launch the model::
 
-   xinference launch --model-name {{ model_name }} --model-type video
+   xinference launch --model-name {{ model_name }} --model-type video{% if lightning_versions %}
+
+For Lightning LoRA acceleration, use::
+
+   xinference launch --model-name {{ model_name }} --model-type video --lightning_version ${{ '{' }}lightning_version{{ '}' }}{% endif %}

--- a/frontend/src/components/pages/launch-model/launch-dialog/launch-dialog.tsx
+++ b/frontend/src/components/pages/launch-model/launch-dialog/launch-dialog.tsx
@@ -1209,6 +1209,21 @@ export default function LaunchDialog({
         show: !!ggufQuantizations,
       },
       {
+        name: 'lightning_version',
+        label: t('launchModel.lightningVersions'),
+        placeholder: t('launchModel.lightningVersionsPlaceholder'),
+        type: 'select',
+        fieldProps: { options: lightningVersionOptions },
+        show: !!lightningVersionOptions.length,
+      },
+      {
+        name: 'lightning_model_path',
+        label: t('launchModel.lightningModelPath'),
+        placeholder: t('launchModel.lightningModelPathPlaceholder'),
+        type: 'input',
+        show: !!lightningVersionOptions.length,
+      },
+      {
         name: 'worker_ip',
         type: 'multi-select',
         label: t('launchModel.workerIp'),

--- a/frontend/src/components/pages/launch-model/utils.tsx
+++ b/frontend/src/components/pages/launch-model/utils.tsx
@@ -490,6 +490,15 @@ export function transformFormToFetch(values: FormValues) {
   if (nextValues.gguf_quantization === 'none') {
     delete nextValues.gguf_quantization;
   }
+  if (nextValues.lightning_version === 'none') {
+    delete nextValues.lightning_version;
+  }
+  if (
+    typeof nextValues.lightning_model_path === 'string' &&
+    nextValues.lightning_model_path.trim() === ''
+  ) {
+    delete nextValues.lightning_model_path;
+  }
 
   // Per-replica placement. `replica_placement_mode` is UI-only and never sent.
   const placementMode = nextValues.replica_placement_mode;

--- a/xinference/model/video/cache_manager.py
+++ b/xinference/model/video/cache_manager.py
@@ -5,6 +5,66 @@ from ..cache_manager import CacheManager
 
 
 class VideoCacheManager(CacheManager):
+    def cache_lightning(self, lightning_version: Optional[str] = None):
+        from ..utils import IS_NEW_HUGGINGFACE_HUB, retry_download, symlink_local_file
+        from .core import VideoModelFamilyV2
+
+        if not lightning_version:
+            return None
+
+        assert isinstance(self._model_family, VideoModelFamilyV2)
+        cache_dir = self.get_cache_dir()
+        filename_template = self._model_family.lightning_model_file_name_template
+        if not filename_template or not self._model_family.lightning_model_id:
+            raise NotImplementedError(
+                f"{self._model_family.model_name} does not support lightning"
+            )
+        if lightning_version not in (self._model_family.lightning_versions or []):
+            raise ValueError(
+                f"Cannot support lightning version {lightning_version}, "
+                f"available lightning versions: {self._model_family.lightning_versions}"
+            )
+
+        filename = filename_template.format(lightning_version=lightning_version)
+        full_path = os.path.join(cache_dir, filename)
+        lightning_revision = self._model_family.lightning_model_revision
+
+        if self._model_family.model_hub == "huggingface":
+            import huggingface_hub
+
+            use_symlinks = {}
+            if not IS_NEW_HUGGINGFACE_HUB:
+                use_symlinks = {"local_dir_use_symlinks": True, "local_dir": cache_dir}
+            download_file_path = retry_download(
+                huggingface_hub.hf_hub_download,
+                self._model_family.model_name,
+                None,
+                self._model_family.lightning_model_id,
+                filename=filename,
+                revision=lightning_revision,
+                **use_symlinks,
+            )
+            if IS_NEW_HUGGINGFACE_HUB:
+                symlink_local_file(download_file_path, cache_dir, filename)
+        elif self._model_family.model_hub == "modelscope":
+            from modelscope.hub.file_download import model_file_download
+
+            download_file_path = retry_download(
+                model_file_download,
+                self._model_family.model_name,
+                None,
+                self._model_family.lightning_model_id,
+                filename,
+                revision=lightning_revision or "master",
+            )
+            symlink_local_file(download_file_path, cache_dir, filename)
+        else:
+            raise NotImplementedError(
+                f"Unsupported lightning model hub: {self._model_family.model_hub}"
+            )
+
+        return full_path
+
     def cache_gguf(self, quantization: Optional[str] = None):
         from ..utils import IS_NEW_HUGGINGFACE_HUB, retry_download, symlink_local_file
         from .core import VideoModelFamilyV2

--- a/xinference/model/video/core.py
+++ b/xinference/model/video/core.py
@@ -44,6 +44,11 @@ class VideoModelFamilyV2(CacheableModelSpec, ModelInstanceInfoMixin):
     gguf_model_id: Optional[str]
     gguf_quantizations: Optional[List[str]]
     gguf_model_file_name_template: Optional[str]
+    lightning_model_id: Optional[str]
+    lightning_model_revision: Optional[str]
+    lightning_versions: Optional[List[str]]
+    lightning_model_file_name_template: Optional[str]
+    lightning_version_configs: Optional[Dict[str, Dict[str, Any]]]
     virtualenv: Optional[VirtualEnvSettings]
 
     class Config:
@@ -116,6 +121,8 @@ def create_video_model_instance(
     model_path: Optional[str] = None,
     gguf_quantization: Optional[str] = None,
     gguf_model_path: Optional[str] = None,
+    lightning_version: Optional[str] = None,
+    lightning_model_path: Optional[str] = None,
     **kwargs,
 ) -> DiffusersVideoModel:
     from .cache_manager import VideoCacheManager
@@ -128,6 +135,11 @@ def create_video_model_instance(
     if not gguf_model_path and gguf_quantization:
         cache_manager = VideoCacheManager(model_spec)
         gguf_model_path = cache_manager.cache_gguf(gguf_quantization)
+    if not lightning_model_path and lightning_version:
+        cache_manager = VideoCacheManager(model_spec)
+        lightning_model_path = cache_manager.cache_lightning(lightning_version)
+    if lightning_model_path and not model_spec.lightning_versions:
+        raise ValueError(f"Model {model_name} does not support lightning acceleration")
     assert model_path is not None
 
     model = DiffusersVideoModel(
@@ -135,6 +147,8 @@ def create_video_model_instance(
         model_path,
         model_spec,
         gguf_model_path=gguf_model_path,
+        lightning_version=lightning_version,
+        lightning_model_path=lightning_model_path,
         **kwargs,
     )
     return model

--- a/xinference/model/video/core.py
+++ b/xinference/model/video/core.py
@@ -135,11 +135,13 @@ def create_video_model_instance(
     if not gguf_model_path and gguf_quantization:
         cache_manager = VideoCacheManager(model_spec)
         gguf_model_path = cache_manager.cache_gguf(gguf_quantization)
+    if (
+        lightning_version or lightning_model_path
+    ) and not model_spec.lightning_versions:
+        raise ValueError(f"Model {model_name} does not support lightning acceleration")
     if not lightning_model_path and lightning_version:
         cache_manager = VideoCacheManager(model_spec)
         lightning_model_path = cache_manager.cache_lightning(lightning_version)
-    if lightning_model_path and not model_spec.lightning_versions:
-        raise ValueError(f"Model {model_name} does not support lightning acceleration")
     assert model_path is not None
 
     model = DiffusersVideoModel(

--- a/xinference/model/video/diffusers.py
+++ b/xinference/model/video/diffusers.py
@@ -150,7 +150,12 @@ class DiffusersVideoModel:
         pipeline.audio_vae.to(onload_device)
 
     def _resolve_minimax_h3_lightning_config(self) -> Optional[dict]:
-        if not self._lightning_model_path:
+        if self._lightning_model_path is None:
+            if self._lightning_version is not None:
+                raise ValueError(
+                    f"Lightning version {self._lightning_version!r} was specified, "
+                    "but no lightning model path was provided."
+                )
             return None
 
         version_configs = self._model_spec.lightning_version_configs or {}

--- a/xinference/model/video/diffusers.py
+++ b/xinference/model/video/diffusers.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import base64
+import gc
 import importlib
 import json
 import logging
@@ -66,6 +67,8 @@ class DiffusersVideoModel:
         model_path: str,
         model_spec: "VideoModelFamilyV2",
         gguf_model_path: Optional[str] = None,
+        lightning_version: Optional[str] = None,
+        lightning_model_path: Optional[str] = None,
         **kwargs,
     ):
         self.model_family = model_spec
@@ -76,6 +79,9 @@ class DiffusersVideoModel:
         self._model = None
         self._kwargs = kwargs
         self._gguf_model_path = gguf_model_path
+        self._lightning_version = lightning_version
+        self._lightning_model_path = lightning_model_path
+        self._minimax_h3_lightning_steps: Optional[int] = None
 
     @property
     def model_spec(self):
@@ -142,6 +148,180 @@ class DiffusersVideoModel:
         )
         pipeline.vae.to(onload_device)
         pipeline.audio_vae.to(onload_device)
+
+    def _resolve_minimax_h3_lightning_config(self) -> Optional[dict]:
+        if not self._lightning_model_path:
+            return None
+
+        version_configs = self._model_spec.lightning_version_configs or {}
+        version = self._lightning_version
+        if version is None:
+            filename = os.path.basename(self._lightning_model_path)
+            template = self._model_spec.lightning_model_file_name_template
+            if template:
+                matches = [
+                    candidate
+                    for candidate in version_configs
+                    if template.format(lightning_version=candidate) == filename
+                ]
+                if len(matches) == 1:
+                    version = matches[0]
+
+        if version not in version_configs:
+            raise ValueError(
+                "Cannot determine the MiniMax-H3 lightning configuration for "
+                f"{self._lightning_model_path!r}. Specify lightning_version from "
+                f"{list(version_configs)}."
+            )
+
+        config = version_configs[version].copy()
+        config["version"] = version
+        required = ("num_inference_steps", "video_shift", "audio_shift", "lora_alpha")
+        missing = [name for name in required if name not in config]
+        if missing:
+            raise ValueError(
+                f"MiniMax-H3 lightning version {version!r} is missing config: {missing}"
+            )
+        if config["num_inference_steps"] < 1:
+            raise ValueError(
+                "MiniMax-H3 lightning num_inference_steps must be positive"
+            )
+        if config["video_shift"] <= 0 or config["audio_shift"] <= 0:
+            raise ValueError("MiniMax-H3 lightning scheduler shifts must be positive")
+        if config["lora_alpha"] < 1:
+            raise ValueError("MiniMax-H3 lightning lora_alpha must be positive")
+        return config
+
+    @staticmethod
+    def _load_minimax_h3_lightning_adapter(transformer, path: str, alpha: int):
+        from peft import LoraConfig
+        from safetensors.torch import load_file
+
+        target_modules = (
+            "to_q",
+            "to_k",
+            "to_v",
+            "to_out.0",
+            "ff.net.0.proj",
+            "ff.net.2",
+        )
+        lora_a_suffix = ".lora_A.default.weight"
+        lora_b_suffix = ".lora_B.default.weight"
+        state_dict = load_file(path, device="cpu")
+        lora_a = {
+            key[: -len(lora_a_suffix)]: tensor
+            for key, tensor in state_dict.items()
+            if key.endswith(lora_a_suffix)
+        }
+        lora_b = {
+            key[: -len(lora_b_suffix)]: tensor
+            for key, tensor in state_dict.items()
+            if key.endswith(lora_b_suffix)
+        }
+        unsupported = [
+            key
+            for key in state_dict
+            if not key.endswith((lora_a_suffix, lora_b_suffix))
+        ]
+        if unsupported:
+            raise ValueError(
+                f"MiniMax-H3 lightning checkpoint has unsupported keys: {unsupported[:3]}"
+            )
+        if not lora_a or lora_a.keys() != lora_b.keys():
+            raise ValueError(
+                "MiniMax-H3 lightning checkpoint has unpaired LoRA tensors"
+            )
+
+        ranks = set()
+        for module_name, a_tensor in lora_a.items():
+            b_tensor = lora_b[module_name]
+            if a_tensor.ndim != 2 or b_tensor.ndim != 2:
+                raise ValueError(
+                    f"MiniMax-H3 LoRA tensors for {module_name} must be matrices"
+                )
+            if a_tensor.shape[0] != b_tensor.shape[1]:
+                raise ValueError(
+                    f"MiniMax-H3 LoRA rank mismatch for {module_name}: "
+                    f"A{tuple(a_tensor.shape)} and B{tuple(b_tensor.shape)}"
+                )
+            if not module_name.endswith(target_modules):
+                raise ValueError(
+                    f"Unsupported MiniMax-H3 LoRA target module {module_name!r}"
+                )
+            ranks.add(a_tensor.shape[0])
+        if len(ranks) != 1:
+            raise ValueError(f"Mixed MiniMax-H3 LoRA ranks are unsupported: {ranks}")
+        rank = ranks.pop()
+
+        transformer.add_adapter(
+            LoraConfig(
+                r=rank,
+                lora_alpha=alpha,
+                init_lora_weights=False,
+                target_modules=list(target_modules),
+                use_rslora=False,
+            )
+        )
+        adapter_parameters = {
+            name: parameter
+            for name, parameter in transformer.named_parameters()
+            if ".lora_A." in name or ".lora_B." in name
+        }
+        missing = sorted(adapter_parameters.keys() - state_dict.keys())
+        unexpected = sorted(state_dict.keys() - adapter_parameters.keys())
+        shape_mismatches = [
+            (name, tuple(state_dict[name].shape), tuple(parameter.shape))
+            for name, parameter in adapter_parameters.items()
+            if name in state_dict and state_dict[name].shape != parameter.shape
+        ]
+        if missing or unexpected or shape_mismatches:
+            raise ValueError(
+                "MiniMax-H3 lightning checkpoint is incompatible with the transformer: "
+                f"missing={missing[:3]}, unexpected={unexpected[:3]}, "
+                f"shape_mismatches={shape_mismatches[:3]}"
+            )
+
+        incompatible = transformer.load_state_dict(state_dict, strict=False)
+        missing_lora = [
+            key
+            for key in incompatible.missing_keys
+            if ".lora_A." in key or ".lora_B." in key
+        ]
+        if incompatible.unexpected_keys or missing_lora:
+            raise RuntimeError(
+                "MiniMax-H3 lightning loading did not consume the adapter tensors: "
+                f"missing={missing_lora[:3]}, "
+                f"unexpected={incompatible.unexpected_keys[:3]}"
+            )
+        transformer.set_adapters("default", weights=1.0)
+        transformer.requires_grad_(False)
+        transformer.eval()
+        del state_dict
+        gc.collect()
+
+    def _apply_minimax_h3_lightning(self, pipeline) -> None:
+        config = self._resolve_minimax_h3_lightning_config()
+        if config is None:
+            return
+
+        assert self._lightning_model_path is not None
+        self._load_minimax_h3_lightning_adapter(
+            pipeline.transformer,
+            self._lightning_model_path,
+            config["lora_alpha"],
+        )
+        pipeline.scheduler.set_shift(config["video_shift"])
+        pipeline.audio_scheduler.set_shift(config["audio_shift"])
+        self._minimax_h3_lightning_steps = config["num_inference_steps"]
+        logger.info(
+            "Loaded MiniMax-H3 lightning version %s from %s with %s NFE, "
+            "video shift %s, and audio shift %s",
+            config["version"],
+            self._lightning_model_path,
+            config["num_inference_steps"],
+            config["video_shift"],
+            config["audio_shift"],
+        )
 
     def _load_minimax_h3_quantized(self, kwargs: dict, torch_dtype, quantization: str):
         import torch
@@ -289,6 +469,8 @@ class DiffusersVideoModel:
             pretrained_model_name_or_path=self._model_path,
         )
 
+        self._apply_minimax_h3_lightning(pipeline)
+
         if kwargs.pop("group_offload", False):
             if quantization == "int4":
                 kwargs.setdefault("use_stream", False)
@@ -330,6 +512,7 @@ class DiffusersVideoModel:
             dtype=torch_dtype,
             pretrained_model_name_or_path=self._model_path,
         )
+        self._apply_minimax_h3_lightning(pipeline)
         self._model = pipeline
 
     @staticmethod
@@ -512,7 +695,7 @@ class DiffusersVideoModel:
         self,
         prompt: str,
         n: int = 1,
-        num_inference_steps: int = 50,
+        num_inference_steps: Optional[int] = None,
         response_format: str = "b64_json",
         **kwargs,
     ) -> VideoList:
@@ -530,6 +713,8 @@ class DiffusersVideoModel:
         generate_kwargs.update(kwargs)
         generate_kwargs["num_videos_per_prompt"] = n
         fps = generate_kwargs.pop("fps", 10)
+        if num_inference_steps is None:
+            num_inference_steps = 50
         logger.debug(
             "diffusers text_to_video args: %s",
             generate_kwargs,
@@ -701,10 +886,17 @@ class DiffusersVideoModel:
 
         generate_kwargs = (self._model_spec.default_generate_config or {}).copy()
         generate_kwargs.update(kwargs)
-        if num_inference_steps is not None:
-            generate_kwargs["num_inference_steps"] = num_inference_steps
+        if num_inference_steps is None:
+            num_inference_steps = generate_kwargs.pop(
+                "num_inference_steps", self._minimax_h3_lightning_steps or 50
+            )
         else:
-            generate_kwargs.setdefault("num_inference_steps", 50)
+            generate_kwargs.pop("num_inference_steps", None)
+        if num_inference_steps < 1:
+            raise ValueError("num_inference_steps must be at least 1")
+        # MiniMaxH3Scheduler includes terminal sigma zero in the requested grid,
+        # so N transformer evaluations require N + 1 grid points.
+        generate_kwargs["num_inference_steps"] = num_inference_steps + 1
 
         pipeline = self._model
         assert callable(pipeline)

--- a/xinference/model/video/diffusers.py
+++ b/xinference/model/video/diffusers.py
@@ -198,6 +198,26 @@ class DiffusersVideoModel:
         return config
 
     @staticmethod
+    @contextmanager
+    def _skip_peft_gptqmodel_probes():
+        # Xinference virtual environments inherit parent site-packages so the
+        # model subprocess can import Xinference and xoscar. PEFT otherwise
+        # probes an unrelated parent GPTQModel installation while injecting a
+        # TorchAO LoRA, and an incompatible GPTQModel can fail before PEFT
+        # reaches its TorchAO dispatcher.
+        peft_awq = importlib.import_module("peft.tuners.lora.awq")
+        peft_gptq = importlib.import_module("peft.tuners.lora.gptq")
+        original_awq_probe = peft_awq.is_gptqmodel_available
+        original_gptq_probe = peft_gptq.is_gptqmodel_available
+        peft_awq.is_gptqmodel_available = lambda: False
+        peft_gptq.is_gptqmodel_available = lambda: False
+        try:
+            yield
+        finally:
+            peft_awq.is_gptqmodel_available = original_awq_probe
+            peft_gptq.is_gptqmodel_available = original_gptq_probe
+
+    @staticmethod
     def _load_minimax_h3_lightning_adapter(transformer, path: str, alpha: int):
         from peft import LoraConfig
         from safetensors.torch import load_file
@@ -258,15 +278,16 @@ class DiffusersVideoModel:
             raise ValueError(f"Mixed MiniMax-H3 LoRA ranks are unsupported: {ranks}")
         rank = ranks.pop()
 
-        transformer.add_adapter(
-            LoraConfig(
-                r=rank,
-                lora_alpha=alpha,
-                init_lora_weights=False,
-                target_modules=list(target_modules),
-                use_rslora=False,
+        with DiffusersVideoModel._skip_peft_gptqmodel_probes():
+            transformer.add_adapter(
+                LoraConfig(
+                    r=rank,
+                    lora_alpha=alpha,
+                    init_lora_weights=False,
+                    target_modules=list(target_modules),
+                    use_rslora=False,
+                )
             )
-        )
         adapter_parameters = {
             name: parameter
             for name, parameter in transformer.named_parameters()

--- a/xinference/model/video/diffusers.py
+++ b/xinference/model/video/diffusers.py
@@ -25,6 +25,7 @@ import uuid
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager, suppress
 from functools import partial, reduce
+from types import MethodType
 from typing import TYPE_CHECKING, Any, List, Optional, Union
 
 import numpy as np
@@ -40,6 +41,48 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
+
+
+def _minimax_h3_memory_efficient_lora_forward(self, x, *args, **kwargs):
+    """Evaluate a TorchAO LoRA branch directly into the base-layer result."""
+    import torch
+
+    if kwargs or self.disable_adapters or self.merged:
+        return type(self).forward(self, x, *args, **kwargs)
+
+    active_adapters = [
+        adapter for adapter in self.active_adapters if adapter in self.lora_A
+    ]
+    if any(
+        adapter in self.lora_variant or self.lora_B[adapter].bias is not None
+        for adapter in active_adapters
+    ):
+        return type(self).forward(self, x, *args, **kwargs)
+
+    result = self.base_layer(x, *args)
+    result_dtype = result.dtype
+    if not result.is_contiguous():
+        raise RuntimeError(
+            "MiniMax-H3 requires contiguous TorchAO linear outputs for its "
+            "memory-efficient lightning adapter"
+        )
+
+    for active_adapter in active_adapters:
+        lora_a = self.lora_A[active_adapter]
+        lora_b = self.lora_B[active_adapter]
+        dropout = self.lora_dropout[active_adapter]
+        lora_input = self._cast_input_dtype(x, lora_a.weight.dtype)
+        low_rank_states = lora_a(dropout(lora_input))
+        torch.addmm(
+            result.view(-1, result.shape[-1]),
+            low_rank_states.view(-1, low_rank_states.shape[-1]),
+            lora_b.weight.T,
+            beta=1.0,
+            alpha=self.scaling[active_adapter],
+            out=result.view(-1, result.shape[-1]),
+        )
+
+    return result.to(result_dtype)
 
 
 def export_to_video_imageio(
@@ -220,6 +263,7 @@ class DiffusersVideoModel:
     @staticmethod
     def _load_minimax_h3_lightning_adapter(transformer, path: str, alpha: int):
         from peft import LoraConfig
+        from peft.tuners.lora.torchao import TorchaoLoraLinear
         from safetensors.torch import load_file
 
         target_modules = (
@@ -320,17 +364,21 @@ class DiffusersVideoModel:
                 f"unexpected={incompatible.unexpected_keys[:3]}"
             )
         transformer.set_adapters("default", weights=1.0)
-        # H3's FFN activations are large enough that evaluating the LoRA branch
-        # separately can add multiple GiB to the per-step peak.  The lightning
-        # adapter is fixed for the lifetime of this pipeline, so merge it into
-        # the quantized transformer once during loading and remove the runtime
-        # PEFT modules.
-        transformer.fuse_lora(
-            lora_scale=1.0,
-            safe_fusing=True,
-            adapter_names=["default"],
-        )
-        transformer.unload_lora()
+        # TorchAO INT4 weights cannot currently be dequantized, so PEFT cannot
+        # fuse this adapter. Its regular forward also materializes and then
+        # scales a full-size LoRA output, adding multiple GiB to H3's peak.
+        # Accumulate B(A(x)) directly into the base output instead.
+        patched_layers = 0
+        for module in transformer.modules():
+            if isinstance(module, TorchaoLoraLinear):
+                module.forward = MethodType(
+                    _minimax_h3_memory_efficient_lora_forward, module
+                )
+                patched_layers += 1
+        if not patched_layers:
+            raise RuntimeError(
+                "MiniMax-H3 lightning did not find any TorchAO LoRA layers"
+            )
         transformer.requires_grad_(False)
         transformer.eval()
         del state_dict

--- a/xinference/model/video/diffusers.py
+++ b/xinference/model/video/diffusers.py
@@ -47,6 +47,7 @@ def _minimax_h3_memory_efficient_lora_forward(self, x, *args, **kwargs):
     """Evaluate a TorchAO LoRA branch directly into the base-layer result."""
     import torch
 
+    self._check_forward_args(x, *args, **kwargs)
     if kwargs or self.disable_adapters or self.merged:
         return type(self).forward(self, x, *args, **kwargs)
 
@@ -60,7 +61,6 @@ def _minimax_h3_memory_efficient_lora_forward(self, x, *args, **kwargs):
         return type(self).forward(self, x, *args, **kwargs)
 
     result = self.base_layer(x, *args)
-    result_dtype = result.dtype
     if not result.is_contiguous():
         raise RuntimeError(
             "MiniMax-H3 requires contiguous TorchAO linear outputs for its "
@@ -73,16 +73,21 @@ def _minimax_h3_memory_efficient_lora_forward(self, x, *args, **kwargs):
         dropout = self.lora_dropout[active_adapter]
         lora_input = self._cast_input_dtype(x, lora_a.weight.dtype)
         low_rank_states = lora_a(dropout(lora_input))
+        if low_rank_states.dtype != result.dtype:
+            low_rank_states = low_rank_states.to(result.dtype)
+        lora_b_weight = lora_b.weight
+        if lora_b_weight.dtype != result.dtype:
+            lora_b_weight = lora_b_weight.to(result.dtype)
         torch.addmm(
             result.view(-1, result.shape[-1]),
             low_rank_states.view(-1, low_rank_states.shape[-1]),
-            lora_b.weight.T,
+            lora_b_weight.T,
             beta=1.0,
             alpha=self.scaling[active_adapter],
             out=result.view(-1, result.shape[-1]),
         )
 
-    return result.to(result_dtype)
+    return result
 
 
 def export_to_video_imageio(

--- a/xinference/model/video/diffusers.py
+++ b/xinference/model/video/diffusers.py
@@ -263,7 +263,7 @@ class DiffusersVideoModel:
     @staticmethod
     def _load_minimax_h3_lightning_adapter(transformer, path: str, alpha: int):
         from peft import LoraConfig
-        from peft.tuners.lora.torchao import TorchaoLoraLinear
+        from peft.tuners.lora.layer import Linear as PeftLoraLinear
         from safetensors.torch import load_file
 
         target_modules = (
@@ -370,15 +370,19 @@ class DiffusersVideoModel:
         # Accumulate B(A(x)) directly into the base output instead.
         patched_layers = 0
         for module in transformer.modules():
-            if isinstance(module, TorchaoLoraLinear):
+            if isinstance(module, PeftLoraLinear):
                 module.forward = MethodType(
                     _minimax_h3_memory_efficient_lora_forward, module
                 )
                 patched_layers += 1
         if not patched_layers:
             raise RuntimeError(
-                "MiniMax-H3 lightning did not find any TorchAO LoRA layers"
+                "MiniMax-H3 lightning did not find any PEFT LoRA linear layers"
             )
+        logger.info(
+            "Enabled memory-efficient MiniMax-H3 lightning forward for %s LoRA layers",
+            patched_layers,
+        )
         transformer.requires_grad_(False)
         transformer.eval()
         del state_dict

--- a/xinference/model/video/diffusers.py
+++ b/xinference/model/video/diffusers.py
@@ -320,6 +320,17 @@ class DiffusersVideoModel:
                 f"unexpected={incompatible.unexpected_keys[:3]}"
             )
         transformer.set_adapters("default", weights=1.0)
+        # H3's FFN activations are large enough that evaluating the LoRA branch
+        # separately can add multiple GiB to the per-step peak.  The lightning
+        # adapter is fixed for the lifetime of this pipeline, so merge it into
+        # the quantized transformer once during loading and remove the runtime
+        # PEFT modules.
+        transformer.fuse_lora(
+            lora_scale=1.0,
+            safe_fusing=True,
+            adapter_names=["default"],
+        )
+        transformer.unload_lora()
         transformer.requires_grad_(False)
         transformer.eval()
         del state_dict

--- a/xinference/model/video/diffusers.py
+++ b/xinference/model/video/diffusers.py
@@ -318,7 +318,10 @@ class DiffusersVideoModel:
                     f"MiniMax-H3 LoRA rank mismatch for {module_name}: "
                     f"A{tuple(a_tensor.shape)} and B{tuple(b_tensor.shape)}"
                 )
-            if not module_name.endswith(target_modules):
+            if not any(
+                module_name == target or module_name.endswith(f".{target}")
+                for target in target_modules
+            ):
                 raise ValueError(
                     f"Unsupported MiniMax-H3 LoRA target module {module_name!r}"
                 )

--- a/xinference/model/video/model_spec.json
+++ b/xinference/model/video/model_spec.json
@@ -560,7 +560,7 @@
       "packages": [
         "git+https://github.com/huggingface/diffusers@2da7040be1a2e5f2fcbc8b985083342a308f5a86",
         "transformers>=5.15.0,<6.0",
-        "peft==0.18.0",
+        "peft==0.20.0",
         "huggingface-hub>=1.23.0,<2.0",
         "safetensors>=0.8.0",
         "torchao>=0.16.0",

--- a/xinference/model/video/model_spec.json
+++ b/xinference/model/video/model_spec.json
@@ -530,6 +530,32 @@
     "default_generate_config": {
       "num_frames": 124
     },
+    "lightning_versions": [
+      "4step_v0.1",
+      "8step_v1.0_bf16",
+      "4step_v1.0_768p_bf16"
+    ],
+    "lightning_model_file_name_template": "minimax_h3_fl2v_turbo_{lightning_version}.safetensors",
+    "lightning_version_configs": {
+      "4step_v0.1": {
+        "num_inference_steps": 4,
+        "video_shift": 12.0,
+        "audio_shift": 3.0,
+        "lora_alpha": 8
+      },
+      "8step_v1.0_bf16": {
+        "num_inference_steps": 8,
+        "video_shift": 12.0,
+        "audio_shift": 3.0,
+        "lora_alpha": 8
+      },
+      "4step_v1.0_768p_bf16": {
+        "num_inference_steps": 4,
+        "video_shift": 6.0,
+        "audio_shift": 3.0,
+        "lora_alpha": 128
+      }
+    },
     "virtualenv": {
       "packages": [
         "git+https://github.com/huggingface/diffusers@2da7040be1a2e5f2fcbc8b985083342a308f5a86",
@@ -551,14 +577,18 @@
     "model_src": {
       "huggingface": {
         "model_id": "MiniMaxAI/MiniMax-H3",
-        "model_revision": "6818f6c32d12b210915e44ad56a4228c2608f160"
+        "model_revision": "6818f6c32d12b210915e44ad56a4228c2608f160",
+        "lightning_model_id": "lightx2v/Minimax-h3-Turbo",
+        "lightning_model_revision": "5d1d4829fe614c1b93fcfd9cc7718e9ba71f73e1"
       },
       "modelscope": {
         "model_id": "MiniMax/MiniMax-H3",
-        "model_revision": "master"
+        "model_revision": "master",
+        "lightning_model_id": "lightx2v/Minimax-h3-Turbo",
+        "lightning_model_revision": "master"
       }
     },
-    "updated_at": 1786704764,
+    "updated_at": 1786840547,
     "featured": false
   }
 ]

--- a/xinference/model/video/tests/test_minimax_h3_video.py
+++ b/xinference/model/video/tests/test_minimax_h3_video.py
@@ -298,7 +298,13 @@ def test_minimax_h3_loads_lightning_peft_checkpoint(monkeypatch):
         def __init__(self, **kwargs):
             self.kwargs = kwargs
 
+    class FakeTorchaoLoraLinear:
+        pass
+
     class FakeTransformer:
+        def __init__(self):
+            self.lora_layer = FakeTorchaoLoraLinear()
+
         def add_adapter(self, config):
             assert fake_peft_awq.is_gptqmodel_available() is False
             assert fake_peft_gptq.is_gptqmodel_available() is False
@@ -315,11 +321,8 @@ def test_minimax_h3_loads_lightning_peft_checkpoint(monkeypatch):
         def set_adapters(self, name, weights):
             calls["set_adapters"] = (name, weights)
 
-        def fuse_lora(self, **kwargs):
-            calls["fuse_lora"] = kwargs
-
-        def unload_lora(self):
-            calls["unload_lora"] = True
+        def modules(self):
+            return [self, self.lora_layer]
 
         def requires_grad_(self, value):
             calls["requires_grad"] = value
@@ -331,6 +334,8 @@ def test_minimax_h3_loads_lightning_peft_checkpoint(monkeypatch):
     fake_peft.LoraConfig = FakeLoraConfig
     fake_peft_tuners = types.ModuleType("peft.tuners")
     fake_peft_lora = types.ModuleType("peft.tuners.lora")
+    fake_peft_torchao = types.ModuleType("peft.tuners.lora.torchao")
+    fake_peft_torchao.TorchaoLoraLinear = FakeTorchaoLoraLinear
     fake_peft_awq = types.ModuleType("peft.tuners.lora.awq")
     fake_peft_gptq = types.ModuleType("peft.tuners.lora.gptq")
 
@@ -341,6 +346,7 @@ def test_minimax_h3_loads_lightning_peft_checkpoint(monkeypatch):
     fake_peft_gptq.is_gptqmodel_available = incompatible_gptqmodel_probe
     fake_peft_lora.awq = fake_peft_awq
     fake_peft_lora.gptq = fake_peft_gptq
+    fake_peft_lora.torchao = fake_peft_torchao
     fake_peft_tuners.lora = fake_peft_lora
     fake_peft.tuners = fake_peft_tuners
     fake_safetensors = types.ModuleType("safetensors")
@@ -352,11 +358,13 @@ def test_minimax_h3_loads_lightning_peft_checkpoint(monkeypatch):
     monkeypatch.setitem(sys.modules, "peft.tuners.lora", fake_peft_lora)
     monkeypatch.setitem(sys.modules, "peft.tuners.lora.awq", fake_peft_awq)
     monkeypatch.setitem(sys.modules, "peft.tuners.lora.gptq", fake_peft_gptq)
+    monkeypatch.setitem(sys.modules, "peft.tuners.lora.torchao", fake_peft_torchao)
     monkeypatch.setitem(sys.modules, "safetensors", fake_safetensors)
     monkeypatch.setitem(sys.modules, "safetensors.torch", fake_safetensors_torch)
 
+    transformer = FakeTransformer()
     DiffusersVideoModel._load_minimax_h3_lightning_adapter(
-        FakeTransformer(), "/tmp/lightning.safetensors", alpha=8
+        transformer, "/tmp/lightning.safetensors", alpha=8
     )
 
     assert calls["config"].kwargs == {
@@ -376,16 +384,61 @@ def test_minimax_h3_loads_lightning_peft_checkpoint(monkeypatch):
     assert calls["loaded_state_dict"] == state_dict
     assert calls["strict"] is False
     assert calls["set_adapters"] == ("default", 1.0)
-    assert calls["fuse_lora"] == {
-        "lora_scale": 1.0,
-        "safe_fusing": True,
-        "adapter_names": ["default"],
-    }
-    assert calls["unload_lora"] is True
+    assert (
+        transformer.lora_layer.forward.__func__
+        is diffusers_module._minimax_h3_memory_efficient_lora_forward
+    )
     assert calls["requires_grad"] is False
     assert calls["eval"] is True
     assert fake_peft_awq.is_gptqmodel_available is incompatible_gptqmodel_probe
     assert fake_peft_gptq.is_gptqmodel_available is incompatible_gptqmodel_probe
+
+
+def test_minimax_h3_memory_efficient_lora_forward_accumulates_in_place(
+    monkeypatch,
+):
+    import torch
+
+    torch.manual_seed(0)
+
+    class FakeLoraLayer:
+        def __init__(self):
+            self.base_layer = torch.nn.Linear(4, 6, bias=False)
+            self.lora_A = {"default": torch.nn.Linear(4, 2, bias=False)}
+            self.lora_B = {"default": torch.nn.Linear(2, 6, bias=False)}
+            self.lora_dropout = {"default": torch.nn.Identity()}
+            self.scaling = {"default": 0.5}
+            self.active_adapters = ["default"]
+            self.lora_variant = {}
+            self.disable_adapters = False
+            self.merged = False
+
+        @staticmethod
+        def _cast_input_dtype(value, dtype):
+            return value.to(dtype)
+
+    layer = FakeLoraLayer()
+    inputs = torch.randn(2, 3, 4)
+    with torch.inference_mode():
+        expected = layer.base_layer(inputs) + 0.5 * layer.lora_B["default"](
+            layer.lora_A["default"](inputs)
+        )
+
+    original_addmm = torch.addmm
+    calls = {}
+
+    def tracked_addmm(input_tensor, mat1, mat2, **kwargs):
+        calls["uses_base_output"] = input_tensor.data_ptr() == kwargs["out"].data_ptr()
+        return original_addmm(input_tensor, mat1, mat2, **kwargs)
+
+    monkeypatch.setattr(torch, "addmm", tracked_addmm)
+    with torch.inference_mode():
+        actual = diffusers_module._minimax_h3_memory_efficient_lora_forward(
+            layer, inputs
+        )
+
+    assert calls["uses_base_output"] is True
+    torch.testing.assert_close(actual, expected)
 
 
 def test_minimax_h3_loads_modular_pipeline(monkeypatch):

--- a/xinference/model/video/tests/test_minimax_h3_video.py
+++ b/xinference/model/video/tests/test_minimax_h3_video.py
@@ -298,12 +298,12 @@ def test_minimax_h3_loads_lightning_peft_checkpoint(monkeypatch):
         def __init__(self, **kwargs):
             self.kwargs = kwargs
 
-    class FakeTorchaoLoraLinear:
+    class FakePeftLoraLinear:
         pass
 
     class FakeTransformer:
         def __init__(self):
-            self.lora_layer = FakeTorchaoLoraLinear()
+            self.lora_layer = FakePeftLoraLinear()
 
         def add_adapter(self, config):
             assert fake_peft_awq.is_gptqmodel_available() is False
@@ -334,8 +334,8 @@ def test_minimax_h3_loads_lightning_peft_checkpoint(monkeypatch):
     fake_peft.LoraConfig = FakeLoraConfig
     fake_peft_tuners = types.ModuleType("peft.tuners")
     fake_peft_lora = types.ModuleType("peft.tuners.lora")
-    fake_peft_torchao = types.ModuleType("peft.tuners.lora.torchao")
-    fake_peft_torchao.TorchaoLoraLinear = FakeTorchaoLoraLinear
+    fake_peft_layer = types.ModuleType("peft.tuners.lora.layer")
+    fake_peft_layer.Linear = FakePeftLoraLinear
     fake_peft_awq = types.ModuleType("peft.tuners.lora.awq")
     fake_peft_gptq = types.ModuleType("peft.tuners.lora.gptq")
 
@@ -346,7 +346,7 @@ def test_minimax_h3_loads_lightning_peft_checkpoint(monkeypatch):
     fake_peft_gptq.is_gptqmodel_available = incompatible_gptqmodel_probe
     fake_peft_lora.awq = fake_peft_awq
     fake_peft_lora.gptq = fake_peft_gptq
-    fake_peft_lora.torchao = fake_peft_torchao
+    fake_peft_lora.layer = fake_peft_layer
     fake_peft_tuners.lora = fake_peft_lora
     fake_peft.tuners = fake_peft_tuners
     fake_safetensors = types.ModuleType("safetensors")
@@ -358,7 +358,7 @@ def test_minimax_h3_loads_lightning_peft_checkpoint(monkeypatch):
     monkeypatch.setitem(sys.modules, "peft.tuners.lora", fake_peft_lora)
     monkeypatch.setitem(sys.modules, "peft.tuners.lora.awq", fake_peft_awq)
     monkeypatch.setitem(sys.modules, "peft.tuners.lora.gptq", fake_peft_gptq)
-    monkeypatch.setitem(sys.modules, "peft.tuners.lora.torchao", fake_peft_torchao)
+    monkeypatch.setitem(sys.modules, "peft.tuners.lora.layer", fake_peft_layer)
     monkeypatch.setitem(sys.modules, "safetensors", fake_safetensors)
     monkeypatch.setitem(sys.modules, "safetensors.torch", fake_safetensors_torch)
 

--- a/xinference/model/video/tests/test_minimax_h3_video.py
+++ b/xinference/model/video/tests/test_minimax_h3_video.py
@@ -21,6 +21,7 @@ from PIL import Image
 
 from .. import diffusers as diffusers_module
 from .. import load_model_family_from_json
+from ..cache_manager import VideoCacheManager
 from ..core import VideoModelFamilyV2, match_diffusion
 from ..diffusers import DiffusersVideoModel
 
@@ -44,6 +45,43 @@ def _model_spec():
     )
 
 
+def _lightning_model_spec():
+    return _model_spec().copy(
+        update={
+            "lightning_model_id": "lightx2v/Minimax-h3-Turbo",
+            "lightning_model_revision": "lightning-revision",
+            "lightning_versions": [
+                "4step_v0.1",
+                "8step_v1.0_bf16",
+                "4step_v1.0_768p_bf16",
+            ],
+            "lightning_model_file_name_template": (
+                "minimax_h3_fl2v_turbo_{lightning_version}.safetensors"
+            ),
+            "lightning_version_configs": {
+                "4step_v0.1": {
+                    "num_inference_steps": 4,
+                    "video_shift": 12.0,
+                    "audio_shift": 3.0,
+                    "lora_alpha": 8,
+                },
+                "8step_v1.0_bf16": {
+                    "num_inference_steps": 8,
+                    "video_shift": 12.0,
+                    "audio_shift": 3.0,
+                    "lora_alpha": 8,
+                },
+                "4step_v1.0_768p_bf16": {
+                    "num_inference_steps": 4,
+                    "video_shift": 6.0,
+                    "audio_shift": 3.0,
+                    "lora_alpha": 128,
+                },
+            },
+        }
+    )
+
+
 def test_minimax_h3_selects_modelscope_source(monkeypatch):
     import xinference.model.video as video_module
 
@@ -58,6 +96,220 @@ def test_minimax_h3_selects_modelscope_source(monkeypatch):
     assert model_spec.model_id == "MiniMax/MiniMax-H3"
     assert model_spec.model_revision == "master"
     assert model_spec.default_model_config["quantization"] == "int4"
+    assert model_spec.lightning_model_id == "lightx2v/Minimax-h3-Turbo"
+    assert model_spec.lightning_model_revision == "master"
+    assert model_spec.lightning_version_configs["4step_v1.0_768p_bf16"] == {
+        "num_inference_steps": 4,
+        "video_shift": 6.0,
+        "audio_shift": 3.0,
+        "lora_alpha": 128,
+    }
+
+
+def test_minimax_h3_selects_huggingface_lightning_source(monkeypatch):
+    import xinference.model.video as video_module
+
+    model_families = {}
+    load_model_family_from_json("model_spec.json", model_families)
+    monkeypatch.setattr(video_module, "BUILTIN_VIDEO_MODELS", model_families)
+    monkeypatch.setenv("XINFERENCE_MODEL_SRC", "huggingface")
+
+    model_spec = match_diffusion("MiniMax-H3")
+
+    assert model_spec.model_hub == "huggingface"
+    assert model_spec.lightning_model_id == "lightx2v/Minimax-h3-Turbo"
+    assert (
+        model_spec.lightning_model_revision
+        == "5d1d4829fe614c1b93fcfd9cc7718e9ba71f73e1"
+    )
+
+
+def test_minimax_h3_downloads_lightning_from_modelscope(monkeypatch, tmp_path):
+    import xinference.model.utils as model_utils
+
+    calls = {}
+    filename = "minimax_h3_fl2v_turbo_4step_v0.1.safetensors"
+
+    def fake_model_file_download(model_id, requested_filename, revision):
+        calls["download"] = (model_id, requested_filename, revision)
+        return f"/downloaded/{requested_filename}"
+
+    fake_modelscope = types.ModuleType("modelscope")
+    fake_modelscope_hub = types.ModuleType("modelscope.hub")
+    fake_modelscope_file_download = types.ModuleType("modelscope.hub.file_download")
+    fake_modelscope_file_download.model_file_download = fake_model_file_download
+    monkeypatch.setitem(sys.modules, "modelscope", fake_modelscope)
+    monkeypatch.setitem(sys.modules, "modelscope.hub", fake_modelscope_hub)
+    monkeypatch.setitem(
+        sys.modules, "modelscope.hub.file_download", fake_modelscope_file_download
+    )
+    monkeypatch.setattr(
+        model_utils,
+        "retry_download",
+        lambda download, _model_name, _model_size, *args, **kwargs: download(
+            *args, **kwargs
+        ),
+    )
+    monkeypatch.setattr(
+        model_utils,
+        "symlink_local_file",
+        lambda source, cache_dir, target: calls.update(
+            symlink=(source, cache_dir, target)
+        ),
+    )
+
+    model_spec = _lightning_model_spec().copy(
+        update={
+            "model_hub": "modelscope",
+            "lightning_model_revision": "master",
+        }
+    )
+    cache_manager = VideoCacheManager(model_spec)
+    cache_manager._cache_dir = str(tmp_path)
+
+    result = cache_manager.cache_lightning("4step_v0.1")
+
+    assert result == str(tmp_path / filename)
+    assert calls["download"] == (
+        "lightx2v/Minimax-h3-Turbo",
+        filename,
+        "master",
+    )
+    assert calls["symlink"] == (
+        f"/downloaded/{filename}",
+        str(tmp_path),
+        filename,
+    )
+
+
+def test_minimax_h3_applies_lightning_version_config(monkeypatch):
+    calls = {}
+
+    class FakeScheduler:
+        def __init__(self, name):
+            self.name = name
+
+        def set_shift(self, shift):
+            calls[f"{self.name}_shift"] = shift
+
+    transformer = object()
+    pipeline = types.SimpleNamespace(
+        transformer=transformer,
+        scheduler=FakeScheduler("video"),
+        audio_scheduler=FakeScheduler("audio"),
+    )
+    model = DiffusersVideoModel(
+        "mock",
+        "/tmp/minimax-h3",
+        _lightning_model_spec(),
+        lightning_version="4step_v1.0_768p_bf16",
+        lightning_model_path="/tmp/minimax_h3_fl2v_turbo_4step_v1.0_768p_bf16.safetensors",
+    )
+    monkeypatch.setattr(
+        model,
+        "_load_minimax_h3_lightning_adapter",
+        lambda loaded_transformer, path, alpha: calls.update(
+            transformer=loaded_transformer, path=path, alpha=alpha
+        ),
+    )
+
+    model._apply_minimax_h3_lightning(pipeline)
+
+    assert calls == {
+        "transformer": transformer,
+        "path": "/tmp/minimax_h3_fl2v_turbo_4step_v1.0_768p_bf16.safetensors",
+        "alpha": 128,
+        "video_shift": 6.0,
+        "audio_shift": 3.0,
+    }
+    assert model._minimax_h3_lightning_steps == 4
+
+
+def test_minimax_h3_infers_lightning_version_from_path():
+    model = DiffusersVideoModel(
+        "mock",
+        "/tmp/minimax-h3",
+        _lightning_model_spec(),
+        lightning_model_path="/tmp/minimax_h3_fl2v_turbo_8step_v1.0_bf16.safetensors",
+    )
+
+    assert model._resolve_minimax_h3_lightning_config() == {
+        "version": "8step_v1.0_bf16",
+        "num_inference_steps": 8,
+        "video_shift": 12.0,
+        "audio_shift": 3.0,
+        "lora_alpha": 8,
+    }
+
+
+def test_minimax_h3_loads_lightning_peft_checkpoint(monkeypatch):
+    import torch
+
+    prefix = "transformer_blocks.0.attn.to_q"
+    state_dict = {
+        f"{prefix}.lora_A.default.weight": torch.zeros((128, 4)),
+        f"{prefix}.lora_B.default.weight": torch.zeros((4, 128)),
+    }
+    calls = {}
+
+    class FakeLoraConfig:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    class FakeTransformer:
+        def add_adapter(self, config):
+            calls["config"] = config
+
+        def named_parameters(self):
+            return state_dict.items()
+
+        def load_state_dict(self, loaded_state_dict, strict):
+            calls["loaded_state_dict"] = loaded_state_dict
+            calls["strict"] = strict
+            return types.SimpleNamespace(missing_keys=[], unexpected_keys=[])
+
+        def set_adapters(self, name, weights):
+            calls["set_adapters"] = (name, weights)
+
+        def requires_grad_(self, value):
+            calls["requires_grad"] = value
+
+        def eval(self):
+            calls["eval"] = True
+
+    fake_peft = types.ModuleType("peft")
+    fake_peft.LoraConfig = FakeLoraConfig
+    fake_safetensors = types.ModuleType("safetensors")
+    fake_safetensors_torch = types.ModuleType("safetensors.torch")
+    fake_safetensors_torch.load_file = lambda path, device: state_dict.copy()
+    fake_safetensors.torch = fake_safetensors_torch
+    monkeypatch.setitem(sys.modules, "peft", fake_peft)
+    monkeypatch.setitem(sys.modules, "safetensors", fake_safetensors)
+    monkeypatch.setitem(sys.modules, "safetensors.torch", fake_safetensors_torch)
+
+    DiffusersVideoModel._load_minimax_h3_lightning_adapter(
+        FakeTransformer(), "/tmp/lightning.safetensors", alpha=8
+    )
+
+    assert calls["config"].kwargs == {
+        "r": 128,
+        "lora_alpha": 8,
+        "init_lora_weights": False,
+        "target_modules": [
+            "to_q",
+            "to_k",
+            "to_v",
+            "to_out.0",
+            "ff.net.0.proj",
+            "ff.net.2",
+        ],
+        "use_rslora": False,
+    }
+    assert calls["loaded_state_dict"] == state_dict
+    assert calls["strict"] is False
+    assert calls["set_adapters"] == ("default", 1.0)
+    assert calls["requires_grad"] is False
+    assert calls["eval"] is True
 
 
 def test_minimax_h3_loads_modular_pipeline(monkeypatch):
@@ -301,8 +553,9 @@ def test_minimax_h3_forwards_workflows_and_muxes_audio(monkeypatch, tmp_path):
 
         def __call__(self, **kwargs):
             calls.append(kwargs)
-            with denoise.progress_bar(total=kwargs["num_inference_steps"]) as bar:
-                for _ in range(kwargs["num_inference_steps"]):
+            num_evaluations = kwargs["num_inference_steps"] - 1
+            with denoise.progress_bar(total=num_evaluations) as bar:
+                for _ in range(num_evaluations):
                     bar.update()
             return {
                 "videos": [[np.zeros((2, 2, 3), dtype=np.uint8)]],
@@ -352,7 +605,7 @@ def test_minimax_h3_forwards_workflows_and_muxes_audio(monkeypatch, tmp_path):
 
     assert result["data"][0]["b64_json"] is not None
     assert calls[0]["num_frames"] == 124
-    assert calls[0]["num_inference_steps"] == 3
+    assert calls[0]["num_inference_steps"] == 4
     assert calls[0]["output"] == ["videos", "audio", "sampling_rate"]
     assert "negative_prompt" not in calls[0]
     assert "guidance_scale" not in calls[0]
@@ -360,17 +613,21 @@ def test_minimax_h3_forwards_workflows_and_muxes_audio(monkeypatch, tmp_path):
     assert progressor.progress_updates[:3] == [1 / 3, 2 / 3, 1.0]
     assert "progress_bar" not in denoise.__dict__
 
+    model._minimax_h3_lightning_steps = 4
+    model.text_to_video("a running fox", response_format="url")
+    assert calls[1]["num_inference_steps"] == 5
+
     image = Image.new("RGB", (2, 2))
     model.image_to_video(image, "animate it", response_format="url")
-    assert calls[1]["image"] is image
+    assert calls[2]["image"] is image
 
     last_image = Image.new("RGB", (2, 2), color="white")
     model.firstlastframe_to_video(
         image, last_image, "transition", response_format="url"
     )
-    assert calls[2]["image"] is image
-    assert calls[2]["last_image"] is last_image
-    assert len(list(tmp_path.glob("*.mp4"))) == 2
+    assert calls[3]["image"] is image
+    assert calls[3]["last_image"] is last_image
+    assert len(list(tmp_path.glob("*.mp4"))) == 3
 
 
 def test_minimax_h3_cleans_up_partial_outputs_on_failure(monkeypatch, tmp_path):

--- a/xinference/model/video/tests/test_minimax_h3_video.py
+++ b/xinference/model/video/tests/test_minimax_h3_video.py
@@ -315,6 +315,12 @@ def test_minimax_h3_loads_lightning_peft_checkpoint(monkeypatch):
         def set_adapters(self, name, weights):
             calls["set_adapters"] = (name, weights)
 
+        def fuse_lora(self, **kwargs):
+            calls["fuse_lora"] = kwargs
+
+        def unload_lora(self):
+            calls["unload_lora"] = True
+
         def requires_grad_(self, value):
             calls["requires_grad"] = value
 
@@ -370,6 +376,12 @@ def test_minimax_h3_loads_lightning_peft_checkpoint(monkeypatch):
     assert calls["loaded_state_dict"] == state_dict
     assert calls["strict"] is False
     assert calls["set_adapters"] == ("default", 1.0)
+    assert calls["fuse_lora"] == {
+        "lora_scale": 1.0,
+        "safe_fusing": True,
+        "adapter_names": ["default"],
+    }
+    assert calls["unload_lora"] is True
     assert calls["requires_grad"] is False
     assert calls["eval"] is True
     assert fake_peft_awq.is_gptqmodel_available is incompatible_gptqmodel_probe

--- a/xinference/model/video/tests/test_minimax_h3_video.py
+++ b/xinference/model/video/tests/test_minimax_h3_video.py
@@ -403,7 +403,7 @@ def test_minimax_h3_memory_efficient_lora_forward_accumulates_in_place(
 
     class FakeLoraLayer:
         def __init__(self):
-            self.base_layer = torch.nn.Linear(4, 6, bias=False)
+            self.base_layer = torch.nn.Linear(4, 6, bias=False, dtype=torch.bfloat16)
             self.lora_A = {"default": torch.nn.Linear(4, 2, bias=False)}
             self.lora_B = {"default": torch.nn.Linear(2, 6, bias=False)}
             self.lora_dropout = {"default": torch.nn.Identity()}
@@ -414,14 +414,21 @@ def test_minimax_h3_memory_efficient_lora_forward_accumulates_in_place(
             self.merged = False
 
         @staticmethod
+        def _check_forward_args(*args, **kwargs):
+            pass
+
+        @staticmethod
         def _cast_input_dtype(value, dtype):
             return value.to(dtype)
 
     layer = FakeLoraLayer()
-    inputs = torch.randn(2, 3, 4)
+    inputs = torch.randn(2, 3, 4, dtype=torch.bfloat16)
     with torch.inference_mode():
-        expected = layer.base_layer(inputs) + 0.5 * layer.lora_B["default"](
-            layer.lora_A["default"](inputs)
+        expected = layer.base_layer(inputs)
+        low_rank_states = layer.lora_A["default"](inputs.float()).to(expected.dtype)
+        expected = expected + 0.5 * torch.nn.functional.linear(
+            low_rank_states,
+            layer.lora_B["default"].weight.to(expected.dtype),
         )
 
     original_addmm = torch.addmm
@@ -429,6 +436,7 @@ def test_minimax_h3_memory_efficient_lora_forward_accumulates_in_place(
 
     def tracked_addmm(input_tensor, mat1, mat2, **kwargs):
         calls["uses_base_output"] = input_tensor.data_ptr() == kwargs["out"].data_ptr()
+        calls["dtypes"] = (input_tensor.dtype, mat1.dtype, mat2.dtype)
         return original_addmm(input_tensor, mat1, mat2, **kwargs)
 
     monkeypatch.setattr(torch, "addmm", tracked_addmm)
@@ -438,6 +446,7 @@ def test_minimax_h3_memory_efficient_lora_forward_accumulates_in_place(
         )
 
     assert calls["uses_base_output"] is True
+    assert calls["dtypes"] == (torch.bfloat16,) * 3
     torch.testing.assert_close(actual, expected)
 
 

--- a/xinference/model/video/tests/test_minimax_h3_video.py
+++ b/xinference/model/video/tests/test_minimax_h3_video.py
@@ -96,6 +96,7 @@ def test_minimax_h3_selects_modelscope_source(monkeypatch):
     assert model_spec.model_id == "MiniMax/MiniMax-H3"
     assert model_spec.model_revision == "master"
     assert model_spec.default_model_config["quantization"] == "int4"
+    assert "peft==0.20.0" in model_spec.virtualenv.packages
     assert model_spec.lightning_model_id == "lightx2v/Minimax-h3-Turbo"
     assert model_spec.lightning_model_revision == "master"
     assert model_spec.lightning_version_configs["4step_v1.0_768p_bf16"] == {
@@ -299,6 +300,8 @@ def test_minimax_h3_loads_lightning_peft_checkpoint(monkeypatch):
 
     class FakeTransformer:
         def add_adapter(self, config):
+            assert fake_peft_awq.is_gptqmodel_available() is False
+            assert fake_peft_gptq.is_gptqmodel_available() is False
             calls["config"] = config
 
         def named_parameters(self):
@@ -320,11 +323,29 @@ def test_minimax_h3_loads_lightning_peft_checkpoint(monkeypatch):
 
     fake_peft = types.ModuleType("peft")
     fake_peft.LoraConfig = FakeLoraConfig
+    fake_peft_tuners = types.ModuleType("peft.tuners")
+    fake_peft_lora = types.ModuleType("peft.tuners.lora")
+    fake_peft_awq = types.ModuleType("peft.tuners.lora.awq")
+    fake_peft_gptq = types.ModuleType("peft.tuners.lora.gptq")
+
+    def incompatible_gptqmodel_probe():
+        raise ImportError("incompatible inherited GPTQModel")
+
+    fake_peft_awq.is_gptqmodel_available = incompatible_gptqmodel_probe
+    fake_peft_gptq.is_gptqmodel_available = incompatible_gptqmodel_probe
+    fake_peft_lora.awq = fake_peft_awq
+    fake_peft_lora.gptq = fake_peft_gptq
+    fake_peft_tuners.lora = fake_peft_lora
+    fake_peft.tuners = fake_peft_tuners
     fake_safetensors = types.ModuleType("safetensors")
     fake_safetensors_torch = types.ModuleType("safetensors.torch")
     fake_safetensors_torch.load_file = lambda path, device: state_dict.copy()
     fake_safetensors.torch = fake_safetensors_torch
     monkeypatch.setitem(sys.modules, "peft", fake_peft)
+    monkeypatch.setitem(sys.modules, "peft.tuners", fake_peft_tuners)
+    monkeypatch.setitem(sys.modules, "peft.tuners.lora", fake_peft_lora)
+    monkeypatch.setitem(sys.modules, "peft.tuners.lora.awq", fake_peft_awq)
+    monkeypatch.setitem(sys.modules, "peft.tuners.lora.gptq", fake_peft_gptq)
     monkeypatch.setitem(sys.modules, "safetensors", fake_safetensors)
     monkeypatch.setitem(sys.modules, "safetensors.torch", fake_safetensors_torch)
 
@@ -351,6 +372,8 @@ def test_minimax_h3_loads_lightning_peft_checkpoint(monkeypatch):
     assert calls["set_adapters"] == ("default", 1.0)
     assert calls["requires_grad"] is False
     assert calls["eval"] is True
+    assert fake_peft_awq.is_gptqmodel_available is incompatible_gptqmodel_probe
+    assert fake_peft_gptq.is_gptqmodel_available is incompatible_gptqmodel_probe
 
 
 def test_minimax_h3_loads_modular_pipeline(monkeypatch):

--- a/xinference/model/video/tests/test_minimax_h3_video.py
+++ b/xinference/model/video/tests/test_minimax_h3_video.py
@@ -22,7 +22,7 @@ from PIL import Image
 from .. import diffusers as diffusers_module
 from .. import load_model_family_from_json
 from ..cache_manager import VideoCacheManager
-from ..core import VideoModelFamilyV2, match_diffusion
+from ..core import VideoModelFamilyV2, create_video_model_instance, match_diffusion
 from ..diffusers import DiffusersVideoModel
 
 
@@ -182,6 +182,35 @@ def test_minimax_h3_downloads_lightning_from_modelscope(monkeypatch, tmp_path):
     )
 
 
+def test_video_rejects_unsupported_lightning_before_cache(monkeypatch):
+    from .. import cache_manager as cache_manager_module
+    from .. import core as core_module
+
+    cache_called = False
+
+    class FakeCacheManager:
+        def __init__(self, model_spec):
+            pass
+
+        def cache_lightning(self, lightning_version):
+            nonlocal cache_called
+            cache_called = True
+            return "/tmp/lightning.safetensors"
+
+    monkeypatch.setattr(core_module, "match_diffusion", lambda *args: _model_spec())
+    monkeypatch.setattr(cache_manager_module, "VideoCacheManager", FakeCacheManager)
+
+    with pytest.raises(ValueError, match="does not support lightning acceleration"):
+        create_video_model_instance(
+            "mock",
+            "MiniMax-H3",
+            model_path="/tmp/minimax-h3",
+            lightning_version="4step_v0.1",
+        )
+
+    assert cache_called is False
+
+
 def test_minimax_h3_applies_lightning_version_config(monkeypatch):
     calls = {}
 
@@ -240,6 +269,18 @@ def test_minimax_h3_infers_lightning_version_from_path():
         "audio_shift": 3.0,
         "lora_alpha": 8,
     }
+
+
+def test_minimax_h3_rejects_lightning_version_without_path():
+    model = DiffusersVideoModel(
+        "mock",
+        "/tmp/minimax-h3",
+        _lightning_model_spec(),
+        lightning_version="4step_v0.1",
+    )
+
+    with pytest.raises(ValueError, match="no lightning model path was provided"):
+        model._resolve_minimax_h3_lightning_config()
 
 
 def test_minimax_h3_loads_lightning_peft_checkpoint(monkeypatch):

--- a/xinference/model/video/tests/test_minimax_h3_video.py
+++ b/xinference/model/video/tests/test_minimax_h3_video.py
@@ -289,8 +289,8 @@ def test_minimax_h3_loads_lightning_peft_checkpoint(monkeypatch):
 
     prefix = "transformer_blocks.0.attn.to_q"
     state_dict = {
-        f"{prefix}.lora_A.default.weight": torch.zeros((128, 4)),
-        f"{prefix}.lora_B.default.weight": torch.zeros((4, 128)),
+        f"{prefix}.lora_A.default.weight": torch.zeros((4, 128)),
+        f"{prefix}.lora_B.default.weight": torch.zeros((128, 4)),
     }
     calls = {}
 
@@ -368,7 +368,7 @@ def test_minimax_h3_loads_lightning_peft_checkpoint(monkeypatch):
     )
 
     assert calls["config"].kwargs == {
-        "r": 128,
+        "r": 4,
         "lora_alpha": 8,
         "init_lora_weights": False,
         "target_modules": [
@@ -392,6 +392,38 @@ def test_minimax_h3_loads_lightning_peft_checkpoint(monkeypatch):
     assert calls["eval"] is True
     assert fake_peft_awq.is_gptqmodel_available is incompatible_gptqmodel_probe
     assert fake_peft_gptq.is_gptqmodel_available is incompatible_gptqmodel_probe
+
+
+def test_minimax_h3_rejects_partial_lora_target_match(monkeypatch):
+    import torch
+
+    prefix = "transformer_blocks.0.attn.add_to_q"
+    state_dict = {
+        f"{prefix}.lora_A.default.weight": torch.zeros((4, 128)),
+        f"{prefix}.lora_B.default.weight": torch.zeros((128, 4)),
+    }
+
+    fake_peft = types.ModuleType("peft")
+    fake_peft.LoraConfig = object
+    fake_peft_tuners = types.ModuleType("peft.tuners")
+    fake_peft_lora = types.ModuleType("peft.tuners.lora")
+    fake_peft_layer = types.ModuleType("peft.tuners.lora.layer")
+    fake_peft_layer.Linear = object
+    fake_safetensors = types.ModuleType("safetensors")
+    fake_safetensors_torch = types.ModuleType("safetensors.torch")
+    fake_safetensors_torch.load_file = lambda path, device: state_dict.copy()
+    fake_safetensors.torch = fake_safetensors_torch
+    monkeypatch.setitem(sys.modules, "peft", fake_peft)
+    monkeypatch.setitem(sys.modules, "peft.tuners", fake_peft_tuners)
+    monkeypatch.setitem(sys.modules, "peft.tuners.lora", fake_peft_lora)
+    monkeypatch.setitem(sys.modules, "peft.tuners.lora.layer", fake_peft_layer)
+    monkeypatch.setitem(sys.modules, "safetensors", fake_safetensors)
+    monkeypatch.setitem(sys.modules, "safetensors.torch", fake_safetensors_torch)
+
+    with pytest.raises(ValueError, match="Unsupported MiniMax-H3 LoRA target module"):
+        DiffusersVideoModel._load_minimax_h3_lightning_adapter(
+            object(), "/tmp/lightning.safetensors", alpha=8
+        )
 
 
 def test_minimax_h3_memory_efficient_lora_forward_accumulates_in_place(


### PR DESCRIPTION
## Summary

- add video-model Lightning metadata, caching, and launch options for the official MiniMax-H3 Turbo LoRAs
- support `4step_v0.1`, `8step_v1.0_bf16`, and `4step_v1.0_768p_bf16` with their required LoRA alpha, scheduler shifts, and default evaluation counts
- download the Lightning checkpoint from the same selected hub as the base model, including both Hugging Face and ModelScope
- document the shared video Lightning options and expose the versions through the existing launch UI

## Implementation notes

MiniMax-H3 Turbo checkpoints use PEFT-format LoRA tensors. The adapter is injected before group offload, while the existing INT4 and group-offload defaults remain unchanged. Since TorchAO INT4 weights cannot be dequantized for LoRA fusion, the adapter forward accumulates into the base output in place to avoid the extra full-size tensor that otherwise exceeds 24 GiB VRAM. Mixed-dtype LoRA operands are cast to the base output dtype before this in-place accumulation.

Per-request `num_inference_steps` represents actual transformer evaluations; Xinference adds the scheduler terminal sigma grid point internally. This correction applies to both Lightning and non-Lightning MiniMax-H3: a request for N evaluations now passes N + 1 scheduler grid points, so non-Lightning output may differ from earlier Xinference versions for the same `num_inference_steps` value. If a request omits the value, the selected Lightning version supplies its recommended 4 or 8 evaluations. The Web UI currently pre-fills 25, so users should change **Inference Steps** to match the selected Lightning version.

## Performance

Single-run wall-clock comparison on an NVIDIA GeForce RTX 3090 (24 GiB), using the same MiniMax-H3 defaults (INT4 plus group offload), prompt, and output settings: 1344x768, 124 frames, 24 FPS, one video.

| Configuration | Transformer evaluations | Denoising | End to end |
| --- | ---: | ---: | ---: |
| Baseline, no Lightning | 25 | 2h 12m 49s | 2h 14m 24s (8064s) |
| `4step_v1.0_768p_bf16` | 4 | 15m 23s | 16m 48s (1008s) |
| Measured speedup | — | 8.6x | 8.0x |

Both requests completed successfully with HTTP 200. These are single-run results on one machine; Lightning reduces denoising work but does not reduce the model's memory requirements.

## Validation

- `python -m pytest xinference/model/video/tests/test_minimax_h3_video.py xinference/model/video/tests/test_diffusers_video.py -q` (15 passed, 2 skipped)
- `pre-commit run --files ...`
- Sphinx dummy build succeeded; only existing unrelated reference warnings were reported
- GPU runtime validation passed for both the 25-step baseline and `4step_v1.0_768p_bf16` on the RTX 3090
