### PR TITLE
feat(image): add Ideogram4 support

### DIFF
--- a/doc/source/models/builtin/image/ideogram4.rst
+++ b/doc/source/models/builtin/image/ideogram4.rst
@@ -1,8 +1,8 @@
 .. _models_builtin_ideogram4:
 
-==========
+=========
 Ideogram4
-==========
+=========
 
 - **Model Name:** Ideogram4
 - **Model Family:** stable_diffusion
@@ -13,19 +13,10 @@ Specifications
 ^^^^^^^^^^^^^^
 
 - **Model ID:** ideogram-ai/ideogram-4-nf4-diffusers
-- **Quantization:** NF4
-- **Hardware:** NVIDIA CUDA GPU
-
-The checkpoint uses the Ideogram 4 Non-Commercial Model Agreement and its
-repository is gated. Accept the license on the selected model hub and
-authenticate with that hub before launching. Ideogram 4 accepts plain text
-prompts, but serialized structured JSON captions provide the best quality and
-control.
 
 Execute the following command to launch the model::
 
    xinference launch --model-name Ideogram4 --model-type image
 
-To download from ModelScope for an individual launch::
 
-   xinference launch --model-name Ideogram4 --model-type image --download_hub modelscope
+

--- a/doc/source/models/builtin/image/ideogram4.rst
+++ b/doc/source/models/builtin/image/ideogram4.rst
@@ -1,0 +1,31 @@
+.. _models_builtin_ideogram4:
+
+==========
+Ideogram4
+==========
+
+- **Model Name:** Ideogram4
+- **Model Family:** stable_diffusion
+- **Abilities:** text2image
+- **Available ControlNet:** None
+
+Specifications
+^^^^^^^^^^^^^^
+
+- **Model ID:** ideogram-ai/ideogram-4-nf4-diffusers
+- **Quantization:** NF4
+- **Hardware:** NVIDIA CUDA GPU
+
+The checkpoint uses the Ideogram 4 Non-Commercial Model Agreement and its
+repository is gated. Accept the license on the selected model hub and
+authenticate with that hub before launching. Ideogram 4 accepts plain text
+prompts, but serialized structured JSON captions provide the best quality and
+control.
+
+Execute the following command to launch the model::
+
+   xinference launch --model-name Ideogram4 --model-type image
+
+To download from ModelScope for an individual launch::
+
+   xinference launch --model-name Ideogram4 --model-type image --download_hub modelscope

--- a/doc/source/models/builtin/image/index.rst
+++ b/doc/source/models/builtin/image/index.rst
@@ -38,6 +38,8 @@ The following is a list of built-in image models in Xinference:
    hunyuandit-v1.2-distilled
   
    hunyuanocr
+
+   ideogram4
   
    kolors
   
@@ -84,4 +86,3 @@ The following is a list of built-in image models in Xinference:
    z-image
   
    z-image-turbo
-  

--- a/doc/source/models/model_abilities/image.rst
+++ b/doc/source/models/model_abilities/image.rst
@@ -96,6 +96,22 @@ Note that GGUF quantization, Lightning acceleration, LoRA and controlnet are
 only available on the ``diffusers`` engine.
 
 
+Ideogram4
+-------------------
+
+:ref:`Ideogram4 <models_builtin_ideogram4>` uses the NF4 checkpoint and
+requires an NVIDIA CUDA GPU. The checkpoint is distributed under the Ideogram
+4 Non-Commercial Model Agreement, and its repositories are gated. Accept the
+license and authenticate with the selected model hub before launching.
+
+Ideogram4 accepts plain text prompts, but serialized structured JSON captions
+provide the best quality and control.
+
+To download from ModelScope for an individual launch::
+
+   xinference launch --model-name Ideogram4 --model-type image --download_hub modelscope
+
+
 Quickstart
 ===================
 

--- a/doc/source/models/model_abilities/image.rst
+++ b/doc/source/models/model_abilities/image.rst
@@ -51,6 +51,7 @@ The Text-to-image API is supported with the following models in Xinference:
 * hunyuandit-v1.2-distilled
 * cogview4
 * Qwen-Image
+* Ideogram4
 
 Image-to-image supported models:
 

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -3065,7 +3065,16 @@ class WorkerActor(xo.StatelessActor):
 
         assert settings is not None  # for mypy type narrowing
 
-        if settings and model_engine and model_engine.lower() not in ("vllm", "sglang"):
+        if (
+            settings
+            and model_engine
+            and model_engine.lower()
+            not in (
+                "vllm",
+                "sglang",
+                "diffusers",
+            )
+        ):
             # Pydantic v1 compatibility: use copy() when model_copy is unavailable.
             if hasattr(settings, "model_copy"):
                 settings = settings.model_copy(deep=True)

--- a/xinference/model/image/model_spec.json
+++ b/xinference/model/image/model_spec.json
@@ -1882,5 +1882,46 @@
     },
     "featured": false,
     "updated_at": 1786072489
+  },
+  {
+    "version": 2,
+    "model_name": "Ideogram4",
+    "model_family": "stable_diffusion",
+    "model_description": "Ideogram 4 is a 9.3B open-weight text-to-image model with multilingual text rendering, structured JSON prompting, layout control, and native 2K generation.",
+    "model_ability": [
+      "text2image"
+    ],
+    "model_src": {
+      "huggingface": {
+        "model_id": "ideogram-ai/ideogram-4-nf4-diffusers",
+        "model_revision": "main"
+      },
+      "modelscope": {
+        "model_id": "ideogram-ai/ideogram-4-nf4-diffusers",
+        "model_revision": "master"
+      }
+    },
+    "default_model_config": {
+      "torch_dtype": "bfloat16"
+    },
+    "default_generate_config": {},
+    "virtualenv": {
+      "packages": [
+        "git+https://github.com/huggingface/diffusers ; #engine# == \"diffusers\"",
+        "transformers>=5.0.0,<6",
+        "huggingface-hub>=1.23.0,<2",
+        "accelerate>=1.0.0",
+        "importlib-metadata",
+        "idna>=3.18",
+        "bitsandbytes>=0.49.2 ; has_cuda",
+        "sentencepiece",
+        "#system_torch#",
+        "#system_numpy#"
+      ],
+      "no_build_isolation": true,
+      "index_strategy": "unsafe-best-match"
+    },
+    "featured": true,
+    "updated_at": 1787016251
   }
 ]

--- a/xinference/model/image/stable_diffusion/core.py
+++ b/xinference/model/image/stable_diffusion/core.py
@@ -136,6 +136,12 @@ class DiffusionModel(SDAPIDiffusionModelMixin):
             and "flux.2" in self._model_spec.model_name.lower()  # type: ignore
         )
 
+    def _is_ideogram4_model(self) -> bool:
+        return bool(
+            self._model_spec
+            and self._model_spec.model_name.lower() == "ideogram4"  # type: ignore
+        )
+
     @staticmethod
     def _get_pipeline_type(ability: str) -> type:
         if ability == "text2image":
@@ -763,6 +769,10 @@ class DiffusionModel(SDAPIDiffusionModelMixin):
                 kwargs["generator"] = generator.manual_seed(seed)
         sampler_name = kwargs.pop("sampler_name", None)
         self._process_progressor(kwargs)
+        if self._is_ideogram4_model() and kwargs.get("guidance_scale") is not None:
+            # Ideogram4 defaults to a per-step guidance schedule. Its pipeline
+            # rejects passing that default together with a constant scale.
+            kwargs.setdefault("guidance_schedule", None)
         assert callable(model)
         with (
             self._reset_when_done(model, sampler_name),


### PR DESCRIPTION
## Summary

- Add Ideogram4 as a built-in text-to-image model.
- Support both model sources:
  - Hugging Face: `ideogram-ai/ideogram-4-nf4-diffusers`, revision `main`
  - ModelScope: `ideogram-ai/ideogram-4-nf4-diffusers`, revision `master`
- Configure the NF4 checkpoint for NVIDIA CUDA GPUs with `bfloat16`.
- Add the required Diffusers, Transformers, Hugging Face Hub, Accelerate,
  bitsandbytes, and SentencePiece virtual-environment dependencies.
- Handle Ideogram4's guidance schedule when callers provide a constant
  `guidance_scale`.
- Add model documentation and update the supported image-model lists.

## Implementation

- Register Ideogram4 under the `stable_diffusion` image family.
- Use the Diffusers engine and install Diffusers from its GitHub repository.
- Preserve model-level virtual-environment index settings for the Diffusers
  engine.
- Set `index_strategy` to `unsafe-best-match` only for Ideogram4, allowing uv
  to select compatible packages across PyPI and the official PyTorch CUDA
  index.
- Disable the pipeline's default `guidance_schedule` when a constant
  `guidance_scale` is supplied.
