### PR TITLE
fix(model): harden batch processor against cancellation and unexpected exits

### DIFF
--- a/xinference/model/batch.py
+++ b/xinference/model/batch.py
@@ -36,6 +36,7 @@ class BatchMixin:
         setattr(self, self._func_name, types.MethodType(self._wrap_method(), self))
 
         self._process_batch_task = None
+        self._pending_batch_futures: set[asyncio.Future] = set()
 
         if "batch_size" in kwargs:
             self.batch_size = int(kwargs.pop("batch_size") or XINFERENCE_BATCH_SIZE)
@@ -50,12 +51,68 @@ class BatchMixin:
             self._queue: asyncio.Queue = asyncio.Queue()
         return self._queue
 
+    def _cleanup_finished_process_batch_task(self):
+        task = self._process_batch_task
+        if task is not None and task.done():
+            # Run cleanup synchronously before a new request is tracked. The
+            # scheduled done callback becomes a no-op once a replacement task is
+            # installed, avoiding both a hang and failure of the new request.
+            self._on_process_batch_done(task)
+
     def _ensure_process_batch_running(self):
-        if self._process_batch_task is not None and not self._process_batch_task.done():
+        self._cleanup_finished_process_batch_task()
+        if self._process_batch_task is not None:
             return
 
-        # create asyncio task to process batch
-        self._process_batch_task = asyncio.create_task(self._process_batch())
+        # Keep the task reference so a failed processor can be restarted by the
+        # next request instead of leaving queued futures waiting forever.
+        task = asyncio.create_task(self._process_batch())
+        self._process_batch_task = task
+        task.add_done_callback(self._on_process_batch_done)
+
+    def _on_process_batch_done(self, task: asyncio.Task):
+        if self._process_batch_task is not task:
+            return
+
+        self._process_batch_task = None
+
+        if task.cancelled():
+            self._fail_pending_requests(asyncio.CancelledError())
+            return
+
+        exception = task.exception()
+        if exception is None:
+            exception = RuntimeError(
+                f"Batch processor {self._func_name} stopped unexpectedly"
+            )
+        logger.error(
+            "Batch processor %s stopped unexpectedly",
+            self._func_name,
+            exc_info=(type(exception), exception, exception.__traceback__),
+        )
+        self._fail_pending_requests(exception)
+
+    def _fail_pending_requests(self, exception: BaseException):
+        # Futures are tracked from enqueue until completion, so this also covers
+        # requests already dequeued by a processor that exits unexpectedly.
+        pending_futures = list(self._pending_batch_futures)
+        for future in pending_futures:
+            if future.done():
+                continue
+            if isinstance(exception, asyncio.CancelledError):
+                future.cancel()
+            else:
+                future.set_exception(exception)
+
+        # Discard queued entries after their futures have been completed. This
+        # prevents a replacement processor from doing work for failed callers.
+        if self._queue is None:
+            return
+        while True:
+            try:
+                self._queue.get_nowait()
+            except asyncio.QueueEmpty:
+                break
 
     def _get_batch_size(self, *args, **kwargs) -> int:
         raise NotImplementedError
@@ -63,9 +120,9 @@ class BatchMixin:
     async def _process_batch(self):
         pending = None
         while True:
-            # Wait until at least one item is available
+            # Wait until at least one item is available.
             if pending is None:
-                (first_args, first_kwargs), first_future = await self._queue.get()
+                (first_args, first_kwargs), first_future = await self.queue.get()
             else:
                 (first_args, first_kwargs), first_future = pending
                 pending = None
@@ -77,13 +134,13 @@ class BatchMixin:
             size = self._get_batch_size(*first_args, **first_kwargs)
             futures = [first_future]
 
-            # Try to gather more items into the same batch within a short timeout window
+            # Try to gather more items into the same batch within a short timeout
+            # window. This allows batching multiple requests that arrive close
+            # together.
             while size < self.batch_size:
                 try:
-                    # Wait for a new request for a short time window (e.g. 3ms)
-                    # This allows batching multiple requests that arrive close in time.
                     (args, kwargs), future = await asyncio.wait_for(
-                        self._queue.get(), timeout=self.batch_interval
+                        self.queue.get(), timeout=self.batch_interval
                     )
                     if future.done():
                         continue
@@ -97,12 +154,10 @@ class BatchMixin:
                     delays.append(self._func.delay(*args, **kwargs))
                     futures.append(future)
                 except asyncio.TimeoutError:
-                    # No new items arrived within the timeout window,
-                    # stop collecting and start processing the current batch.
                     break
 
-            logger.debug("Calling batch %s with %d size", self._func_name, size)
-
+            # A caller awaiting its future may be cancelled while its item is
+            # queued. Do not execute work solely for cancelled callers.
             active = [
                 (delay, future)
                 for delay, future in zip(delays, futures)
@@ -110,34 +165,47 @@ class BatchMixin:
             ]
             if not active:
                 continue
-            delays, futures = map(list, zip(*active))
+            active_delays, active_futures = zip(*active)
 
+            logger.debug("Calling batch %s with %d size", self._func_name, size)
             try:
-                results = self._func.batch(*delays)
+                results = self._func.batch(*active_delays)
                 if inspect.isawaitable(results):
                     results = await results
-                if len(results) != len(futures):
+                if len(results) != len(active_futures):
                     raise RuntimeError(
                         "#results should be equal to #futures, "
-                        f"got {len(results)} and {len(futures)}"
+                        f"got {len(results)} and {len(active_futures)}"
                     )
-            except Exception as e:  # Handle errors for the entire batch
-                for fut in futures:
-                    if not fut.done():
-                        fut.set_exception(e)
+            except asyncio.CancelledError:
+                for future in futures:
+                    if not future.done():
+                        future.cancel()
+                raise
+            except Exception as error:  # Handle errors for the entire batch.
+                for future in futures:
+                    if not future.done():
+                        future.set_exception(error)
             else:
-                # Deliver the results to the corresponding waiting callers
-                for fut, result in zip(futures, results):
-                    if not fut.done():
-                        fut.set_result(result)
+                # A future can also be cancelled while the batch function is
+                # running. Skipping completed futures prevents InvalidStateError
+                # from terminating the processor and stalling later requests.
+                for future, result in zip(active_futures, results):
+                    if not future.done():
+                        future.set_result(result)
 
     def _wrap_method(self):
 
         async def _replaced_async_method(model, *args, **kwargs):
-            self._ensure_process_batch_running()
+            # Finish cleanup for a processor that exited between event-loop turns
+            # before associating the new request with the replacement processor.
+            self._cleanup_finished_process_batch_task()
             loop = asyncio.get_running_loop()
             fut = loop.create_future()
-            await self.queue.put(((args, kwargs), fut))
+            self._pending_batch_futures.add(fut)
+            fut.add_done_callback(self._pending_batch_futures.discard)
+            self.queue.put_nowait(((args, kwargs), fut))
+            self._ensure_process_batch_running()
             return await fut
 
         return _replaced_async_method

--- a/xinference/model/batch.py
+++ b/xinference/model/batch.py
@@ -102,7 +102,10 @@ class BatchMixin:
             if isinstance(exception, asyncio.CancelledError):
                 future.cancel()
             else:
-                future.set_exception(exception)
+                try:
+                    future.set_exception(type(exception)(*exception.args))
+                except Exception:
+                    future.set_exception(exception)
 
         # Discard queued entries after their futures have been completed. This
         # prevents a replacement processor from doing work for failed callers.

--- a/xinference/model/tests/test_batch.py
+++ b/xinference/model/tests/test_batch.py
@@ -147,6 +147,28 @@ async def _stop_batch_processor(model):
 
 
 @pytest.mark.asyncio
+async def test_batch_processor_uses_distinct_exceptions_for_pending_callers():
+    probe = _BatchProbe(batch_size=4)
+    loop = asyncio.get_running_loop()
+    first = loop.create_future()
+    second = loop.create_future()
+    probe._pending_batch_futures.update((first, second))
+
+    exception = RuntimeError("processor failed")
+    probe._fail_pending_requests(exception)
+
+    first_exception = first.exception()
+    second_exception = second.exception()
+    assert isinstance(first_exception, RuntimeError)
+    assert isinstance(second_exception, RuntimeError)
+    assert first_exception.args == exception.args
+    assert second_exception.args == exception.args
+    assert first_exception is not exception
+    assert second_exception is not exception
+    assert first_exception is not second_exception
+
+
+@pytest.mark.asyncio
 async def test_batch_processor_survives_cancelled_caller():
     model = _BatchModel()
 

--- a/xinference/model/tests/test_batch.py
+++ b/xinference/model/tests/test_batch.py
@@ -80,3 +80,155 @@ async def test_batch_mixin_respects_batch_size_and_order(
         ] == [f"request-{i}" for i in range(len(requests))]
     finally:
         await _shutdown_batch_processor(probe)
+
+
+class _BatchModel(BatchMixin):
+    def __init__(self):
+        self.batch_started = asyncio.Event()
+        self.batch_completed = asyncio.Event()
+        self.release_batch = asyncio.Event()
+        self.batch_error = None
+        self.batch_values = []
+        BatchMixin.__init__(self, self.infer, batch_interval=0.05)
+
+    def _get_batch_size(self, *args, **kwargs) -> int:
+        return 1
+
+    @extensible
+    def infer(self, value: int) -> int:
+        return value * 2
+
+    @infer.batch  # type: ignore[no-redef]
+    async def infer(self, args_list, kwargs_list):
+        self.batch_values = [args[0] for args in args_list]
+        self.batch_started.set()
+        try:
+            await self.release_batch.wait()
+            if self.batch_error is not None:
+                raise self.batch_error
+            return [args[0] * 2 for args in args_list]
+        finally:
+            self.batch_completed.set()
+
+
+class _QueuedBatchModel(_BatchModel):
+    def __init__(self):
+        self.release_processor = asyncio.Event()
+        super().__init__()
+
+    async def _process_batch(self):
+        await self.release_processor.wait()
+        await super()._process_batch()
+
+
+class _FailOnceProcessorModel(_BatchModel):
+    def __init__(self):
+        super().__init__()
+        self.processor_failed = asyncio.Event()
+
+    async def _process_batch(self):
+        if not self.processor_failed.is_set():
+            # Remove the request from the queue before failing, exercising the
+            # in-flight cleanup path rather than only draining queued requests.
+            await self.queue.get()
+            self.processor_failed.set()
+            raise RuntimeError("processor failed")
+        await super()._process_batch()
+
+
+async def _stop_batch_processor(model):
+    task = model._process_batch_task
+    if task is None:
+        return
+    if not task.done():
+        task.cancel()
+    await asyncio.gather(task, return_exceptions=True)
+    await asyncio.sleep(0)
+
+
+@pytest.mark.asyncio
+async def test_batch_processor_survives_cancelled_caller():
+    model = _BatchModel()
+
+    first = asyncio.create_task(model.infer(1))
+    second = asyncio.create_task(model.infer(2))
+    try:
+        await model.batch_started.wait()
+        assert model.batch_values == [1, 2]
+
+        first.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await first
+
+        model.release_batch.set()
+        assert await asyncio.wait_for(second, timeout=1) == 4
+        assert model._process_batch_task is not None
+        assert not model._process_batch_task.done()
+    finally:
+        await _stop_batch_processor(model)
+
+
+@pytest.mark.asyncio
+async def test_batch_processor_skips_caller_cancelled_while_queued():
+    model = _QueuedBatchModel()
+
+    first = asyncio.create_task(model.infer(1))
+    second = asyncio.create_task(model.infer(2))
+    try:
+        while model.queue.qsize() < 2:
+            await asyncio.sleep(0)
+
+        first.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await first
+
+        model.release_processor.set()
+        await model.batch_started.wait()
+        assert model.batch_values == [2]
+
+        model.release_batch.set()
+        assert await asyncio.wait_for(second, timeout=1) == 4
+    finally:
+        model.release_processor.set()
+        await _stop_batch_processor(model)
+
+
+@pytest.mark.asyncio
+async def test_batch_processor_survives_cancelled_caller_when_batch_fails():
+    model = _BatchModel()
+
+    first = asyncio.create_task(model.infer(1))
+    try:
+        await model.batch_started.wait()
+        first.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await first
+
+        model.batch_error = RuntimeError("batch failed")
+        model.release_batch.set()
+        await model.batch_completed.wait()
+        model.batch_error = None
+
+        assert await asyncio.wait_for(model.infer(2), timeout=1) == 4
+        assert model._process_batch_task is not None
+        assert not model._process_batch_task.done()
+    finally:
+        await _stop_batch_processor(model)
+
+
+@pytest.mark.asyncio
+async def test_batch_processor_fails_inflight_request_after_unexpected_exit():
+    model = _FailOnceProcessorModel()
+
+    first = asyncio.create_task(model.infer(1))
+    try:
+        await model.processor_failed.wait()
+        with pytest.raises(RuntimeError, match="processor failed"):
+            await asyncio.wait_for(first, timeout=1)
+
+        model.release_batch.set()
+        assert await asyncio.wait_for(model.infer(2), timeout=1) == 4
+        assert model._process_batch_task is not None
+        assert not model._process_batch_task.done()
+    finally:
+        await _stop_batch_processor(model)


### PR DESCRIPTION
## Summary

- track outstanding `BatchMixin` caller futures independently from the queue
- remove cancelled callers before invoking the batch method
- cancel or fail all outstanding callers when the processor task is cancelled or exits unexpectedly
- clean up a completed processor task and start a replacement for the next request
- add cancellation, crash, and restart regression coverage while retaining FIFO/capacity coverage from #5172

## Why

`BatchMixin` is shared by batched model methods. A processor task can be cancelled or fail after callers have been queued, leaving their futures unresolved indefinitely. A cancelled caller can also be fulfilled again, raising `InvalidStateError` and terminating the processor.

#5172 improves shared FIFO/capacity behavior and batch-level error handling; this patch covers the processor-task exit path and every pending caller's completion guarantee.

Fixes #5358.

## Validation

- `XINFERENCE_HOME=/tmp/xinference-home python -m pytest -q xinference/model/tests/test_batch.py -p no:cacheprovider --timeout=60 --timeout-method=thread` — 8 passed
- `pre-commit run --files xinference/model/batch.py xinference/model/tests/test_batch.py` — passed
- `git diff --check` — passed
