### PR TITLE
Enh: Expose VoiceDesign ability to Qwen3-TTS-Voice-Design

### DIFF
--- a/xinference/model/audio/model_spec.json
+++ b/xinference/model/audio/model_spec.json
@@ -2281,7 +2281,8 @@
     "model_description": "This is a custom model description.",
     "multilingual": true,
     "model_ability": [
-      "text2audio"
+      "text2audio",
+      "text2audio_voice_design"
     ],
     "model_family": "qwen3_tts",
     "engine": "PyTorch",
@@ -2315,7 +2316,8 @@
     "model_description": "Qwen3-TTS VoiceDesign 8-bit optimized for Apple Silicon with mlx-audio.",
     "multilingual": true,
     "model_ability": [
-      "text2audio"
+      "text2audio",
+      "text2audio_voice_design"
     ],
     "model_family": "qwen3_tts",
     "engine": "MLX",


### PR DESCRIPTION
## Summary

Add the `text2audio_voice_design` ability to both PyTorch and MLX specifications of `Qwen3-TTS-12Hz-1.7B-VoiceDesign`.

This enables the Web UI voice instruction field and routes its value to the existing `generate_voice_design` implementation through `instruct`.

