### PR TITLE
feat: [new model] minimax music3

### DIFF
--- a/doc/source/models/builtin/audio/index.rst
+++ b/doc/source/models/builtin/audio/index.rst
@@ -61,6 +61,8 @@ The following is a list of built-in audio models in Xinference:
   
    melotts-spanish
   
+   minimax-music3
+
    paraformer-zh
   
    paraformer-zh-hotword

--- a/doc/source/models/builtin/audio/minimax-music3.rst
+++ b/doc/source/models/builtin/audio/minimax-music3.rst
@@ -1,0 +1,39 @@
+.. _models_builtin_minimax-music3:
+
+==============
+MiniMax-Music3
+==============
+
+- **Model Name:** MiniMax-Music3
+- **Model Family:** minimax_music3
+- **Abilities:** ['text2music']
+- **Multilingual:** True
+- **Accelerator:** NVIDIA CUDA only
+- **License:** `MiniMax-Music3 Community License <https://huggingface.co/MiniMaxAI/MiniMax-Music3/blob/main/LICENSE>`_
+
+Specifications
+^^^^^^^^^^^^^^
+
+- **Model ID:** MiniMaxAI/MiniMax-Music3
+- **Engine:** diffusers
+
+MiniMax-Music3 generates songs from lyrics plus a music description. Xinference
+uses the Diffusers ``ModularPipeline`` backend and does not install or proxy
+SGLang-Omni. The per-model virtual environment pins the Diffusers commit that
+first included the pipeline (`2da7040be1a2e5f2fcbc8b985083342a308f5a86
+<https://github.com/huggingface/diffusers/commit/2da7040be1a2e5f2fcbc8b985083342a308f5a86>`_)
+because Diffusers 0.39.0 predates that integration.
+
+Launch the model on an NVIDIA CUDA worker::
+
+   xinference launch --model-name MiniMax-Music3 --model-type audio --model-engine diffusers
+
+The default load configuration uses BF16 with automatic CPU offload. Group
+offload can be enabled for lower VRAM usage (at the cost of speed)::
+
+   xinference launch --model-name MiniMax-Music3 --model-type audio \
+     --model-engine diffusers --group_offload true
+
+See :ref:`MiniMax-Music3 speech usage <minimax_music3_speech>` for request
+examples and parameter limits. The model weights are distributed under the
+MiniMax-Music3 Community License, not Apache-2.0.

--- a/doc/source/models/builtin/audio/minimax-music3.rst
+++ b/doc/source/models/builtin/audio/minimax-music3.rst
@@ -28,7 +28,7 @@ Launch the model on an NVIDIA CUDA worker::
 
    xinference launch --model-name MiniMax-Music3 --model-type audio --model-engine diffusers
 
-The default load configuration uses BF16 with automatic CPU offload. Group
+The default load configuration uses BF16 and keeps the pipeline on CUDA. Group
 offload can be enabled for lower VRAM usage (at the cost of speed)::
 
    xinference launch --model-name MiniMax-Music3 --model-type audio \

--- a/doc/source/models/model_abilities/audio.rst
+++ b/doc/source/models/model_abilities/audio.rst
@@ -4,7 +4,8 @@
 Audio
 =====
 
-Learn how to turn audio into text, text into audio, or audio into speaker embeddings with Xinference.
+Learn how to turn audio into text, synthesize speech, generate music, or extract
+speaker embeddings with Xinference.
 
 
 Introduction
@@ -108,6 +109,11 @@ Text to audio (TTS)
 * MeloTTS series
 * :ref:`Kokoro-82M <models_builtin_kokoro-82m>`
 * :ref:`MegaTTS3 <models_builtin_megatts3>`
+
+Music generation
+~~~~~~~~~~~~~~~~
+
+* :ref:`MiniMax-Music3 <models_builtin_minimax-music3>` (NVIDIA CUDA only)
 
 Speaker embeddings
 ~~~~~~~~~~~~~~~~~~
@@ -352,6 +358,94 @@ Speech API use non-stream by default as
   .. code-tab:: output
 
     The output will be an audio binary.
+
+
+.. _minimax_music3_speech:
+
+MiniMax-Music3 Usage
+~~~~~~~~~~~~~~~~~~~~
+
+``MiniMax-Music3`` reuses the Speech endpoint for text-to-music generation.
+Put the lyrics in ``input`` and the required music description in
+``prompt_text`` inside the existing ``kwargs`` field. Preserve line breaks and
+put tags such as ``[Verse]`` and ``[Chorus]`` on their own lines.
+
+``duration`` is the maximum generated length in seconds. Its range is 0.04
+through 360 and its default is 60. Xinference passes it directly to the
+Diffusers pipeline as ``audio_duration``. The model may emit an end-of-audio
+token and finish before the limit.
+The initial integration only accepts ``response_format=wav``, ``stream=false``,
+``speed=1.0``, and ``voice`` set to ``default``, an empty string, or null.
+Inference requires NVIDIA CUDA. Sampling steps and classifier-free guidance
+remain at the Diffusers defaults and are not request parameters.
+
+Xinference preserves the Diffusers pipeline's native 44.1 kHz stereo samples.
+It wraps them in an IEEE-float WAV container without resampling or integer PCM
+quantization.
+
+``prompt_text``, ``seed``, and ``duration`` are model options passed through the
+existing ``kwargs`` channel rather than additional Speech API parameters. Raw
+REST requests encode ``kwargs`` as a JSON string. The Xinference sync and async
+clients accept these names through their existing ``**kwargs`` argument.
+
+.. tabs::
+
+  .. code-tab:: bash cURL
+
+    curl 'http://<XINFERENCE_HOST>:<XINFERENCE_PORT>/v1/audio/speech' \
+      -H 'Content-Type: application/json' \
+      -d '{
+        "model": "<MODEL_UID>",
+        "input": "[Verse]\nMorning light filtering through the pine\n[Chorus]\nSoftly the world begins to breathe",
+        "voice": "default",
+        "response_format": "wav",
+        "speed": 1.0,
+        "stream": false,
+        "kwargs": "{\"prompt_text\": \"Warm acoustic pop with intimate female vocals, fingerpicked guitar, soft piano, and a wide final chorus.\", \"seed\": 7, \"duration\": 60}"
+      }' \
+      --output music3.wav
+
+  .. code-tab:: python OpenAI Python Client
+
+    import json
+
+    from openai import OpenAI
+
+    client = OpenAI(
+        api_key="cannot be empty",
+        base_url="http://<XINFERENCE_HOST>:<XINFERENCE_PORT>/v1",
+    )
+    response = client.audio.speech.create(
+        model="<MODEL_UID>",
+        input="[Verse]\nMorning light\n[Chorus]\nSing again",
+        voice="default",
+        response_format="wav",
+        extra_body={
+            "kwargs": json.dumps({
+                "prompt_text": "Warm acoustic pop with intimate vocals and soft piano.",
+                "seed": 7,
+                "duration": 60,
+            })
+        },
+    )
+    response.write_to_file("music3.wav")
+
+  .. code-tab:: python Xinference Python Client
+
+    from xinference.client import Client
+
+    client = Client("http://<XINFERENCE_HOST>:<XINFERENCE_PORT>")
+    model = client.get_model("<MODEL_UID>")
+    wav = model.speech(
+        input="[Verse]\nMorning light\n[Chorus]\nSing again",
+        prompt_text="Warm acoustic pop with intimate vocals and soft piano.",
+        voice="default",
+        response_format="wav",
+        seed=7,
+        duration=60,
+    )
+    with open("music3.wav", "wb") as output:
+        output.write(wav)
 
 
 ChatTTS Usage

--- a/doc/source/models/model_abilities/audio.rst
+++ b/doc/source/models/model_abilities/audio.rst
@@ -367,7 +367,7 @@ MiniMax-Music3 Usage
 
 ``MiniMax-Music3`` reuses the Speech endpoint for text-to-music generation.
 Put the lyrics in ``input`` and the required music description in
-``prompt_text`` inside the existing ``kwargs`` field. Preserve line breaks and
+``instruct`` inside the existing ``kwargs`` field. Preserve line breaks and
 put tags such as ``[Verse]`` and ``[Chorus]`` on their own lines.
 
 ``duration`` is the maximum generated length in seconds. Its range is 0.04
@@ -383,7 +383,7 @@ Xinference preserves the Diffusers pipeline's native 44.1 kHz stereo samples.
 It wraps them in an IEEE-float WAV container without resampling or integer PCM
 quantization.
 
-``prompt_text``, ``seed``, and ``duration`` are model options passed through the
+``instruct``, ``seed``, and ``duration`` are model options passed through the
 existing ``kwargs`` channel rather than additional Speech API parameters. Raw
 REST requests encode ``kwargs`` as a JSON string. The Xinference sync and async
 clients accept these names through their existing ``**kwargs`` argument.
@@ -401,7 +401,7 @@ clients accept these names through their existing ``**kwargs`` argument.
         "response_format": "wav",
         "speed": 1.0,
         "stream": false,
-        "kwargs": "{\"prompt_text\": \"Warm acoustic pop with intimate female vocals, fingerpicked guitar, soft piano, and a wide final chorus.\", \"seed\": 7, \"duration\": 60}"
+        "kwargs": "{\"instruct\": \"Warm acoustic pop with intimate female vocals, fingerpicked guitar, soft piano, and a wide final chorus.\", \"seed\": 7, \"duration\": 60}"
       }' \
       --output music3.wav
 
@@ -422,7 +422,7 @@ clients accept these names through their existing ``**kwargs`` argument.
         response_format="wav",
         extra_body={
             "kwargs": json.dumps({
-                "prompt_text": "Warm acoustic pop with intimate vocals and soft piano.",
+                "instruct": "Warm acoustic pop with intimate vocals and soft piano.",
                 "seed": 7,
                 "duration": 60,
             })
@@ -438,7 +438,7 @@ clients accept these names through their existing ``**kwargs`` argument.
     model = client.get_model("<MODEL_UID>")
     wav = model.speech(
         input="[Verse]\nMorning light\n[Chorus]\nSing again",
-        prompt_text="Warm acoustic pop with intimate vocals and soft piano.",
+        instruct="Warm acoustic pop with intimate vocals and soft piano.",
         voice="default",
         response_format="wav",
         seed=7,

--- a/frontend/src/components/pages/running-model-detail/capability-config.tsx
+++ b/frontend/src/components/pages/running-model-detail/capability-config.tsx
@@ -748,7 +748,7 @@ export const CAPABILITY_CONFIGS: Partial<Record<ModelAbility, CapabilityConfig>>
           key: 'kwargs',
           required: true,
           value: JSON.stringify({
-            prompt_text: 'Warm acoustic pop with intimate vocals',
+            instruct: 'Warm acoustic pop with intimate vocals',
             seed: 7,
             duration: 60,
           }),
@@ -759,7 +759,7 @@ export const CAPABILITY_CONFIGS: Partial<Record<ModelAbility, CapabilityConfig>>
     },
     initialValues: {
       input: '',
-      prompt_text: '',
+      instruct: '',
       seed: 0,
       duration: 60,
     },
@@ -772,7 +772,7 @@ export const CAPABILITY_CONFIGS: Partial<Record<ModelAbility, CapabilityConfig>>
       voice: 'default',
       response_format: 'wav',
       kwargs: JSON.stringify({
-        prompt_text: stringValue(values.prompt_text),
+        instruct: stringValue(values.instruct),
         seed: numberValue(values.seed, 0),
         duration: numberValue(values.duration, 60),
       }),

--- a/frontend/src/components/pages/running-model-detail/capability-config.tsx
+++ b/frontend/src/components/pages/running-model-detail/capability-config.tsx
@@ -7,6 +7,7 @@ import {
   ImageUp,
   ListFilter,
   Mic,
+  Music2,
   Paintbrush,
   ScanText,
   Video,
@@ -727,5 +728,54 @@ export const CAPABILITY_CONFIGS: Partial<Record<ModelAbility, CapabilityConfig>>
         kwargs
       );
     },
+  },
+  [ModelAbility.Text2music]: {
+    ability: ModelAbility.Text2music,
+    label: 'Music Generation',
+    icon: Music2,
+    requestApi: '/v1/audio/speech',
+    codeExample: {
+      method: 'POST',
+      contentType: 'json',
+      fields: [
+        { key: 'model', required: true },
+        {
+          key: 'input',
+          required: true,
+          value: '[Verse]\nMorning light across the city\n[Chorus]\nSing it back to me',
+        },
+        {
+          key: 'kwargs',
+          required: true,
+          value: JSON.stringify({
+            prompt_text: 'Warm acoustic pop with intimate vocals',
+            seed: 7,
+            duration: 60,
+          }),
+        },
+        { key: 'voice', required: true, value: 'default' },
+        { key: 'response_format', required: true, value: 'wav' },
+      ],
+    },
+    initialValues: {
+      input: '',
+      prompt_text: '',
+      seed: 0,
+      duration: 60,
+    },
+    formPanel: SpeechPanel,
+    resultPanel: ResultPanels.Universal,
+    responseType: 'blob',
+    transformValues: ({ modelUid, values }) => ({
+      model: modelUid,
+      input: stringValue(values.input),
+      voice: 'default',
+      response_format: 'wav',
+      kwargs: JSON.stringify({
+        prompt_text: stringValue(values.prompt_text),
+        seed: values.seed,
+        duration: values.duration,
+      }),
+    }),
   },
 };

--- a/frontend/src/components/pages/running-model-detail/capability-config.tsx
+++ b/frontend/src/components/pages/running-model-detail/capability-config.tsx
@@ -773,8 +773,8 @@ export const CAPABILITY_CONFIGS: Partial<Record<ModelAbility, CapabilityConfig>>
       response_format: 'wav',
       kwargs: JSON.stringify({
         prompt_text: stringValue(values.prompt_text),
-        seed: values.seed,
-        duration: values.duration,
+        seed: numberValue(values.seed, 0),
+        duration: numberValue(values.duration, 60),
       }),
     }),
   },

--- a/frontend/src/components/pages/running-model-detail/panels/capability-task-panel.tsx
+++ b/frontend/src/components/pages/running-model-detail/panels/capability-task-panel.tsx
@@ -40,6 +40,14 @@ function normalizeProgress(response: ProgressResponse) {
   return Math.max(0, Math.min(100, response.progress * 100));
 }
 
+function audioFileName(modelName: string, blob: Blob) {
+  const mimeSubtype = blob.type.split(';', 1)[0].split('/')[1];
+  const extension = mimeSubtype === 'mpeg' ? 'mp3' : mimeSubtype || 'mp3';
+  const timestamp = new Date().toLocaleString('sv-SE').replace(/\D/g, '');
+  const safeModelName = modelName.replace(/[<>:"/\\|?*]/g, '_');
+  return `${safeModelName}_${timestamp}.${extension}`;
+}
+
 const CapabilityTaskPanel = forwardRef<CapabilityTaskPanelMethod, CapabilityTaskPanelProps>(
   ({ config, model, modelUid }, ref) => {
     const form = useMemo(() => createForm(), []);
@@ -147,7 +155,13 @@ const CapabilityTaskPanel = forwardRef<CapabilityTaskPanelMethod, CapabilityTask
         .then((response) => {
           if (runTokenRef.current !== runToken) return;
 
-          setResult(response);
+          setResult(
+            response instanceof Blob
+              ? new File([response], audioFileName(model.model_name, response), {
+                  type: response.type,
+                })
+              : response
+          );
           setResultValues(values);
         })
         .finally(() => {

--- a/frontend/src/components/pages/running-model-detail/panels/form-panels.tsx
+++ b/frontend/src/components/pages/running-model-detail/panels/form-panels.tsx
@@ -478,6 +478,7 @@ function EmotionVectorInput({ value, onChange, disabled, error }: BaseFormFieldP
 }
 
 export function SpeechPanel({ form, model }: CapabilityFormProps) {
+  const isMusicGeneration = model.model_ability.includes(ModelAbility.Text2music);
   const supportsVoiceCloning = model.model_ability.includes(ModelAbility.Text2audioVoiceCloning);
   const supportsEmotionVector =
     isIndexTTSEmotionModel(model.model_family, model.model_name) &&
@@ -486,17 +487,44 @@ export function SpeechPanel({ form, model }: CapabilityFormProps) {
 
   return (
     <>
-      <FormField name="input" label="Text" rules={[{ required: true }]}>
+      <FormField
+        name="input"
+        label={isMusicGeneration ? 'Lyrics' : 'Text'}
+        rules={[{ required: true }]}
+      >
         <Textarea className="min-h-32" placeholder="Enter text to synthesize..." />
       </FormField>
-      <div className="grid grid-cols-2 gap-3">
-        <FormField name="voice" label="Voice" placeholder="Optional voice ID">
-          <Input />
-        </FormField>
-        <FormField name="speed" label="Speed" normalize={normalizeNumberInput}>
-          <Input type="number" min={0.5} max={2} step={0.1} />
-        </FormField>
-      </div>
+      {!isMusicGeneration && (
+        <div className="grid grid-cols-2 gap-3">
+          <FormField name="voice" label="Voice" placeholder="Optional voice ID">
+            <Input />
+          </FormField>
+          <FormField name="speed" label="Speed" normalize={normalizeNumberInput}>
+            <Input type="number" min={0.5} max={2} step={0.1} />
+          </FormField>
+        </div>
+      )}
+      {isMusicGeneration && (
+        <div className="grid grid-cols-2 gap-3">
+          <div className="flex items-end gap-2">
+            <FormField name="seed" label="Seed" normalize={normalizeNumberInput} className="flex-1">
+              <Input type="number" />
+            </FormField>
+            <Button
+              variant="outline"
+              size="icon"
+              aria-label="Generate random seed"
+              title="Generate random seed"
+              onClick={() => form.setFieldValue('seed', Math.floor(Math.random() * 2 ** 31))}
+            >
+              <span aria-hidden="true">🎲</span>
+            </Button>
+          </div>
+          <FormField name="duration" label="Duration (seconds)" normalize={normalizeNumberInput}>
+            <Input type="number" />
+          </FormField>
+        </div>
+      )}
       {supportsVoiceCloning && (
         <>
           <FormField name="prompt_speech">
@@ -535,6 +563,14 @@ export function SpeechPanel({ form, model }: CapabilityFormProps) {
             <EmotionVectorInput />
           </FormField>
         </div>
+      )}
+      {isMusicGeneration && (
+        <FormField name="prompt_text" label="Music description" rules={[{ required: true }]}>
+          <Textarea
+            className="min-h-28"
+            placeholder="Describe the genre, mood, vocals, instrumentation, and arrangement..."
+          />
+        </FormField>
       )}
     </>
   );

--- a/frontend/src/components/pages/running-model-detail/panels/form-panels.tsx
+++ b/frontend/src/components/pages/running-model-detail/panels/form-panels.tsx
@@ -525,7 +525,7 @@ export function SpeechPanel({ form, model }: CapabilityFormProps) {
           </FormField>
         </div>
       )}
-      {supportsVoiceCloning && (
+      {supportsVoiceCloning && !isMusicGeneration && (
         <>
           <FormField name="prompt_speech">
             <FileUpload
@@ -565,11 +565,8 @@ export function SpeechPanel({ form, model }: CapabilityFormProps) {
         </div>
       )}
       {isMusicGeneration && (
-        <FormField name="prompt_text" label="Music description" rules={[{ required: true }]}>
-          <Textarea
-            className="min-h-28"
-            placeholder="Describe the genre, mood, vocals, instrumentation, and arrangement..."
-          />
+        <FormField name="instruct" label="Music description" rules={[{ required: true }]}>
+          <Textarea placeholder="Describe the music to generate" />
         </FormField>
       )}
     </>

--- a/frontend/src/components/pages/running-model-detail/panels/result-panels.tsx
+++ b/frontend/src/components/pages/running-model-detail/panels/result-panels.tsx
@@ -184,7 +184,14 @@ function BlobMediaPreview({
 
   if (!url) return null;
 
-  return <MediaPreview type={type} url={url} className={className} />;
+  return (
+    <MediaPreview
+      type={type}
+      url={url}
+      title={blob instanceof File ? blob.name : undefined}
+      className={className}
+    />
+  );
 }
 
 function MediaResultPanel({ result, type }: { result: unknown; type: MediaType }) {

--- a/frontend/src/components/pages/running-model-detail/panels/result-panels.tsx
+++ b/frontend/src/components/pages/running-model-detail/panels/result-panels.tsx
@@ -97,7 +97,7 @@ function isVisualAbility(ability: ModelAbility) {
 }
 
 function isAudioResultAbility(ability: ModelAbility) {
-  return [ModelAbility.Text2audio, ModelAbility.Audio2audio, ModelAbility.Audio2audio].includes(
+  return [ModelAbility.Text2audio, ModelAbility.Text2music, ModelAbility.Audio2audio].includes(
     ability
   );
 }

--- a/frontend/src/constants/index.ts
+++ b/frontend/src/constants/index.ts
@@ -59,6 +59,7 @@ export enum ModelAbility {
   Audio2text = 'audio2text',
   SpeakerEmbedding = 'speaker_embedding',
   Text2audio = 'text2audio',
+  Text2music = 'text2music',
   Audio2audio = 'audio2audio',
   Text2video = 'text2video',
   Image2video = 'image2video',

--- a/frontend/src/constants/register.ts
+++ b/frontend/src/constants/register.ts
@@ -225,11 +225,13 @@ export const MODEL_ABILITY_IMAGE_OPTIONS = [
 ];
 export enum ModelAbilityForAudio {
   Text2audio = 'text2audio',
+  Text2music = 'text2music',
   Audio2text = 'audio2text',
   SpeakerEmbedding = 'speaker_embedding',
 }
 export const MODEL_ABILITY_AUDIO_OPTIONS = [
   { label: 'Text2audio', value: ModelAbilityForAudio.Text2audio },
+  { label: 'MusicGeneration', value: ModelAbilityForAudio.Text2music },
   { label: 'Audio2text', value: ModelAbilityForAudio.Audio2text },
   { label: 'SpeakerEmbedding', value: ModelAbilityForAudio.SpeakerEmbedding },
 ];

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -49,6 +49,7 @@ const en = {
     audio2text: 'Audio to Text',
     speaker_embedding: 'Speaker Embedding',
     text2audio: 'Text to Audio',
+    text2music: 'Music Generation',
     text2audio_zero_shot: 'Text to Audio (Zero-Shot)',
     text2audio_voice_cloning: 'Text to Audio (Voice Cloning)',
     text2audio_emotion_control: 'Text to Audio (Emotion Control)',

--- a/frontend/src/i18n/locales/ja.ts
+++ b/frontend/src/i18n/locales/ja.ts
@@ -49,6 +49,7 @@ const ja = {
     audio2text: '音声からテキスト',
     speaker_embedding: '話者埋め込み',
     text2audio: 'テキストから音声',
+    text2music: '音楽生成',
     text2audio_zero_shot: 'テキストから音声(ゼロショット)',
     text2audio_voice_cloning: 'テキストから音声(声のクローン)',
     text2audio_emotion_control: 'テキストから音声(感情制御)',

--- a/frontend/src/i18n/locales/ko.ts
+++ b/frontend/src/i18n/locales/ko.ts
@@ -49,6 +49,7 @@ const ko = {
     audio2text: '오디오에서 텍스트',
     speaker_embedding: '화자 임베딩',
     text2audio: '텍스트에서 오디오',
+    text2music: '음악 생성',
     text2audio_zero_shot: '텍스트에서 오디오(제로 샷)',
     text2audio_voice_cloning: '텍스트에서 오디오(음성 클로닝)',
     text2audio_emotion_control: '텍스트에서 오디오(감정 제어)',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -49,6 +49,7 @@ const zh = {
     audio2text: '语音转文本',
     speaker_embedding: '说话人向量',
     text2audio: '文本转语音',
+    text2music: '音乐生成',
     text2audio_zero_shot: '文本转语音(零样本)',
     text2audio_voice_cloning: '文本转语音(声音克隆)',
     text2audio_emotion_control: '文本转语音(情感控制)',

--- a/xinference/model/audio/core.py
+++ b/xinference/model/audio/core.py
@@ -30,8 +30,8 @@ from .kokoro_mlx import KokoroMLXModel
 from .kokoro_zh import KokoroZHModel
 from .megatts import MegaTTSModel
 from .melotts import MeloTTSModel
-from .mlx_audio import MLXAudioSTTModel, MLXAudioTTSModel
 from .minimax_music3 import MiniMaxMusic3Model
+from .mlx_audio import MLXAudioSTTModel, MLXAudioTTSModel
 from .qwen3_asr import Qwen3ASRModel
 from .qwen3_tts import Qwen3TTSModel
 from .speaker_embedding import ModelScopeSpeakerEmbeddingModel

--- a/xinference/model/audio/core.py
+++ b/xinference/model/audio/core.py
@@ -251,6 +251,12 @@ def create_audio_model_instance(
     model_spec = match_audio(model_name, download_hub, model_engine=model_engine)
     audio_cls = None
 
+    if (
+        model_spec.model_family == "minimax_music3"
+        and model_spec.model_name not in AUDIO_ENGINES
+    ):
+        raise ValueError("MiniMax-Music3 requires an NVIDIA CUDA device.")
+
     # Engine-aware dispatch for model families with multiple engines
     # (e.g. qwen3_asr on transformers or vLLM). Families without registered
     # engines keep the legacy dispatch below.

--- a/xinference/model/audio/core.py
+++ b/xinference/model/audio/core.py
@@ -31,6 +31,7 @@ from .kokoro_zh import KokoroZHModel
 from .megatts import MegaTTSModel
 from .melotts import MeloTTSModel
 from .mlx_audio import MLXAudioSTTModel, MLXAudioTTSModel
+from .minimax_music3 import MiniMaxMusic3Model
 from .qwen3_asr import Qwen3ASRModel
 from .qwen3_tts import Qwen3TTSModel
 from .speaker_embedding import ModelScopeSpeakerEmbeddingModel
@@ -226,6 +227,7 @@ def create_audio_model_instance(
     F5TTSModel,
     F5TTSMLXModel,
     MeloTTSModel,
+    MiniMaxMusic3Model,
     KokoroModel,
     KokoroMLXModel,
     KokoroZHModel,

--- a/xinference/model/audio/engine.py
+++ b/xinference/model/audio/engine.py
@@ -331,7 +331,7 @@ class DiffusersMiniMaxMusic3AudioModel(MiniMaxMusic3Model, AudioEngineModel):
 
     @classmethod
     def match(cls, model_family: "AudioModelFamilyV2") -> bool:
-        return model_family.model_family == "minimax_music3"
+        return has_cuda_device() and model_family.model_family == "minimax_music3"
 
 
 def register_builtin_audio_engines() -> None:

--- a/xinference/model/audio/engine.py
+++ b/xinference/model/audio/engine.py
@@ -16,7 +16,7 @@ import importlib.util
 import platform
 from typing import TYPE_CHECKING, Tuple, Union
 
-from ..utils import has_cuda_device
+from ..utils import has_cuda_device, virtual_env_allows_missing_engine
 from .engine_family import SUPPORTED_ENGINES, AudioEngineModel
 from .f5tts import F5TTSModel
 from .f5tts_mlx import F5TTSMLXModel
@@ -322,6 +322,12 @@ class MLXAudioTTSEngineModel(MLXAudioTTSModel, AudioEngineModel):
 
 class DiffusersMiniMaxMusic3AudioModel(MiniMaxMusic3Model, AudioEngineModel):
     required_libs = ("diffusers",)
+
+    @classmethod
+    def check_lib(cls):
+        if virtual_env_allows_missing_engine():
+            return True
+        return super().check_lib()
 
     @classmethod
     def match(cls, model_family: "AudioModelFamilyV2") -> bool:

--- a/xinference/model/audio/engine.py
+++ b/xinference/model/audio/engine.py
@@ -25,6 +25,7 @@ from .kokoro import KokoroModel
 from .kokoro_mlx import KokoroMLXModel
 from .melotts import MeloTTSModel
 from .mlx_audio import MLXAudioSTTModel, MLXAudioTTSModel
+from .minimax_music3 import MiniMaxMusic3Model
 from .qwen3_asr import Qwen3ASRModel
 from .qwen3_tts import Qwen3TTSModel
 from .vllm import VLLMQwen3ASRModel
@@ -319,6 +320,14 @@ class MLXAudioTTSEngineModel(MLXAudioTTSModel, AudioEngineModel):
         return model_family.model_name in MLX_AUDIO_TTS_MODEL_NAMES
 
 
+class DiffusersMiniMaxMusic3AudioModel(MiniMaxMusic3Model, AudioEngineModel):
+    required_libs = ("diffusers",)
+
+    @classmethod
+    def match(cls, model_family: "AudioModelFamilyV2") -> bool:
+        return model_family.model_family == "minimax_music3"
+
+
 def register_builtin_audio_engines() -> None:
     # the first registered engine is the default one for a model
     SUPPORTED_ENGINES["transformers"] = [
@@ -341,3 +350,4 @@ def register_builtin_audio_engines() -> None:
         MLXAudioSTTEngineModel,
         MLXAudioTTSEngineModel,
     ]
+    SUPPORTED_ENGINES["diffusers"] = [DiffusersMiniMaxMusic3AudioModel]

--- a/xinference/model/audio/engine.py
+++ b/xinference/model/audio/engine.py
@@ -24,8 +24,8 @@ from .funasr import FunASRModel
 from .kokoro import KokoroModel
 from .kokoro_mlx import KokoroMLXModel
 from .melotts import MeloTTSModel
-from .mlx_audio import MLXAudioSTTModel, MLXAudioTTSModel
 from .minimax_music3 import MiniMaxMusic3Model
+from .mlx_audio import MLXAudioSTTModel, MLXAudioTTSModel
 from .qwen3_asr import Qwen3ASRModel
 from .qwen3_tts import Qwen3TTSModel
 from .vllm import VLLMQwen3ASRModel

--- a/xinference/model/audio/minimax_music3.py
+++ b/xinference/model/audio/minimax_music3.py
@@ -1,0 +1,281 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import io
+import logging
+import struct
+from typing import TYPE_CHECKING, Any, Optional
+
+from ...device_utils import get_available_device
+
+if TYPE_CHECKING:
+    from .core import AudioModelFamilyV2
+
+logger = logging.getLogger(__name__)
+
+
+class MiniMaxMusic3Model:
+    """Diffusers-backed MiniMax-Music3 text-to-music model."""
+
+    def __init__(
+        self,
+        model_uid: str,
+        model_path: str,
+        model_spec: "AudioModelFamilyV2",
+        device: Optional[str] = None,
+        **kwargs: Any,
+    ):
+        self._model_uid = model_uid
+        self._model_path = model_path
+        self._model_spec = model_spec
+        self._device = device
+        self._model = None
+        self._kwargs = kwargs
+
+    @property
+    def model_spec(self) -> "AudioModelFamilyV2":
+        return self._model_spec
+
+    @property
+    def model_ability(self):
+        return self._model_spec.model_ability
+
+    @staticmethod
+    def _resolve_dtype(torch_module, dtype):
+        if dtype is None:
+            return torch_module.bfloat16
+        if isinstance(dtype, str):
+            try:
+                dtype = getattr(torch_module, dtype)
+            except AttributeError as e:
+                raise ValueError(
+                    f"Unsupported MiniMax-Music3 torch_dtype: {dtype}"
+                ) from e
+        if dtype is not torch_module.bfloat16:
+            raise ValueError(
+                "MiniMax-Music3 currently supports torch_dtype=bfloat16 only."
+            )
+        return dtype
+
+    def load(self):
+        try:
+            import torch
+            from diffusers import ComponentsManager, ModularPipeline
+        except ImportError as e:
+            raise ImportError(
+                "MiniMax-Music3 requires Diffusers with ModularPipeline support. "
+                "Enable the model virtual environment or install the dependencies "
+                "declared in its built-in model specification."
+            ) from e
+
+        if (
+            not torch.cuda.is_available()
+            or getattr(torch.version, "hip", None) is not None
+        ):
+            raise RuntimeError(
+                "MiniMax-Music3 inference requires an NVIDIA CUDA device; "
+                "CPU, MPS, and ROCm are not supported."
+            )
+
+        device = self._device or get_available_device()
+        if torch.device(device).type != "cuda":
+            raise ValueError(
+                f"MiniMax-Music3 requires a CUDA device, but received {device!r}."
+            )
+        self._device = str(torch.device(device))
+
+        config = (self._model_spec.default_model_config or {}).copy()
+        config.update(self._kwargs)
+        torch_dtype = self._resolve_dtype(torch, config.pop("torch_dtype", None))
+        cpu_offload = config.pop("cpu_offload", True)
+        group_offload = config.pop("group_offload", False)
+        quantization = config.pop("quantization", None)
+        if quantization not in (None, "none", "bf16"):
+            raise ValueError(
+                "MiniMax-Music3 quantization is not supported in this initial "
+                "Diffusers integration."
+            )
+
+        manager = None
+        if cpu_offload or group_offload:
+            manager = ComponentsManager()
+            manager.enable_auto_cpu_offload(device=self._device)
+
+        pipeline_kwargs = {}
+        if manager is not None:
+            pipeline_kwargs["components_manager"] = manager
+        pipeline = ModularPipeline.from_pretrained(
+            self._model_path,
+            **pipeline_kwargs,
+        )
+        pipeline.load_components(dtype=torch_dtype)
+
+        if group_offload:
+            from diffusers.hooks import apply_group_offloading
+
+            apply_group_offloading(
+                pipeline.language_model,
+                onload_device=torch.device(self._device),
+                offload_device=torch.device("cpu"),
+                offload_type="leaf_level",
+                use_stream=True,
+            )
+        elif manager is None:
+            pipeline.to(self._device)
+
+        if config:
+            logger.warning(
+                "Ignoring unsupported MiniMax-Music3 load option(s): %s",
+                ", ".join(sorted(config)),
+            )
+        self._model = pipeline
+
+    @staticmethod
+    def _validate_speech_request(
+        input: str,
+        prompt_text: Optional[str],
+        voice: Optional[str],
+        response_format: Optional[str],
+        speed: Optional[float],
+        stream: Optional[bool],
+        seed: int,
+        duration: float,
+        kwargs: dict,
+    ) -> None:
+        if not isinstance(input, str) or not input.strip():
+            raise ValueError("MiniMax-Music3 requires non-empty lyrics in `input`.")
+        if not isinstance(prompt_text, str) or not prompt_text.strip():
+            raise ValueError(
+                "MiniMax-Music3 requires a non-empty music description in "
+                "`prompt_text`."
+            )
+        if voice not in (None, "", "default"):
+            raise ValueError(
+                "MiniMax-Music3 only accepts `voice` as null, an empty string, "
+                "or 'default'."
+            )
+        if response_format is None or response_format.lower() != "wav":
+            raise ValueError(
+                "MiniMax-Music3 currently supports `response_format=wav` only."
+            )
+        if speed != 1.0:
+            raise ValueError("MiniMax-Music3 only supports `speed=1.0`.")
+        if stream is not False:
+            raise ValueError("MiniMax-Music3 only supports non-streaming generation.")
+        if isinstance(seed, bool) or not isinstance(seed, int) or seed < 0:
+            raise ValueError("MiniMax-Music3 `seed` must be a non-negative integer.")
+        if (
+            isinstance(duration, bool)
+            or not isinstance(duration, (int, float))
+            or not 0.04 <= duration <= 360
+        ):
+            raise ValueError(
+                "MiniMax-Music3 `duration` must be a number from 0.04 to 360 seconds."
+            )
+        if kwargs:
+            raise ValueError(
+                "MiniMax-Music3 does not support speech parameter(s): "
+                + ", ".join(sorted(kwargs))
+            )
+
+    @staticmethod
+    def _audio_to_native_wav(audio, sample_rate: int) -> bytes:
+        import numpy as np
+
+        if hasattr(audio, "detach"):
+            audio = audio.detach().float().cpu().numpy()
+        audio = np.asarray(audio, dtype=np.float32)
+        if audio.ndim != 2:
+            raise RuntimeError(
+                f"MiniMax-Music3 returned audio with unexpected shape {audio.shape}."
+            )
+        if audio.shape[0] == 2:
+            audio = audio.T
+        elif audio.shape[1] != 2:
+            raise RuntimeError(
+                f"MiniMax-Music3 returned audio with unexpected shape {audio.shape}; "
+                "stereo output was expected."
+            )
+
+        audio = np.ascontiguousarray(audio, dtype="<f4")
+        channels = audio.shape[1]
+        bytes_per_sample = audio.dtype.itemsize
+        block_align = channels * bytes_per_sample
+        audio_bytes = audio.tobytes(order="C")
+        fmt_chunk = struct.pack(
+            "<HHIIHH",
+            3,  # WAVE_FORMAT_IEEE_FLOAT
+            channels,
+            sample_rate,
+            sample_rate * block_align,
+            block_align,
+            bytes_per_sample * 8,
+        )
+        fact_chunk = struct.pack("<I", audio.shape[0])
+        riff_size = 4 + 8 + len(fmt_chunk) + 8 + len(fact_chunk) + 8 + len(audio_bytes)
+        with io.BytesIO() as output:
+            # IEEE-float WAV preserves the pipeline samples. No sample-rate
+            # conversion or integer PCM quantization is applied.
+            output.write(b"RIFF")
+            output.write(struct.pack("<I", riff_size))
+            output.write(b"WAVE")
+            output.write(b"fmt ")
+            output.write(struct.pack("<I", len(fmt_chunk)))
+            output.write(fmt_chunk)
+            output.write(b"fact")
+            output.write(struct.pack("<I", len(fact_chunk)))
+            output.write(fact_chunk)
+            output.write(b"data")
+            output.write(struct.pack("<I", len(audio_bytes)))
+            output.write(audio_bytes)
+            return output.getvalue()
+
+    def speech(
+        self,
+        input: str,
+        voice: Optional[str] = None,
+        response_format: Optional[str] = "wav",
+        speed: Optional[float] = 1.0,
+        stream: Optional[bool] = False,
+        **kwargs: Any,
+    ) -> bytes:
+        assert self._model is not None
+        prompt_text = kwargs.pop("prompt_text", None)
+        seed = kwargs.pop("seed", 0)
+        duration = kwargs.pop("duration", 60.0)
+        self._validate_speech_request(
+            input,
+            prompt_text,
+            voice,
+            response_format,
+            speed,
+            stream,
+            seed,
+            duration,
+            kwargs,
+        )
+
+        import torch
+
+        generator = torch.Generator(device=self._device).manual_seed(seed)
+        result = self._model(
+            prompt=prompt_text,
+            lyrics=input,
+            audio_duration=float(duration),
+            generator=generator,
+            output="audios",
+        )
+        audio = result[0]
+        sample_rate = int(self._model.sampling_rate)
+        return self._audio_to_native_wav(audio, sample_rate)

--- a/xinference/model/audio/minimax_music3.py
+++ b/xinference/model/audio/minimax_music3.py
@@ -149,7 +149,7 @@ class MiniMaxMusic3Model:
     @staticmethod
     def _validate_speech_request(
         input: str,
-        prompt_text: Optional[str],
+        instruct: Optional[str],
         voice: Optional[str],
         response_format: Optional[str],
         speed: Optional[float],
@@ -160,10 +160,10 @@ class MiniMaxMusic3Model:
     ) -> None:
         if not isinstance(input, str) or not input.strip():
             raise ValueError("MiniMax-Music3 requires non-empty lyrics in `input`.")
-        if not isinstance(prompt_text, str) or not prompt_text.strip():
+        if not isinstance(instruct, str) or not instruct.strip():
             raise ValueError(
                 "MiniMax-Music3 requires a non-empty music description in "
-                "`prompt_text`."
+                "`instruct`."
             )
         if voice not in (None, "", "default"):
             raise ValueError(
@@ -257,12 +257,12 @@ class MiniMaxMusic3Model:
         **kwargs: Any,
     ) -> bytes:
         assert self._model is not None
-        prompt_text = kwargs.pop("prompt_text", None)
+        instruct = kwargs.pop("instruct", None)
         seed = kwargs.pop("seed", 0)
         duration = kwargs.pop("duration", 60.0)
         self._validate_speech_request(
             input,
-            prompt_text,
+            instruct,
             voice,
             response_format,
             speed,
@@ -276,7 +276,7 @@ class MiniMaxMusic3Model:
 
         generator = torch.Generator(device=self._device).manual_seed(seed)
         result = self._model(
-            prompt=prompt_text,
+            prompt=instruct,
             lyrics=input,
             audio_duration=float(duration),
             generator=generator,

--- a/xinference/model/audio/minimax_music3.py
+++ b/xinference/model/audio/minimax_music3.py
@@ -36,6 +36,7 @@ class MiniMaxMusic3Model:
         device: Optional[str] = None,
         **kwargs: Any,
     ):
+        self.model_family = model_spec
         self._model_uid = model_uid
         self._model_path = model_path
         self._model_spec = model_spec
@@ -98,7 +99,7 @@ class MiniMaxMusic3Model:
         config = (self._model_spec.default_model_config or {}).copy()
         config.update(self._kwargs)
         torch_dtype = self._resolve_dtype(torch, config.pop("torch_dtype", None))
-        cpu_offload = config.pop("cpu_offload", True)
+        cpu_offload = config.pop("cpu_offload", False)
         group_offload = config.pop("group_offload", False)
         quantization = config.pop("quantization", None)
         if quantization not in (None, "none", "bf16"):
@@ -119,7 +120,11 @@ class MiniMaxMusic3Model:
             self._model_path,
             **pipeline_kwargs,
         )
-        pipeline.load_components(dtype=torch_dtype)
+        pipeline.load_components(
+            dtype=torch_dtype,
+            pretrained_model_name_or_path=self._model_path,
+            local_files_only=True,
+        )
 
         if group_offload:
             from diffusers.hooks import apply_group_offloading
@@ -214,13 +219,14 @@ class MiniMaxMusic3Model:
         block_align = channels * bytes_per_sample
         audio_bytes = audio.tobytes(order="C")
         fmt_chunk = struct.pack(
-            "<HHIIHH",
+            "<HHIIHHH",
             3,  # WAVE_FORMAT_IEEE_FLOAT
             channels,
             sample_rate,
             sample_rate * block_align,
             block_align,
             bytes_per_sample * 8,
+            0,  # cbSize: no format-specific extension bytes
         )
         fact_chunk = struct.pack("<I", audio.shape[0])
         riff_size = 4 + 8 + len(fmt_chunk) + 8 + len(fact_chunk) + 8 + len(audio_bytes)

--- a/xinference/model/audio/model_spec.json
+++ b/xinference/model/audio/model_spec.json
@@ -2546,5 +2546,39 @@
     },
     "updated_at": 1786731468,
     "featured": true
+  },
+  {
+    "version": 2,
+    "model_name": "MiniMax-Music3",
+    "model_family": "minimax_music3",
+    "model_description": "MiniMax-Music3 generates complete songs from lyrics and a music description. The model is distributed under the MiniMax-Music3 Community License and requires NVIDIA CUDA for inference.",
+    "model_ability": [
+      "text2music"
+    ],
+    "multilingual": true,
+    "default_model_config": {
+      "torch_dtype": "bfloat16",
+      "cpu_offload": true,
+      "group_offload": false
+    },
+    "virtualenv": {
+      "packages": [
+        "diffusers @ git+https://github.com/huggingface/diffusers.git@2da7040be1a2e5f2fcbc8b985083342a308f5a86 ; #engine# == \"diffusers\"",
+        "transformers>=5.15.0,<6.0",
+        "accelerate>=1.13.0",
+        "huggingface-hub>=1.23.0,<2.0",
+        "safetensors>=0.8.0",
+        "#system_torch#",
+        "#system_numpy#"
+      ]
+    },
+    "model_src": {
+      "huggingface": {
+        "model_id": "MiniMaxAI/MiniMax-Music3",
+        "model_revision": "fbdf52fbaaca799592917417eb05f1899f1255ec"
+      }
+    },
+    "updated_at": 1786859407,
+    "featured": true
   }
 ]

--- a/xinference/model/audio/model_spec.json
+++ b/xinference/model/audio/model_spec.json
@@ -2558,12 +2558,24 @@
     "multilingual": true,
     "default_model_config": {
       "torch_dtype": "bfloat16",
-      "cpu_offload": true,
+      "cpu_offload": false,
       "group_offload": false
+    },
+    "cache_config": {
+      "allow_patterns": [
+        "modular_model_index.json",
+        "condition_encoder/*",
+        "language_model/*",
+        "rvq_depth_decoder/*",
+        "scheduler/*",
+        "tokenizer/*",
+        "transformer/*",
+        "vocoder/*"
+      ]
     },
     "virtualenv": {
       "packages": [
-        "diffusers @ git+https://github.com/huggingface/diffusers.git@2da7040be1a2e5f2fcbc8b985083342a308f5a86 ; #engine# == \"diffusers\"",
+        "git+https://github.com/huggingface/diffusers@2da7040be1a2e5f2fcbc8b985083342a308f5a86",
         "transformers>=5.15.0,<6.0",
         "accelerate>=1.13.0",
         "huggingface-hub>=1.23.0,<2.0",
@@ -2575,7 +2587,11 @@
     "model_src": {
       "huggingface": {
         "model_id": "MiniMaxAI/MiniMax-Music3",
-        "model_revision": "fbdf52fbaaca799592917417eb05f1899f1255ec"
+        "model_revision": "main"
+      },
+      "modelscope": {
+        "model_id": "MiniMax/MiniMax-Music3",
+        "model_revision": "master"
       }
     },
     "updated_at": 1786859407,

--- a/xinference/model/audio/tests/test_audio_engine.py
+++ b/xinference/model/audio/tests/test_audio_engine.py
@@ -34,6 +34,7 @@ from .. import platform as audio_platform
 from .. import sys as audio_sys
 from ..core import create_audio_model_instance, resolve_audio_model_name_and_engine
 from ..engine import (
+    DiffusersMiniMaxMusic3AudioModel,
     MLXAudioSTTEngineModel,
     MLXAudioTTSEngineModel,
     MLXF5TTSAudioModel,
@@ -174,6 +175,20 @@ def test_vllm_engine_not_matched_without_cuda():
         patch.object(engine_mod, "has_cuda_device", return_value=True),
     ):
         assert VLLMQwen3ASRAudioModel.match(_get_spec("Qwen3-ASR-0.6B")) is False
+
+
+def test_minimax_music3_engine_not_registered_without_cuda():
+    engine_mod = __import__(
+        DiffusersMiniMaxMusic3AudioModel.__module__, fromlist=["has_cuda_device"]
+    )
+    with (
+        patch.object(engine_mod, "has_cuda_device", return_value=False),
+        patch.dict(AUDIO_ENGINES, {}, clear=True),
+    ):
+        register_builtin_audio_engines()
+        for model_spec in BUILTIN_AUDIO_MODELS["MiniMax-Music3"]:
+            generate_engine_config_by_model_name(model_spec)
+        assert "MiniMax-Music3" not in AUDIO_ENGINES
 
 
 def test_create_audio_model_instance_default_engine():

--- a/xinference/model/audio/tests/test_audio_engine.py
+++ b/xinference/model/audio/tests/test_audio_engine.py
@@ -34,7 +34,6 @@ from .. import platform as audio_platform
 from .. import sys as audio_sys
 from ..core import create_audio_model_instance, resolve_audio_model_name_and_engine
 from ..engine import (
-    DiffusersMiniMaxMusic3AudioModel,
     MLXAudioSTTEngineModel,
     MLXAudioTTSEngineModel,
     MLXF5TTSAudioModel,
@@ -175,20 +174,6 @@ def test_vllm_engine_not_matched_without_cuda():
         patch.object(engine_mod, "has_cuda_device", return_value=True),
     ):
         assert VLLMQwen3ASRAudioModel.match(_get_spec("Qwen3-ASR-0.6B")) is False
-
-
-def test_minimax_music3_engine_not_registered_without_cuda():
-    engine_mod = __import__(
-        DiffusersMiniMaxMusic3AudioModel.__module__, fromlist=["has_cuda_device"]
-    )
-    with (
-        patch.object(engine_mod, "has_cuda_device", return_value=False),
-        patch.dict(AUDIO_ENGINES, {}, clear=True),
-    ):
-        register_builtin_audio_engines()
-        for model_spec in BUILTIN_AUDIO_MODELS["MiniMax-Music3"]:
-            generate_engine_config_by_model_name(model_spec)
-        assert "MiniMax-Music3" not in AUDIO_ENGINES
 
 
 def test_create_audio_model_instance_default_engine():

--- a/xinference/model/audio/tests/test_audio_engine.py
+++ b/xinference/model/audio/tests/test_audio_engine.py
@@ -198,6 +198,27 @@ def test_invalid_audio_engine_is_rejected_before_download():
     cache.assert_not_called()
 
 
+def test_minimax_music3_without_cuda_is_rejected_before_download():
+    engine_mod = __import__(
+        register_builtin_audio_engines.__module__, fromlist=["has_cuda_device"]
+    )
+    with (
+        patch.object(engine_mod, "has_cuda_device", return_value=False),
+        patch.dict(AUDIO_ENGINES, {}, clear=True),
+        patch.object(CacheManager, "cache") as cache,
+    ):
+        register_builtin_audio_engines()
+        for model_spec in BUILTIN_AUDIO_MODELS["MiniMax-Music3"]:
+            generate_engine_config_by_model_name(model_spec)
+        with pytest.raises(ValueError, match="requires an NVIDIA CUDA device"):
+            create_audio_model_instance(
+                "uid",
+                "MiniMax-Music3",
+                enable_virtual_env=False,
+            )
+    cache.assert_not_called()
+
+
 def test_consolidated_mlx_specs_and_legacy_aliases(apple_mlx_engines):
     models = apple_mlx_engines
     assert "whisper-tiny-mlx" not in models


### PR DESCRIPTION
## Summary

This PR adds initial MiniMax-Music3 support as a built-in audio model with the new `text2music` ability.

- Adds `MiniMax-Music3` using Diffusers `ModularPipeline`
- Supports Hugging Face and ModelScope model sources
- Adds a dedicated Music Generation Web UI
- Reuses the OpenAI-compatible `POST /v1/audio/speech` endpoint
- Adds user documentation and request examples

## Backend

- Model family: `minimax_music3`
- Model ability: `text2music`
- Engine: Diffusers only
- Accelerator: NVIDIA CUDA only
- Default dtype: BF16
- Supports optional CPU and group offload
- Loads pipeline components from the local Xinference model cache to avoid duplicate downloads
- Pins the Diffusers commit containing MiniMax-Music3 ModularPipeline support
- Preserves the pipeline's native 44.1 kHz, stereo, float32 audio without resampling or quantization
- Encodes the result as a standards-compliant IEEE-float WAV

The model is registered under the MiniMax-Music3 Community License.

## API

Music generation reuses `/v1/audio/speech`:

- `input`: lyrics
- `kwargs.instruct`: music description
- `kwargs.seed`: non-negative random seed, default `0`
- `kwargs.duration`: maximum duration in seconds, default `60`, range `0.04` to `360`
- `response_format`: `wav` only

Unsupported speech or sampling parameters are rejected with model-specific validation errors.

## Web UI

Adds a distinct Music Generation capability with:

- Multiline lyrics input
- Music description input
- Seed input with a random-seed button
- Duration in seconds
- WAV audio playback

Regular TTS and voice-cloning forms retain their existing behavior.


<img width="1545" height="900" alt="1eec3e0c37196c411e0e52a72dc0bf7e" src="https://github.com/user-attachments/assets/5f645c92-f194-4d10-9664-f9fda32c4352" />
