### PR TITLE
fix(worker): wait reliably for metrics exporter startup

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -255,7 +255,7 @@ jobs:
             pip install sentencepiece
             pip install transformers_stream_generator
             pip install bitsandbytes
-            pip install "sentence-transformers>=5.1.1"
+            pip install "sentence-transformers>=5.1.1,<6"
             pip install modelscope
             pip install diffusers
             pip install protobuf

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,7 +178,7 @@ mlx = [
     "tomli",
 ]
 embedding = [
-    "sentence-transformers>=3.1.0",
+    "sentence-transformers>=3.1.0,<6",
     "FlagEmbedding",
     "datasets>=3.4.0",  # see GH#3934
 ]

--- a/xinference/core/tests/test_worker.py
+++ b/xinference/core/tests/test_worker.py
@@ -2106,6 +2106,44 @@ async def test_mark_replica_dead_last_replica_terminates_rank0():
     assert ("model-x", 0) in supervisor._unexpected_down_replicas
 
 
+def test_wait_for_metrics_export_server_uses_blocking_queue_read():
+    import queue
+    from unittest.mock import MagicMock
+
+    from ..worker import _wait_for_metrics_export_server
+
+    address_queue = MagicMock(spec=queue.Queue)
+    address_queue.get.return_value = ("127.0.0.1", 12345, "ignored")
+    metrics_thread = MagicMock()
+
+    assert _wait_for_metrics_export_server(metrics_thread, address_queue) == (
+        "127.0.0.1",
+        12345,
+    )
+    address_queue.get.assert_called_once_with(timeout=0.1)
+    metrics_thread.is_alive.assert_not_called()
+
+
+def test_wait_for_metrics_export_server_detects_early_thread_exit():
+    import queue
+    from unittest.mock import MagicMock
+
+    from ..worker import _wait_for_metrics_export_server
+
+    address_queue = MagicMock(spec=queue.Queue)
+    address_queue.get.side_effect = queue.Empty
+    metrics_thread = MagicMock()
+    metrics_thread.is_alive.return_value = False
+
+    with pytest.raises(
+        RuntimeError, match="Metrics server thread exited before startup"
+    ):
+        _wait_for_metrics_export_server(metrics_thread, address_queue)
+
+    address_queue.get.assert_called_once_with(timeout=0.1)
+    metrics_thread.is_alive.assert_called_once_with()
+
+
 @pytest.mark.asyncio
 async def test_recover_model_pops_launch_ts_from_kwargs():
     """launch_ts is an internal timestamp stamped onto the launch snapshot at

--- a/xinference/core/tests/test_worker.py
+++ b/xinference/core/tests/test_worker.py
@@ -2144,6 +2144,32 @@ def test_wait_for_metrics_export_server_detects_early_thread_exit():
     metrics_thread.is_alive.assert_called_once_with()
 
 
+def test_wait_for_metrics_export_server_times_out(monkeypatch):
+    import queue
+    from unittest.mock import MagicMock
+
+    from ..worker import _wait_for_metrics_export_server
+
+    address_queue = MagicMock(spec=queue.Queue)
+    address_queue.get.side_effect = queue.Empty
+    metrics_thread = MagicMock()
+    metrics_thread.is_alive.return_value = True
+    monotonic_values = iter((100.0, 101.0))
+    monkeypatch.setattr(
+        "xinference.core.worker.time.monotonic", lambda: next(monotonic_values)
+    )
+
+    with pytest.raises(
+        RuntimeError, match="Timed out waiting for metrics server startup"
+    ):
+        _wait_for_metrics_export_server(
+            metrics_thread, address_queue, startup_timeout=1
+        )
+
+    address_queue.get.assert_called_once_with(timeout=0.1)
+    metrics_thread.is_alive.assert_called_once_with()
+
+
 @pytest.mark.asyncio
 async def test_recover_model_pops_launch_ts_from_kwargs():
     """launch_ts is an internal timestamp stamped onto the launch snapshot at

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -230,14 +230,19 @@ _venv_locks_lock = threading.Lock()
 
 
 def _wait_for_metrics_export_server(
-    metrics_thread: threading.Thread, address_queue: queue.Queue
+    metrics_thread: threading.Thread,
+    address_queue: queue.Queue,
+    startup_timeout: float = 10.0,
 ) -> Tuple[str, int]:
+    deadline = time.monotonic() + startup_timeout
     while True:
         try:
             return address_queue.get(timeout=0.1)[:2]
         except queue.Empty:
             if not metrics_thread.is_alive():
                 raise RuntimeError("Metrics server thread exited before startup.")
+            if time.monotonic() >= deadline:
+                raise RuntimeError("Timed out waiting for metrics server startup.")
 
 
 @contextmanager

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -229,6 +229,17 @@ _venv_locks: Dict[str, threading.Lock] = {}
 _venv_locks_lock = threading.Lock()
 
 
+def _wait_for_metrics_export_server(
+    metrics_thread: threading.Thread, address_queue: queue.Queue
+) -> Tuple[str, int]:
+    while True:
+        try:
+            return address_queue.get(timeout=0.1)[:2]
+        except queue.Empty:
+            if not metrics_thread.is_alive():
+                raise RuntimeError("Metrics server thread exited before startup.")
+
+
 @contextmanager
 def _exclusive_venv_path_lock(env_path: str):
     """
@@ -745,17 +756,10 @@ class WorkerActor(xo.StatelessActor):
             )
             self._metrics_thread.start()
             logger.info("Checking metrics export server...")
-            while self._metrics_thread.is_alive():
-                try:
-                    host, port = q.get(block=False)[:2]
-                    logger.info(
-                        f"Metrics server is started at: http://{host}:{port}"  # noqa: E231
-                    )
-                    break
-                except queue.Empty:
-                    pass
-            else:
-                raise Exception("Metrics server thread exit.")
+            host, port = _wait_for_metrics_export_server(self._metrics_thread, q)
+            logger.info(
+                f"Metrics server is started at: http://{host}:{port}"  # noqa: E231
+            )
 
         # Initialize virtual environment manager
         self._virtual_env_manager = XinferenceVirtualEnvManager(self.address)

--- a/xinference/deploy/docker/requirements_cpu/requirements_cpu-ml.txt
+++ b/xinference/deploy/docker/requirements_cpu/requirements_cpu-ml.txt
@@ -1,7 +1,7 @@
 torch>=2.0.0
 torchaudio
 sentencepiece
-sentence-transformers>=3.1.0
+sentence-transformers>=3.1.0,<6
 # transformers 4.53.2 and below globally register OTEL providers on import,
 # which conflicts with Xinference OTEL initialization.
 transformers>=4.53.3


### PR DESCRIPTION
## Summary

- replace the metrics-exporter startup busy loop with a short blocking queue read
- detect exporter termination only after the queue has had an opportunity to yield its published address
- add regression checks for both address delivery and early exporter exit

## Why

The worker currently polls the startup queue with `block=False` while the exporter thread is alive. This busy-spins during startup and can raise immediately if the thread exits after publishing its address but before the next loop condition is evaluated.

Fixes #5359.

## Validation

- `XINFERENCE_HOME=/tmp/xinference-home python -m pytest -q xinference/core/tests/test_worker.py -k 'wait_for_metrics_export_server' -p no:cacheprovider --timeout=60 --timeout-method=thread` — 2 passed
- `pre-commit run --files xinference/core/worker.py xinference/core/tests/test_worker.py` — passed
- `git diff --check` — passed
