### PR TITLE
ci: skip GPU tests for video and flexible model changes

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -136,9 +136,16 @@ jobs:
                 # This also covers restful_api.py (the launch/inference
                 # endpoints), dependencies.py, and the models/videos routers.
                 xinference/core/*|xinference/api/*|xinference/client/*|xinference/deploy/*) full=true; break ;;
-                # Model families not broken out above (flexible, video, ...)
-                # and top-level files directly under xinference/model/ have
-                # no dedicated GPU test group; play it safe and run every group.
+                # video/ and flexible/ have no GPU test group at all: no
+                # group below runs a single test from either package, so a full
+                # run costs every GPU minute while covering none of the change.
+                # Their tests (video/tests/, flexible/tests/) run in the
+                # ubuntu/macos/windows CI, which is where they are covered.
+                xinference/model/video/*|xinference/model/flexible/*) ;;
+                # Remaining model families with no dedicated group, plus
+                # top-level files directly under xinference/model/ (batch.py,
+                # cache_manager.py, core.py, custom.py, utils.py) which are
+                # shared by every family; play it safe and run every group.
                 xinference/model/*) full=true; break ;;
                 # The rest of the package (deploy/, docs, examples, other
                 # top-level modules) is not exercised by any GPU test.


### PR DESCRIPTION
## Summary

The `gpu_test_job` has four test groups — `llm`, `embedding`, `image`, `audio` — and **none of them runs a single test from `xinference/model/video/` or `xinference/model/flexible/`**. Both packages previously fell through to the `xinference/model/*)` catch-all in the `changes` job, which sets `full=true` and runs all four groups.

The result: a video-only change paid for the entire GPU matrix while covering none of the changed code. This routes both packages to the no-GPU arm instead.

## Why this is safe

Their tests (`video/tests/`, `flexible/tests/`) run in the ubuntu/macos/windows CI across all 10 OS/Python combinations, and neither is in that job's `--ignore` list, so coverage is not lost — it just moves to where it actually exists.

The catch-all still covers the remaining families and the top-level files directly under `xinference/model/` (`batch.py`, `cache_manager.py`, `core.py`, `custom.py`, `utils.py`), which are shared by every family.

## Validation

I extracted the patched `case` block into a harness and ran it against real changesets:

| Changed paths | Groups selected |
| --- | --- |
| #5338's exact 10-file list (video + docs + web UI) | `none` (was `llm embedding image audio`) |
| `model/flexible/core.py` | `none` |
| `model/utils.py`, `model/batch.py` | `llm embedding image audio` (unchanged) |
| `model/audio/whisper.py` | `audio` (unchanged) |
| `model/llm/core.py` | `llm` (unchanged) |
| `core/model.py` | `llm embedding image audio` (unchanged) |
| `model/video/core.py` **+** `model/llm/core.py` | `llm` |
| `model/video/core.py` **+** `core/model.py` | `llm embedding image audio` |
| `.github/workflows/python.yaml` | `llm embedding image audio` (unchanged) |

Mixed changesets still escalate correctly — adding a video file never suppresses a group another path selected. `yaml.safe_load` parses the workflow and all four jobs resolve.

## Context

Noticed while reviewing #5338, which triggered a full 33-minute four-group GPU run for a video-only change. That PR is unaffected by this one; this only changes which groups future runs select.
