### PR TITLE
fix(ui): include scrollbar in dropdown width

### DIFF
--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -200,9 +200,10 @@ export function Select<T extends SelectValue = SelectValue>({
     const optionsContainerPadding =
       Number.parseFloat(optionsContainerStyle.paddingLeft) +
       Number.parseFloat(optionsContainerStyle.paddingRight);
+    const scrollbarWidth = optionsContainer.offsetWidth - optionsContainer.clientWidth;
     const dropdownBorderWidth = dropdown.offsetWidth - dropdown.clientWidth;
     const measuredWidth = Math.ceil(
-      widestOptionWidth + optionsContainerPadding + dropdownBorderWidth
+      widestOptionWidth + optionsContainerPadding + scrollbarWidth + dropdownBorderWidth
     );
 
     if (autoDropdownWidthRef.current === measuredWidth) return;


### PR DESCRIPTION
## Summary

Fix auto-width dropdowns truncating long option labels when a vertical scrollbar is present.

## Root Cause

The dropdown width calculation included:

- Widest option width
- Container padding
- Dropdown border width

However, it did not include the width occupied by the vertical scrollbar. When the option list exceeded its maximum height, the scrollbar reduced the available content width and caused labels to remain truncated.

## Changes

- Calculate scrollbar width using:

  ```ts
  optionsContainer.offsetWidth - optionsContainer.clientWidth
  ```

- Include scrollbar width in the final dropdown width.
- Preserve existing behavior when no scrollbar is present, where the calculated scrollbar width is `0`.

### before
<img width="338" height="385" alt="bf235fad3f3f0ed9cdb7ae7c73db2c05" src="https://github.com/user-attachments/assets/76802e81-ac65-4d41-a36f-0143c69703bf" />


### after
<img width="202" height="248" alt="a5c1ff7163aad14d06a56e2ca4a9016c" src="https://github.com/user-attachments/assets/fabfc1e6-9462-403e-a654-ef7e1cfd2137" />

