### PR TITLE
fix(core): normalize distributed worker count

### DIFF
--- a/xinference/core/supervisor.py
+++ b/xinference/core/supervisor.py
@@ -72,6 +72,7 @@ from .utils import (
     iter_replica_model_uid,
     log_async,
     log_sync,
+    normalize_n_worker,
     parse_model_version,
     parse_replica_model_uid,
 )
@@ -2373,6 +2374,7 @@ class SupervisorActor(xo.StatelessActor):
         envs: Optional[Dict[str, str]] = None,
         **kwargs,
     ) -> str:
+        n_worker = normalize_n_worker(n_worker)
         if (model_type or "").lower() == "audio":
             from ..model.audio.core import resolve_audio_model_name_and_engine
 
@@ -2966,6 +2968,7 @@ class SupervisorActor(xo.StatelessActor):
         envs: Optional[Dict[str, str]] = None,
         **kwargs,
     ):
+        n_worker = normalize_n_worker(n_worker)
         available_workers = []
         # search workers if registered
         tasks = []

--- a/xinference/core/tests/test_launch_strategy.py
+++ b/xinference/core/tests/test_launch_strategy.py
@@ -387,6 +387,35 @@ async def test_distributed_launch_avoids_same_worker_for_shards():
 
 
 @pytest.mark.asyncio
+async def test_distributed_launch_normalizes_string_n_worker():
+    launched = []
+    worker1 = DummyWorkerRef("w1:1000", model_count=1, launched=launched)
+    worker2 = DummyWorkerRef("w2:1000", model_count=0, launched=launched)
+    supervisor = DummySupervisor({"w1:1000": worker1, "w2:1000": worker2})
+
+    await supervisor.launch_builtin_model(
+        model_uid="demo-model",
+        model_name="demo",
+        model_size_in_billions=None,
+        model_format=None,
+        quantization=None,
+        model_engine=None,
+        model_type="LLM",
+        n_gpu=1,
+        n_worker="2",
+        worker_ip=["w1:1000", "w2:1000"],
+        wait_ready=True,
+    )
+
+    assert set(launched) == {"w1:1000", "w2:1000"}
+    assert {
+        call["n_worker"]
+        for worker in (worker1, worker2)
+        for call in worker.launch_kwargs
+    } == {2}
+
+
+@pytest.mark.asyncio
 async def test_download_hub_resolved_from_selected_workers_before_fanout(monkeypatch):
     monkeypatch.setenv("XINFERENCE_MODEL_SRC", "huggingface")
     launched = []

--- a/xinference/core/tests/test_utils.py
+++ b/xinference/core/tests/test_utils.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
+
 from ..utils import (
     build_replica_model_uid,
     build_subpool_envs_for_virtual_env,
@@ -19,6 +21,7 @@ from ..utils import (
     is_valid_model_uid,
     iter_replica_model_uid,
     merge_virtual_env_packages,
+    normalize_n_worker,
     normalize_sglang_kernel_packages,
     parse_legacy_replica_model_uid,
     parse_replica_model_uid,
@@ -30,6 +33,17 @@ from ..virtual_env_manager import (
     get_xllamacpp_cuda_index_url,
     pin_sentence_transformers_numpy_abi,
 )
+
+
+@pytest.mark.parametrize(("value", "expected"), [(None, 1), (1, 1), ("2", 2)])
+def test_normalize_n_worker(value, expected):
+    assert normalize_n_worker(value) == expected
+
+
+@pytest.mark.parametrize("value", [True, 1.5, "2.0", "invalid", 0, "0", -1])
+def test_normalize_n_worker_rejects_non_positive_or_non_integral_values(value):
+    with pytest.raises(ValueError, match="n_worker must be a positive integer"):
+        normalize_n_worker(value)
 
 
 def test_replica_model_uid():

--- a/xinference/core/utils.py
+++ b/xinference/core/utils.py
@@ -50,6 +50,21 @@ def truncate_log_arg(arg) -> str:
     return s
 
 
+def normalize_n_worker(value: Any) -> int:
+    """Normalize the distributed worker count from RPC/JSON launch arguments."""
+    if value is None:
+        return 1
+    if isinstance(value, (bool, float)):
+        raise ValueError("n_worker must be a positive integer.")
+    try:
+        n_worker = int(value)
+    except (TypeError, ValueError, OverflowError):
+        raise ValueError("n_worker must be a positive integer.") from None
+    if n_worker < 1:
+        raise ValueError("n_worker must be a positive integer.")
+    return n_worker
+
+
 def log_async(
     logger,
     level=logging.DEBUG,

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -102,6 +102,7 @@ from .utils import (
     log_async,
     log_sync,
     merge_virtual_env_packages,
+    normalize_n_worker,
     normalize_sglang_kernel_packages,
     parse_legacy_replica_model_uid,
     parse_replica_model_uid,
@@ -3335,6 +3336,7 @@ class WorkerActor(xo.StatelessActor):
         envs: Optional[Dict[str, str]] = None,
         **kwargs,
     ):
+        n_worker = normalize_n_worker(n_worker)
         # !!! Note that The following code must be placed at the very beginning of this function,
         # or there will be problems with auto-recovery.
         # Because `locals()` will collect all the local parameters of this function and pass to this function again.


### PR DESCRIPTION
## Summary

- normalize `n_worker` at supervisor and worker launch boundaries
- accept positive integer strings from JSON/RPC launch payloads, such as `"2"`
- reject booleans, fractional values, zero, negative values, and malformed strings with a clear `ValueError`
- add utility coverage and a distributed launch regression test that verifies workers receive an integer count

## Why

The REST handler forwards `n_worker` through `**kwargs`. A JSON caller can therefore supply a numeric string, which reaches distributed worker launch paths that directly evaluate `n_worker > 1` and crashes the worker actor with `TypeError: '>' not supported between instances of 'str' and 'int'`.

Normalizing at both supervisor and worker boundaries also covers direct RPC callers and persisted launch arguments used during recovery.

Fixes #5365.

## Validation

- `XINFERENCE_HOME=/tmp/xinference-home python -m pytest -q xinference/core/tests/test_utils.py xinference/core/tests/test_launch_strategy.py -p no:cacheprovider --timeout=60 --timeout-method=thread` — 77 passed
- `pre-commit run --files xinference/core/utils.py xinference/core/supervisor.py xinference/core/worker.py xinference/core/tests/test_utils.py xinference/core/tests/test_launch_strategy.py` — passed
- `git diff --check upstream/main...HEAD` — passed
