### PR TITLE
fix: bound transformers<5 for DeepDoc OCR virtualenv (fix #5295)

### DIFF
--- a/xinference/model/image/model_spec.json
+++ b/xinference/model/image/model_spec.json
@@ -1867,7 +1867,7 @@
       "packages": [
         "deepdoc-lib[gpu]~=0.2.2 ; has_cuda",
         "deepdoc-lib~=0.2.2 ; not has_cuda",
-        "transformers<5 ; #engine# == \"deepdoc\""
+        "transformers<5"
       ]
     },
     "model_src": {

--- a/xinference/model/image/tests/test_deepdoc.py
+++ b/xinference/model/image/tests/test_deepdoc.py
@@ -226,3 +226,20 @@ def test_deepdoc_ocr(setup):
     payload = model.ocr(image=bio.getvalue(), task="table")
     assert payload["task"] == "table"
     assert isinstance(payload["structures"], list)
+
+
+def test_deepdoc_virtualenv_binds_transformers_without_engine():
+    """DeepDoc OCR launches without an engine; the transformers upper bound
+    must still apply so the virtualenv never resolves transformers 5.x
+    (incompatible with the pinned huggingface_hub). See issue #5295.
+    """
+    from ....core.utils import filter_virtualenv_packages_by_markers
+    from .. import BUILTIN_IMAGE_MODELS, register_builtin_model
+
+    register_builtin_model()
+    packages = BUILTIN_IMAGE_MODELS["DeepDoc"][0].virtualenv.packages
+    # Engine is None on the OCR model path (no #engine# is set), so a
+    # transformer constraint gated behind `#engine# == "deepdoc"` would be
+    # dropped and pip would pull in transformers 5.x.
+    prepared = filter_virtualenv_packages_by_markers(packages, None, None)
+    assert "transformers<5" in prepared


### PR DESCRIPTION
## Summary

DeepDoc fails to launch on a clean environment because its virtualenv resolves `transformers` to 5.x, which is incompatible with the `huggingface_hub` version pinned alongside it (`ImportError: cannot import name 'is_offline_mode' from 'huggingface_hub'`). This is issue #5295.

## Root cause

`xinference/model/image/model_spec.json` lists DeepDoc's transformer constraint as:

```json
"transformers<5 ; #engine# == \"deepdoc\""
```

The `#engine#` marker is evaluated by `filter_virtualenv_packages_by_markers` in `xinference/core/utils.py`. DeepDoc is launched as an **OCR** model, which sets no engine, so `model_engine` is `None`. When the engine is `None`, every package whose marker contains `#engine#` is filtered out entirely — including this constraint. The result is that DeepDoc's virtualenv has **no** upper bound on `transformers` and pip happily pulls in 5.x, which crashes at load time.

Notably, the existing test `test_deepdoc_virtualenv_selects_runtime_package` calls the filter with `model_engine="deepdoc"`, which activates the gated constraint and masks the bug. The OCR launch path uses `model_engine=None`, which is what actually breaks.

## Fix

Make the upper bound unconditional so it always applies to DeepDoc, regardless of engine:

```json
"transformers<5"
```

DeepDoc doesn't import `transformers` at all (verified via `grep -rn "import transformers" deepdoc/`), so the constraint only exists to keep the environment consistent; bounding it to `<5` is safe and fixes the launch.

## Test

Added `test_deepdoc_virtualenv_binds_transformers_without_engine`, which exercises the real OCR launch path (`model_engine=None`) and asserts `transformers<5` survives filtering. This fails against the old spec and passes after the fix, so it guards against the constraint being re-gated.

## Checklist

- [x] Fix references the root cause described in #5295
- [x] Added a regression test covering the `model_engine=None` path
