### PR TITLE
BUG: pin DeepDoc transformers to >=4.51,<5 for OCR launches

### DIFF
--- a/xinference/model/image/model_spec.json
+++ b/xinference/model/image/model_spec.json
@@ -1867,7 +1867,7 @@
       "packages": [
         "deepdoc-lib[gpu]~=0.2.2 ; has_cuda",
         "deepdoc-lib~=0.2.2 ; not has_cuda",
-        "transformers<5 ; #engine# == \"deepdoc\""
+        "transformers>=4.51.0,<5"
       ]
     },
     "model_src": {

--- a/xinference/model/image/tests/test_deepdoc.py
+++ b/xinference/model/image/tests/test_deepdoc.py
@@ -74,7 +74,7 @@ def test_deepdoc_virtualenv_selects_runtime_package(
 
     assert expected in selected
     assert unexpected not in selected
-    assert "transformers<5" in selected
+    assert "transformers>=4.51.0,<5" in selected
 
 
 def test_deepdoc_gpu_repairs_onnxruntime_namespace(monkeypatch):

--- a/xinference/model/image/tests/test_deepdoc.py
+++ b/xinference/model/image/tests/test_deepdoc.py
@@ -64,7 +64,7 @@ def test_deepdoc_virtualenv_selects_runtime_package(
     packages = BUILTIN_IMAGE_MODELS["DeepDoc"][0].virtualenv.packages
     # Xinference must preserve xoscar's extended has_cuda marker until the
     # virtual environment is created on the target worker.
-    prepared = filter_virtualenv_packages_by_markers(packages, "deepdoc", None)
+    prepared = filter_virtualenv_packages_by_markers(packages, None, None)
     assert any("has_cuda" in package for package in prepared)
 
     env = virtualenv_core.get_env()
@@ -74,7 +74,7 @@ def test_deepdoc_virtualenv_selects_runtime_package(
 
     assert expected in selected
     assert unexpected not in selected
-    assert "transformers>=4.51.0,<5" in selected
+    assert "transformers<5,>=4.51.0" in selected
 
 
 def test_deepdoc_gpu_repairs_onnxruntime_namespace(monkeypatch):


### PR DESCRIPTION
## Summary

Fixes #5295.

DeepDoc OCR launches do not set `#engine#`, so `transformers<5 ; #engine# == "deepdoc"` never applies. The shared `transformers>=4.51.0` then resolves transformers 5.x and the worker crashes.

This makes the DeepDoc pin unconditional: `transformers>=4.51.0,<5`.

The shared image-model constraint is unchanged.

## Test plan

- [x] model_spec.json still parses as valid JSON
- I do not have DeepDoc GPU weights here; the change matches the issue workaround `pip install "transformers>=4.51,<5"`.