### PR TITLE
fix(core): refine autostart transition handling and reset retry attempts

### DIFF
--- a/xinference/core/supervisor.py
+++ b/xinference/core/supervisor.py
@@ -180,9 +180,7 @@ class WorkerNotRegisteredError(Exception):
     supervisor restart clears the in-memory registry while workers keep their
     cached refs. Raising forces the worker into ``report_status``'s reconnect
     branch, which re-runs ``add_worker`` and self-heals the registry (and thus
-    ``workers_total``). Subclasses ``Exception`` (not ``RuntimeError``) on
-    purpose: the worker report loop treats some ``RuntimeError``s as fatal and
-    breaks, which must never happen here.
+    ``workers_total``).
     """
 
 
@@ -1081,17 +1079,24 @@ class SupervisorActor(xo.StatelessActor):
                 logger.exception("Skip invalid autostart entry: %s", raw_entry)
         return entries
 
-    async def _autostart_model_is_active(self, model_uid: str) -> bool:
-        if model_uid in self._model_uid_to_replica_info:
-            return True
+    async def _get_autostart_model_status(self, model_uid: str) -> Optional[str]:
         infos = await self._status_guard_ref.get_instance_info(model_uid=model_uid)
-        active_statuses = {
+        statuses = {info.status for info in infos}
+        for status in (
+            LaunchStatus.READY.name,
             LaunchStatus.CREATING.name,
+            LaunchStatus.LOADING.name,
             LaunchStatus.UPDATING.name,
             LaunchStatus.TERMINATING.name,
-            LaunchStatus.READY.name,
-        }
-        return any(info.status in active_statuses for info in infos)
+        ):
+            if status in statuses:
+                return status
+
+        # Backward-compatible fallback for model mappings created before status
+        # tracking was available. Do not override an explicit non-active status.
+        if not infos and model_uid in self._model_uid_to_replica_info:
+            return LaunchStatus.READY.name
+        return None
 
     def _autostart_waiting_for_worker(self, launch: Dict[str, Any]) -> bool:
         worker_ip = launch.get("worker_ip")
@@ -1145,16 +1150,30 @@ class SupervisorActor(xo.StatelessActor):
         launch = entry["launch"]
         model_uid = launch["model_uid"]
         state = self._autostart_model_states.setdefault(model_uid, {"attempts": 0})
+        retry_interval = float(entry.get("retry_interval_seconds", 30))
 
-        if await self._autostart_model_is_active(model_uid):
+        model_status = await self._get_autostart_model_status(model_uid)
+        if model_status == LaunchStatus.READY.name:
             state.update(
                 {
                     "status": "active",
+                    "attempts": 0,
                     "message": "Model is already active.",
                     "last_error": None,
                 }
             )
             return None
+        if model_status is not None:
+            # CREATING/LOADING/UPDATING/TERMINATING suppress duplicate launches
+            # but do not prove a successful recovery. Preserve the retry budget
+            # and revisit the entry after the normal retry interval.
+            state.update(
+                {
+                    "status": "waiting_model",
+                    "message": f"Model is {model_status.lower()}.",
+                }
+            )
+            return retry_interval
 
         if self._autostart_waiting_for_worker(launch):
             state.update(
@@ -1166,7 +1185,6 @@ class SupervisorActor(xo.StatelessActor):
             return None
 
         max_retries = int(entry.get("max_retries", 3))
-        retry_interval = float(entry.get("retry_interval_seconds", 30))
         attempts = int(state.get("attempts", 0))
         if attempts >= max_retries:
             state.update(
@@ -1197,6 +1215,7 @@ class SupervisorActor(xo.StatelessActor):
             state.update(
                 {
                     "status": "active",
+                    "attempts": 0,
                     "model_uid": launched_uid,
                     "last_started_ts": int(time.time()),
                     "last_error": None,

--- a/xinference/core/supervisor.py
+++ b/xinference/core/supervisor.py
@@ -1080,17 +1080,21 @@ class SupervisorActor(xo.StatelessActor):
         return entries
 
     async def _get_autostart_model_status(self, model_uid: str) -> Optional[str]:
-        infos = await self._status_guard_ref.get_instance_info(model_uid=model_uid)
-        statuses = {info.status for info in infos}
-        for status in (
-            LaunchStatus.READY.name,
-            LaunchStatus.CREATING.name,
-            LaunchStatus.LOADING.name,
-            LaunchStatus.UPDATING.name,
-            LaunchStatus.TERMINATING.name,
-        ):
-            if status in statuses:
-                return status
+        status_guard_ref = self._status_guard_ref
+        if status_guard_ref is not None:
+            infos = await status_guard_ref.get_instance_info(model_uid=model_uid)
+            statuses = {info.status for info in infos}
+            for status in (
+                LaunchStatus.READY.name,
+                LaunchStatus.CREATING.name,
+                LaunchStatus.LOADING.name,
+                LaunchStatus.UPDATING.name,
+                LaunchStatus.TERMINATING.name,
+            ):
+                if status in statuses:
+                    return status
+        else:
+            infos = []
 
         # Backward-compatible fallback for model mappings created before status
         # tracking was available. Do not override an explicit non-active status.

--- a/xinference/core/tests/test_autostart.py
+++ b/xinference/core/tests/test_autostart.py
@@ -32,6 +32,27 @@ class _DummySupervisor:
         return func(*args)
 
 
+class _DummyAutostartRunner:
+    _autostart_one_model = SupervisorActor._autostart_one_model
+
+    def __init__(self, model_status: str | None, attempts: int):
+        self._model_status = model_status
+        self._autostart_model_states = {
+            "uid-1": {"attempts": attempts, "last_error": "previous failure"}
+        }
+        self.launched: list = []
+
+    async def _get_autostart_model_status(self, model_uid: str) -> str | None:
+        return self._model_status
+
+    def _autostart_waiting_for_worker(self, launch):
+        return False
+
+    async def _launch_autostart_model(self, launch):
+        self.launched.append(launch)
+        return launch["model_uid"]
+
+
 @pytest.mark.asyncio
 async def test_load_autostart_entries_reads_sqlite_store_and_normalizes():
     supervisor = _DummySupervisor(
@@ -66,3 +87,72 @@ async def test_load_autostart_entries_reads_sqlite_store_and_normalizes():
         }
     ]
     supervisor._launch_history_store.list_autostart.assert_called_once_with(None)
+
+
+@pytest.mark.asyncio
+async def test_autostart_ready_model_resets_retry_attempts():
+    supervisor = _DummyAutostartRunner(model_status="READY", attempts=3)
+    entry = {
+        "max_retries": 3,
+        "retry_interval_seconds": 30,
+        "launch": {"model_name": "llama", "model_uid": "uid-1"},
+    }
+
+    retry_delay = await supervisor._autostart_one_model(entry)
+
+    assert retry_delay is None
+    assert supervisor.launched == []
+    assert supervisor._autostart_model_states["uid-1"] == {
+        "attempts": 0,
+        "status": "active",
+        "message": "Model is already active.",
+        "last_error": None,
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "model_status", ["CREATING", "LOADING", "UPDATING", "TERMINATING"]
+)
+async def test_autostart_transitional_model_preserves_retry_attempts(model_status):
+    supervisor = _DummyAutostartRunner(model_status=model_status, attempts=2)
+    entry = {
+        "max_retries": 3,
+        "retry_interval_seconds": 30,
+        "launch": {"model_name": "llama", "model_uid": "uid-1"},
+    }
+
+    retry_delay = await supervisor._autostart_one_model(entry)
+
+    assert retry_delay == 30
+    assert supervisor.launched == []
+    assert supervisor._autostart_model_states["uid-1"] == {
+        "attempts": 2,
+        "status": "waiting_model",
+        "message": f"Model is {model_status.lower()}.",
+        "last_error": "previous failure",
+    }
+
+
+@pytest.mark.asyncio
+async def test_autostart_successful_launch_resets_retry_attempts():
+    supervisor = _DummyAutostartRunner(model_status=None, attempts=2)
+    launch = {"model_name": "llama", "model_uid": "uid-1"}
+    entry = {
+        "max_retries": 3,
+        "retry_interval_seconds": 30,
+        "launch": launch,
+    }
+
+    retry_delay = await supervisor._autostart_one_model(entry)
+
+    assert retry_delay is None
+    assert supervisor.launched == [launch]
+    state = supervisor._autostart_model_states["uid-1"]
+    assert state["attempts"] == 0
+    assert state["status"] == "active"
+    assert state["model_uid"] == "uid-1"
+    assert state["message"] == "Model is ready."
+    assert state["last_error"] is None
+    assert isinstance(state["last_attempt_ts"], int)
+    assert isinstance(state["last_started_ts"], int)

--- a/xinference/core/tests/test_autostart.py
+++ b/xinference/core/tests/test_autostart.py
@@ -35,14 +35,14 @@ class _DummySupervisor:
 class _DummyAutostartRunner:
     _autostart_one_model = SupervisorActor._autostart_one_model
 
-    def __init__(self, model_status: str | None, attempts: int):
+    def __init__(self, model_status, attempts: int):
         self._model_status = model_status
         self._autostart_model_states = {
             "uid-1": {"attempts": attempts, "last_error": "previous failure"}
         }
         self.launched: list = []
 
-    async def _get_autostart_model_status(self, model_uid: str) -> str | None:
+    async def _get_autostart_model_status(self, model_uid: str):
         return self._model_status
 
     def _autostart_waiting_for_worker(self, launch):
@@ -51,6 +51,18 @@ class _DummyAutostartRunner:
     async def _launch_autostart_model(self, launch):
         self.launched.append(launch)
         return launch["model_uid"]
+
+
+@pytest.mark.asyncio
+async def test_autostart_status_falls_back_without_status_guard():
+    class DummySupervisor:
+        _get_autostart_model_status = SupervisorActor._get_autostart_model_status
+
+        def __init__(self):
+            self._status_guard_ref = None
+            self._model_uid_to_replica_info = {"uid-1": object()}
+
+    assert await DummySupervisor()._get_autostart_model_status("uid-1") == "READY"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- distinguish a model confirmed as `READY` from transitional `CREATING`, `LOADING`, `UPDATING`, and `TERMINATING` states when processing autostart entries
- keep transitional entries retryable at their configured interval while suppressing duplicate launches
- reset the autostart retry counter after a model reaches `READY` or a launch succeeds
- add regression coverage for ready, transitional, and successful-launch retry semantics

## Why

The existing active-model check treats all tracked lifecycle states as a successful recovery. A transitional instance prevents a duplicate launch, but it does not prove that recovery completed. If it later disappears, a stale retry count can prematurely exhaust the recovery budget. Conversely, a successful recovery should clear prior failures.

This follows up on the autostart recovery work in #5318 but addresses the state-machine/retry semantics rather than persisted replica normalization.

Fixes #5357.

## Validation

- `XINFERENCE_HOME=/tmp/xinference-home python -m pytest -q xinference/core/tests/test_autostart.py -p no:cacheprovider --timeout=60 --timeout-method=thread` — 7 passed
- `pre-commit run --files xinference/core/supervisor.py xinference/core/tests/test_autostart.py` — passed
- `git diff --check` — passed
