### PR TITLE
fix: validate LLM metadata before packaging

### DIFF
--- a/build_backend.py
+++ b/build_backend.py
@@ -62,7 +62,7 @@ def _validate_builtin_model_specs(root=None):
         if not isinstance(family, dict):
             invalid_families.append(f"entry {index}")
         elif not isinstance(family.get("model_specs"), list):
-            invalid_families.append(family.get("model_name", f"entry {index}"))
+            invalid_families.append(family.get("model_name") or f"entry {index}")
 
     if invalid_families:
         names = ", ".join(repr(name) for name in invalid_families)

--- a/build_backend.py
+++ b/build_backend.py
@@ -26,6 +26,7 @@ wheels, sdists, and editable installs:
   file is kept as-is.
 """
 
+import json
 import os
 import re
 import subprocess
@@ -37,6 +38,38 @@ from build_web import build_web
 
 _repo_root = os.path.dirname(os.path.abspath(__file__))
 _FULL_SHA = re.compile(r"[0-9a-f]{40}")
+
+
+def _validate_builtin_model_specs(root=None):
+    """Reject malformed built-in model metadata before packaging it."""
+    root = root or _repo_root
+    relative_path = os.path.join(
+        "xinference", "model", "llm", "llm_family.json"
+    )
+    path = os.path.join(root, relative_path)
+
+    try:
+        with open(path, encoding="utf-8") as f:
+            families = json.load(f)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"Cannot validate {relative_path}: {exc}") from exc
+
+    if not isinstance(families, list):
+        raise RuntimeError(f"{relative_path} must contain a list of model families")
+
+    invalid_families = []
+    for index, family in enumerate(families):
+        if not isinstance(family, dict):
+            invalid_families.append(f"entry {index}")
+        elif not isinstance(family.get("model_specs"), list):
+            invalid_families.append(family.get("model_name", f"entry {index}"))
+
+    if invalid_families:
+        names = ", ".join(repr(name) for name in invalid_families)
+        raise RuntimeError(
+            f"Invalid LLM families {names} in {relative_path}: "
+            "each entry must define 'model_specs' as a list"
+        )
 
 
 def _git_head_revision(root):
@@ -95,6 +128,7 @@ def _record_full_revision(root=None):
 
 
 def _pre_build():
+    _validate_builtin_model_specs()
     _record_full_revision()
     build_web()
 

--- a/xinference/tests/test_build_backend.py
+++ b/xinference/tests/test_build_backend.py
@@ -15,6 +15,7 @@
 """Unit tests for the in-tree build backend's revision recording."""
 
 import importlib.util
+import json
 import os
 import shutil
 import subprocess
@@ -66,6 +67,13 @@ def _make_source_tree(root):
     os.makedirs(os.path.join(root, "xinference"), exist_ok=True)
     with open(os.path.join(root, "xinference", "__init__.py"), "w") as f:
         f.write("")
+
+
+def _write_llm_families(root, families):
+    llm_dir = os.path.join(root, "xinference", "model", "llm")
+    os.makedirs(llm_dir, exist_ok=True)
+    with open(os.path.join(llm_dir, "llm_family.json"), "w") as f:
+        json.dump(families, f)
 
 
 def _git(cwd, *args):
@@ -169,3 +177,32 @@ def test_existing_record_kept_without_revision_source(backend, tmp_path):
     backend._record_full_revision(str(src))
 
     assert _read_recorded(str(src)) == sha
+
+
+def test_validates_llm_family_specs(backend, tmp_path):
+    src = tmp_path / "src"
+    src.mkdir()
+    _write_llm_families(
+        str(src),
+        [{"model_name": "valid-family", "model_specs": []}],
+    )
+
+    backend._validate_builtin_model_specs(str(src))
+
+
+def test_rejects_llm_family_without_model_specs(backend, tmp_path):
+    src = tmp_path / "src"
+    src.mkdir()
+    _write_llm_families(
+        str(src),
+        [
+            {"model_name": "valid-family", "model_specs": []},
+            {"model_name": "misplaced-audio-model", "model_family": "audio"},
+        ],
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="misplaced-audio-model.*model_specs",
+    ):
+        backend._validate_builtin_model_specs(str(src))

--- a/xinference/tests/test_build_backend.py
+++ b/xinference/tests/test_build_backend.py
@@ -206,3 +206,22 @@ def test_rejects_llm_family_without_model_specs(backend, tmp_path):
         match="misplaced-audio-model.*model_specs",
     ):
         backend._validate_builtin_model_specs(str(src))
+
+
+def test_reports_entry_index_for_unnamed_invalid_llm_families(backend, tmp_path):
+    src = tmp_path / "src"
+    src.mkdir()
+    _write_llm_families(
+        str(src),
+        [
+            {"model_name": None},
+            {"model_name": ""},
+            {},
+        ],
+    )
+
+    with pytest.raises(RuntimeError) as exc_info:
+        backend._validate_builtin_model_specs(str(src))
+
+    message = str(exc_info.value)
+    assert all(f"'entry {index}'" in message for index in range(3))


### PR DESCRIPTION
## Summary

- validate the built-in LLM family metadata before wheel, sdist, or editable builds
- reject non-object entries and families whose `model_specs` field is missing or not a list
- include the offending model name in the build error
- add focused regression coverage to the existing build-backend test suite

## Root cause

The published `xinference==3.2.0` wheel contains the audio model `speech_campplus_sv_zh-cn_16k-common` inside `xinference/model/llm/llm_family.json`. That entry has no `model_specs` field, so every Xinference entry point fails during import with `KeyError: 'model_specs'`.

The wheel records build commit `324c8afebb2ba795e59c965b500580ba777afb01`, where the malformed entry was present. The current `v3.2.0` tag points to a later commit where it has been removed, which explains why checking the current tag alone does not reproduce the artifact.

This change makes malformed built-in LLM metadata a packaging error before the web build and PyPI upload can proceed.

## User impact

Future releases cannot package this class of malformed LLM metadata silently. The error identifies the offending family, for example:

```
Invalid LLM families 'speech_campplus_sv_zh-cn_16k-common' in xinference/model/llm/llm_family.json: each entry must define 'model_specs' as a list
```

The already-published 3.2.0 wheel still requires a new release or replacement version from the maintainers.

## Validation

- `.venv/bin/python -m pytest --noconftest -q xinference/tests/test_build_backend.py` — 8 passed
- `.venv/bin/pre-commit run --files build_backend.py xinference/tests/test_build_backend.py` — all hooks passed
- `NO_WEB_UI=1 .venv/bin/python -m build --wheel ...` — wheel built successfully
- the validator rejects the official 3.2.0 wheel and names `speech_campplus_sv_zh-cn_16k-common`

Addresses #5347.