### PR TITLE
fix(core): make worker supervisor reconnection generation-safe

### DIFF
--- a/xinference/core/tests/test_worker.py
+++ b/xinference/core/tests/test_worker.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import asyncio
 import itertools
+import threading
 from types import SimpleNamespace
 from typing import Any, List, Optional, Tuple, Union
 
@@ -151,8 +152,10 @@ class MockWorkerActor(WorkerActor):
 
     # --- test helpers for report_status GPU attribution ---
     def set_supervisor_ref_for_test(self, ref):
-        self._supervisor_ref = ref
-        self._registered = True
+        with self._supervisor_ref_lock:
+            self._supervisor_ref = ref
+            self._registered = True
+            self._supervisor_ref_generation += 1
 
     def set_gpu_attribution_tables_for_test(self, pid, subpool, total_devices):
         self._model_uid_to_pid = dict(pid)
@@ -402,10 +405,18 @@ class DummyVirtualEnvManager:
 
 
 class DummySupervisorRef:
-    def __init__(self, fail_report_status_times: int = 0):
+    def __init__(
+        self,
+        fail_report_status_times: int = 0,
+        fail_heartbeat_times: int = 0,
+        cancel_after_report: bool = False,
+    ):
         self.fail_report_status_times = fail_report_status_times
+        self.fail_heartbeat_times = fail_heartbeat_times
+        self.cancel_after_report = cancel_after_report
         self.add_worker_calls: List[Tuple[str, List[dict], List[str]]] = []
         self.report_worker_status_calls: List[Tuple[str, Any]] = []
+        self.heartbeat_calls: List[str] = []
 
     async def add_worker(
         self,
@@ -426,6 +437,14 @@ class DummySupervisorRef:
             self.fail_report_status_times -= 1
             raise RuntimeError("stale supervisor")
         self.report_worker_status_calls.append((worker_address, status))
+        if self.cancel_after_report:
+            raise asyncio.CancelledError
+
+    async def receive_heartbeat(self, worker_address: str):
+        self.heartbeat_calls.append(worker_address)
+        if self.fail_heartbeat_times > 0:
+            self.fail_heartbeat_times -= 1
+            raise RuntimeError("heartbeat failed")
 
     async def record_model_version(self, model_version_infos, worker_address: str):
         return None
@@ -449,15 +468,18 @@ async def test_worker_heartbeat_failure_clears_cached_supervisor_refs():
         def __init__(self):
             self.address = "test://worker"
             self._supervisor_ref = FailingSupervisorRef()
+            self._supervisor_ref_address = "test://supervisor"
+            self._supervisor_ref_lock = threading.Lock()
+            self._supervisor_ref_generation = 0
             self._registered = True
             self._status_guard_ref = object()
             self._event_collector_ref = object()
             self._cache_tracker_ref = object()
             self._progress_tracker_ref = object()
 
-        async def get_supervisor_ref(self, add_worker=True):
+        async def _get_supervisor_ref_with_generation(self, add_worker=True):
             assert not add_worker
-            return self._supervisor_ref
+            return self._supervisor_ref, self._supervisor_ref_generation
 
     worker = DummyWorker()
 
@@ -2168,6 +2190,331 @@ def test_wait_for_metrics_export_server_times_out(monkeypatch):
 
     address_queue.get.assert_called_once_with(timeout=0.1)
     metrics_thread.is_alive.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "message",
+    [
+        "transient RPC failure",
+        "cannot schedule new futures after shutdown",
+        "Executor shutdown has been called",
+    ],
+)
+async def test_periodical_report_status_recovers_from_runtime_error(
+    monkeypatch, message
+):
+    heartbeat_calls = 0
+    report_calls = 0
+    sleep_calls = 0
+
+    class DummyWorker:
+        async def heartbeat(self):
+            nonlocal heartbeat_calls
+            heartbeat_calls += 1
+            if heartbeat_calls == 1:
+                raise RuntimeError(message)
+
+        async def report_status(self):
+            nonlocal report_calls
+            report_calls += 1
+            raise asyncio.CancelledError
+
+    async def fake_sleep(_interval):
+        nonlocal sleep_calls
+        sleep_calls += 1
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+    await WorkerActor._periodical_report_status(DummyWorker())  # type: ignore[arg-type]
+
+    assert heartbeat_calls == 2
+    assert report_calls == 1
+    assert sleep_calls == 1
+
+
+def test_clear_supervisor_refs_does_not_remove_newer_reference():
+    old_supervisor = DummySupervisorRef()
+    new_supervisor = DummySupervisorRef()
+    barrier = threading.Barrier(2)
+    result = []
+
+    class DummyWorker:
+        _clear_supervisor_refs = WorkerActor._clear_supervisor_refs
+        _get_supervisor_ref_on_actor_loop = (
+            WorkerActor._get_supervisor_ref_on_actor_loop
+        )
+        _clear_unregistered_supervisor_refs = (
+            WorkerActor._clear_unregistered_supervisor_refs
+        )
+
+        def __init__(self):
+            self._supervisor_ref_lock = threading.Lock()
+            self._supervisor_ref = old_supervisor
+            self._supervisor_ref_generation = 1
+            self._registered = True
+            self._status_guard_ref = object()
+            self._event_collector_ref = object()
+            self._cache_tracker_ref = object()
+            self._progress_tracker_ref = object()
+
+    worker = DummyWorker()
+
+    def clear_old_reference():
+        barrier.wait()
+        result.append(
+            worker._clear_supervisor_refs(expected_supervisor_ref=old_supervisor)
+        )
+
+    thread = threading.Thread(target=clear_old_reference)
+    thread.start()
+    with worker._supervisor_ref_lock:
+        worker._supervisor_ref = new_supervisor
+    barrier.wait()
+    thread.join(timeout=1)
+
+    assert not thread.is_alive()
+    assert result == [False]
+    assert worker._supervisor_ref is new_supervisor
+    assert worker._registered is True
+
+
+def test_clear_supervisor_refs_does_not_remove_newer_same_reference_generation():
+    supervisor = DummySupervisorRef()
+    barrier = threading.Barrier(2)
+    result = []
+
+    class DummyWorker:
+        _clear_supervisor_refs = WorkerActor._clear_supervisor_refs
+        _get_supervisor_ref_on_actor_loop = (
+            WorkerActor._get_supervisor_ref_on_actor_loop
+        )
+        _clear_unregistered_supervisor_refs = (
+            WorkerActor._clear_unregistered_supervisor_refs
+        )
+
+        def __init__(self):
+            self._supervisor_ref_lock = threading.Lock()
+            self._supervisor_ref = supervisor
+            self._supervisor_ref_generation = 1
+            self._registered = False
+            self._status_guard_ref = None
+            self._event_collector_ref = None
+            self._cache_tracker_ref = None
+            self._progress_tracker_ref = None
+
+    worker = DummyWorker()
+
+    def clear_old_generation():
+        barrier.wait()
+        result.append(
+            worker._clear_supervisor_refs(
+                expected_supervisor_ref=supervisor,
+                expected_generation=1,
+            )
+        )
+
+    thread = threading.Thread(target=clear_old_generation)
+    thread.start()
+    with worker._supervisor_ref_lock:
+        worker._status_guard_ref = object()
+        worker._event_collector_ref = object()
+        worker._cache_tracker_ref = object()
+        worker._registered = True
+        worker._supervisor_ref_generation = 2
+    barrier.wait()
+    thread.join(timeout=1)
+
+    assert not thread.is_alive()
+    assert result == [False]
+    assert worker._supervisor_ref is supervisor
+    assert worker._supervisor_ref_generation == 2
+    assert worker._registered is True
+
+
+@pytest.mark.asyncio
+async def test_periodical_report_status_reregisters_after_heartbeat_failure(
+    monkeypatch,
+):
+    stale_supervisor = DummySupervisorRef(fail_heartbeat_times=1)
+    fresh_supervisor = DummySupervisorRef(cancel_after_report=True)
+    supervisor_refs = iter([stale_supervisor, fresh_supervisor, fresh_supervisor])
+    sleep_calls = 0
+
+    class DummyWorker:
+        get_supervisor_ref = WorkerActor.get_supervisor_ref
+        _get_supervisor_ref_with_generation = (
+            WorkerActor._get_supervisor_ref_with_generation
+        )
+        _get_supervisor_ref_generation = WorkerActor._get_supervisor_ref_generation
+        _clear_supervisor_refs = WorkerActor._clear_supervisor_refs
+        _get_supervisor_ref_on_actor_loop = (
+            WorkerActor._get_supervisor_ref_on_actor_loop
+        )
+        _clear_unregistered_supervisor_refs = (
+            WorkerActor._clear_unregistered_supervisor_refs
+        )
+        heartbeat = WorkerActor.heartbeat
+        report_status = WorkerActor.report_status
+
+        def __init__(self):
+            self.address = "test://worker"
+            self._supervisor_address = "test://supervisor"
+            self._supervisor_endpoint = None
+            self._supervisor_ref = None
+            self._supervisor_ref_address = None
+            self._supervisor_ref_lock = threading.Lock()
+            self._supervisor_ref_generation = 0
+            self._actor_loop = None
+            self._supervisor_init_lock = None
+            self._registered = False
+            self._status_guard_ref = None
+            self._event_collector_ref = None
+            self._cache_tracker_ref = None
+            self._progress_tracker_ref = None
+            self._total_gpu_devices = []
+
+        def _get_running_replica_states(self):
+            return [{"replica_model_uid": "model-a-0", "n_worker": 1, "shard": 0}]
+
+        async def _refresh_supervisor_address(self):
+            pytest.fail("the configured supervisor address should be reachable")
+
+    async def fake_actor_ref(address, uid):
+        if uid == SupervisorActor.default_uid():
+            return next(supervisor_refs)
+        return None
+
+    async def fake_sleep(_interval):
+        nonlocal sleep_calls
+        sleep_calls += 1
+
+    worker = DummyWorker()
+    monkeypatch.setattr(xo, "actor_ref", fake_actor_ref)
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr(
+        "xinference.core.worker.gather_node_info", lambda: {"cpu": "ok"}
+    )
+
+    await WorkerActor._periodical_report_status(worker)  # type: ignore[arg-type]
+
+    assert stale_supervisor.heartbeat_calls == [worker.address]
+    assert stale_supervisor.add_worker_calls == []
+    assert fresh_supervisor.heartbeat_calls == [worker.address]
+    assert fresh_supervisor.add_worker_calls == [
+        (
+            worker.address,
+            [{"replica_model_uid": "model-a-0", "n_worker": 1, "shard": 0}],
+            [],
+        )
+    ]
+    assert fresh_supervisor.report_worker_status_calls == [
+        (worker.address, {"cpu": "ok"})
+    ]
+    assert worker._supervisor_ref is fresh_supervisor
+    assert worker._registered is True
+    assert sleep_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_supervisor_registration_is_single_flight_and_replays_latest_snapshot(
+    monkeypatch,
+):
+    first_registration_started = asyncio.Event()
+    release_first_registration = asyncio.Event()
+
+    class BlockingSupervisor(DummySupervisorRef):
+        async def add_worker(
+            self,
+            worker_address: str,
+            replica_states=None,
+            replica_model_uids=None,
+        ):
+            await super().add_worker(
+                worker_address,
+                replica_states=replica_states,
+                replica_model_uids=replica_model_uids,
+            )
+            if len(self.add_worker_calls) == 1:
+                first_registration_started.set()
+                await release_first_registration.wait()
+
+    supervisor = BlockingSupervisor()
+
+    class DummyWorker:
+        get_supervisor_ref = WorkerActor.get_supervisor_ref
+        _get_supervisor_ref_with_generation = (
+            WorkerActor._get_supervisor_ref_with_generation
+        )
+        _clear_supervisor_refs = WorkerActor._clear_supervisor_refs
+        _get_supervisor_ref_on_actor_loop = (
+            WorkerActor._get_supervisor_ref_on_actor_loop
+        )
+        _clear_unregistered_supervisor_refs = (
+            WorkerActor._clear_unregistered_supervisor_refs
+        )
+
+        def __init__(self):
+            self.address = "test://worker"
+            self._supervisor_address = "test://supervisor"
+            self._supervisor_endpoint = None
+            self._supervisor_ref = None
+            self._supervisor_ref_address = None
+            self._supervisor_ref_lock = threading.Lock()
+            self._supervisor_ref_generation = 0
+            self._actor_loop = None
+            self._supervisor_init_lock = None
+            self._registered = False
+            self._status_guard_ref = None
+            self._event_collector_ref = None
+            self._cache_tracker_ref = None
+            self._progress_tracker_ref = None
+            self.replica_states = [
+                {"replica_model_uid": "model-a-0", "n_worker": 1, "shard": 0}
+            ]
+
+        def _get_running_replica_states(self):
+            return [dict(state) for state in self.replica_states]
+
+        async def _refresh_supervisor_address(self):
+            pytest.fail("the configured supervisor address should be reachable")
+
+    async def fake_actor_ref(address, uid):
+        if uid == SupervisorActor.default_uid():
+            return supervisor
+        return None
+
+    worker = DummyWorker()
+    monkeypatch.setattr(xo, "actor_ref", fake_actor_ref)
+
+    first = asyncio.create_task(worker.get_supervisor_ref(add_worker=True))
+    await first_registration_started.wait()
+    worker.replica_states = [
+        {"replica_model_uid": "model-b-0", "n_worker": 1, "shard": 0}
+    ]
+    second = asyncio.create_task(worker.get_supervisor_ref(add_worker=True))
+    await asyncio.sleep(0)
+    release_first_registration.set()
+
+    first_ref, second_ref = await asyncio.gather(first, second)
+
+    assert first_ref is supervisor
+    assert second_ref is supervisor
+    assert supervisor.add_worker_calls == [
+        (
+            worker.address,
+            [{"replica_model_uid": "model-a-0", "n_worker": 1, "shard": 0}],
+            [],
+        ),
+        (
+            worker.address,
+            [{"replica_model_uid": "model-b-0", "n_worker": 1, "shard": 0}],
+            [],
+        ),
+    ]
+    assert worker._registered is True
+    assert worker._supervisor_init_lock is not None
+    assert not worker._supervisor_init_lock.locked()
 
 
 @pytest.mark.asyncio

--- a/xinference/core/tests/test_worker.py
+++ b/xinference/core/tests/test_worker.py
@@ -710,17 +710,25 @@ async def test_worker_report_status_reconnects_and_replays_running_models(
     refs = [first_supervisor, second_supervisor]
     monkeypatch.setattr("xinference.core.worker.time.time", lambda: 1710000000)
 
-    async def fake_get_supervisor_ref(self, add_worker=True):
+    async def fake_get_supervisor_ref_with_generation(self, add_worker=True):
         if self._supervisor_ref is None:
-            self._supervisor_ref = refs.pop(0)
+            with self._supervisor_ref_lock:
+                self._supervisor_ref = refs.pop(0)
+                self._supervisor_ref_generation += 1
+        supervisor_ref = self._supervisor_ref
+        generation = self._supervisor_ref_generation
         if add_worker:
-            await self._supervisor_ref.add_worker(
+            await supervisor_ref.add_worker(
                 self.address,
                 replica_states=self._get_running_replica_states(),
             )
-        return self._supervisor_ref
+        return supervisor_ref, generation
 
-    monkeypatch.setattr(WorkerActor, "get_supervisor_ref", fake_get_supervisor_ref)
+    monkeypatch.setattr(
+        WorkerActor,
+        "_get_supervisor_ref_with_generation",
+        fake_get_supervisor_ref_with_generation,
+    )
     monkeypatch.setattr(
         "xinference.core.worker.gather_node_info", lambda: {"cpu": "ok"}
     )

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -227,6 +227,7 @@ def _mark_venv_setup_done(
 # and provides a fast uncontended path on Unix as well.
 _venv_locks: Dict[str, threading.Lock] = {}
 _venv_locks_lock = threading.Lock()
+_SUPERVISOR_INIT_TIMEOUT = 60
 
 
 def _wait_for_metrics_export_server(
@@ -694,6 +695,11 @@ class WorkerActor(xo.StatelessActor):
         self._supervisor_address = supervisor_address
         self._supervisor_endpoint = supervisor_endpoint
         self._supervisor_ref: Optional[xo.ActorRefType] = None
+        self._supervisor_ref_lock = threading.Lock()
+        self._supervisor_ref_generation = 0
+        self._supervisor_ref_address: Optional[str] = None
+        self._supervisor_init_lock: Optional[asyncio.Lock] = None
+        self._actor_loop: Optional[asyncio.AbstractEventLoop] = None
         self._main_pool = main_pool
         self._main_pool.recover_sub_pool = self.recover_sub_pool
         self._status_guard_ref: xo.ActorRefType[
@@ -1176,6 +1182,9 @@ class WorkerActor(xo.StatelessActor):
             logger.debug("Startup VRAM poll failed", exc_info=True)
 
     async def __post_create__(self):
+        self._actor_loop = asyncio.get_running_loop()
+        self._supervisor_init_lock = asyncio.Lock()
+
         from ..model.audio import (
             CustomAudioModelFamilyV2,
             generate_audio_description,
@@ -1344,63 +1353,150 @@ class WorkerActor(xo.StatelessActor):
         Params:
             add_worker: By default will call supervisor.add_worker after first connect
         """
-        from .supervisor import SupervisorActor
+        supervisor_ref, _ = await self._get_supervisor_ref_with_generation(add_worker)
+        return supervisor_ref
 
-        # Cache hit: return immediately only when no registration is required,
-        # or the worker has already been registered. When add_worker=True and
-        # _registered=False, we must fall through to perform add_worker even if
-        # the ref is cached (this happens after heartbeat populated the ref via
-        # add_worker=False before registration completed).
-        if self._supervisor_ref is not None and (not add_worker or self._registered):
-            return self._supervisor_ref
-        try:
-            supervisor_ref = await xo.actor_ref(  # type: ignore
-                address=self._supervisor_address, uid=SupervisorActor.default_uid()
-            )
-        except Exception:
-            await self._refresh_supervisor_address()
-            supervisor_ref = await xo.actor_ref(  # type: ignore
-                address=self._supervisor_address, uid=SupervisorActor.default_uid()
-            )
-        # Prevent concurrent operations leads to double initialization, check again.
-        if self._supervisor_ref is not None and (not add_worker or self._registered):
-            return self._supervisor_ref
-        self._supervisor_ref = supervisor_ref
-        try:
-            if add_worker and not self._registered:
-                replica_states = self._get_running_replica_states()
-                await supervisor_ref.add_worker(
-                    self.address, replica_states=replica_states
-                )
-                self._registered = True
-                if replica_states:
-                    logger.info(
-                        "Connected to supervisor and replayed %s running model replicas",
-                        len(replica_states),
-                    )
-                else:
-                    logger.info("Connected to supervisor as a fresh worker")
+    async def _get_supervisor_ref_with_generation(
+        self, add_worker: bool = True
+    ) -> Tuple[xo.ActorRefType, int]:
+        running_loop = asyncio.get_running_loop()
+        if self._actor_loop is None:
+            # Test/local fallback. Production sets these before the first connect
+            # in __post_create__.
+            self._actor_loop = running_loop
+            self._supervisor_init_lock = asyncio.Lock()
 
-            self._status_guard_ref = await xo.actor_ref(
-                address=self._supervisor_address, uid=StatusGuardActor.default_uid()
+        try:
+            if running_loop is self._actor_loop:
+                return await self._get_supervisor_ref_on_actor_loop(add_worker)
+
+            future = asyncio.run_coroutine_threadsafe(
+                self._get_supervisor_ref_on_actor_loop(add_worker), self._actor_loop
             )
-            self._event_collector_ref = await xo.actor_ref(
-                address=self._supervisor_address, uid=EventCollectorActor.default_uid()
-            )
-            self._cache_tracker_ref = await xo.actor_ref(
-                address=self._supervisor_address, uid=CacheTrackerActor.default_uid()
-            )
-            self._progress_tracker_ref = None
-        except Exception:
-            self._clear_supervisor_refs()
+            return await asyncio.wrap_future(future)
+        except BaseException:
+            # A follower cancelled while waiting for the actor-loop lock must not
+            # clear the leader's in-flight initialization.
+            self._clear_unregistered_supervisor_refs()
             raise
 
-        # record_model_version is an auxiliary cache-management feature.
-        # Its failure must NOT block the worker's core heartbeat/status-report
-        # channel. Guard against _cache_tracker_ref being None when the first
-        # try block failed and cleared all refs (defensive: avoids AttributeError).
-        if self._cache_tracker_ref is None:
-            return self._supervisor_ref
+    async def _get_supervisor_ref_on_actor_loop(
+        self, add_worker: bool
+    ) -> Tuple[xo.ActorRefType, int]:
+        from .supervisor import SupervisorActor
+
+        if self._supervisor_init_lock is None:
+            self._supervisor_init_lock = asyncio.Lock()
+
+        cache_tracker_ref = None
+        replica_states: List[Dict[str, Any]] = []
+        async with self._supervisor_init_lock:
+            # Cache hit: return immediately only when no registration is required,
+            # or the worker has already been registered.
+            with self._supervisor_ref_lock:
+                if self._supervisor_ref is not None and (
+                    not add_worker or self._registered
+                ):
+                    return self._supervisor_ref, self._supervisor_ref_generation
+                supervisor_ref = self._supervisor_ref
+                supervisor_address = self._supervisor_ref_address
+                generation = self._supervisor_ref_generation
+
+            async with timeout(_SUPERVISOR_INIT_TIMEOUT):
+                if supervisor_ref is None:
+                    supervisor_address = self._supervisor_address
+                    try:
+                        supervisor_ref = await xo.actor_ref(  # type: ignore
+                            address=supervisor_address,
+                            uid=SupervisorActor.default_uid(),
+                        )
+                    except Exception:
+                        await self._refresh_supervisor_address()
+                        supervisor_address = self._supervisor_address
+                        supervisor_ref = await xo.actor_ref(  # type: ignore
+                            address=supervisor_address,
+                            uid=SupervisorActor.default_uid(),
+                        )
+
+                    with self._supervisor_ref_lock:
+                        if self._supervisor_ref is None:
+                            self._supervisor_ref = supervisor_ref
+                            self._supervisor_ref_address = supervisor_address
+                            self._supervisor_ref_generation += 1
+                        elif not add_worker or self._registered:
+                            return (
+                                self._supervisor_ref,
+                                self._supervisor_ref_generation,
+                            )
+                        supervisor_ref = self._supervisor_ref
+                        supervisor_address = self._supervisor_ref_address
+                        generation = self._supervisor_ref_generation
+
+                assert supervisor_ref is not None
+                assert supervisor_address is not None
+                if not add_worker:
+                    return supervisor_ref, generation
+
+                # All registration work runs on the actor loop under one asyncio
+                # lock. If the replica set changes while an RPC is in flight,
+                # replay serially until the supervisor has the latest snapshot.
+                while True:
+                    replica_states = self._get_running_replica_states()
+                    await supervisor_ref.add_worker(
+                        self.address, replica_states=replica_states
+                    )
+                    status_guard_ref = await xo.actor_ref(
+                        address=supervisor_address,
+                        uid=StatusGuardActor.default_uid(),
+                    )
+                    event_collector_ref = await xo.actor_ref(
+                        address=supervisor_address,
+                        uid=EventCollectorActor.default_uid(),
+                    )
+                    cache_tracker_ref = await xo.actor_ref(
+                        address=supervisor_address,
+                        uid=CacheTrackerActor.default_uid(),
+                    )
+                    if self._get_running_replica_states() == replica_states:
+                        break
+
+                # No await occurs between the final snapshot check and this
+                # publication, so actor-loop model mutations cannot create a
+                # stale registered snapshot. Address and generation are checked
+                # together to prevent mixing refs from different supervisors.
+                with self._supervisor_ref_lock:
+                    if (
+                        self._supervisor_ref is not supervisor_ref
+                        or self._supervisor_ref_generation != generation
+                        or self._supervisor_ref_address != supervisor_address
+                        or self._supervisor_address != supervisor_address
+                    ):
+                        raise RuntimeError(
+                            "Supervisor reference changed during initialization"
+                        )
+                    self._status_guard_ref = status_guard_ref
+                    self._event_collector_ref = event_collector_ref
+                    self._cache_tracker_ref = cache_tracker_ref
+                    self._progress_tracker_ref = None
+                    self._registered = True
+                    self._supervisor_ref_generation += 1
+                    generation = self._supervisor_ref_generation
+
+        if replica_states:
+            logger.info(
+                "Connected to supervisor and replayed %s running model replicas",
+                len(replica_states),
+            )
+        else:
+            logger.info("Connected to supervisor as a fresh worker")
+
+        if cache_tracker_ref is not None:
+            asyncio.create_task(
+                self._record_model_versions_best_effort(cache_tracker_ref)
+            )
+        return supervisor_ref, generation
+
+    async def _record_model_versions_best_effort(self, cache_tracker_ref):
         try:
             # cache_tracker is on supervisor
             from ..model.audio import get_audio_model_descriptions
@@ -1411,7 +1507,6 @@ class WorkerActor(xo.StatelessActor):
             from ..model.rerank import get_rerank_model_descriptions
             from ..model.video import get_video_model_descriptions
 
-            # record model version
             model_version_infos: Dict[str, List[Dict]] = {}  # type: ignore
             model_version_infos.update(get_llm_version_infos())
             model_version_infos.update(get_embedding_model_descriptions())
@@ -1420,9 +1515,14 @@ class WorkerActor(xo.StatelessActor):
             model_version_infos.update(get_audio_model_descriptions())
             model_version_infos.update(get_video_model_descriptions())
             model_version_infos.update(get_flexible_model_descriptions())
-            await self._cache_tracker_ref.record_model_version(
-                model_version_infos, self.address
+            await xo.wait_for(
+                cache_tracker_ref.record_model_version(
+                    model_version_infos, self.address
+                ),
+                XINFERENCE_TCP_REQUEST_TIMEOUT,
             )
+        except asyncio.CancelledError:
+            raise
         except Exception:
             logger.warning(
                 "Failed to record model version info to cache tracker; "
@@ -1430,17 +1530,58 @@ class WorkerActor(xo.StatelessActor):
                 exc_info=True,
             )
 
-        return self._supervisor_ref
+    def _clear_unregistered_supervisor_refs(self) -> bool:
+        init_lock = self._supervisor_init_lock
+        if init_lock is not None and init_lock.locked():
+            return False
+        with self._supervisor_ref_lock:
+            if self._registered:
+                return False
+            self._supervisor_ref = None
+            self._supervisor_ref_address = None
+            self._status_guard_ref = None  # type: ignore
+            self._event_collector_ref = None  # type: ignore
+            self._cache_tracker_ref = None  # type: ignore
+            self._progress_tracker_ref = None
+            self._supervisor_ref_generation += 1
+            return True
 
-    def _clear_supervisor_refs(self):
-        self._supervisor_ref = None
-        # Reset registration state so the next get_supervisor_ref(add_worker=True)
-        # re-runs add_worker. Keep this in sync with _supervisor_ref lifecycle.
-        self._registered = False
-        self._status_guard_ref = None  # type: ignore
-        self._event_collector_ref = None  # type: ignore
-        self._cache_tracker_ref = None  # type: ignore
-        self._progress_tracker_ref = None
+    def _get_supervisor_ref_generation(
+        self, supervisor_ref: xo.ActorRefType
+    ) -> Optional[int]:
+        with self._supervisor_ref_lock:
+            if self._supervisor_ref is supervisor_ref:
+                return self._supervisor_ref_generation
+            return None
+
+    def _clear_supervisor_refs(
+        self,
+        expected_supervisor_ref: Optional[xo.ActorRefType] = None,
+        expected_generation: Optional[int] = None,
+    ) -> bool:
+        with self._supervisor_ref_lock:
+            if (
+                expected_supervisor_ref is not None
+                and self._supervisor_ref is not expected_supervisor_ref
+            ):
+                return False
+            if (
+                expected_generation is not None
+                and self._supervisor_ref_generation != expected_generation
+            ):
+                return False
+            self._supervisor_ref = None
+            self._supervisor_ref_address = None
+            # Reset registration state so the next
+            # get_supervisor_ref(add_worker=True) re-runs add_worker. Keep this
+            # in sync with _supervisor_ref lifecycle.
+            self._registered = False
+            self._status_guard_ref = None  # type: ignore
+            self._event_collector_ref = None  # type: ignore
+            self._cache_tracker_ref = None  # type: ignore
+            self._progress_tracker_ref = None
+            self._supervisor_ref_generation += 1
+            return True
 
     async def _refresh_supervisor_address(self):
         if self._supervisor_endpoint is None:
@@ -4280,17 +4421,34 @@ class WorkerActor(xo.StatelessActor):
             raise
         except Exception:
             logger.exception("Report status got error.")
+        supervisor_ref = None
+        supervisor_generation = None
         try:
-            supervisor_ref = await self.get_supervisor_ref()
-            await supervisor_ref.report_worker_status(self.address, status)
+            (
+                supervisor_ref,
+                supervisor_generation,
+            ) = await self._get_supervisor_ref_with_generation()
+            await xo.wait_for(
+                supervisor_ref.report_worker_status(self.address, status),
+                XINFERENCE_TCP_REQUEST_TIMEOUT,
+            )
         except Exception:
             logger.warning(
                 "Failed to report worker status, clearing cached supervisor references",
                 exc_info=True,
             )
-            self._clear_supervisor_refs()
-            supervisor_ref = await self.get_supervisor_ref(add_worker=True)
-            await supervisor_ref.report_worker_status(self.address, status)
+            if supervisor_ref is not None and supervisor_generation is not None:
+                self._clear_supervisor_refs(
+                    expected_supervisor_ref=supervisor_ref,
+                    expected_generation=supervisor_generation,
+                )
+            supervisor_ref, _ = await self._get_supervisor_ref_with_generation(
+                add_worker=True
+            )
+            await xo.wait_for(
+                supervisor_ref.report_worker_status(self.address, status),
+                XINFERENCE_TCP_REQUEST_TIMEOUT,
+            )
 
     async def ping(self) -> bool:
         """Lightweight liveness probe for supervisor reverse-channel check."""
@@ -4309,15 +4467,23 @@ class WorkerActor(xo.StatelessActor):
         next attempt can refresh a supervisor whose internal address changed
         after a restart.
         """
+        (
+            supervisor_ref,
+            supervisor_generation,
+        ) = await self._get_supervisor_ref_with_generation(add_worker=False)
         try:
             await xo.wait_for(
-                (await self.get_supervisor_ref(add_worker=False)).receive_heartbeat(
-                    self.address
-                ),
+                supervisor_ref.receive_heartbeat(self.address),
                 XINFERENCE_TCP_REQUEST_TIMEOUT,
             )
+        except asyncio.CancelledError:
+            raise
         except Exception:
-            self._clear_supervisor_refs()
+            if supervisor_generation is not None:
+                self._clear_supervisor_refs(
+                    expected_supervisor_ref=supervisor_ref,
+                    expected_generation=supervisor_generation,
+                )
             raise
 
     async def _periodical_report_status(self):
@@ -4340,14 +4506,13 @@ class WorkerActor(xo.StatelessActor):
                 _heartbeat_fail_count = 0  # reset on success
             except asyncio.CancelledError:  # pragma: no cover
                 break
-            except RuntimeError as ex:  # pragma: no cover
-                if "cannot schedule new futures" not in str(ex):
-                    # when atexit is triggered, the default pool might be shutdown
-                    # and to_thread will fail
-                    break
-            except (
-                Exception
-            ) as ex:  # pragma: no cover  # noqa: E722  # nosec  # pylint: disable=bare-except
+            except Exception as ex:  # pragma: no cover
+                # Isolation.stop() cancels this coroutine during normal shutdown.
+                # Every other exception is treated as recoverable: a transient RPC
+                # RuntimeError must not permanently stop heartbeats and let the
+                # supervisor evict an otherwise healthy worker. The failing RPC
+                # path conditionally invalidates only its own cached ref.
+                report_count = 0
                 _heartbeat_fail_count += 1
                 # §4.4: Log exception type and full traceback.
                 # Print full traceback on 1st failure and every 10th consecutive failure


### PR DESCRIPTION
## Summary

- serialize supervisor reference initialization and registration on the worker actor loop
- associate cached supervisor references with a generation and conditionally clear only the stale reference used by a failed RPC
- replay the latest replica snapshot when the worker's state changes during registration
- make periodic heartbeat/status reporting retry ordinary RPC failures instead of terminating liveness reporting
- add regression coverage for stale-reference cleanup, re-registration after heartbeat failure, concurrent registration, and periodic-report recovery

## Why

#5250 restores reconnection after a supervisor restart, but a concurrent failing heartbeat or status-report RPC can still unconditionally clear a newly installed supervisor reference. Concurrent `get_supervisor_ref(add_worker=True)` calls can also overlap registration and mark the worker registered using an outdated replica snapshot.

This patch makes the recovery path generation-safe and single-flight while preserving the supervisor restart/replica recovery behavior from #5250 and #5290.

Fixes #5360.

## Validation

- `XINFERENCE_HOME=/tmp/xinference-home python -m pytest -q xinference/core/tests/test_worker.py -k 'worker_heartbeat_failure_clears_cached_supervisor_refs or periodical_report_status or clear_supervisor_refs or supervisor_registration' -p no:cacheprovider --timeout=60 --timeout-method=thread` — 8 passed
- `pre-commit run --files xinference/core/worker.py xinference/core/tests/test_worker.py` — passed
- `git diff --check` — passed
