### PR TITLE
fix(core): guard missing/invalid usage in non-stream chat metrics

### DIFF
--- a/xinference/core/model.py
+++ b/xinference/core/model.py
@@ -881,7 +881,7 @@ class ModelActor(xo.StatelessActor, CancelMixin):
             if record and isinstance(record, dict):
                 usage = record.get("usage")
                 # Some backends may not have a valid usage, we just skip them.
-                if usage:
+                if isinstance(usage, dict):
                     completion_tokens = usage.get("completion_tokens")
                     prompt_tokens = usage.get("prompt_tokens")
                     if completion_tokens is not None and prompt_tokens is not None:

--- a/xinference/core/model.py
+++ b/xinference/core/model.py
@@ -879,15 +879,17 @@ class ModelActor(xo.StatelessActor, CancelMixin):
             elif isinstance(response, bytes):
                 record = json.loads(response)
             if record and isinstance(record, dict):
-                usage = record["usage"]
+                usage = record.get("usage")
                 # Some backends may not have a valid usage, we just skip them.
-                completion_tokens = usage["completion_tokens"]
-                prompt_tokens = usage["prompt_tokens"]
-                await self._record_completion_metrics(
-                    time.time() - start_time,
-                    completion_tokens,
-                    prompt_tokens,
-                )
+                if usage:
+                    completion_tokens = usage.get("completion_tokens")
+                    prompt_tokens = usage.get("prompt_tokens")
+                    if completion_tokens is not None and prompt_tokens is not None:
+                        await self._record_completion_metrics(
+                            time.time() - start_time,
+                            completion_tokens,
+                            prompt_tokens,
+                        )
                 await self.record_metrics(
                     "time_to_first_token_seconds",
                     "observe",

--- a/xinference/core/tests/test_model.py
+++ b/xinference/core/tests/test_model.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import asyncio
+import json
 import types
 
 import pytest
@@ -271,3 +272,74 @@ async def test_pre_destroy_frees_gpu_memory(
     else:
         assert len(calls) == 0
         assert stub._model is not None
+
+
+# ---------------------------------------------------------------------------
+# Regression test for the non-stream chat metrics guard (candidate #2).
+# A backend whose non-stream chat completion lacks a "usage" field (or sets
+# it to None) must not crash ModelActor.chat inside its `finally` metrics
+# block. The streaming path already guards with `if final_usage is not None`;
+# this keeps the non-stream path consistent with that intent.
+# ---------------------------------------------------------------------------
+class _NoUsageChatModel:
+    def __init__(self):
+        self.model_family = MockModelFamily()
+
+    async def chat(self, messages, **kwargs):
+        # Intentionally omit "usage" to mimic backends that don't report tokens.
+        return {
+            "id": "chatcmpl-test",
+            "object": "chat.completion",
+            "created": 0,
+            "model": "fake-no-usage",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "hello"},
+                    "finish_reason": "stop",
+                }
+            ],
+        }
+
+
+class _NoUsageChatModelActor(MockModelActor):
+    def __init__(self, supervisor_address, worker_address, replica_model_uid):
+        super().__init__(supervisor_address, worker_address, replica_model_uid)
+        # Replace the placeholder MockModel with one that returns no usage.
+        self._model = _NoUsageChatModel()
+
+
+@pytest_asyncio.fixture
+async def _chat_pool():
+    pool = await create_actor_pool(
+        f"test://127.0.0.1:{xo.utils.get_next_port()}", n_process=0
+    )
+    async with pool:
+        yield pool
+
+
+@pytest.mark.asyncio
+async def test_chat_without_usage_does_not_crash(_chat_pool):
+    # Before the fix, `await actor.chat(...)` raised KeyError/TypeError from
+    # the `finally` block because it indexed `record["usage"]` unconditionally.
+    pool = _chat_pool
+    addr = pool.external_address
+    actor = await xo.create_actor(
+        _NoUsageChatModelActor,
+        address=addr,
+        uid=_NoUsageChatModelActor.default_uid(),
+        supervisor_address="test:123",
+        worker_address="test:345",
+        replica_model_uid="test_chat_no_usage",
+    )
+    result = await actor.chat([{"role": "user", "content": "hi"}])
+    # Tolerate both a raw bytes return and an xoscar generator wrapper.
+    if isinstance(result, (bytes, str)):
+        parsed = json.loads(result)
+    else:
+        collected = []
+        async for chunk in result:
+            collected.append(chunk)
+        first = collected[0]
+        parsed = json.loads(first if isinstance(first, (bytes, str)) else first.decode())
+    assert parsed["choices"][0]["message"]["content"] == "hello"

--- a/xinference/core/tests/test_model.py
+++ b/xinference/core/tests/test_model.py
@@ -341,7 +341,9 @@ async def test_chat_without_usage_does_not_crash(_chat_pool):
         async for chunk in result:
             collected.append(chunk)
         first = collected[0]
-        parsed = json.loads(first if isinstance(first, (bytes, str)) else first.decode())
+        parsed = json.loads(
+            first if isinstance(first, (bytes, str)) else first.decode()
+        )
     assert parsed["choices"][0]["message"]["content"] == "hello"
 
 
@@ -398,5 +400,7 @@ async def test_chat_with_non_dict_usage_does_not_crash(_chat_pool):
         async for chunk in result:
             collected.append(chunk)
         first = collected[0]
-        parsed = json.loads(first if isinstance(first, (bytes, str)) else first.decode())
+        parsed = json.loads(
+            first if isinstance(first, (bytes, str)) else first.decode()
+        )
     assert parsed["choices"][0]["message"]["content"] == "hi"

--- a/xinference/core/tests/test_model.py
+++ b/xinference/core/tests/test_model.py
@@ -343,3 +343,60 @@ async def test_chat_without_usage_does_not_crash(_chat_pool):
         first = collected[0]
         parsed = json.loads(first if isinstance(first, (bytes, str)) else first.decode())
     assert parsed["choices"][0]["message"]["content"] == "hello"
+
+
+class _NonDictUsageChatModel:
+    """A model whose non-stream chat returns usage as a non-dict truthy value
+    (e.g. a string). The original `if usage:` guard would have crashed on it
+    via AttributeError when calling .get()."""
+
+    def __init__(self):
+        self.model_family = MockModelFamily()
+
+    async def chat(self, messages, **kwargs):
+        return {
+            "id": "chatcmpl-test",
+            "object": "chat.completion",
+            "created": 0,
+            "model": "fake-non-dict-usage",
+            "usage": "unexpected-string-usage",  # truthy but NOT a dict
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": "hi"},
+                    "finish_reason": "stop",
+                }
+            ],
+        }
+
+
+class _NonDictUsageChatModelActor(MockModelActor):
+    def __init__(self, supervisor_address, worker_address, replica_model_uid):
+        super().__init__(supervisor_address, worker_address, replica_model_uid)
+        self._model = _NonDictUsageChatModel()
+
+
+@pytest.mark.asyncio
+async def test_chat_with_non_dict_usage_does_not_crash(_chat_pool):
+    # Regression test for the isinstance(usage, dict) guard: a non-dict truthy
+    # usage (string/list) must not raise AttributeError from .get().
+    pool = _chat_pool
+    addr = pool.external_address
+    actor = await xo.create_actor(
+        _NonDictUsageChatModelActor,
+        address=addr,
+        uid=_NonDictUsageChatModelActor.default_uid(),
+        supervisor_address="test:123",
+        worker_address="test:345",
+        replica_model_uid="test_chat_non_dict_usage",
+    )
+    result = await actor.chat([{"role": "user", "content": "hi"}])
+    if isinstance(result, (bytes, str)):
+        parsed = json.loads(result)
+    else:
+        collected = []
+        async for chunk in result:
+            collected.append(chunk)
+        first = collected[0]
+        parsed = json.loads(first if isinstance(first, (bytes, str)) else first.decode())
+    assert parsed["choices"][0]["message"]["content"] == "hi"


### PR DESCRIPTION
## What

In `ModelActor.chat`, the non-stream metrics block in the `finally` clause indexes `record["usage"]` unconditionally:

```python
usage = record["usage"]
completion_tokens = usage["completion_tokens"]
prompt_tokens = usage["prompt_tokens"]
```

If a backend returns a non-stream chat completion **without** a `usage` field (or with `usage: null`), this raises `KeyError` / `TypeError` inside the `finally` block, which masks the otherwise successful response and turns a working request into a 500.

The in-code comment already says *"Some backends may not have a valid usage, we just skip them."* — the intent was to skip, but the code never guarded against a missing/invalid `usage`.

## Why it's reachable

The non-stream path returns `orjson.dumps(dict)` (bytes); the `finally` block does `record = json.loads(response)` and then blindly indexes `usage`. The streaming path (`_to_generator` / `_to_async_gen`) already guards with `if final_usage is not None`, so the non-stream path was simply missing the same protection.

## Fix

Use `.get()` and only record token metrics when `usage` is present and valid. The `time_to_first_token_seconds` metric (non-stream latency) keeps being recorded as before, so existing behavior is unchanged for the normal case.

## Test

Added `test_chat_without_usage_does_not_crash` in `xinference/core/tests/test_model.py`, reusing the existing `MockModelActor` harness: a model whose non-stream chat returns a completion without `usage` must not raise.
