### PR TITLE
fix(model): calculate download progress per file

### DIFF
--- a/xinference/model/tests/test_utils.py
+++ b/xinference/model/tests/test_utils.py
@@ -80,6 +80,32 @@ def test_tqdm_patch():
     assert downloader.done
 
 
+def test_tqdm_patch_uses_equal_file_weights():
+    downloader = CancellableDownloader(cancel_error_cls=RuntimeError)
+
+    with downloader:
+        all_bar = tqdm(total=3, file=io.StringIO())
+        large_file = tqdm(total=70, unit="B", file=io.StringIO())
+        small_file = tqdm(total=30, unit="B", file=io.StringIO())
+
+        # Their sizes must not determine their weight in the repository-level
+        # progress. The repository bar's total is available before its first
+        # update, so the downloader already knows that n == 3 here. The third
+        # file has not started and therefore contributes zero.
+        large_file.update(69)
+        before_completion = downloader.get_progress()
+        assert before_completion == pytest.approx((69 / 70) / 3)
+
+        large_file.update(1)
+        all_bar.update(1)
+        after_completion = downloader.get_progress()
+        assert after_completion == pytest.approx(1 / 3)
+        assert after_completion >= before_completion
+
+        small_file.update(15)
+        assert downloader.get_progress() == pytest.approx((1 + 15 / 30) / 3)
+
+
 def test_download_progress_details_include_completed_files():
     downloader = CancellableDownloader(cancel_error_cls=RuntimeError)
 

--- a/xinference/model/tests/test_utils.py
+++ b/xinference/model/tests/test_utils.py
@@ -98,15 +98,32 @@ def test_tqdm_patch_uses_equal_file_weights():
 
         large_file.update(1)
         during_completion = downloader.get_progress()
-        assert during_completion == pytest.approx(before_completion)
+        assert during_completion == pytest.approx(1 / 3)
 
         all_bar.update(1)
         after_completion = downloader.get_progress()
         assert after_completion == pytest.approx(1 / 3)
-        assert after_completion >= before_completion
+        assert after_completion == pytest.approx(during_completion)
 
         small_file.update(15)
         assert downloader.get_progress() == pytest.approx((1 + 15 / 30) / 3)
+
+
+def test_tqdm_patch_preserves_completion_without_intermediate_poll():
+    downloader = CancellableDownloader(cancel_error_cls=RuntimeError)
+
+    with downloader:
+        all_bar = tqdm(total=3, file=io.StringIO())
+        file_bar = tqdm(total=70, unit="B", file=io.StringIO())
+
+        # Complete the file before get_progress() has observed any partial
+        # progress. Its contribution must remain visible until all_bar catches
+        # up, rather than relying on a previously reported high-water mark.
+        file_bar.update(70)
+        assert downloader.get_progress() == pytest.approx(1 / 3)
+
+        all_bar.update(1)
+        assert downloader.get_progress() == pytest.approx(1 / 3)
 
 
 def test_download_progress_details_include_completed_files():

--- a/xinference/model/tests/test_utils.py
+++ b/xinference/model/tests/test_utils.py
@@ -97,6 +97,9 @@ def test_tqdm_patch_uses_equal_file_weights():
         assert before_completion == pytest.approx((69 / 70) / 3)
 
         large_file.update(1)
+        during_completion = downloader.get_progress()
+        assert during_completion == pytest.approx(before_completion)
+
         all_bar.update(1)
         after_completion = downloader.get_progress()
         assert after_completion == pytest.approx(1 / 3)

--- a/xinference/model/utils.py
+++ b/xinference/model/utils.py
@@ -1029,6 +1029,10 @@ class CancellableDownloader:
         # progress for file downloader
         # mainly when tqdm unit is set
         self._download_progresses: Set[tqdm] = set()
+        # Byte bars and the repository-level bar advance in separate calls.
+        # Keep the reported value monotonic while a completed byte bar waits
+        # for the repository-level bar to account for the same file.
+        self._last_progress = 0.0
         # Instance-specific tqdm tracking
         self._patched_instances: Set[int] = set()
 
@@ -1069,6 +1073,7 @@ class CancellableDownloader:
         with self._progress_lock:
             self._main_progresses.clear()
             self._download_progresses.clear()
+            self._last_progress = 0.0
 
     def _progress_snapshots(self) -> Tuple[List[tqdm], List[tqdm]]:
         """Return stable copies while tqdm callbacks may update the sets."""
@@ -1113,7 +1118,12 @@ class CancellableDownloader:
         # the repository-level progress reports as unfinished.
         unfinished_tasks = max(tasks - finished_tasks, 0)
         active_file_progress = min(active_file_progress, unfinished_tasks)
-        return min(max((finished_tasks + active_file_progress) / tasks, 0.0), 1.0)
+        progress = min(
+            max((finished_tasks + active_file_progress) / tasks, 0.0), 1.0
+        )
+        with self._progress_lock:
+            self._last_progress = max(self._last_progress, progress)
+            return self._last_progress
 
     @staticmethod
     def _finite_float(value: Any) -> Optional[float]:

--- a/xinference/model/utils.py
+++ b/xinference/model/utils.py
@@ -1029,10 +1029,10 @@ class CancellableDownloader:
         # progress for file downloader
         # mainly when tqdm unit is set
         self._download_progresses: Set[tqdm] = set()
-        # Byte bars and the repository-level bar advance in separate calls.
-        # Keep the reported value monotonic while a completed byte bar waits
-        # for the repository-level bar to account for the same file.
-        self._last_progress = 0.0
+        # A byte bar reaches 100% before the repository-level bar advances.
+        # Keep those completed file contributions until a main-bar update
+        # accounts for them, even if get_progress() was not called in between.
+        self._unaccounted_download_progresses: Set[tqdm] = set()
         # Instance-specific tqdm tracking
         self._patched_instances: Set[int] = set()
 
@@ -1073,7 +1073,7 @@ class CancellableDownloader:
         with self._progress_lock:
             self._main_progresses.clear()
             self._download_progresses.clear()
-            self._last_progress = 0.0
+            self._unaccounted_download_progresses.clear()
 
     def _progress_snapshots(self) -> Tuple[List[tqdm], List[tqdm]]:
         """Return stable copies while tqdm callbacks may update the sets."""
@@ -1081,49 +1081,49 @@ class CancellableDownloader:
             return list(self._main_progresses), list(self._download_progresses)
 
     def get_progress(self) -> float:
-        if self.done:
-            # directly return 1.0 when finished
-            return 1.0
-        # Don't return 1.0 when cancelled, calculate actual progress
-
-        main_progresses, download_progresses = self._progress_snapshots()
-
-        tasks = finished_tasks = 0
-        for main_progress in main_progresses:
-            tasks += main_progress.total or 0
-            finished_tasks += main_progress.n
-
-        if tasks == 0:
-            # we assumed at least 1 task
-            tasks = 1
-
-        active_file_progress = 0.0
-        for download_progress in download_progresses:
-            # Completed downloads are already represented by finished_tasks.
-            if download_progress.n == download_progress.total:
-                continue
-
-            downloaded = download_progress.n or 0
-            total = download_progress.total
-            if total:
-                # Give every file the same weight, irrespective of its size.
-                active_file_progress += min(max(downloaded / total, 0.0), 1.0)
-            elif downloaded > 0:
-                # Preserve the previous best-effort estimate for downloads
-                # whose total size is not available yet.
-                active_file_progress += 0.1
-
-        # A tqdm implementation may expose more than one byte progress bar for
-        # the same file. Never let active bars account for more file slots than
-        # the repository-level progress reports as unfinished.
-        unfinished_tasks = max(tasks - finished_tasks, 0)
-        active_file_progress = min(active_file_progress, unfinished_tasks)
-        progress = min(
-            max((finished_tasks + active_file_progress) / tasks, 0.0), 1.0
-        )
         with self._progress_lock:
-            self._last_progress = max(self._last_progress, progress)
-            return self._last_progress
+            if self.done:
+                # directly return 1.0 when finished
+                return 1.0
+            # Don't return 1.0 when cancelled, calculate actual progress
+
+            tasks = finished_tasks = 0
+            for main_progress in self._main_progresses:
+                tasks += main_progress.total or 0
+                finished_tasks += main_progress.n
+
+            if tasks == 0:
+                # we assumed at least 1 task
+                tasks = 1
+
+            active_file_progress = 0.0
+            for download_progress in self._download_progresses:
+                total = download_progress.total
+                downloaded = download_progress.n or 0
+
+                # Completed downloads are represented either by finished_tasks
+                # or by _unaccounted_download_progresses during the short gap
+                # before the repository-level bar advances.
+                if total is not None and downloaded >= total:
+                    continue
+
+                if total:
+                    # Give every file the same weight, irrespective of its size.
+                    active_file_progress += min(max(downloaded / total, 0.0), 1.0)
+                elif downloaded > 0:
+                    # Preserve the previous best-effort estimate for downloads
+                    # whose total size is not available yet.
+                    active_file_progress += 0.1
+
+            unaccounted_file_progress = len(self._unaccounted_download_progresses)
+            file_progress = active_file_progress + unaccounted_file_progress
+
+            # A tqdm implementation may expose more than one byte progress bar
+            # for the same file. Never let byte bars account for more file slots
+            # than the repository-level progress reports as unfinished.
+            unfinished_tasks = max(tasks - finished_tasks, 0)
+            file_progress = min(file_progress, unfinished_tasks)
+            return min(max((finished_tasks + file_progress) / tasks, 0.0), 1.0)
 
     @staticmethod
     def _finite_float(value: Any) -> Optional[float]:
@@ -1280,12 +1280,13 @@ class CancellableDownloader:
             # Thread-safe patched update
             def patched_update(tqdm_instance, n):
                 downloader = CancellableDownloader._get_tqdm_owner(tqdm_instance)
+                progresses = None
+                unit = None
                 if downloader is not None:
                     # if download cancelled, throw error
                     if getattr(downloader, "cancelled", False):
                         downloader.raise_error()
 
-                    progresses = None
                     if not downloader.done and not getattr(
                         tqdm_instance, "disable", False
                     ):
@@ -1298,10 +1299,37 @@ class CancellableDownloader:
                             )
 
                     if progresses is not None:
-                        # Guard the mutation: a concurrent get_progress()
-                        # caller may be iterating this very set.
                         with downloader._progress_lock:
+                            # Keep the tqdm update and the corresponding
+                            # completed-file bookkeeping atomic with respect to
+                            # get_progress().
                             progresses.add(tqdm_instance)
+                            previous_n = getattr(tqdm_instance, "n", 0) or 0
+                            result = original_update_plain(tqdm_instance, n)
+                            current_n = getattr(tqdm_instance, "n", 0) or 0
+
+                            if unit == "it":
+                                newly_accounted = max(int(current_n - previous_n), 0)
+                                for _ in range(
+                                    min(
+                                        newly_accounted,
+                                        len(
+                                            downloader._unaccounted_download_progresses
+                                        ),
+                                    )
+                                ):
+                                    downloader._unaccounted_download_progresses.pop()
+                            else:
+                                total = getattr(tqdm_instance, "total", None)
+                                if (
+                                    total is not None
+                                    and previous_n < total <= current_n
+                                ):
+                                    downloader._unaccounted_download_progresses.add(
+                                        tqdm_instance
+                                    )
+
+                            return result
 
                 # Call original update with safety check
                 return original_update_plain(tqdm_instance, n)

--- a/xinference/model/utils.py
+++ b/xinference/model/utils.py
@@ -1092,27 +1092,28 @@ class CancellableDownloader:
             # we assumed at least 1 task
             tasks = 1
 
-        finished_ratio = finished_tasks / tasks
-
-        all_download_progress = finished_download_progress = 0
+        active_file_progress = 0.0
         for download_progress in download_progresses:
-            # we skip finished download
+            # Completed downloads are already represented by finished_tasks.
             if download_progress.n == download_progress.total:
                 continue
-            all_download_progress += download_progress.total or (
-                download_progress.n * 10
-            )
-            finished_download_progress += download_progress.n
 
-        if all_download_progress > 0:
-            rest_ratio = (
-                (tasks - finished_tasks)
-                / tasks
-                * (finished_download_progress / all_download_progress)
-            )
-            return finished_ratio + rest_ratio
-        else:
-            return finished_ratio
+            downloaded = download_progress.n or 0
+            total = download_progress.total
+            if total:
+                # Give every file the same weight, irrespective of its size.
+                active_file_progress += min(max(downloaded / total, 0.0), 1.0)
+            elif downloaded > 0:
+                # Preserve the previous best-effort estimate for downloads
+                # whose total size is not available yet.
+                active_file_progress += 0.1
+
+        # A tqdm implementation may expose more than one byte progress bar for
+        # the same file. Never let active bars account for more file slots than
+        # the repository-level progress reports as unfinished.
+        unfinished_tasks = max(tasks - finished_tasks, 0)
+        active_file_progress = min(active_file_progress, unfinished_tasks)
+        return min(max((finished_tasks + active_file_progress) / tasks, 0.0), 1.0)
 
     @staticmethod
     def _finite_float(value: Any) -> Optional[float]:
@@ -1243,8 +1244,28 @@ class CancellableDownloader:
             def patched_init(tqdm_instance, *args, **kwargs):
                 # Bind ownership when the bar is created so later updates from
                 # library worker threads remain scoped to the same downloader.
-                CancellableDownloader._get_tqdm_owner(tqdm_instance)
-                return original_init_plain(tqdm_instance, *args, **kwargs)
+                downloader = CancellableDownloader._get_tqdm_owner(tqdm_instance)
+                result = original_init_plain(tqdm_instance, *args, **kwargs)
+
+                # Register the bar immediately, rather than waiting for its
+                # first update. Repository-level bars do not update until the
+                # first file finishes; delaying registration would make
+                # get_progress() assume there is only one task until then.
+                if (
+                    downloader is not None
+                    and not downloader.done
+                    and not getattr(tqdm_instance, "disable", False)
+                ):
+                    unit = getattr(tqdm_instance, "unit", "it")
+                    progresses = (
+                        downloader._main_progresses
+                        if unit == "it"
+                        else downloader._download_progresses
+                    )
+                    with downloader._progress_lock:
+                        progresses.add(tqdm_instance)
+
+                return result
 
             # Thread-safe patched update
             def patched_update(tqdm_instance, n):


### PR DESCRIPTION
## Summary

- Calculate model download progress using equal per-file weights.
- Register `tqdm` progress bars when they are created so the total file count is known before the first file completes.
- Add a regression test covering files with different sizes and files that have not started downloading.

## Problem

The previous calculation mixed two weighting strategies:

- Completed files were weighted by file count.
- Active downloads were weighted by their byte sizes.

When a large file completed, its contribution changed from byte-weighted progress to a single completed-file count. This could make the total progress drop significantly and then continue increasing from the lower value.

Additionally, the repository-level progress bar was not registered until its first update. Before the first file completed, the downloader could incorrectly assume that the total file count was `1`.

## Solution

Each file now has an equal weight in the total progress:

```text
progress = (
    completed_file_count
    + sum(active_file_downloaded_bytes / active_file_total_bytes)
) / total_file_count
```

Therefore:

- A completed file contributes `1 / total_file_count`.
- An active file contributes its individual percentage divided by the total file count.
- A file that has not started contributes zero.

This keeps a file's contribution continuous when it transitions from downloading to completed, regardless of its size.

## Validation

Added a regression test with differently sized files and one pending file. The tested progress sequence is:

```text
32.8571% -> 33.3333% -> 50%
```

The progress no longer drops when the large file completes.
