### PR TITLE
feat(image): sensenova u1.5

### DIFF
--- a/xinference/core/tests/test_worker.py
+++ b/xinference/core/tests/test_worker.py
@@ -591,6 +591,42 @@ def test_jina_v3_allocator_env_is_persisted_for_recovery(monkeypatch):
     assert launch_args["envs"] == envs
 
 
+@pytest.mark.asyncio
+async def test_launch_image_resolves_default_engine_before_virtualenv(monkeypatch):
+    import inspect
+
+    from ...model.image.engine_family import IMAGE_ENGINES
+
+    monkeypatch.setitem(IMAGE_ENGINES, "test-image", {"transformers": []})
+    captured = {}
+
+    class EarlyLaunchStop(Exception):
+        pass
+
+    def capture_launch_args(model_type, model_name, envs, launch_args):
+        captured["model_engine"] = launch_args["model_engine"]
+        raise EarlyLaunchStop
+
+    monkeypatch.setattr(
+        "xinference.core.worker._inject_jina_v3_allocator_env", capture_launch_args
+    )
+    launch_builtin_model = inspect.unwrap(WorkerActor.launch_builtin_model)
+
+    with pytest.raises(EarlyLaunchStop):
+        await launch_builtin_model(
+            SimpleNamespace(),
+            model_uid="test-image-0",
+            model_name="test-image",
+            model_size_in_billions=None,
+            model_format=None,
+            quantization=None,
+            model_engine=None,
+            model_type="image",
+        )
+
+    assert captured["model_engine"] == "transformers"
+
+
 def test_jina_v3_allocator_env_preserves_user_configuration():
     launch_args = {"envs": None}
     user_envs = {"PYTORCH_CUDA_ALLOC_CONF": "max_split_size_mb:128"}

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -3494,6 +3494,11 @@ class WorkerActor(xo.StatelessActor):
             )
             launch_args["model_name"] = model_name
             launch_args["model_engine"] = model_engine
+        elif model_type.lower() == "image":
+            from ..model.image.core import resolve_image_model_engine
+
+            model_engine = resolve_image_model_engine(model_name, model_engine)
+            launch_args["model_engine"] = model_engine
         envs = _inject_jina_v3_allocator_env(model_type, model_name, envs, launch_args)
 
         try:

--- a/xinference/model/image/core.py
+++ b/xinference/model/image/core.py
@@ -322,12 +322,13 @@ def create_image_model_instance(
         lora_fuse_kwargs = None
 
     from .engine_family import (
+        IMAGE_ENGINES,
         check_engine_by_model_name_and_engine,
         check_engine_by_model_name_and_engine_with_virtual_env,
     )
 
     if model_engine is None:
-        model_engine = "diffusers"
+        model_engine = next(iter(IMAGE_ENGINES.get(model_name, {})), "diffusers")
 
     if enable_virtual_env is None:
         from ...constants import XINFERENCE_ENABLE_VIRTUAL_ENV

--- a/xinference/model/image/core.py
+++ b/xinference/model/image/core.py
@@ -114,6 +114,26 @@ def generate_image_description(
     return res
 
 
+def resolve_image_model_engine(
+    model_name: str, model_engine: Optional[str] = None
+) -> Optional[str]:
+    from .engine_family import IMAGE_ENGINES
+
+    available_engines = IMAGE_ENGINES.get(model_name)
+    if not available_engines:
+        return model_engine
+    if model_engine is None:
+        return next(iter(available_engines))
+    return next(
+        (
+            engine
+            for engine in available_engines
+            if engine.lower() == model_engine.lower()
+        ),
+        model_engine,
+    )
+
+
 def match_diffusion(
     model_name: str,
     download_hub: Optional[
@@ -322,13 +342,11 @@ def create_image_model_instance(
         lora_fuse_kwargs = None
 
     from .engine_family import (
-        IMAGE_ENGINES,
         check_engine_by_model_name_and_engine,
         check_engine_by_model_name_and_engine_with_virtual_env,
     )
 
-    if model_engine is None:
-        model_engine = next(iter(IMAGE_ENGINES.get(model_name, {})), "diffusers")
+    model_engine = resolve_image_model_engine(model_name, model_engine) or "diffusers"
 
     if enable_virtual_env is None:
         from ...constants import XINFERENCE_ENABLE_VIRTUAL_ENV

--- a/xinference/model/image/engine.py
+++ b/xinference/model/image/engine.py
@@ -39,7 +39,7 @@ class DiffusersImageModel(DiffusionModel, ImageEngineModel):
 class TransformersSenseNovaU1ImageModel(SenseNovaU1Model, ImageEngineModel):
     engine_model_format = "pytorch"
     engine_quantization = "none"
-    required_libs = ("sensenova_u1",)
+    required_libs = ("torch", "transformers")
 
     @classmethod
     def match(cls, model_family: "ImageModelFamilyV2") -> bool:

--- a/xinference/model/image/engine.py
+++ b/xinference/model/image/engine.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING
 
 from ..utils import has_cuda_device
 from .engine_family import SUPPORTED_ENGINES, ImageEngineModel
+from .sensenova_u1 import SenseNovaU1Model
 from .sglang.core import SGLANG_SUPPORTED_IMAGE_MODELS, SGLangDiffusionModel
 from .stable_diffusion.core import DiffusionModel
 from .vllm.core import VLLM_SUPPORTED_IMAGE_MODELS, VLLMDiffusionModel
@@ -32,7 +33,17 @@ class DiffusersImageModel(DiffusionModel, ImageEngineModel):
 
     @classmethod
     def match(cls, model_family: "ImageModelFamilyV2") -> bool:
-        return model_family.model_family != "ocr"
+        return model_family.model_family not in ("ocr", "sensenova_u1")
+
+
+class TransformersSenseNovaU1ImageModel(SenseNovaU1Model, ImageEngineModel):
+    engine_model_format = "pytorch"
+    engine_quantization = "none"
+    required_libs = ("sensenova_u1",)
+
+    @classmethod
+    def match(cls, model_family: "ImageModelFamilyV2") -> bool:
+        return model_family.model_family == "sensenova_u1"
 
 
 class VLLMImageModel(VLLMDiffusionModel, ImageEngineModel):
@@ -65,5 +76,6 @@ class SGLangImageModel(SGLangDiffusionModel, ImageEngineModel):
 
 def register_builtin_image_engines() -> None:
     SUPPORTED_ENGINES["diffusers"] = [DiffusersImageModel]
+    SUPPORTED_ENGINES["transformers"] = [TransformersSenseNovaU1ImageModel]
     SUPPORTED_ENGINES["vLLM"] = [VLLMImageModel]
     SUPPORTED_ENGINES["SGLang"] = [SGLangImageModel]

--- a/xinference/model/image/model_spec.json
+++ b/xinference/model/image/model_spec.json
@@ -1882,5 +1882,43 @@
     },
     "featured": false,
     "updated_at": 1786072489
+  },
+  {
+    "version": 2,
+    "model_name": "SenseNova-U1.5-8B-MoT-Preview",
+    "model_description": "SenseNova-U1.5-8B-MoT-Preview is a natively unified multimodal model for text-to-image generation and single- or multi-reference image editing, with native 4K generation support.",
+    "model_family": "sensenova_u1",
+    "model_ability": [
+      "text2image",
+      "image2image"
+    ],
+    "controlnet": [],
+    "model_src": {
+      "huggingface": {
+        "model_id": "sensenova/SenseNova-U1.5-8B-MoT-Preview",
+        "model_revision": "main"
+      },
+      "modelscope": {
+        "model_id": "SenseNova/SenseNova-U1.5-8B-MoT-Preview",
+        "model_revision": "master"
+      }
+    },
+    "default_model_config": {
+      "torch_dtype": "bfloat16",
+      "device_map": "auto"
+    },
+    "default_generate_config": {
+      "cfg_scale": 4.0,
+      "cfg_norm": "none",
+      "timestep_shift": 3.0,
+      "num_steps": 50
+    },
+    "virtualenv": {
+      "packages": [
+        "sensenova-u1 @ git+https://github.com/OpenSenseNova/SenseNova-U1.git@35fb2fc520869aa09223a819882abdb3dc328ecd ; #engine# == \"transformers\""
+      ]
+    },
+    "featured": true,
+    "updated_at": 1787019514
   }
 ]

--- a/xinference/model/image/model_spec.json
+++ b/xinference/model/image/model_spec.json
@@ -1915,7 +1915,14 @@
     },
     "virtualenv": {
       "packages": [
-        "sensenova-u1 @ git+https://github.com/OpenSenseNova/SenseNova-U1.git@35fb2fc520869aa09223a819882abdb3dc328ecd ; #engine# == \"transformers\""
+        "transformers>=4.57.1,<6 ; #engine# == \"transformers\"",
+        "accelerate>=1.1,<2 ; #engine# == \"transformers\"",
+        "huggingface-hub>=0.34,<2 ; #engine# == \"transformers\"",
+        "safetensors>=0.4.3,<1 ; #engine# == \"transformers\"",
+        "sentencepiece==0.2.1 ; #engine# == \"transformers\"",
+        "#system_torch# ; #engine# == \"transformers\"",
+        "#system_torchvision# ; #engine# == \"transformers\"",
+        "#system_numpy# ; #engine# == \"transformers\""
       ]
     },
     "featured": true,

--- a/xinference/model/image/sensenova_u1.py
+++ b/xinference/model/image/sensenova_u1.py
@@ -1,0 +1,407 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import contextlib
+import logging
+import re
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Tuple, Union
+
+import PIL.Image
+
+from .sdapi import SDAPIDiffusionModelMixin
+from .utils import handle_image_result
+
+if TYPE_CHECKING:
+    from ...types import LoRA
+    from .core import ImageModelFamilyV2
+
+logger = logging.getLogger(__name__)
+
+_IMAGE_GRID_FACTOR = 32
+_DEFAULT_TARGET_PIXELS = 2048 * 2048
+_DEFAULT_INPUT_MAX_PIXELS = 2048 * 2048
+_MIN_INPUT_MAX_PIXELS = 512 * 512
+
+
+class SenseNovaU1Model(SDAPIDiffusionModelMixin):
+    """SenseNova-U1 image generation and editing model."""
+
+    def __init__(
+        self,
+        model_uid: str,
+        model_path: str,
+        model_spec: "ImageModelFamilyV2",
+        device: Optional[str] = None,
+        lora_model: Optional[List["LoRA"]] = None,
+        lora_load_kwargs: Optional[Dict[str, Any]] = None,
+        lora_fuse_kwargs: Optional[Dict[str, Any]] = None,
+        gguf_model_path: Optional[str] = None,
+        lightning_model_path: Optional[str] = None,
+        **kwargs: Any,
+    ) -> None:
+        self.model_family = model_spec
+        self._model_uid = model_uid
+        self._model_path = model_path
+        self._model_spec = model_spec
+        self._abilities = model_spec.model_ability or []
+        self._device = device
+        self._lora_model = lora_model
+        self._lora_load_kwargs = lora_load_kwargs or {}
+        self._lora_fuse_kwargs = lora_fuse_kwargs or {}
+        self._gguf_model_path = gguf_model_path
+        self._lightning_model_path = lightning_model_path
+        self._kwargs = kwargs
+        self._model = None
+        self._tokenizer = None
+        self._prefetch_count = 0
+        self._vram_mode = "full"
+        self._offload_kwargs: Dict[str, Any] = {}
+
+    @property
+    def model_spec(self) -> "ImageModelFamilyV2":
+        return self._model_spec
+
+    @property
+    def model_ability(self) -> List[str]:
+        return self._abilities
+
+    def load(self) -> None:
+        import sensenova_u1
+        import torch
+        from sensenova_u1.utils import (
+            DEFAULT_FAST_ACTIVATION_RESERVE_GIB,
+            DEFAULT_FAST_VRAM_FRACTION,
+            DEFAULT_FAST_VRAM_HEADROOM_GIB,
+            DEFAULT_VRAM_MODE,
+            best_available_device,
+            load_and_merge_lora_weight_from_safetensors,
+            load_model_and_tokenizer,
+            vram_mode_to_prefetch_count,
+        )
+
+        if self._lightning_model_path:
+            raise ValueError("SenseNova-U1 does not support lightning models.")
+
+        kwargs = self._kwargs.copy()
+        torch_dtype = kwargs.pop("torch_dtype", torch.bfloat16)
+        if isinstance(torch_dtype, str):
+            torch_dtype = getattr(torch, torch_dtype.removeprefix("torch."))
+
+        attn_backend = kwargs.pop("attn_backend", "auto")
+        sensenova_u1.set_attn_backend(attn_backend)
+
+        self._vram_mode = kwargs.pop("vram_mode", DEFAULT_VRAM_MODE)
+        self._prefetch_count = vram_mode_to_prefetch_count(self._vram_mode)
+        self._device = self._device or str(best_available_device())
+        device_map = kwargs.pop("device_map", None)
+        max_memory = kwargs.pop("max_memory", None)
+
+        self._offload_kwargs = {
+            "fast_vram_fraction": kwargs.pop(
+                "fast_vram_fraction", DEFAULT_FAST_VRAM_FRACTION
+            ),
+            "fast_vram_headroom_gib": kwargs.pop(
+                "fast_vram_headroom_gib", DEFAULT_FAST_VRAM_HEADROOM_GIB
+            ),
+            "fast_activation_reserve_gib": kwargs.pop(
+                "fast_activation_reserve_gib", DEFAULT_FAST_ACTIVATION_RESERVE_GIB
+            ),
+            "fast_vram_budget_gib": kwargs.pop("fast_vram_budget_gib", None),
+        }
+        if kwargs:
+            logger.warning("Ignore unsupported SenseNova-U1 load options: %s", kwargs)
+
+        self._model, self._tokenizer = load_model_and_tokenizer(
+            self._model_path,
+            dtype=torch_dtype,
+            device=self._device,
+            gguf_checkpoint=self._gguf_model_path,
+            device_map=device_map,
+            max_memory=max_memory,
+            for_offload=self._prefetch_count > 0,
+        )
+
+        if self._lora_model:
+            if self._lora_load_kwargs or self._lora_fuse_kwargs:
+                logger.warning("SenseNova-U1 ignores image LoRA load and fuse options.")
+            for lora in self._lora_model:
+                self._model = load_and_merge_lora_weight_from_safetensors(
+                    self._model, lora.local_path
+                )
+
+    def _offload_context(self):
+        if self._model is None:
+            raise RuntimeError("SenseNova-U1 model is not loaded.")
+        if self._prefetch_count == 0:
+            return contextlib.nullcontext(self._model)
+
+        from sensenova_u1.utils import (
+            make_offload_ctx,
+            vram_mode_keeps_generation_resident,
+        )
+
+        return make_offload_ctx(
+            self._model,
+            self._prefetch_count,
+            self._device,
+            keep_generation_resident=vram_mode_keeps_generation_resident(
+                self._vram_mode
+            ),
+            **self._offload_kwargs,
+        )
+
+    @staticmethod
+    def _to_pil(batch: Any) -> List[PIL.Image.Image]:
+        import numpy as np
+
+        batch = (batch.float() * 0.5 + 0.5).clamp(0, 1)
+        array = batch.permute(0, 2, 3, 1).cpu().numpy()
+        array = (array * 255.0).round().astype(np.uint8)
+        return [PIL.Image.fromarray(image) for image in array]
+
+    @staticmethod
+    def _parse_size(size: str) -> Tuple[int, int]:
+        dimensions = [int(value) for value in re.split(r"[^\d]+", size) if value]
+        if len(dimensions) != 2:
+            raise ValueError(f"Invalid image size: {size!r}.")
+        width, height = dimensions
+        SenseNovaU1Model._validate_size(width, height)
+        return width, height
+
+    @staticmethod
+    def _validate_size(width: int, height: int) -> None:
+        if width <= 0 or height <= 0:
+            raise ValueError("Image width and height must be positive.")
+        if width % _IMAGE_GRID_FACTOR or height % _IMAGE_GRID_FACTOR:
+            raise ValueError(
+                "SenseNova-U1 image width and height must both be multiples of "
+                f"{_IMAGE_GRID_FACTOR}, got {width}x{height}."
+            )
+
+    def _get_generate_config(self, kwargs: Dict[str, Any]) -> Dict[str, Any]:
+        config = (self._model_spec.default_generate_config or {}).copy()
+        config.update(
+            {key: value for key, value in kwargs.items() if value is not None}
+        )
+
+        if "guidance_scale" in config and "cfg_scale" not in kwargs:
+            config["cfg_scale"] = config.pop("guidance_scale")
+        else:
+            config.pop("guidance_scale", None)
+        if "num_inference_steps" in config and "num_steps" not in kwargs:
+            config["num_steps"] = config.pop("num_inference_steps")
+        else:
+            config.pop("num_inference_steps", None)
+
+        for key in (
+            "negative_prompt",
+            "denoising_strength",
+            "progressor",
+            "request_id",
+        ):
+            config.pop(key, None)
+        if "cfg_interval" in config:
+            config["cfg_interval"] = tuple(config["cfg_interval"])
+        return config
+
+    @staticmethod
+    def _filter_generate_config(
+        config: Dict[str, Any], *, image_to_image: bool
+    ) -> Dict[str, Any]:
+        supported = {
+            "cfg_scale",
+            "cfg_norm",
+            "timestep_shift",
+            "enable_timestep_shift",
+            "cfg_interval",
+            "num_steps",
+            "method",
+            "t_eps",
+            "think_mode",
+            "seed",
+        }
+        if image_to_image:
+            supported.add("img_cfg_scale")
+        ignored = sorted(set(config) - supported)
+        if ignored:
+            logger.warning(
+                "Ignore unsupported SenseNova-U1 generation options: %s", ignored
+            )
+        return {key: value for key, value in config.items() if key in supported}
+
+    def text_to_image(
+        self,
+        prompt: str,
+        n: int = 1,
+        size: str = "1024*1024",
+        response_format: str = "url",
+        **kwargs: Any,
+    ):
+        if "text2image" not in self._abilities:
+            raise RuntimeError(f"{self._model_uid} does not support text2image.")
+        if self._tokenizer is None:
+            raise RuntimeError("SenseNova-U1 model is not loaded.")
+        if not isinstance(prompt, str):
+            raise ValueError("SenseNova-U1 text-to-image requires a string prompt.")
+
+        import torch
+
+        width, height = self._parse_size(size)
+        generate_config = self._filter_generate_config(
+            self._get_generate_config(kwargs), image_to_image=False
+        )
+        with torch.inference_mode(), self._offload_context() as model:
+            output = model.t2i_generate(
+                self._tokenizer,
+                prompt,
+                image_size=(width, height),
+                batch_size=n,
+                **generate_config,
+            )
+        if generate_config.get("think_mode"):
+            output = output[0]
+        return handle_image_result(response_format, self._to_pil(output))
+
+    @staticmethod
+    def _convert_to_rgb(image: PIL.Image.Image) -> PIL.Image.Image:
+        if image.mode == "RGBA":
+            background = PIL.Image.new("RGB", image.size, (255, 255, 255))
+            background.paste(image, mask=image.getchannel("A"))
+            return background
+        return image.convert("RGB") if image.mode != "RGB" else image
+
+    @staticmethod
+    def _resolve_input_max_pixels(value: Any, num_images: int) -> Optional[int]:
+        if value is None:
+            return None
+        if value == "auto":
+            if num_images <= 2:
+                return _DEFAULT_INPUT_MAX_PIXELS
+            return max(
+                _MIN_INPUT_MAX_PIXELS,
+                2 * _DEFAULT_INPUT_MAX_PIXELS // num_images,
+            )
+        pixels = int(value)
+        if pixels < _MIN_INPUT_MAX_PIXELS:
+            raise ValueError(
+                f"input_max_pixels must be at least {_MIN_INPUT_MAX_PIXELS}."
+            )
+        return pixels
+
+    @staticmethod
+    def _smart_resize(image: PIL.Image.Image, target_pixels: int) -> PIL.Image.Image:
+        from sensenova_u1.models.neo_unify.utils import smart_resize
+
+        height, width = smart_resize(
+            height=image.height,
+            width=image.width,
+            factor=_IMAGE_GRID_FACTOR,
+            min_pixels=target_pixels,
+            max_pixels=target_pixels,
+        )
+        if (width, height) == image.size:
+            return image
+        resampling = getattr(PIL.Image, "Resampling", PIL.Image)
+        return image.resize((width, height), resampling.LANCZOS)
+
+    @classmethod
+    def _prepare_input_images(
+        cls,
+        images: Sequence[PIL.Image.Image],
+        *,
+        do_resize: bool,
+        input_max_pixels: Optional[int],
+    ) -> List[PIL.Image.Image]:
+        prepared = [cls._convert_to_rgb(image) for image in images]
+        if do_resize and input_max_pixels is not None:
+            prepared = [
+                cls._smart_resize(image, input_max_pixels) for image in prepared
+            ]
+        return prepared
+
+    @staticmethod
+    def _auto_output_size(
+        image: PIL.Image.Image, target_pixels: int
+    ) -> Tuple[int, int]:
+        from sensenova_u1.models.neo_unify.utils import smart_resize
+
+        height, width = smart_resize(
+            height=image.height,
+            width=image.width,
+            factor=_IMAGE_GRID_FACTOR,
+            min_pixels=target_pixels,
+            max_pixels=target_pixels,
+        )
+        return width, height
+
+    def image_to_image(
+        self,
+        image: Union[PIL.Image.Image, List[PIL.Image.Image]],
+        prompt: Optional[str] = None,
+        n: int = 1,
+        size: Optional[str] = None,
+        response_format: str = "url",
+        **kwargs: Any,
+    ):
+        if "image2image" not in self._abilities:
+            raise RuntimeError(f"{self._model_uid} does not support image2image.")
+        if self._tokenizer is None:
+            raise RuntimeError("SenseNova-U1 model is not loaded.")
+        if prompt is None:
+            raise ValueError("SenseNova-U1 image editing requires a prompt.")
+        if not isinstance(prompt, str):
+            raise ValueError("SenseNova-U1 image editing requires a string prompt.")
+
+        import torch
+
+        images = list(image) if isinstance(image, list) else [image]
+        reference_images = kwargs.pop("reference_images", []) or []
+        if not isinstance(reference_images, list):
+            reference_images = [reference_images]
+        images.extend(reference_images)
+        if not images:
+            raise ValueError("SenseNova-U1 image editing requires at least one image.")
+
+        do_resize = kwargs.pop("do_resize", True)
+        input_max_pixels = self._resolve_input_max_pixels(
+            kwargs.pop("input_max_pixels", "auto"), len(images)
+        )
+        target_pixels = int(kwargs.pop("target_pixels", _DEFAULT_TARGET_PIXELS))
+        images = self._prepare_input_images(
+            images,
+            do_resize=do_resize,
+            input_max_pixels=input_max_pixels,
+        )
+
+        if size and size.lower() != "original":
+            width, height = self._parse_size(size)
+        else:
+            width, height = self._auto_output_size(images[0], target_pixels)
+            self._validate_size(width, height)
+
+        generate_config = self._filter_generate_config(
+            self._get_generate_config(kwargs), image_to_image=True
+        )
+        with torch.inference_mode(), self._offload_context() as model:
+            output = model.it2i_generate(
+                self._tokenizer,
+                prompt,
+                images,
+                image_size=(width, height),
+                batch_size=n,
+                **generate_config,
+            )
+        if generate_config.get("think_mode"):
+            output = output[0]
+        return handle_image_result(response_format, self._to_pil(output))

--- a/xinference/model/image/sensenova_u1.py
+++ b/xinference/model/image/sensenova_u1.py
@@ -15,6 +15,7 @@
 import contextlib
 import logging
 import os
+import random
 import re
 import sys
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Tuple, Union
@@ -221,6 +222,9 @@ class SenseNovaU1Model(SDAPIDiffusionModelMixin):
             config.pop(key, None)
         if "cfg_interval" in config:
             config["cfg_interval"] = tuple(config["cfg_interval"])
+        seed = config.get("seed")
+        if seed is None or seed == -1:
+            config["seed"] = random.randint(0, 2**31 - 1)
         return config
 
     @staticmethod

--- a/xinference/model/image/sensenova_u1.py
+++ b/xinference/model/image/sensenova_u1.py
@@ -14,7 +14,9 @@
 
 import contextlib
 import logging
+import os
 import re
+import sys
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Tuple, Union
 
 import PIL.Image
@@ -77,6 +79,12 @@ class SenseNovaU1Model(SDAPIDiffusionModelMixin):
         return self._abilities
 
     def load(self) -> None:
+        thirdparty_dir = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), "../../thirdparty")
+        )
+        if thirdparty_dir not in sys.path:
+            sys.path.insert(0, thirdparty_dir)
+
         import sensenova_u1
         import torch
         from sensenova_u1.utils import (

--- a/xinference/model/image/tests/test_sensenova_u1.py
+++ b/xinference/model/image/tests/test_sensenova_u1.py
@@ -1,0 +1,43 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+import pytest
+
+from .. import sensenova_u1
+
+
+def _make_model():
+    model_spec = SimpleNamespace(
+        model_ability=["text2image", "image2image"],
+        default_generate_config={},
+    )
+    return sensenova_u1.SenseNovaU1Model("test", "/path", model_spec)
+
+
+@pytest.mark.parametrize("kwargs", [{}, {"seed": None}, {"seed": -1}])
+def test_generate_config_randomizes_default_seed(monkeypatch, kwargs):
+    monkeypatch.setattr(sensenova_u1.random, "randint", lambda lower, upper: 1234)
+
+    config = _make_model()._get_generate_config(kwargs)
+
+    assert config["seed"] == 1234
+
+
+@pytest.mark.parametrize("seed", [0, 1, 1234])
+def test_generate_config_preserves_non_negative_seed(seed):
+    config = _make_model()._get_generate_config({"seed": seed})
+
+    assert config["seed"] == seed

--- a/xinference/thirdparty/sensenova_u1/LICENSE
+++ b/xinference/thirdparty/sensenova_u1/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/xinference/thirdparty/sensenova_u1/README.xinference.md
+++ b/xinference/thirdparty/sensenova_u1/README.xinference.md
@@ -1,0 +1,10 @@
+# SenseNova-U1 vendored runtime
+
+This directory vendors `src/sensenova_u1` from:
+
+- Repository: https://github.com/OpenSenseNova/SenseNova-U1
+- Commit: `35fb2fc520869aa09223a819882abdb3dc328ecd`
+- License: Apache License 2.0; see `LICENSE`
+
+The upstream source is kept unchanged. Xinference adds only this provenance file
+and the copied upstream license.

--- a/xinference/thirdparty/sensenova_u1/__init__.py
+++ b/xinference/thirdparty/sensenova_u1/__init__.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from importlib import metadata as _metadata
+from typing import Any
+
+from .models.neo_unify import (
+    NEOChatConfig,
+    NEOChatModel,
+    NEOLLMConfig,
+    NEOMoELLMConfig,
+    NEOVisionConfig,
+    NEOVisionModel,
+    effective_attn_backend,
+    get_attn_backend,
+    has_flash_attn,
+    set_attn_backend,
+)
+from .models.neo_unify import (
+    register as _register,
+)
+
+try:
+    __version__ = _metadata.version("sensenova-u1")
+except _metadata.PackageNotFoundError:  # pragma: no cover - editable / not installed
+    __version__ = "0.1.0"
+
+__all__ = [
+    "__version__",
+    "NEOChatConfig",
+    "NEOLLMConfig",
+    "NEOMoELLMConfig",
+    "NEOVisionConfig",
+    "NEOChatModel",
+    "NEOVisionModel",
+    "check_checkpoint_compatibility",
+    "set_attn_backend",
+    "get_attn_backend",
+    "effective_attn_backend",
+    "has_flash_attn",
+    "main",
+]
+
+
+def check_checkpoint_compatibility(config_or_dict: Any) -> None:
+    """Raise ``RuntimeError`` if the installed ``sensenova_u1`` is too old for the checkpoint.
+
+    The checkpoint can advertise a minimum package version by setting
+    ``sensenova_u1_min_version`` in its ``config.json``. If the field is
+    absent, no check is performed. This lets us evolve the modeling code
+    in git while keeping old checkpoints loadable, and hard-fail with a
+    clear message when a newer checkpoint requires a newer package.
+    """
+    try:
+        from packaging.version import Version
+    except ImportError:  # pragma: no cover
+        return
+
+    if hasattr(config_or_dict, "to_dict"):
+        cfg: dict = config_or_dict.to_dict()
+    elif isinstance(config_or_dict, dict):
+        cfg = config_or_dict
+    else:
+        return
+
+    required = cfg.get("sensenova_u1_min_version")
+    if not required:
+        return
+
+    if Version(__version__) < Version(str(required)):
+        raise RuntimeError(
+            f"This checkpoint requires sensenova-u1 >= {required}, "
+            f"but the installed version is {__version__}. "
+            f"Please upgrade with `uv sync` or `pip install -U sensenova-u1`."
+        )
+
+
+_register()
+
+
+def main() -> None:
+    print(f"SenseNova-U1 v{__version__}")

--- a/xinference/thirdparty/sensenova_u1/models/__init__.py
+++ b/xinference/thirdparty/sensenova_u1/models/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from . import neo_unify  # noqa: F401  (re-export & register on import)
+
+__all__ = ["neo_unify"]

--- a/xinference/thirdparty/sensenova_u1/models/neo_unify/__init__.py
+++ b/xinference/thirdparty/sensenova_u1/models/neo_unify/__init__.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from .configuration_neo_chat import NEOChatConfig, NEOLLMConfig, NEOMoELLMConfig
+from .configuration_neo_vit import NEOVisionConfig
+from .modeling_neo_chat import NEOChatModel
+from .modeling_neo_vit import NEOVisionModel
+from .modeling_qwen3 import (
+    _HAS_FLASH_ATTN as has_flash_attn,
+    effective_attn_backend,
+    get_attn_backend,
+    set_attn_backend,
+)
+from .modeling_qwen3 import Qwen3ForCausalLM
+from .modeling_qwen3_moe import Qwen3MoeForCausalLM
+
+__all__ = [
+    "NEOChatConfig",
+    "NEOLLMConfig",
+    "NEOMoELLMConfig",
+    "NEOVisionConfig",
+    "NEOChatModel",
+    "NEOVisionModel",
+    "Qwen3ForCausalLM",
+    "Qwen3MoeForCausalLM",
+    "register",
+    "set_attn_backend",
+    "get_attn_backend",
+    "effective_attn_backend",
+    "has_flash_attn",
+]
+
+
+_REGISTERED = False
+
+
+def register() -> None:
+    """Register NEO-Unify types with ``transformers.Auto*``.
+
+    After calling this (or simply ``import sensenova_u1``), users can load a
+    SenseNova-U1 checkpoint via plain ``AutoConfig.from_pretrained`` /
+    ``AutoModel.from_pretrained``.
+    """
+    global _REGISTERED
+    if _REGISTERED:
+        return
+
+    from transformers import AutoConfig, AutoModel
+
+    AutoConfig.register("neo_vision", NEOVisionConfig, exist_ok=True)
+    AutoConfig.register("neo_chat", NEOChatConfig, exist_ok=True)
+
+    AutoModel.register(NEOVisionConfig, NEOVisionModel, exist_ok=True)
+    AutoModel.register(NEOChatConfig, NEOChatModel, exist_ok=True)
+
+    _REGISTERED = True

--- a/xinference/thirdparty/sensenova_u1/models/neo_unify/configuration_neo_chat.py
+++ b/xinference/thirdparty/sensenova_u1/models/neo_unify/configuration_neo_chat.py
@@ -1,0 +1,197 @@
+import copy
+
+from transformers import Qwen3Config, Qwen3MoeConfig
+from transformers.utils import logging
+from transformers.configuration_utils import PretrainedConfig
+
+from .configuration_neo_vit import NEOVisionConfig
+
+
+logger = logging.get_logger(__name__)
+
+
+def _restore_legacy_rope_theta(config) -> None:
+    """Expose the v4 rope attribute expected by the vendored model code."""
+    if hasattr(config, "rope_theta"):
+        return
+    rope_parameters = getattr(config, "rope_parameters", None) or {}
+    config.rope_theta = float(rope_parameters.get("rope_theta", 10000.0))
+
+
+class NEOLLMConfig(Qwen3Config):
+    """Config for the dense Qwen3 backbone used by NEO-Unify.
+
+    Extends ``Qwen3Config`` with two extra rope knobs used by the spatial
+    (height/width) rotary axes that are layered on top of the temporal one.
+    """
+
+    def __init__(self, rope_theta_hw=10000.0, max_position_embeddings_hw=10000, **kwargs):
+        super().__init__(**kwargs)
+        _restore_legacy_rope_theta(self)
+        self.rope_theta_hw = rope_theta_hw
+        self.max_position_embeddings_hw = max_position_embeddings_hw
+
+
+class NEOMoELLMConfig(Qwen3MoeConfig):
+    """Config for the Qwen3-MoE backbone used by NEO-Unify.
+
+    Extends ``Qwen3MoeConfig`` with the same ``rope_theta_hw`` /
+    ``max_position_embeddings_hw`` extras as :class:`NEOLLMConfig`, and adds a
+    *generation-path* MoE branch alongside the standard understanding-path one.
+    In the A3B unified model every decoder layer carries two parallel sparse
+    MoE blocks routed by the per-token ``image_gen_indicators`` mask:
+
+        * ``mlp``           - sparse MoE for the understanding path
+                              (``num_experts`` experts, ``num_experts_per_tok`` active,
+                              expert width ``moe_intermediate_size``).
+        * ``mlp_mot_gen``   - sparse MoE for the image generation path
+                              (``gen_num_experts`` experts, ``gen_num_experts_per_tok``
+                              active, expert width ``gen_moe_intermediate_size``).
+
+    Each gen-path knob falls back to its understanding-path counterpart when
+    unset, so vanilla single-MoE configs keep working without changes.
+    """
+
+    def __init__(
+        self,
+        rope_theta_hw=10000.0,
+        max_position_embeddings_hw=10000,
+        gen_num_experts=None,
+        gen_num_experts_per_tok=None,
+        gen_moe_intermediate_size=None,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        _restore_legacy_rope_theta(self)
+        self.rope_theta_hw = rope_theta_hw
+        self.max_position_embeddings_hw = max_position_embeddings_hw
+
+        # Generation-path MoE knobs default to the understanding-path values
+        # so legacy single-MoE configs (where both branches share the same
+        # router width / expert count) keep working unchanged.
+        self.gen_num_experts = (
+            int(gen_num_experts) if gen_num_experts is not None else int(self.num_experts)
+        )
+        self.gen_num_experts_per_tok = (
+            int(gen_num_experts_per_tok)
+            if gen_num_experts_per_tok is not None
+            else int(self.num_experts_per_tok)
+        )
+        self.gen_moe_intermediate_size = (
+            int(gen_moe_intermediate_size)
+            if gen_moe_intermediate_size is not None
+            else int(self.moe_intermediate_size)
+        )
+
+        # ``Qwen3Attention`` (used by NEO-Unify MoE layers) reads
+        # ``config.layer_types[layer_idx]`` to decide between ``"full_attention"``
+        # and ``"sliding_attention"``. Older / vanilla ``Qwen3MoeConfig`` does
+        # not populate that field, so we backfill it here mirroring the dense
+        # ``Qwen3Config`` behaviour: sliding-attention layers start at
+        # ``max_window_layers`` when ``use_sliding_window`` is enabled.
+        existing = getattr(self, "layer_types", None)
+        if not existing or len(existing) != self.num_hidden_layers:
+            use_swa = bool(getattr(self, "use_sliding_window", False)) and getattr(
+                self, "sliding_window", None
+            ) is not None
+            max_window_layers = int(getattr(self, "max_window_layers", 0) or 0)
+            self.layer_types = [
+                "sliding_attention" if (use_swa and i >= max_window_layers) else "full_attention"
+                for i in range(self.num_hidden_layers)
+            ]
+
+
+def _is_moe_llm_config(llm_config) -> bool:
+    """Detect whether an ``llm_config`` (dict or object) targets a MoE backbone.
+
+    Order of checks: explicit ``model_type``, ``architectures`` entry that
+    contains ``MoE/MoeForCausalLM``, or presence of MoE-specific keys
+    (``num_experts``).
+    """
+    if isinstance(llm_config, dict):
+        model_type = llm_config.get("model_type", "")
+        archs = llm_config.get("architectures") or []
+        has_num_experts = "num_experts" in llm_config
+    else:
+        model_type = getattr(llm_config, "model_type", "")
+        archs = getattr(llm_config, "architectures", None) or []
+        has_num_experts = hasattr(llm_config, "num_experts")
+
+    if isinstance(model_type, str) and "moe" in model_type.lower():
+        return True
+    for arch in archs:
+        arch_str = str(arch)
+        if "Moe" in arch_str or "MoE" in arch_str:
+            return True
+    return bool(has_num_experts) and getattr(llm_config, "num_experts", 0) and int(getattr(llm_config, "num_experts", 0)) > 1
+
+
+def _build_llm_config(llm_config):
+    """Instantiate the right LLM config object from a dict or pre-built config."""
+    if isinstance(llm_config, dict):
+        if _is_moe_llm_config(llm_config):
+            return NEOMoELLMConfig(**llm_config)
+        return NEOLLMConfig(**llm_config)
+    return llm_config
+
+
+class NEOChatConfig(PretrainedConfig):
+    model_type = 'neo_chat'
+    is_composition = True
+
+    def __init__(
+        self,
+        vision_config=None,
+        llm_config=None,
+        use_backbone_lora=0,
+        use_llm_lora=0,
+        downsample_ratio=0.5,
+        template=None,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+
+        if vision_config is None:
+            vision_config = {'architectures': ['NEOVisionModel']}
+            logger.info('vision_config is None. Initializing the NEOVisionConfig with default values.')
+
+        if llm_config is None:
+            llm_config = {'architectures': ['Qwen3ForCausalLM']}
+            logger.info('llm_config is None. Initializing the LlamaConfig config with default values (`LlamaConfig`).')
+        assert 'architectures' in llm_config, "Should specify architecture in llm_config"
+
+        if isinstance(vision_config, dict):
+            self.vision_config = NEOVisionConfig(**vision_config)
+        else:
+            self.vision_config = vision_config
+
+        self.llm_config = _build_llm_config(llm_config)
+
+        self.use_backbone_lora = use_backbone_lora
+        self.use_llm_lora = use_llm_lora
+        self.downsample_ratio = downsample_ratio
+        self.template = template
+        self.tie_word_embeddings = self.llm_config.tie_word_embeddings
+
+    @property
+    def is_moe_llm(self) -> bool:
+        """Convenience flag so callers can switch between dense / MoE LLM."""
+        return isinstance(self.llm_config, NEOMoELLMConfig)
+
+    def to_dict(self):
+        """
+        Serializes this instance to a Python dictionary. Override the default [`~PretrainedConfig.to_dict`].
+
+        Returns:
+            `Dict[str, any]`: Dictionary of all the attributes that make up this configuration instance,
+        """
+        output = copy.deepcopy(self.__dict__)
+        output['vision_config'] = self.vision_config.to_dict()
+        output['llm_config'] = self.llm_config.to_dict()
+        output['model_type'] = self.__class__.model_type
+        output['use_backbone_lora'] = self.use_backbone_lora
+        output['use_llm_lora'] = self.use_llm_lora
+        output['downsample_ratio'] = self.downsample_ratio
+        output['template'] = self.template
+
+        return output

--- a/xinference/thirdparty/sensenova_u1/models/neo_unify/configuration_neo_vit.py
+++ b/xinference/thirdparty/sensenova_u1/models/neo_unify/configuration_neo_vit.py
@@ -1,0 +1,52 @@
+import os
+from typing import Union
+
+from transformers.configuration_utils import PretrainedConfig
+from transformers.utils import logging
+
+logger = logging.get_logger(__name__)
+
+
+class NEOVisionConfig(PretrainedConfig):
+
+    model_type = 'neo_vision'
+
+    def __init__(
+            self,
+            num_channels=3,
+            patch_size=16,
+            hidden_size=1024,
+            llm_hidden_size=2048,
+            downsample_ratio=0.5,
+            rope_theta_vision=10000.0,
+            max_position_embeddings_vision=10000,
+            min_pixels=65536,
+            max_pixels=4194304,
+            **kwargs,
+    ):
+        super().__init__(**kwargs)
+
+        self.hidden_size = hidden_size
+        self.llm_hidden_size = llm_hidden_size,
+        self.downsample_ratio = downsample_ratio,
+        self.rope_theta_vision = rope_theta_vision
+        self.max_position_embeddings_vision = max_position_embeddings_vision
+        self.num_channels = num_channels
+        self.patch_size = patch_size
+        self.min_pixels = min_pixels
+        self.max_pixels = max_pixels
+
+    @classmethod
+    def from_pretrained(cls, pretrained_model_name_or_path: Union[str, os.PathLike], **kwargs) -> 'PretrainedConfig':
+        config_dict, kwargs = cls.get_config_dict(pretrained_model_name_or_path, **kwargs)
+
+        if 'vision_config' in config_dict:
+            config_dict = config_dict['vision_config']
+
+        if 'model_type' in config_dict and hasattr(cls, 'model_type') and config_dict['model_type'] != cls.model_type:
+            logger.warning(
+                f"You are using a model of type {config_dict['model_type']} to instantiate a model of type "
+                f'{cls.model_type}. This is not supported for all configurations of models and can yield errors.'
+            )
+
+        return cls.from_dict(config_dict, **kwargs)

--- a/xinference/thirdparty/sensenova_u1/models/neo_unify/conversation.py
+++ b/xinference/thirdparty/sensenova_u1/models/neo_unify/conversation.py
@@ -1,0 +1,397 @@
+"""
+Conversation prompt templates.
+
+We kindly request that you import fastchat instead of copying this file if you wish to use it.
+If you have changes in mind, please contribute back so the community can benefit collectively and continue to maintain these valuable templates.
+
+Modified from https://github.com/lm-sys/FastChat/blob/main/fastchat/conversation.py
+"""
+
+import dataclasses
+from enum import IntEnum, auto
+from typing import Dict, List, Tuple, Union
+
+
+class SeparatorStyle(IntEnum):
+    """Separator styles."""
+
+    ADD_COLON_SINGLE = auto()
+    ADD_COLON_TWO = auto()
+    ADD_COLON_SPACE_SINGLE = auto()
+    NO_COLON_SINGLE = auto()
+    NO_COLON_TWO = auto()
+    ADD_NEW_LINE_SINGLE = auto()
+    LLAMA2 = auto()
+    CHATGLM = auto()
+    CHATML = auto()
+    CHATINTERN = auto()
+    DOLLY = auto()
+    RWKV = auto()
+    PHOENIX = auto()
+    ROBIN = auto()
+    FALCON_CHAT = auto()
+    CHATGLM3 = auto()
+    INTERNVL_ZH = auto()
+    MPT = auto()
+
+
+@dataclasses.dataclass
+class Conversation:
+    """A class that manages prompt templates and keeps all conversation history."""
+
+    # The name of this template
+    name: str
+    # The template of the system prompt
+    system_template: str = '{system_message}'
+    # The system message
+    system_message: str = ''
+    # The names of two roles
+    roles: Tuple[str] = ('USER', 'ASSISTANT')
+    # All messages. Each item is (role, message).
+    messages: List[List[str]] = ()
+    # The number of few shot examples
+    offset: int = 0
+    # The separator style and configurations
+    sep_style: SeparatorStyle = SeparatorStyle.ADD_COLON_SINGLE
+    sep: str = '\n'
+    sep2: str = None
+    # Stop criteria (the default one is EOS token)
+    stop_str: Union[str, List[str]] = None
+    # Stops generation if meeting any token in this list
+    stop_token_ids: List[int] = None
+
+    def get_prompt(self) -> str:
+        """Get the prompt for generation."""
+        if self.system_message is not None and self.system_message != '':
+            system_prompt = self.system_template.format(system_message=self.system_message)
+        else:
+            system_prompt = ''
+        
+        if self.sep_style == SeparatorStyle.ADD_COLON_SINGLE:
+            ret = '' if system_prompt == '' else system_prompt + self.sep
+            for role, message in self.messages:
+                if message:
+                    ret += role + ': ' + message + self.sep
+                else:
+                    ret += role + ':'
+            return ret
+        elif self.sep_style == SeparatorStyle.ADD_COLON_TWO:
+            seps = [self.sep, self.sep2]
+            ret = '' if system_prompt == '' else system_prompt + seps[0]
+            for i, (role, message) in enumerate(self.messages):
+                if message:
+                    ret += role + ': ' + message + seps[i % 2]
+                else:
+                    ret += role + ':'
+            return ret
+        elif self.sep_style == SeparatorStyle.ADD_COLON_SPACE_SINGLE:
+            ret = '' if system_prompt == '' else system_prompt + self.sep
+            for role, message in self.messages:
+                if message:
+                    ret += role + ': ' + message + self.sep
+                else:
+                    ret += role + ': '  # must be end with a space
+            return ret
+        elif self.sep_style == SeparatorStyle.ADD_NEW_LINE_SINGLE:
+            ret = '' if system_prompt == '' else system_prompt + self.sep
+            for role, message in self.messages:
+                if message:
+                    ret += role + '\n' + message + self.sep
+                else:
+                    ret += role + '\n'
+            return ret
+        elif self.sep_style == SeparatorStyle.NO_COLON_SINGLE:
+            ret = system_prompt
+            for role, message in self.messages:
+                if message:
+                    ret += role + message + self.sep
+                else:
+                    ret += role
+            return ret
+        elif self.sep_style == SeparatorStyle.NO_COLON_TWO:
+            seps = [self.sep, self.sep2]
+            ret = system_prompt
+            for i, (role, message) in enumerate(self.messages):
+                if message:
+                    ret += role + message + seps[i % 2]
+                else:
+                    ret += role
+            return ret
+        elif self.sep_style == SeparatorStyle.RWKV:
+            ret = system_prompt
+            for i, (role, message) in enumerate(self.messages):
+                if message:
+                    ret += (
+                        role
+                        + ': '
+                        + message.replace('\r\n', '\n').replace('\n\n', '\n')
+                    )
+                    ret += '\n\n'
+                else:
+                    ret += role + ':'
+            return ret
+        elif self.sep_style == SeparatorStyle.LLAMA2:
+            seps = [self.sep, self.sep2]
+            ret = system_prompt if system_prompt != '' else '[INST] '
+            for i, (role, message) in enumerate(self.messages):
+                tag = self.roles[i % 2]
+                if message:
+                    if i == 0:
+                        ret += message + ' '
+                    else:
+                        ret += tag + ' ' + message + seps[i % 2]
+                else:
+                    ret += tag
+            return ret
+        elif self.sep_style == SeparatorStyle.CHATGLM:
+            # source: https://huggingface.co/THUDM/chatglm-6b/blob/1d240ba371910e9282298d4592532d7f0f3e9f3e/modeling_chatglm.py#L1302-L1308
+            # source2: https://huggingface.co/THUDM/chatglm2-6b/blob/e186c891cf64310ac66ef10a87e6635fa6c2a579/modeling_chatglm.py#L926
+            round_add_n = 1 if self.name == 'chatglm2' else 0
+            ret = '' if system_prompt == '' else system_prompt + self.sep
+
+            for i, (role, message) in enumerate(self.messages):
+                if i % 2 == 0:
+                    ret += f'[Round {i//2 + round_add_n}]{self.sep}'
+
+                if message:
+                    ret += f'{role}：{message}{self.sep}'
+                else:
+                    ret += f'{role}：'
+            return ret
+        elif self.sep_style == SeparatorStyle.CHATML:
+            ret = '' if system_prompt == '' else system_prompt + self.sep + '\n'
+            for role, message in self.messages:
+                if message:
+                    ret += role + '\n' + message + self.sep + '\n'
+                else:
+                    ret += role + '\n'
+            return ret
+        elif self.sep_style == SeparatorStyle.CHATGLM3:
+            ret = system_prompt
+            for role, message in self.messages:
+                if message:
+                    ret += role + '\n' + ' ' + message
+                else:
+                    ret += role
+            return ret
+        elif self.sep_style == SeparatorStyle.CHATINTERN:
+            # source: https://huggingface.co/internlm/internlm-chat-7b-8k/blob/bd546fa984b4b0b86958f56bf37f94aa75ab8831/modeling_internlm.py#L771
+            seps = [self.sep, self.sep2]
+            ret = system_prompt
+            for i, (role, message) in enumerate(self.messages):
+                # if i % 2 == 0:
+                #     ret += "<s>"
+                if message:
+                    ret += role + ':' + message + seps[i % 2] + '\n'
+                else:
+                    ret += role + ':'
+            return ret
+        elif self.sep_style == SeparatorStyle.DOLLY:
+            seps = [self.sep, self.sep2]
+            ret = system_prompt
+            for i, (role, message) in enumerate(self.messages):
+                if message:
+                    ret += role + ':\n' + message + seps[i % 2]
+                    if i % 2 == 1:
+                        ret += '\n\n'
+                else:
+                    ret += role + ':\n'
+            return ret
+        elif self.sep_style == SeparatorStyle.PHOENIX:
+            ret = system_prompt
+            for role, message in self.messages:
+                if message:
+                    ret += role + ': ' + '<s>' + message + '</s>'
+                else:
+                    ret += role + ': ' + '<s>'
+            return ret
+        elif self.sep_style == SeparatorStyle.ROBIN:
+            ret = '' if system_prompt == '' else system_prompt + self.sep
+            for role, message in self.messages:
+                if message:
+                    ret += role + ':\n' + message + self.sep
+                else:
+                    ret += role + ':\n'
+            return ret
+        elif self.sep_style == SeparatorStyle.FALCON_CHAT:
+            ret = '' if system_prompt == '' else system_prompt + self.sep
+            for role, message in self.messages:
+                if message:
+                    ret += role + ': ' + message + self.sep
+                else:
+                    ret += role + ':'
+
+            return ret
+        elif self.sep_style == SeparatorStyle.INTERNVL_ZH:
+            seps = [self.sep, self.sep2]
+            ret = '' if system_prompt == '' else self.system_message + seps[0]
+            for i, (role, message) in enumerate(self.messages):
+                if message:
+                    ret += role + ': ' + message + seps[i % 2]
+                else:
+                    ret += role + ':'
+            return ret
+        elif self.sep_style == SeparatorStyle.MPT:
+            ret = '' if system_prompt == '' else system_prompt + self.sep
+            for i, (role, message) in enumerate(self.messages):
+                if message:
+                    if type(message) is tuple:
+                        message, _, _ = message
+                    ret += role + message + self.sep
+                else:
+                    if i != len(self.messages) and message is not None:
+                        ret += role + self.sep
+                    else:
+                        ret += role
+            return ret
+        else:
+            raise ValueError(f'Invalid style: {self.sep_style}')
+
+    def set_system_message(self, system_message: str):
+        """Set the system message."""
+        self.system_message = system_message
+
+    def append_message(self, role: str, message: str):
+        """Append a new message."""
+        self.messages.append([role, message])
+
+    def update_last_message(self, message: str):
+        """Update the last output.
+
+        The last message is typically set to be None when constructing the prompt,
+        so we need to update it in-place after getting the response from a model.
+        """
+        self.messages[-1][1] = message
+
+    def to_gradio_chatbot(self):
+        """Convert the conversation to gradio chatbot format."""
+        ret = []
+        for i, (role, msg) in enumerate(self.messages[self.offset :]):
+            if i % 2 == 0:
+                ret.append([msg, None])
+            else:
+                ret[-1][-1] = msg
+        return ret
+
+    def to_openai_api_messages(self):
+        """Convert the conversation to OpenAI chat completion format."""
+        ret = [{'role': 'system', 'content': self.system_message}]
+
+        for i, (_, msg) in enumerate(self.messages[self.offset :]):
+            if i % 2 == 0:
+                ret.append({'role': 'user', 'content': msg})
+            else:
+                if msg is not None:
+                    ret.append({'role': 'assistant', 'content': msg})
+        return ret
+
+    def copy(self):
+        return Conversation(
+            name=self.name,
+            system_template=self.system_template,
+            system_message=self.system_message,
+            roles=self.roles,
+            messages=[[x, y] for x, y in self.messages],
+            offset=self.offset,
+            sep_style=self.sep_style,
+            sep=self.sep,
+            sep2=self.sep2,
+            stop_str=self.stop_str,
+            stop_token_ids=self.stop_token_ids,
+        )
+
+    def dict(self):
+        return {
+            'template_name': self.name,
+            'system_message': self.system_message,
+            'roles': self.roles,
+            'messages': self.messages,
+            'offset': self.offset,
+        }
+
+
+# A global registry for all conversation templates
+conv_templates: Dict[str, Conversation] = {}
+
+
+def register_conv_template(template: Conversation, override: bool = False):
+    """Register a new conversation template."""
+    if not override:
+        assert (
+            template.name not in conv_templates
+        ), f'{template.name} has been registered.'
+
+    conv_templates[template.name] = template
+
+
+def get_conv_template(name: str) -> Conversation:
+    """Get a conversation template."""
+    return conv_templates[name].copy()
+
+
+# Both Hermes-2 and neo1_0-chat are chatml-format conversation templates. The difference
+# is that during training, the preprocessing function for the Hermes-2 template doesn't add
+# <s> at the beginning of the tokenized sequence, while the neo1_0-chat template does.
+# Therefore, they are completely equivalent during inference.
+
+register_conv_template(
+    Conversation(
+        name='Hermes-2',
+        system_template='<|im_start|>system\n{system_message}',
+        # note: The new system prompt was not used here to avoid changes in benchmark performance.
+        # system_message='我是书生·万象，英文名是InternVL，是由上海人工智能实验室、清华大学及多家合作单位联合开发的多模态大语言模型。',
+        system_message='你是由上海人工智能实验室联合商汤科技开发的书生多模态大模型，英文名叫InternVL, 是一个有用无害的人工智能助手。',
+        roles=('<|im_start|>user\n', '<|im_start|>assistant\n'),
+        sep_style=SeparatorStyle.MPT,
+        sep='<|im_end|>',
+        stop_str='<|endoftext|>',
+    )
+)
+
+register_conv_template(
+    Conversation(
+        name='internlm2-chat',
+        system_template='<|im_start|>system\n{system_message}',
+        # note: The new system prompt was not used here to avoid changes in benchmark performance.
+        # system_message='我是书生·万象，英文名是InternVL，是由上海人工智能实验室、清华大学及多家合作单位联合开发的多模态大语言模型。',
+        system_message='你是由上海人工智能实验室联合商汤科技开发的书生多模态大模型，英文名叫InternVL, 是一个有用无害的人工智能助手。',
+        roles=('<|im_start|>user\n', '<|im_start|>assistant\n'),
+        sep_style=SeparatorStyle.MPT,
+        sep='<|im_end|>',
+    )
+)
+
+register_conv_template(
+    Conversation(
+        name='phi3-chat',
+        system_template='<|system|>\n{system_message}',
+        # note: The new system prompt was not used here to avoid changes in benchmark performance.
+        # system_message='我是书生·万象，英文名是InternVL，是由上海人工智能实验室、清华大学及多家合作单位联合开发的多模态大语言模型。',
+        system_message='你是由上海人工智能实验室联合商汤科技开发的书生多模态大模型，英文名叫InternVL, 是一个有用无害的人工智能助手。',
+        roles=('<|user|>\n', '<|assistant|>\n'),
+        sep_style=SeparatorStyle.MPT,
+        sep='<|end|>',
+    )
+)
+
+register_conv_template(
+    Conversation(
+        name='internvl2_5',
+        system_template='<|im_start|>system\n{system_message}',
+        system_message='你是书生·万象，英文名是InternVL，是由上海人工智能实验室、清华大学及多家合作单位联合开发的多模态大语言模型。',
+        roles=('<|im_start|>user\n', '<|im_start|>assistant\n'),
+        sep_style=SeparatorStyle.MPT,
+        sep='<|im_end|>\n',
+    )
+)
+
+register_conv_template(
+    Conversation(
+        name='neo1_0',
+        system_template='<|im_start|>system\n{system_message}',
+        system_message='',
+        roles=('<|im_start|>user\n', '<|im_start|>assistant\n'),
+        sep_style=SeparatorStyle.MPT,
+        sep='<|im_end|>\n',
+    )
+)

--- a/xinference/thirdparty/sensenova_u1/models/neo_unify/modeling_fm_modules.py
+++ b/xinference/thirdparty/sensenova_u1/models/neo_unify/modeling_fm_modules.py
@@ -1,0 +1,591 @@
+import numpy as np
+import torch
+import torch.nn as nn
+import math
+from functools import lru_cache
+
+from torch.utils.checkpoint import checkpoint
+def modulate(x, shift, scale=None):
+    if shift is None:
+        return x * (1 + scale)
+    return x * (1 + scale) + shift
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim: int, eps: float = 1e-5):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        output = x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + self.eps)
+        return output * self.weight
+
+class TimestepEmbedder(nn.Module):
+    """
+    Embeds scalar timesteps into vector representations.
+    """
+
+    def __init__(self, hidden_size, frequency_embedding_size=256):
+        super().__init__()
+        self.mlp = nn.Sequential(
+            nn.Linear(frequency_embedding_size, hidden_size, bias=True),
+            nn.SiLU(),
+            nn.Linear(hidden_size, hidden_size, bias=True),
+        )
+        self.frequency_embedding_size = frequency_embedding_size
+
+    @staticmethod
+    def timestep_embedding(t: torch.Tensor, dim: int, max_period: float = 10000.0):
+        """
+        Create sinusoidal timestep embeddings.
+        :param t: a 1-D Tensor of N indices, one per batch element. These may be fractional.
+        :param dim: the dimension of the output.
+        :param max_period: controls the minimum frequency of the embeddings.
+        :return: an (N, D) Tensor of positional embeddings.
+        """
+        # https://github.com/openai/glide-text2im/blob/main/glide_text2im/nn.py
+        half = dim // 2
+        freqs = torch.exp(-math.log(max_period) * torch.arange(start=0, end=half, dtype=torch.float32) / half).to(
+            device=t.device
+        )
+        args = t[:, None].float() * freqs[None]
+        embedding = torch.cat([torch.cos(args), torch.sin(args)], dim=-1)
+        if dim % 2:
+            embedding = torch.cat([embedding, torch.zeros_like(embedding[:, :1])], dim=-1)
+        return embedding
+
+    def forward(self, t):
+        t_freq = self.timestep_embedding(t, self.frequency_embedding_size)
+        t_emb = self.mlp(t_freq.to(self.mlp[0].weight.dtype))
+        return t_emb
+
+class ResBlock(nn.Module):
+
+    def __init__(self, channels, mlp_ratio=1.0):
+        super().__init__()
+        self.channels = channels
+        self.intermediate_size = int(channels * mlp_ratio)
+
+        self.in_ln = nn.LayerNorm(self.channels, eps=1e-6)
+        self.mlp = nn.Sequential(
+            nn.Linear(self.channels, self.intermediate_size),
+            nn.SiLU(),
+            nn.Linear(self.intermediate_size, self.channels),
+        )
+
+        self.adaLN_modulation = nn.Sequential(nn.SiLU(), nn.Linear(channels, 3 * channels, bias=True))
+
+    def forward(self, x, y):
+        shift_mlp, scale_mlp, gate_mlp = self.adaLN_modulation(y).chunk(3, dim=-1)
+        h = modulate(self.in_ln(x), shift_mlp, scale_mlp)
+        h = self.mlp(h)
+        return x + gate_mlp * h
+
+# class FinalLayer(nn.Module):
+
+#     def __init__(self, model_channels, out_channels):
+#         super().__init__()
+#         self.norm_final = nn.LayerNorm(model_channels, elementwise_affine=False, eps=1e-6)
+#         self.linear = nn.Linear(model_channels, out_channels, bias=True)
+#         self.adaLN_modulation = nn.Sequential(nn.SiLU(), nn.Linear(model_channels, 2 * model_channels, bias=True))
+
+#     def forward(self, x, c):
+#         shift, scale = self.adaLN_modulation(c).chunk(2, dim=-1)
+#         x = modulate(self.norm_final(x), shift, scale)
+#         x = self.linear(x)
+#         return x
+
+# class SimpleMLPAdaLN(nn.Module):
+
+#     def __init__(self, input_dim, out_dim, dim=1536, layers=12, mlp_ratio=1.0):
+#         super().__init__()
+#         self.input_dim = input_dim
+#         self.out_dim = out_dim
+#         self.dim = dim
+#         self.layers = layers
+#         self.mlp_ratio = mlp_ratio
+
+#         self.time_embed = TimestepEmbedder(dim)
+#         self.input_proj = nn.Linear(input_dim, dim)
+
+#         res_blocks = []
+#         for _ in range(layers):
+#             res_blocks.append(ResBlock(dim, mlp_ratio))
+#         self.res_blocks = nn.ModuleList(res_blocks)
+
+#         self.final_layer = FinalLayer(dim, out_dim)
+
+#         self.grad_checkpointing = False
+
+#         self.initialize_weights()
+
+#     def initialize_weights(self):
+#         def _basic_init(module):
+#             if isinstance(module, nn.Linear):
+#                 torch.nn.init.xavier_uniform_(module.weight)
+#                 if module.bias is not None:
+#                     nn.init.constant_(module.bias, 0)
+
+#         self.apply(_basic_init)
+
+#         # Initialize timestep embedding MLP
+#         nn.init.normal_(self.time_embed.mlp[0].weight, std=0.02)
+#         nn.init.normal_(self.time_embed.mlp[2].weight, std=0.02)
+
+#         # Zero-out adaLN modulation layers
+#         for block in self.res_blocks:
+#             nn.init.constant_(block.adaLN_modulation[-1].weight, 0)
+#             nn.init.constant_(block.adaLN_modulation[-1].bias, 0)
+
+#         # Zero-out output layers
+#         nn.init.constant_(self.final_layer.adaLN_modulation[-1].weight, 0)
+#         nn.init.constant_(self.final_layer.adaLN_modulation[-1].bias, 0)
+#         nn.init.constant_(self.final_layer.linear.weight, 0)
+#         nn.init.constant_(self.final_layer.linear.bias, 0)
+
+#     def forward(self, x, t):
+#         """
+#         x.shape = (bsz, input_dim)
+#         t.shape = (bsz,)
+#         """
+
+#         x = self.input_proj(x)
+#         t = self.time_embed(t)
+
+#         y = t
+
+#         for block in self.res_blocks:
+#             if self.grad_checkpointing and self.training:
+#                 x = checkpoint(block, x, y, use_reentrant=True)
+#             else:
+#                 x = block(x, y)
+
+#         return self.final_layer(x, y)
+
+class FlowMatchingHead(nn.Module):
+
+    def __init__(self, input_dim, out_dim, dim=1536, layers=12, mlp_ratio=1.0):
+        super(FlowMatchingHead, self).__init__()
+        self.net = SimpleMLPAdaLN(input_dim=input_dim, out_dim=out_dim, dim=dim, layers=layers, mlp_ratio=mlp_ratio)
+
+    @property
+    def dtype(self):
+        return self.net.input_proj.weight.dtype
+
+    @property
+    def device(self):
+        return self.net.input_proj.weight.device
+
+    def forward(self, x, t):
+        x = self.net(x, t)
+        return x
+
+
+def precompute_freqs_cis_2d(dim: int, height: int, width:int, theta: float = 10000.0, scale=16.0):
+    # assert  H * H == end
+    # flat_patch_pos = torch.linspace(-1, 1, end) # N = end
+    x_pos = torch.linspace(0, scale, width)
+    y_pos = torch.linspace(0, scale, height)
+    y_pos, x_pos = torch.meshgrid(y_pos, x_pos, indexing="ij")
+    y_pos = y_pos.reshape(-1)
+    x_pos = x_pos.reshape(-1)
+    freqs = 1.0 / (theta ** (torch.arange(0, dim, 4)[: (dim // 4)].float() / dim)) # Hc/4
+    x_freqs = torch.outer(x_pos, freqs).float() # N Hc/4
+    y_freqs = torch.outer(y_pos, freqs).float() # N Hc/4
+    x_cis = torch.polar(torch.ones_like(x_freqs), x_freqs)
+    y_cis = torch.polar(torch.ones_like(y_freqs), y_freqs)
+    freqs_cis = torch.cat([x_cis.unsqueeze(dim=-1), y_cis.unsqueeze(dim=-1)], dim=-1) # N,Hc/4,2
+    freqs_cis = freqs_cis.reshape(height*width, -1)
+    return freqs_cis
+
+class NerfEmbedder(nn.Module):
+    def __init__(self, in_channels, hidden_size_input, max_freqs):
+        super().__init__()
+        self.max_freqs = max_freqs
+        self.hidden_size_input = hidden_size_input
+        self.embedder = nn.Sequential(
+            nn.Linear(in_channels+max_freqs**2, hidden_size_input, bias=True),
+        )
+
+    @lru_cache
+    def fetch_pos(self, patch_size, device, dtype):
+        pos = precompute_freqs_cis_2d(self.max_freqs ** 2 * 2, patch_size, patch_size).real
+        pos = pos[None, :, :].to(device=device, dtype=dtype)
+        return pos
+
+
+    def forward(self, inputs):
+        B, P2, C = inputs.shape
+        patch_size = int(P2 ** 0.5)
+        device = inputs.device
+        dtype = inputs.dtype
+        dct = self.fetch_pos(patch_size, device, dtype)
+        dct = dct.repeat(B, 1, 1)
+        inputs = torch.cat([inputs, dct], dim=-1)
+        inputs = self.embedder(inputs)
+        return inputs
+
+class SimpleMLPAdaLN(nn.Module):
+    """
+    The MLP for Diffusion Loss.
+    :param in_channels: channels in the input Tensor.
+    :param model_channels: base channel count for the model.
+    :param out_channels: channels in the output Tensor.
+    :param z_channels: channels in the condition.
+    :param num_res_blocks: number of residual blocks per downsample.
+    """
+
+    def __init__(
+        self,
+        in_channels,
+        model_channels,
+        out_channels,
+        z_channels,
+        num_res_blocks,
+        patch_size,
+        grad_checkpointing=False
+    ):
+        super().__init__()
+
+        self.in_channels = in_channels
+        self.model_channels = model_channels
+        self.out_channels = out_channels
+        self.num_res_blocks = num_res_blocks
+        self.grad_checkpointing = grad_checkpointing
+        self.patch_size = patch_size
+
+        self.cond_embed = nn.Linear(z_channels, patch_size**2*model_channels)
+
+        self.input_proj = nn.Linear(in_channels, model_channels)
+        
+        res_blocks = []
+        for i in range(num_res_blocks):
+            res_blocks.append(ResBlock(
+                model_channels,
+            ))
+
+        self.res_blocks = nn.ModuleList(res_blocks)
+        self.final_layer = FinalLayer(model_channels, out_channels)
+
+        self.initialize_weights()
+
+    def initialize_weights(self):
+        def _basic_init(module):
+            if isinstance(module, nn.Linear):
+                torch.nn.init.xavier_uniform_(module.weight)
+                if module.bias is not None:
+                    nn.init.constant_(module.bias, 0)
+        self.apply(_basic_init)
+
+        # Zero-out adaLN modulation layers
+        for block in self.res_blocks:
+            nn.init.constant_(block.adaLN_modulation[-1].weight, 0)
+            nn.init.constant_(block.adaLN_modulation[-1].bias, 0)
+
+        # Zero-out output layers
+        nn.init.constant_(self.final_layer.linear.weight, 0)
+        nn.init.constant_(self.final_layer.linear.bias, 0)
+
+    def forward(self, x, c):
+        """
+        Apply the model to an input batch.
+        :param x: an [N x C] Tensor of inputs.
+        :param t: a 1-D batch of timesteps.
+        :param c: conditioning from AR transformer.
+        :return: an [N x C] Tensor of outputs.
+        """
+        x = self.input_proj(x)
+        c = self.cond_embed(c)
+
+        y = c.reshape(-1, self.patch_size**2, self.model_channels)
+
+        for block in self.res_blocks:
+            x = block(x, y)
+
+        return self.final_layer(x)
+
+
+class FinalLayer(nn.Module):
+    """
+    The final layer adopted from DiT.
+    """
+    def __init__(self, model_channels, out_channels):
+        super().__init__()
+        self.norm_final = nn.LayerNorm(model_channels, elementwise_affine=False, eps=1e-6)
+        self.linear = nn.Linear(model_channels, out_channels, bias=True)
+
+    def forward(self, x):
+        x = self.norm_final(x)
+        x = self.linear(x)
+        return x
+
+#################################################################################
+#                   Sine/Cosine Positional Embedding Functions                  #
+#################################################################################
+# https://github.com/facebookresearch/mae/blob/main/util/pos_embed.py
+
+
+def get_2d_sincos_pos_embed(embed_dim, grid_size, cls_token=False, extra_tokens=0, pe_interpolation=1.0):
+    """
+    grid_size: int of the grid height and width
+    return:
+    pos_embed: [grid_size*grid_size, embed_dim] or [1+grid_size*grid_size, embed_dim] (w/ or w/o cls_token)
+    """
+    grid_h = np.arange(grid_size, dtype=np.float32) / pe_interpolation
+    grid_w = np.arange(grid_size, dtype=np.float32) / pe_interpolation
+    grid = np.meshgrid(grid_w, grid_h)  # here w goes first
+    grid = np.stack(grid, axis=0)
+
+    grid = grid.reshape([2, 1, grid_size, grid_size])
+    pos_embed = get_2d_sincos_pos_embed_from_grid(embed_dim, grid)
+    if cls_token and extra_tokens > 0:
+        pos_embed = np.concatenate([np.zeros([extra_tokens, embed_dim]), pos_embed], axis=0)
+    return pos_embed
+
+
+def get_2d_sincos_pos_embed_from_grid(embed_dim, grid):
+    assert embed_dim % 2 == 0
+
+    # use half of dimensions to encode grid_h
+    emb_h = get_1d_sincos_pos_embed_from_grid(embed_dim // 2, grid[0])  # (H*W, D/2)
+    emb_w = get_1d_sincos_pos_embed_from_grid(embed_dim // 2, grid[1])  # (H*W, D/2)
+
+    emb = np.concatenate([emb_h, emb_w], axis=1)  # (H*W, D)
+    return emb
+
+
+def get_1d_sincos_pos_embed_from_grid(embed_dim, pos):
+    """
+    embed_dim: output dimension for each position
+    pos: a list of positions to be encoded: size (M,)
+    out: (M, D)
+    """
+    assert embed_dim % 2 == 0
+    omega = np.arange(embed_dim // 2, dtype=np.float64)
+    omega /= embed_dim / 2.0
+    omega = 1.0 / 10000**omega  # (D/2,)
+
+    pos = pos.reshape(-1)  # (M,)
+    out = np.einsum("m,d->md", pos, omega)  # (M, D/2), outer product
+
+    emb_sin = np.sin(out)  # (M, D/2)
+    emb_cos = np.cos(out)  # (M, D/2)
+
+    emb = np.concatenate([emb_sin, emb_cos], axis=1)  # (M, D)
+    return emb
+
+# --------------------------------------------------------
+# Interpolate position embeddings for high-resolution
+# References:
+# DeiT: https://github.com/facebookresearch/deit
+# --------------------------------------------------------
+def interpolate_pos_embed(model_path, pe_key: str = "gen_pos_embed", new_len: int = 4096):
+    state_dict = torch.load(model_path, map_location="cpu")
+
+    pos_embed_1d = state_dict[pe_key]
+    _, ori_len, embed_dim = pos_embed_1d.shape
+
+    ori_size = int(ori_len**0.5)
+    new_size = int(new_len**0.5)
+
+    if ori_size != new_size:
+        logger.info("Position interpolate from %dx%d to %dx%d" % (ori_size, ori_size, new_size, new_size))
+        pos_embed_2d = pos_embed_1d.reshape(-1, ori_size, ori_size, embed_dim).permute(0, 3, 1, 2)
+        pos_embed_2d = torch.nn.functional.interpolate(
+            pos_embed_2d, size=(new_size, new_size), mode="bicubic", align_corners=False
+        )
+        pos_embed_1d = pos_embed_2d.permute(0, 2, 3, 1).flatten(1, 2)
+        state_dict[pe_key] = pos_embed_1d
+
+    torch.save(state_dict, model_path)
+
+class PositionEmbedding(nn.Module):
+    def __init__(self, max_num_patch_per_side, hidden_size):
+        super().__init__()
+        self.max_num_patch_per_side = max_num_patch_per_side
+        self.hidden_size = hidden_size
+        self.pos_embed = nn.Parameter(
+            torch.zeros(max_num_patch_per_side ** 2, hidden_size), 
+            requires_grad=False
+        )
+        self._init_weights()
+
+    def _init_weights(self):
+        # Initialize (and freeze) pos_embed by sin-cos embedding:
+        pos_embed = get_2d_sincos_pos_embed(self.hidden_size, self.max_num_patch_per_side)
+        self.pos_embed.data.copy_(torch.from_numpy(pos_embed).float())
+
+    def forward(self, position_ids):
+        return self.pos_embed[position_ids]
+
+
+class ResidualConvBlock(nn.Module):
+    def __init__(self, channels: int):
+        super().__init__()
+        self.block = nn.Sequential(
+            nn.Conv2d(channels, channels, kernel_size=3, padding=1),
+            nn.SiLU(),
+            nn.Conv2d(channels, channels, kernel_size=3, padding=1),
+        )
+        nn.init.zeros_(self.block[2].weight)
+        nn.init.zeros_(self.block[2].bias)
+
+    def forward(self, x):
+        return x + self.block(x)
+
+
+class PostConvSmoother(nn.Module):
+    def __init__(self, in_channels=3, hidden_channels=64, num_blocks=3):
+        super().__init__()
+        self.in_proj = nn.Conv2d(in_channels, hidden_channels, kernel_size=3, padding=1)
+        self.blocks = nn.Sequential(*[ResidualConvBlock(hidden_channels) for _ in range(num_blocks)])
+        self.out_proj = nn.Conv2d(hidden_channels, in_channels, kernel_size=1)
+
+        nn.init.zeros_(self.out_proj.weight)
+        nn.init.zeros_(self.out_proj.bias)
+
+    def forward(self, x):
+        h = self.in_proj(x)
+        h = self.blocks(h)
+        return x + self.out_proj(h)
+
+
+class ProgressiveConvDecoder(nn.Module):
+    def __init__(self, hidden_dim=4096, out_channels=3):
+        super().__init__()
+        
+        # self.proj = nn.Linear(hidden_dim, 1024)
+        # self.act = nn.SiLU()
+        
+        self.up_blocks = nn.ModuleList([
+            nn.Sequential(
+                nn.Upsample(scale_factor=2, mode='nearest'),
+                nn.Conv2d(hidden_dim, 512, kernel_size=3, padding=1),
+                nn.GroupNorm(32, 512),
+                nn.SiLU()
+            ),
+            nn.Sequential(
+                nn.Upsample(scale_factor=2, mode='nearest'),
+                nn.Conv2d(512, 256, kernel_size=3, padding=1),
+                nn.GroupNorm(32, 256),
+                nn.SiLU()
+            ),
+            nn.Sequential(
+                nn.Upsample(scale_factor=2, mode='nearest'),
+                nn.Conv2d(256, 64, kernel_size=3, padding=1),
+                nn.GroupNorm(32, 64),
+                nn.SiLU()
+            ),
+            nn.Sequential(
+                nn.Upsample(scale_factor=2, mode='nearest'),
+                nn.Conv2d(64, 32, kernel_size=3, padding=1),
+                nn.GroupNorm(16, 32),
+                nn.SiLU()
+            ),
+            nn.Sequential(
+                nn.Upsample(scale_factor=2, mode='nearest'),
+                nn.Conv2d(32, 16, kernel_size=3, padding=1),
+                nn.SiLU()
+            )
+        ])
+        
+        self.out_conv = nn.Conv2d(16, out_channels, kernel_size=3, padding=1)
+
+    def forward(self, x_2d):
+        # B, C, H, W = x_2d.shape
+        # x = x_2d.permute(0, 2, 3, 1).contiguous() # (B, H, W, C)
+        # x = self.proj(x)
+        # x = self.act(x)
+        # x = x.permute(0, 3, 1, 2).contiguous()    # (B, 512, H, W)
+        x = x_2d
+        for block in self.up_blocks:
+            x = block(x)
+            
+        out = self.out_conv(x)
+        return out
+
+
+class PatchDecoder_postps(nn.Module):
+    def __init__(self):
+        super().__init__()
+        # layer 1: H/32 -> H/8 (4x upscale)
+      
+        self.conv1 = nn.Conv2d(4096, 4096, kernel_size=3, padding=1)
+        self.ps1 = nn.PixelShuffle(4)
+        self.act1 = nn.GELU()
+
+        # layer 2: H/8 -> H (8x upscale)
+        self.conv2 = nn.Conv2d(256, 192, kernel_size=3, padding=1)
+        self.ps2 = nn.PixelShuffle(8)
+
+    def forward(self, x):
+        # x shape: [B, 4096, H/32, W/32]
+        x = self.ps1(self.act1(self.conv1(x))) # -> [B, 256, H/8, W/8]        
+        x = self.ps2(self.conv2(x)) # -> [B, 3, H, W]
+        return x
+
+
+class PatchDecoder_preps(nn.Module):
+    def __init__(self):
+        super().__init__()
+        # layer 1: H/32 -> H/16 (2x upscale)
+        self.ps1 = nn.PixelShuffle(2)
+        self.conv1 = nn.Conv2d(1024, 1024, kernel_size=3, padding=1)
+        self.act1 = nn.GELU()
+
+        # layer 2: H/16 -> H/8 (2x upscale)
+        self.ps2 = nn.PixelShuffle(2)
+        self.conv2 = nn.Conv2d(256, 256, kernel_size=3, padding=1)
+        self.act2 = nn.GELU()
+
+        # layer 3: H/8 -> H (8x upscale)
+        self.ps3 = nn.PixelShuffle(8)
+        self.conv3 = nn.Conv2d(4, 3, kernel_size=3, padding=1)
+
+    def forward(self, x):
+        # x shape: [B, 4096, H/32, W/32]
+        x = self.act1(self.conv1(self.ps1((x)))) # -> [B, 256, H/16, W/16]
+        x = self.act2(self.conv2(self.ps2((x)))) # -> [B, 256, H/8, W/8]
+        x = self.conv3(self.ps3((x))) # -> [B, 3, H, W]
+        return x
+
+class PatchDecoder_preps1(nn.Module):
+    def __init__(self):
+        super().__init__()
+        # layer 1: H/32 -> H/16 (2x upscale)
+        self.ps1 = nn.PixelShuffle(2)
+        self.conv1 = nn.Conv2d(1024, 1024, kernel_size=3, padding=1)
+        self.act1 = nn.GELU()
+
+        # layer 2: H/16 -> H/8 (2x upscale)
+        self.ps2 = nn.PixelShuffle(2)
+        self.conv2 = nn.Conv2d(256, 192, kernel_size=3, padding=1)
+
+        # layer 3: H/8 -> H (8x upscale)
+        self.ps3 = nn.PixelShuffle(8)
+
+    def forward(self, x):
+        # x shape: [B, 4096, H/32, W/32]
+        x = self.act1(self.conv1(self.ps1((x)))) # -> [B, 256, H/16, W/16]
+        x = self.ps3(self.conv2(self.ps2((x)))) # -> [B, 256, H/8, W/8]
+        return x
+
+class ConvDecoder(nn.Module):
+    def __init__(self, input_dim=4096, hidden_dim=1024):
+        super().__init__()
+        # layer 1: H/32 -> H/16 (2x upscale)
+        self.ps1 = nn.PixelShuffle(2)
+        self.conv1 = nn.Conv2d(input_dim // 4, hidden_dim, kernel_size=3, padding=1)
+        self.act1 = nn.GELU()
+
+        # layer 2: H/16 -> H/8 (2x upscale)
+        self.ps2 = nn.PixelShuffle(2)
+        self.conv2 = nn.Conv2d(hidden_dim // 4, 192, kernel_size=3, padding=1)
+
+        # layer 3: H/8 -> H (8x upscale)
+        self.ps3 = nn.PixelShuffle(8)
+
+    def forward(self, x):
+        x = self.act1(self.conv1(self.ps1((x))))
+        x = self.ps3(self.conv2(self.ps2((x))))
+        return x

--- a/xinference/thirdparty/sensenova_u1/models/neo_unify/modeling_neo_chat.py
+++ b/xinference/thirdparty/sensenova_u1/models/neo_unify/modeling_neo_chat.py
@@ -1,0 +1,1992 @@
+from typing import List, Optional, Tuple, Union
+import math
+import os
+import torch.utils.checkpoint
+from torch import nn
+import transformers
+from torch.nn import CrossEntropyLoss
+from transformers import GenerationConfig
+from transformers.modeling_outputs import CausalLMOutputWithPast
+from transformers.modeling_utils import PreTrainedModel
+from transformers.utils import logging
+
+from .configuration_neo_chat import NEOChatConfig, NEOMoELLMConfig
+from .conversation import get_conv_template
+from .modeling_neo_vit import NEOVisionModel
+from .modeling_qwen3 import Qwen3ForCausalLM, create_block_causal_mask
+from .modeling_qwen3_moe import Qwen3MoeForCausalLM
+from .modeling_fm_modules import PositionEmbedding, TimestepEmbedder, FlowMatchingHead, RMSNorm, NerfEmbedder, SimpleMLPAdaLN, ConvDecoder
+from .utils import load_image_native, SYSTEM_MESSAGE_FOR_GEN
+
+logger = logging.get_logger(__name__)
+
+
+def version_cmp(v1, v2, op='eq'):
+    import operator
+
+    from packaging import version
+    op_func = getattr(operator, op)
+    return op_func(version.parse(v1), version.parse(v2))
+
+def prepare_flash_kv_cache(
+    past_key_values,
+    current_len: int,
+    batch_size: int,
+):
+    """
+    Convert prefix cache from [B, H, S, D] to flash-attn friendly [B, S, H, D],
+    and preallocate full KV buffer for [prefix + current].
+
+    This is done once before denoising loop.
+    """
+    if past_key_values is None:
+        return
+
+    for layer in past_key_values.layers:
+        past_k = layer.keys
+        past_v = layer.values
+
+        if past_k is None or past_v is None:
+            layer.flash_prefix_len = 0
+            layer.flash_total_len = current_len
+            layer.flash_k_cache = None
+            layer.flash_v_cache = None
+            continue
+
+        # original cache layout assumed: [B, H, S, D]
+        past_k_flash = past_k.transpose(1, 2).contiguous()  # [B, S, H, D]
+        past_v_flash = past_v.transpose(1, 2).contiguous()  # [B, S, H, D]
+
+        prefix_len = past_k_flash.shape[1]
+        total_len = prefix_len + current_len
+
+        k_cache = torch.empty(
+            (batch_size, total_len, past_k_flash.shape[2], past_k_flash.shape[3]),
+            device=past_k_flash.device,
+            dtype=past_k_flash.dtype,
+        )
+        v_cache = torch.empty(
+            (batch_size, total_len, past_v_flash.shape[2], past_v_flash.shape[3]),
+            device=past_v_flash.device,
+            dtype=past_v_flash.dtype,
+        )
+
+        k_cache[:, :prefix_len].copy_(past_k_flash)
+        v_cache[:, :prefix_len].copy_(past_v_flash)
+
+        layer.flash_prefix_len = prefix_len
+        layer.flash_total_len = total_len
+        layer.flash_k_cache = k_cache
+        layer.flash_v_cache = v_cache
+
+def clear_flash_kv_cache(past_key_values):
+    if past_key_values is None:
+        return
+    for layer in past_key_values.layers:
+        if hasattr(layer, "flash_prefix_len"):
+            delattr(layer, "flash_prefix_len")
+        if hasattr(layer, "flash_total_len"):
+            delattr(layer, "flash_total_len")
+        if hasattr(layer, "flash_k_cache"):
+            delattr(layer, "flash_k_cache")
+        if hasattr(layer, "flash_v_cache"):
+            delattr(layer, "flash_v_cache")
+
+def optimized_scale(positive_flat, negative_flat):
+    # Force the divisor computation to float32 regardless of the surrounding
+    # autocast (the squared-norm/division is what we don't want in fp16/bf16).
+    # ``device_type`` is taken from the input so this runs equally on CUDA and
+    # XPU; ``mps`` is rerouted to ``cpu`` because torch.autocast rejects it.
+    device_type = positive_flat.device.type
+    if device_type == "mps":
+        device_type = "cpu"
+    with torch.autocast(device_type=device_type, enabled=False):
+        positive_flat = positive_flat.float()
+        negative_flat = negative_flat.float()
+
+        # Calculate dot production
+        dot_product = torch.sum(positive_flat * negative_flat, dim=1, keepdim=True)
+
+        # Squared norm of uncondition
+        squared_norm = torch.sum(negative_flat ** 2, dim=1, keepdim=True) + 1e-8
+
+        # st_star = v_cond^T * v_uncond / ||v_uncond||^2
+        st_star = dot_product / squared_norm
+
+    return st_star
+
+def build_abs_positions_from_grid_hw(grid_hw: torch.Tensor, device=None):
+    """
+    Compute patch coordinates (x, y)
+
+    Args:
+        grid_hw: (B, 2) tensor representing (H, W) per image
+    """
+    device = grid_hw.device
+    B = grid_hw.shape[0]
+
+    # Get the number of patches per image
+    H = grid_hw[:, 0]
+    W = grid_hw[:, 1]
+    N = H * W
+    N_total = N.sum()
+
+    # Create the batch index for each patch (B x patch count)
+    patch_to_sample = torch.repeat_interleave(torch.arange(B, device=device), N)  # (N_total,)
+
+    # Generate intra-image patch index (row-major order)
+    patch_id_within_image = torch.arange(N_total, device=device)
+    patch_id_within_image = patch_id_within_image - torch.cumsum(
+        torch.cat([torch.tensor([0], device=device), N[:-1]]), dim=0
+    )[patch_to_sample]
+
+    # Get H/W for each patch according to its image
+    W_per_patch = W[patch_to_sample]
+    abs_x = patch_id_within_image % W_per_patch
+    abs_y = patch_id_within_image // W_per_patch
+
+    return abs_x, abs_y
+
+
+class NEOChatModel(PreTrainedModel):
+    config_class = NEOChatConfig
+    main_input_name = 'pixel_values'
+    base_model_prefix = 'language_model'
+    _supports_flash_attn_2 = True
+    supports_gradient_checkpointing = True
+    _no_split_modules = [
+        "NEOVisionModel",
+        "Qwen3DecoderLayer",
+        "Qwen3MoeDecoderLayer",
+    ]
+    _denoise_offload_module_paths = (
+        "language_model.model.embed_tokens",
+        "language_model.lm_head",
+    )
+
+    # support transformers 4.51.+
+    _tp_plan = ''
+
+    def __init__(self, config: NEOChatConfig, vision_model=None, language_model=None, use_flash_attn=True):
+        super().__init__(config)
+
+        assert version_cmp(transformers.__version__, '4.37.0', 'ge')
+        patch_size = config.vision_config.patch_size
+        self.patch_size = patch_size
+        self.template = config.template
+        self.downsample_ratio = config.downsample_ratio
+        config.llm_config._attn_implementation = 'eager'
+
+        if vision_model is not None:
+            self.vision_model = vision_model
+        else:
+            self.vision_model = NEOVisionModel(config.vision_config)
+            vision_model_mot_gen = NEOVisionModel(config.vision_config)
+        if language_model is not None:
+            self.language_model = language_model
+        else:
+            # Pick the right backbone class based on the LLM config: dense
+            # Qwen3 (DANCE family) or Qwen3-MoE (A3B family). The two share
+            # the same NEO-Unify two-branch attention/norm layout, so the
+            # rest of this class works against either.
+            if isinstance(config.llm_config, NEOMoELLMConfig):
+                self.language_model = Qwen3MoeForCausalLM(config.llm_config)
+            else:
+                self.language_model = Qwen3ForCausalLM(config.llm_config)
+
+        merge_size = int(1 / self.downsample_ratio)
+        output_dim = 3*(patch_size*merge_size)**2
+        llm_hidden_size = self.config.llm_config.hidden_size
+        self.use_deep_fm_head = self.config.fm_head_layers > 2
+        self.use_pixel_head = self.config.use_pixel_head
+        if self.use_deep_fm_head:
+                fm_head = FlowMatchingHead(llm_hidden_size, output_dim, dim=self.config.fm_head_dim, layers=self.config.fm_head_layers, mlp_ratio=self.config.fm_head_mlp_ratio)
+        else:
+            fm_head = nn.Sequential(
+                    nn.Linear(llm_hidden_size, 4096, bias=True),
+                    nn.GELU(),
+                    nn.Linear(4096, output_dim, bias=True),
+                )
+
+        timestep_embedder = TimestepEmbedder(llm_hidden_size)
+        self.fm_modules = nn.ModuleDict(
+                    {   
+                        "vision_model_mot_gen": vision_model_mot_gen,
+                        "timestep_embedder": timestep_embedder,
+                        "fm_head": fm_head
+                    }
+                )
+
+        if self.use_pixel_head:
+            self.fm_modules["fm_head"] = ConvDecoder(llm_hidden_size)
+
+        self.concat_time_token_num = config.concat_time_token_num
+        self.noise_scale = config.noise_scale
+        self.noise_scale_mode = config.noise_scale_mode
+        self.noise_scale_base_image_seq_len = config.noise_scale_base_image_seq_len
+        self.add_noise_scale_embedding = config.add_noise_scale_embedding
+        self.noise_scale_max_value = config.noise_scale_max_value
+        self.time_schedule = config.time_schedule
+        self.time_shift_type = config.time_shift_type
+        self.base_shift = config.base_shift
+        self.max_shift = config.max_shift
+        self.base_image_seq_len = config.base_image_seq_len
+        self.max_image_seq_len = config.max_image_seq_len
+
+        if self.add_noise_scale_embedding:
+            noise_scale_embedder = TimestepEmbedder(llm_hidden_size)
+            self.fm_modules['noise_scale_embedder'] = noise_scale_embedder
+
+
+        self.img_context_token_id = None
+        self.img_start_token_id = 151670
+        self.last_think_content = ""
+        self.conv_template = get_conv_template(self.template)
+        self.system_message = self.conv_template.system_message
+
+        # Transformers 5 builds composite-model metadata (including
+        # ``all_tied_weights_keys``) in ``post_init``.  Without this call a
+        # real checkpoint reaches the final loading pass with that metadata
+        # missing, even though the nested language model initialized it.
+        self.post_init()
+
+    def _notify_layer_offload_phase(self, phase: str) -> None:
+        callback = getattr(self, "_layer_offload_phase_callback", None)
+        if callback is not None:
+            callback(phase)
+
+    def forward(
+            self,
+            pixel_values: torch.FloatTensor,
+            input_ids: torch.LongTensor = None,
+            attention_mask: Optional[torch.Tensor] = None,
+            position_ids: Optional[torch.LongTensor] = None,
+            image_flags: Optional[torch.LongTensor] = None,
+            past_key_values: Optional[List[torch.FloatTensor]] = None,
+            labels: Optional[torch.LongTensor] = None,
+            use_cache: Optional[bool] = None,
+            output_attentions: Optional[bool] = None,
+            output_hidden_states: Optional[bool] = None,
+            return_dict: Optional[bool] = None,
+    ) -> Union[Tuple, CausalLMOutputWithPast]:
+        raise NotImplementedError('forward')
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+
+        image_flags = image_flags.squeeze(-1)
+        input_embeds = self.language_model.get_input_embeddings()(input_ids).clone()
+
+        vit_embeds = self.extract_feature(pixel_values)
+        vit_embeds = vit_embeds[image_flags == 1]
+
+        B, N, C = input_embeds.shape
+        input_embeds = input_embeds.reshape(B * N, C)
+
+        # if torch.distributed.is_initialized() and torch.distributed.get_rank() == 0:
+        #     print(f'dynamic ViT batch size: {vit_batch_size}, images per sample: {vit_batch_size / B}, dynamic token length: {N}')
+
+        input_ids = input_ids.reshape(B * N)
+        selected = (input_ids == self.img_context_token_id)
+        try:
+            input_embeds[selected] = input_embeds[selected] * 0.0 + vit_embeds.reshape(-1, C)
+        except Exception as e:
+            vit_embeds = vit_embeds.reshape(-1, C)
+            print(f'warning: {e}, input_embeds[selected].shape={input_embeds[selected].shape}, '
+                  f'vit_embeds.shape={vit_embeds.shape}')
+            n_token = min(selected.sum(), vit_embeds.size(0))
+            input_embeds[selected][:n_token] = input_embeds[selected][:n_token] * 0.0 + vit_embeds[:n_token]
+
+        input_embeds = input_embeds.reshape(B, N, C)
+
+        outputs = self.language_model(
+            inputs_embeds=input_embeds,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            use_cache=use_cache,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict=return_dict,
+        )
+        logits = outputs.logits
+
+        loss = None
+        if labels is not None:
+            # Shift so that tokens < n predict n
+            shift_logits = logits[..., :-1, :].contiguous()
+            shift_labels = labels[..., 1:].contiguous()
+            # Flatten the tokens
+            loss_fct = CrossEntropyLoss()
+            shift_logits = shift_logits.view(-1, self.language_model.config.vocab_size)
+            shift_labels = shift_labels.view(-1)
+            # Enable model parallelism
+            shift_labels = shift_labels.to(shift_logits.device)
+            loss = loss_fct(shift_logits, shift_labels)
+
+        if not return_dict:
+            output = (logits,) + outputs[1:]
+            return (loss,) + output if loss is not None else output
+
+        return CausalLMOutputWithPast(
+            loss=loss,
+            logits=logits,
+            past_key_values=outputs.past_key_values,
+            hidden_states=outputs.hidden_states,
+            attentions=outputs.attentions,
+        )
+
+    def extract_feature(self, pixel_values, gen_model=False, grid_hw=None):
+        if gen_model:
+            return self.fm_modules['vision_model_mot_gen'](pixel_values=pixel_values, 
+                                 output_hidden_states=False, 
+                                 return_dict=True, 
+                                 grid_hw=grid_hw).last_hidden_state
+        else:
+            return self.vision_model(pixel_values=pixel_values, 
+                                 output_hidden_states=False, 
+                                 return_dict=True, 
+                                 grid_hw=grid_hw).last_hidden_state
+
+    def batch_chat(self, tokenizer, pixel_values, questions, generation_config, num_patches_list=None,
+                   history=None, return_history=False, IMG_START_TOKEN='<img>', IMG_END_TOKEN='</img>',
+                   IMG_CONTEXT_TOKEN='<IMG_CONTEXT>', verbose=False, image_counts=None):
+        raise NotImplementedError('batch_chat')
+        if history is not None or return_history:
+            print('Now multi-turn chat is not supported in batch_chat.')
+            raise NotImplementedError
+
+        if image_counts is not None:
+            num_patches_list = image_counts
+            print('Warning: `image_counts` is deprecated. Please use `num_patches_list` instead.')
+
+        img_context_token_id = tokenizer.convert_tokens_to_ids(IMG_CONTEXT_TOKEN)
+        self.img_context_token_id = img_context_token_id
+
+        if verbose and pixel_values is not None:
+            image_bs = pixel_values.shape[0]
+            print(f'dynamic ViT batch size: {image_bs}')
+
+        queries = []
+        for idx, num_patches in enumerate(num_patches_list):
+            question = questions[idx]
+            if pixel_values is not None and '<image>' not in question:
+                question = '<image>\n' + question
+            template = get_conv_template(self.template)
+            template.system_message = self.system_message
+            template.append_message(template.roles[0], question)
+            template.append_message(template.roles[1], None)
+            query = template.get_prompt()
+
+            image_tokens = IMG_START_TOKEN + IMG_CONTEXT_TOKEN + IMG_END_TOKEN
+            query = query.replace('<image>', image_tokens, 1)
+            queries.append(query)
+
+        tokenizer.padding_side = 'left'
+        model_inputs = tokenizer(queries, return_tensors='pt', padding=True)
+        input_ids = model_inputs['input_ids'].to(self.device)
+        attention_mask = model_inputs['attention_mask'].to(self.device)
+        eos_token_id = tokenizer.convert_tokens_to_ids(template.sep.strip())
+        generation_config['eos_token_id'] = eos_token_id
+        generation_output = self.generate(
+            pixel_values=pixel_values,
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            **generation_config
+        )
+        responses = tokenizer.batch_decode(generation_output, skip_special_tokens=True)
+        responses = [response.split(template.sep.strip())[0].strip() for response in responses]
+        return responses
+    
+    def patchify(self, images, patch_size, channel_first=False):
+        """
+        images: (N, 3, H, W)
+        x: (N, L, patch_size**2 *3)
+        """
+        h, w = images.shape[2] // patch_size, images.shape[3] // patch_size
+        x = images.reshape(shape=(images.shape[0], 3, h, patch_size, w, patch_size))
+
+        if channel_first:
+            x = torch.einsum('nchpwq->nhwcpq', x)
+        else:
+            x = torch.einsum('nchpwq->nhwpqc', x)
+        
+        x = x.reshape(shape=(images.shape[0], h * w, patch_size**2 * 3))
+        return x
+    
+    def unpatchify(sle, x, patch_size, h=None, w=None):
+        """
+        x: (N, L, patch_size**2 *3)
+        images: (N, 3, H, W)
+        """
+        if h is None or w is None:
+            h = w = int(x.shape[1]**.5)
+        else:
+            h = h // patch_size
+            w = w // patch_size        
+        x = x.reshape(shape=(x.shape[0], h, w, patch_size, patch_size, 3))
+        x = torch.einsum('nhwpqc->nchpwq', x)
+        images = x.reshape(shape=(x.shape[0], 3, h * patch_size, w * patch_size))
+        return images
+    
+    def _euler_step(self, v_pred, z, t, t_next):
+        z_next = z + (t_next - t) * v_pred
+        return z_next
+
+    def _calculate_dynamic_mu(self, image_seq_len: int) -> float:
+        denom = self.max_image_seq_len - self.base_image_seq_len
+        if denom == 0:
+            return float(self.base_shift)
+        m = (self.max_shift - self.base_shift) / denom
+        b = self.base_shift - m * self.base_image_seq_len
+        return float(image_seq_len) * m + b
+
+    def _apply_time_schedule(self, t: torch.Tensor, image_seq_len: int, timestep_shift: float) -> torch.Tensor:
+        self.time_schedule = "standard"
+        sigma = 1 - t
+        if timestep_shift != 1:
+            self.time_schedule = "standard"
+        if self.time_schedule == "standard":
+            shift = timestep_shift
+            sigma = shift * sigma / (1 + (shift - 1) * sigma)
+        elif self.time_schedule == "dynamic":
+            mu = self._calculate_dynamic_mu(image_seq_len)
+            mu_t = t.new_tensor(mu)
+            if self.time_shift_type == "exponential":
+                shift = torch.exp(mu_t)
+                sigma = shift * sigma / (1 + (shift - 1) * sigma)
+            elif self.time_shift_type == "linear":
+                sigma = mu_t / (mu_t + (1 / sigma - 1))
+            else:
+                raise ValueError(f"Unsupported time_shift_type: {self.time_shift_type}")
+        else:
+            raise ValueError(f"Unsupported time_schedule: {self.time_schedule}")
+        return 1 - sigma
+
+    def _build_t2i_query(self, prompt_text, system_message=None, append_text=None):
+        template = get_conv_template(self.template)
+        template.system_message = self.system_message if system_message is None else system_message
+        template.append_message(template.roles[0], prompt_text)
+        template.append_message(template.roles[1], None)
+        if append_text is not None:
+            return template.get_prompt() + append_text
+        return template.get_prompt()
+
+    def _build_t2i_text_inputs(self, tokenizer, query: str):
+        model_inputs = tokenizer(query, return_tensors="pt")
+        input_ids = model_inputs["input_ids"].to(self.device)
+
+        t_idx = torch.arange(0, input_ids.shape[1], dtype=torch.long, device=input_ids.device)
+        h_idx = torch.zeros_like(t_idx)
+        w_idx = torch.zeros_like(t_idx)
+        indexes = torch.stack([t_idx, h_idx, w_idx], dim=0)
+
+        attention_mask = {"full_attention": create_block_causal_mask(indexes[0])}
+        return input_ids, indexes, attention_mask
+    
+    def _build_t2i_image_indexes(self, token_h, token_w, text_len, device):
+        t_image = torch.full((token_h * token_w,), text_len, dtype=torch.long, device=device)
+        idx = torch.arange(token_h * token_w, device=device, dtype=torch.long)
+        h_image = idx // token_w
+        w_image = idx % token_w
+        return torch.stack([t_image, h_image, w_image], dim=0)
+    
+    def _t2i_prefix_forward(self, input_ids, indexes, attention_mask):
+        out = self.language_model.model(
+            input_ids=input_ids,
+            indexes=indexes,
+            attention_mask=attention_mask,
+            use_cache=True,
+        )
+        return out.past_key_values, out.last_hidden_state
+
+    def _it2i_prefix_forward(self, input_imbeds, indexes, attention_mask, gen_indicators=None):
+        out = self.language_model.model(
+            inputs_embeds=input_imbeds,
+            indexes=indexes,
+            attention_mask=attention_mask,
+            use_cache=True,
+            image_gen_indicators=gen_indicators.view(1, -1) if gen_indicators is not None else None
+        )
+        return out.past_key_values, out.last_hidden_state
+
+    def _think_prefix_forward(self, **kwargs):
+        """Build the Think prefix cache without materialising per-token logits."""
+        return self.language_model(use_cache=True, logits_to_keep=1, **kwargs)
+
+    def _append_text_tokens_to_cache(self, cache, t_idx, input_ids):
+        if input_ids.shape[1] == 0:
+            return t_idx
+
+        device = input_ids.device
+        seq_len = input_ids.shape[1]
+        inputs_embeds = self.language_model.get_input_embeddings()(input_ids)
+
+        t_indexes = torch.arange(t_idx + 1, t_idx + 1 + seq_len, dtype=torch.long, device=device)
+        h_indexes = torch.zeros(seq_len, dtype=torch.long, device=device)
+        w_indexes = torch.zeros(seq_len, dtype=torch.long, device=device)
+        indexes = torch.stack([t_indexes, h_indexes, w_indexes], dim=0)
+
+        past_len = cache.get_seq_length()
+        mask = torch.zeros(1, 1, seq_len, past_len + seq_len, device=device)
+        causal_mask = torch.tril(torch.ones(seq_len, seq_len, device=device))
+        causal_mask = torch.where(causal_mask == 1, 0.0, float('-inf'))
+        mask[:, :, :, past_len:] = causal_mask
+        attention_mask_dict = {"full_attention": mask}
+
+        self.language_model.model(
+            inputs_embeds=inputs_embeds,
+            indexes=indexes,
+            attention_mask=attention_mask_dict,
+            past_key_values=cache,
+            use_cache=True
+        )
+        return t_idx + seq_len
+
+    def _generate_think(
+        self,
+        tokenizer,
+        prefix_outputs,
+        past_key_values,
+        t_idx,
+        IMG_START_TOKEN,
+        max_think_tokens=1024,
+    ):
+        template = get_conv_template(self.template)
+        eos_token_id = tokenizer.convert_tokens_to_ids(template.sep.strip())
+        think_end_token_id = tokenizer.convert_tokens_to_ids('</think>')
+        think_token_ids = []
+        next_token = torch.argmax(prefix_outputs.logits[:, -1, :], dim=-1)
+
+        for _ in range(max_think_tokens):
+            token_item = next_token.item()
+            if token_item == eos_token_id:
+                break
+            if token_item == think_end_token_id:
+                self.language_model.model.current_index = t_idx
+                outputs = self.language_model(
+                    input_ids=next_token.unsqueeze(0),
+                    past_key_values=past_key_values,
+                    use_cache=True
+                )
+                past_key_values = outputs.past_key_values
+                t_idx += 1
+                think_token_ids.append(token_item)
+                break
+
+            think_token_ids.append(token_item)
+
+            self.language_model.model.current_index = t_idx
+            outputs = self.language_model(
+                input_ids=next_token.unsqueeze(0),
+                past_key_values=past_key_values,
+                use_cache=True
+            )
+            past_key_values = outputs.past_key_values
+            t_idx += 1
+
+            next_token = torch.argmax(outputs.logits[:, -1, :], dim=-1)
+
+        append_ids = tokenizer(
+            '\n\n' + IMG_START_TOKEN,
+            return_tensors='pt',
+            add_special_tokens=False,
+        )['input_ids'].to(self.device)
+        t_idx = self._append_text_tokens_to_cache(past_key_values, t_idx, append_ids)
+
+        think_text = tokenizer.decode(think_token_ids, skip_special_tokens=False)
+
+        return past_key_values, t_idx, think_text
+    
+    def _t2i_predict_v(self, input_embeds, indexes_image, attn_mask, past_key_values, t, z, image_token_num, timestep_embeddings=None, image_size=None):
+        B, L = z.shape[0], z.shape[1]
+
+        outputs = self.language_model.model(
+            inputs_embeds=input_embeds,
+            image_gen_indicators=torch.ones((input_embeds.shape[0], input_embeds.shape[1]), dtype=torch.bool, device=input_embeds.device),
+            indexes=indexes_image,
+            attention_mask=attn_mask,
+            past_key_values=past_key_values,
+            update_cache=False,
+            use_cache=True,
+        )
+
+        if self.use_pixel_head:
+            merge_size = int(1 / self.downsample_ratio)
+            token_h = image_size[1] // (self.patch_size * merge_size)
+            token_w = image_size[0] // (self.patch_size * merge_size)
+
+            img_reshaped = outputs.last_hidden_state[:, -image_token_num:].view(B, token_h, token_w, -1)
+            img_2d = torch.einsum("b h w c -> b c h w", img_reshaped)
+            img_2d = img_2d.contiguous().view(B, -1, token_h, token_w)
+                
+            smoothed_img_2d = self.fm_modules['fm_head'](img_2d)
+                
+            smoothed_reshaped = smoothed_img_2d.view(B, 3, token_h, self.patch_size * merge_size, token_w, self.patch_size * merge_size)
+            smoothed_reshaped = torch.einsum("b c h p w q -> b h w p q c", smoothed_reshaped)
+            out_1d = smoothed_reshaped.contiguous().view(B, L, self.patch_size * merge_size * self.patch_size * merge_size * 3)
+            x_pred = out_1d
+        else:
+            if self.use_deep_fm_head:
+                x_pred = self.fm_modules["fm_head"](
+                outputs.last_hidden_state[:, -image_token_num:].view(B*L, -1), t.repeat(B*L)
+                ).view(B, L, -1)
+            else:
+                x_pred = self.fm_modules["fm_head"](
+                    outputs.last_hidden_state[:, -image_token_num:].view(B, L, -1)
+                ).view(B, L, -1)
+            
+        
+        v_pred = (x_pred - z) / (1 - t).clamp_min(self.config.t_eps)
+        return v_pred
+    
+    def _build_it2i_inputs(self, tokenizer, query, pixel_values=None, grid_hw=None):
+        model_inputs = tokenizer(query, return_tensors="pt")
+        input_ids = model_inputs["input_ids"].to(self.device)
+
+        indexes = self.get_thw_indexes(input_ids[0], grid_hw)
+
+        attention_mask = {"full_attention": create_block_causal_mask(indexes[0])}
+
+        input_embeds = self.language_model.get_input_embeddings()(input_ids)
+        B, N, C = input_embeds.shape
+        if pixel_values is not None:
+            vit_embeds = self.extract_feature(pixel_values, grid_hw=grid_hw)
+            input_embeds = input_embeds.reshape(B * N, C)
+            input_ids = input_ids.reshape(B * N)
+            selected = (input_ids == self.img_context_token_id)
+            assert selected.sum() != 0
+            input_embeds[selected] = vit_embeds.reshape(-1, C).to(input_embeds.device)
+            input_embeds = input_embeds.reshape(B, N, C)
+
+        return input_embeds, indexes, attention_mask
+
+    @torch.no_grad()
+    def interleave_gen_image_only(
+            self,
+            tokenizer,
+            prompt,
+            gt_text,
+            images=None,
+            gt_images=None,
+            cfg_scale=1.0,
+            img_cfg_scale=1.0,
+            cfg_norm='none',
+            max_images=10,
+            enable_timestep_shift=True,
+            timestep_shift=1.0,
+            image_size=(256, 256),
+            num_steps=30,
+            IMG_START_TOKEN='<img>',
+            IMG_END_TOKEN='</img>',
+            IMG_CONTEXT_TOKEN='<IMG_CONTEXT>',
+            method='euler',
+            cfg_interval=(0, 1),
+            t_eps=0.02,
+            verbose=False,
+            system_message='',
+    ):
+        self.img_context_token_id = tokenizer.convert_tokens_to_ids(IMG_CONTEXT_TOKEN)
+        self.img_start_token_id = tokenizer.convert_tokens_to_ids(IMG_START_TOKEN)
+        self.config.t_eps = t_eps
+
+        if isinstance(image_size, tuple):
+            image_size_list = [image_size] * max_images
+        elif isinstance(image_size, list) and isinstance(image_size[0], tuple):
+            image_size_list = image_size
+            if len(image_size) < max_images:
+                image_size_list += [image_size_list[-1]] * (max_images - len(image_size_list))
+        else:
+            assert False, "image size should be a tuple or a list of tuple"
+
+        if images is None:
+            images =[]
+
+        image_token_count = prompt.count('<image>')
+        assert len(images) >= image_token_count
+        if len(images) > image_token_count:
+            prompt = "<image>\n" * (len(images) - image_token_count) + prompt
+
+        pixel_values =[]
+        grid_hw =[]
+        for image in images:
+            cur_pixel_values, cur_grid_hw = load_image_native(image, self.patch_size, self.downsample_ratio, min_pixels=512*512, max_pixels=min(2048*2048, (4096*4096)//max(1, len(images))), upscale=False)
+            grid_hw.append(cur_grid_hw.to(self.device))
+            pixel_values.append(cur_pixel_values.to(self.device).to(torch.bfloat16))
+
+        merge_size = int(1 / self.downsample_ratio)
+        pv_tensor = torch.cat(pixel_values) if pixel_values else None
+        ghw_tensor = torch.cat(grid_hw) if grid_hw else None
+
+        # Condition Initial Cache
+        template_cond = get_conv_template(self.template)
+        template_cond.system_message = system_message
+        template_cond.append_message(template_cond.roles[0], prompt)
+        template_cond.append_message(template_cond.roles[1], None)
+        query_cond = template_cond.get_prompt() + '<think>\n\n</think>\n\n'
+
+        def replace_image_tokens(query, grid_hw_list):
+            for i in range(len(grid_hw_list)):
+                num_patch_token = int(grid_hw_list[i][0, 0] * grid_hw_list[i][0, 1] * self.downsample_ratio**2)
+                image_tokens = IMG_START_TOKEN + IMG_CONTEXT_TOKEN * num_patch_token + IMG_END_TOKEN
+                query = query.replace('<image>', image_tokens, 1)
+            return query
+
+        query_cond = replace_image_tokens(query_cond, grid_hw)
+        input_embeds_cond, indexes_cond, attention_mask_cond = self._build_it2i_inputs(tokenizer, query_cond, pv_tensor, ghw_tensor)
+        
+        outputs_cond = self.language_model(inputs_embeds=input_embeds_cond, indexes=indexes_cond, attention_mask=attention_mask_cond, use_cache=True)
+        past_key_values_cond = outputs_cond.past_key_values
+        t_index_cond = indexes_cond[0].max().item()
+
+        # Text Uncondition Cache Initial
+        question_text_uncondition = '<image>' * len(images)
+        template_tu = get_conv_template(self.template)
+        template_tu.system_message = self.system_message
+        template_tu.append_message(template_tu.roles[0], question_text_uncondition)
+        template_tu.append_message(template_tu.roles[1], None)
+        query_text_uncond = template_tu.get_prompt()
+        query_text_uncond = replace_image_tokens(query_text_uncond, grid_hw)
+
+        input_embeds_tu, indexes_tu, attention_mask_tu = self._build_it2i_inputs(tokenizer, query_text_uncond, pv_tensor, ghw_tensor)
+        outputs_tu = self.language_model(inputs_embeds=input_embeds_tu, indexes=indexes_tu, attention_mask=attention_mask_tu, use_cache=True)
+        past_key_values_tu = outputs_tu.past_key_values
+        t_index_tu = indexes_tu[0].max().item()
+
+        # Img Uncondition Cache Initial
+        query_img_uncond = self._build_t2i_query("", append_text=IMG_START_TOKEN)
+        input_embeds_iu, indexes_iu, attention_mask_iu = self._build_it2i_inputs(tokenizer, query_img_uncond)
+        outputs_iu = self.language_model(inputs_embeds=input_embeds_iu, indexes=indexes_iu, attention_mask=attention_mask_iu, use_cache=True)
+        past_key_values_iu = outputs_iu.past_key_values
+
+
+        generated_images =[]
+        img_count = 0
+        device = self.device
+
+        def append_ids_to_cache(cache, t_idx, input_ids):
+            if input_ids.shape[1] == 0:
+                return t_idx
+            seq_len = input_ids.shape[1]
+            inputs_embeds = self.language_model.get_input_embeddings()(input_ids)
+            
+            t_indexes = torch.arange(t_idx + 1, t_idx + 1 + seq_len, dtype=torch.long, device=device)
+            h_indexes = torch.zeros(seq_len, dtype=torch.long, device=device)
+            w_indexes = torch.zeros(seq_len, dtype=torch.long, device=device)
+            indexes = torch.stack([t_indexes, h_indexes, w_indexes], dim=0)
+            
+            past_len = cache.get_seq_length()
+            mask = torch.zeros(1, 1, seq_len, past_len + seq_len, device=device)
+            causal_mask = torch.tril(torch.ones(seq_len, seq_len, device=device))
+            causal_mask = torch.where(causal_mask == 1, 0.0, float('-inf'))
+            mask[:, :, :, past_len:] = causal_mask
+            attention_mask_dict = {"full_attention": mask}
+            
+            self.language_model(
+                inputs_embeds=inputs_embeds,
+                indexes=indexes,
+                attention_mask=attention_mask_dict,
+                past_key_values=cache,
+                use_cache=True
+            )
+            return t_idx + seq_len
+
+        def append_image_to_cache(cache, t_idx, inputs_embeds_img, N_img_tokens, abs_pos_w, abs_pos_h):
+            past_len = cache.get_seq_length()
+            tgt_len = N_img_tokens + 1
+            
+            t_indexes = torch.zeros(tgt_len, dtype=torch.long, device=device)
+            t_indexes[:N_img_tokens] = t_idx + 1
+            t_indexes[N_img_tokens] = t_idx + 2
+            
+            h_indexes = torch.zeros(tgt_len, dtype=torch.long, device=device)
+            w_indexes = torch.zeros(tgt_len, dtype=torch.long, device=device)
+            h_indexes[:N_img_tokens] = abs_pos_h
+            w_indexes[:N_img_tokens] = abs_pos_w
+            
+            indexes = torch.stack([t_indexes, h_indexes, w_indexes], dim=0)
+            
+            mask = torch.zeros(1, 1, tgt_len, past_len + tgt_len, device=device)
+            mask[0, 0, :N_img_tokens, past_len + N_img_tokens] = float('-inf')
+            attention_mask_dict = {"full_attention": mask}
+            
+            self.language_model(
+                inputs_embeds=inputs_embeds_img,
+                indexes=indexes,
+                attention_mask=attention_mask_dict,
+                past_key_values=cache,
+                use_cache=True
+            )
+            return t_idx + 2
+
+        parts = gt_text.split('<image>')
+        img_start_id_tensor = torch.tensor([[self.img_start_token_id]], device=device)
+
+        for i, part in enumerate(parts):
+            if len(part) > 0:
+                if verbose:
+                    print(part, end='', flush=True)
+                part_ids = tokenizer(part, return_tensors='pt', add_special_tokens=False)['input_ids'].to(device)
+                t_index_cond = append_ids_to_cache(past_key_values_cond, t_index_cond, part_ids)
+
+            if i < len(parts) - 1:
+                if img_count >= max_images:
+                    break
+                    
+                if verbose:
+                    print("<image>", end='', flush=True)
+
+                t_index_cond = append_ids_to_cache(past_key_values_cond, t_index_cond, img_start_id_tensor)
+                t_index_tu = append_ids_to_cache(past_key_values_tu, t_index_tu, img_start_id_tensor)
+
+                cur_image_size = image_size_list[img_count]
+                token_h = cur_image_size[1] // (self.patch_size * merge_size)
+                token_w = cur_image_size[0] // (self.patch_size * merge_size)
+
+                indexes_image_condition = self._build_t2i_image_indexes(token_h, token_w, t_index_cond + 1, device=device)
+                indexes_image_text_uncondition = self._build_t2i_image_indexes(token_h, token_w, t_index_tu + 1, device=device)
+                indexes_image_img_uncondition = self._build_t2i_image_indexes(token_h, token_w, indexes_iu[0].max() + 1, device=device)
+
+                grid_h = cur_image_size[1] // self.patch_size
+                grid_w = cur_image_size[0] // self.patch_size
+                gen_grid_hw = torch.tensor([[grid_h, grid_w]], device=device)
+
+                noise_scale = self.noise_scale
+                if self.noise_scale_mode in ("resolution", "dynamic", 'dynamic_sqrt'):
+                    noise_scale = math.sqrt((grid_h*grid_w)/(merge_size**2) / self.noise_scale_base_image_seq_len)
+                    base = float(self.noise_scale_base_image_seq_len)
+                    noise_scale = math.sqrt((grid_h*grid_w)/(merge_size**2)/base) * float(self.noise_scale)
+                    if self.noise_scale_mode == 'dynamic_sqrt':
+                        noise_scale = math.sqrt(noise_scale)
+                noise_scale = min(noise_scale, self.noise_scale_max_value)
+                image_prediction = noise_scale * torch.randn((1, 3, cur_image_size[1], cur_image_size[0]), device=device, dtype=outputs_cond.logits.dtype)
+
+                past_key_values_cond_cfg = past_key_values_cond
+                past_key_values_tu_cfg = past_key_values_tu
+                past_key_values_iu_cfg = past_key_values_iu
+
+                # attention_mask_condition = {"full_attention": torch.zeros(1, 1, token_h*token_w, past_key_values_cond.get_seq_length() + token_h*token_w, device=device)}
+                # attention_mask_text_uncondition = {"full_attention": torch.zeros(1, 1, token_h*token_w, past_key_values_tu.get_seq_length() + token_h*token_w, device=device)}
+                # attention_mask_img_uncondition = {"full_attention": torch.zeros(1, 1, token_h*token_w, past_key_values_iu.get_seq_length() + token_h*token_w, device=device)}
+                attention_mask_condition = {"full_attention": None}
+                attention_mask_text_uncondition = {"full_attention": None}
+                attention_mask_img_uncondition = {"full_attention": None}
+
+                prepare_flash_kv_cache(
+                    past_key_values_cond_cfg,
+                    current_len=token_h * token_w,
+                    batch_size=1,
+                )
+                prepare_flash_kv_cache(
+                    past_key_values_tu_cfg,
+                    current_len=token_h * token_w,
+                    batch_size=1,
+                )
+                prepare_flash_kv_cache(
+                    past_key_values_iu_cfg,
+                    current_len=token_h * token_w,
+                    batch_size=1,
+                )
+
+                timesteps = torch.linspace(0.0, 1.0, num_steps+1, device=device)
+                if enable_timestep_shift:
+                    timesteps = self._apply_time_schedule(timesteps, token_h*token_w, timestep_shift)
+
+                step_iter = range(num_steps)
+                if verbose:
+                    try:
+                        from tqdm import tqdm as _tqdm
+                        step_iter = _tqdm(
+                            step_iter,
+                            desc=f"image {img_count + 1} ({image_size[0]}x{image_size[1]})",
+                            total=num_steps,
+                            leave=False,
+                        )
+                    except ImportError:
+                        pass
+                for step_i in step_iter:
+                    t = timesteps[step_i]
+                    t_next = timesteps[step_i + 1]
+
+                    z = self.patchify(image_prediction, self.patch_size * merge_size)
+                    image_input = self.patchify(image_prediction, self.patch_size, channel_first=True)
+                    image_embeds = self.extract_feature(image_input.view(1 * grid_h*grid_w, -1), gen_model=True, grid_hw=gen_grid_hw).view(1, token_h*token_w, -1)
+                    t_expanded = t.expand(token_h*token_w)
+                    timestep_embeddings = self.fm_modules['timestep_embedder'](t_expanded).view(1, token_h*token_w, -1)
+                    if self.add_noise_scale_embedding:
+                        noise_scale_tensor = torch.full_like(t_expanded, noise_scale/self.noise_scale_max_value)
+                        noise_embeddings = self.fm_modules['noise_scale_embedder'](noise_scale_tensor).view(1, token_h*token_w, -1)
+                        timestep_embeddings += noise_embeddings
+                    image_embeds = image_embeds + timestep_embeddings
+
+                    use_cfg = (t > cfg_interval[0] and t < cfg_interval[1]) or cfg_interval[0] == 0
+                    out_cond = self._t2i_predict_v(image_embeds, indexes_image_condition, attention_mask_condition, past_key_values_cond_cfg, t, z, image_token_num=token_h*token_w, timestep_embeddings=timestep_embeddings)
+                    if not use_cfg:
+                        v_pred = out_cond
+                    elif cfg_scale == 1 and img_cfg_scale == 1:
+                        v_pred = out_cond
+                    elif img_cfg_scale == 1:
+                        out_img_cond = self._t2i_predict_v(image_embeds, indexes_image_text_uncondition, attention_mask_text_uncondition, past_key_values_tu_cfg, t, z, image_token_num=token_h*token_w, timestep_embeddings=timestep_embeddings)
+                        v_pred = out_img_cond + cfg_scale * (out_cond - out_img_cond)
+                    elif cfg_scale == img_cfg_scale:
+                        out_uncond = self._t2i_predict_v(image_embeds, indexes_image_img_uncondition, attention_mask_img_uncondition, past_key_values_iu_cfg, t, z, image_token_num=token_h*token_w, timestep_embeddings=timestep_embeddings)
+                        v_pred = out_uncond + cfg_scale * (out_cond - out_uncond)
+                    else:
+                        out_img_cond = self._t2i_predict_v(image_embeds, indexes_image_text_uncondition, attention_mask_text_uncondition, past_key_values_tu_cfg, t, z, image_token_num=token_h*token_w, timestep_embeddings=timestep_embeddings)
+                        out_uncond = self._t2i_predict_v(image_embeds, indexes_image_img_uncondition, attention_mask_img_uncondition, past_key_values_iu_cfg, t, z, image_token_num=token_h*token_w, timestep_embeddings=timestep_embeddings)
+                        v_pred = (
+                            out_uncond
+                            + cfg_scale * (out_cond - out_img_cond)
+                            + img_cfg_scale * (out_img_cond - out_uncond)
+                        )
+                    if (cfg_scale > 1 or img_cfg_scale > 1) and use_cfg:
+                        if cfg_norm == 'global':
+                            norm_v_condition = torch.norm(out_cond, dim=(1,2), keepdim=True)
+                            norm_v_cfg = torch.norm(v_pred, dim=(1,2), keepdim=True)
+                            scale = (norm_v_condition / (norm_v_cfg + 1e-8)).clamp(min=0, max=1.0)
+                            v_pred = v_pred * scale
+                        elif cfg_norm == 'channel':
+                            norm_v_condition = torch.norm(out_cond, dim=-1, keepdim=True)
+                            norm_v_cfg = torch.norm(v_pred, dim=-1, keepdim=True)
+                            scale = (norm_v_condition / (norm_v_cfg + 1e-8)).clamp(min=0, max=1.0)
+                            v_pred = v_pred * scale
+
+                    z = z + (t_next - t) * v_pred
+                    image_prediction = self.unpatchify(z, self.patch_size * merge_size, cur_image_size[1], cur_image_size[0])
+
+                generated_images.append(image_prediction)
+
+                clear_flash_kv_cache(past_key_values_cond_cfg)
+                clear_flash_kv_cache(past_key_values_tu_cfg)
+                clear_flash_kv_cache(past_key_values_iu_cfg)
+
+                if gt_images is not None and img_count < len(gt_images):
+                    gt_img_pil = gt_images[img_count]
+                    gt_pixel_values, gt_grid_hw = load_image_native(gt_img_pil, self.patch_size, self.downsample_ratio, min_pixels=512*512, max_pixels=(2048*2048), upscale=False)
+                    gt_pixel_values = gt_pixel_values.to(device).to(torch.bfloat16)
+                    
+                    flatten_pixel_values = gt_pixel_values
+                    gen_grid_hw_und = gt_grid_hw
+                else:
+                    pred_img = image_prediction[0].unsqueeze(0).to(torch.bfloat16)
+                    raw_img = pred_img * 0.5 + 0.5
+                    img_mean = torch.tensor([0.485, 0.456, 0.406], dtype=raw_img.dtype, device=device).view(1, 3, 1, 1)
+                    img_std = torch.tensor([0.229, 0.224, 0.225], dtype=raw_img.dtype, device=device).view(1, 3, 1, 1)
+                    und_img = (raw_img - img_mean) / img_std
+                    
+                    c, h, w = und_img[0].shape
+                    ps = self.patch_size
+                    p_grid_h = h // ps
+                    p_grid_w = w // ps
+                    flatten_pixel_values = (
+                        und_img[0].view(c, p_grid_h, ps, p_grid_w, ps)
+                        .permute(1, 3, 0, 2, 4)
+                        .reshape(p_grid_h * p_grid_w, c * ps ** 2)
+                    )
+                    gen_grid_hw_und = torch.tensor([[p_grid_h, p_grid_w]], device=device)
+
+                vit_embeds = self.extract_feature(flatten_pixel_values, grid_hw=gen_grid_hw_und[:1]).unsqueeze(0)
+                
+                img_end_id = tokenizer.convert_tokens_to_ids(IMG_END_TOKEN)
+                img_end_embed = self.language_model.get_input_embeddings()(torch.tensor([[img_end_id]], device=device))
+                inputs_embeds_img = torch.cat([vit_embeds, img_end_embed], dim=1) # (1, N + 1, C)
+                
+                N_img_tokens = vit_embeds.shape[1]
+                abs_pos_w, abs_pos_h = build_abs_positions_from_grid_hw(gen_grid_hw_und[:1] // int(1 / self.downsample_ratio), device=device)
+
+                t_index_cond = append_image_to_cache(past_key_values_cond, t_index_cond, inputs_embeds_img, N_img_tokens, abs_pos_w, abs_pos_h)
+                t_index_tu = append_image_to_cache(past_key_values_tu, t_index_tu, inputs_embeds_img, N_img_tokens, abs_pos_w, abs_pos_h)
+
+                img_count += 1
+
+        return generated_images
+
+    @torch.no_grad()
+    def interleave_gen(
+            self,
+            tokenizer,
+            prompt,
+            images=None,
+            generation_config=None,
+            cfg_scale=1.0,
+            img_cfg_scale=1.0,
+            cfg_norm='none',
+            max_images=10,
+            enable_timestep_shift=True,
+            timestep_shift=1.0,
+            image_size=(256, 256),
+            num_steps=30,
+            IMG_START_TOKEN='<img>',
+            IMG_END_TOKEN='</img>',
+            IMG_CONTEXT_TOKEN='<IMG_CONTEXT>',
+            method='euler',
+            cfg_interval=(0, 1),
+            t_eps=0.02,
+            verbose=False,
+            system_message='',
+            think_mode=False,
+            seed=0,
+    ):
+        self.img_context_token_id = tokenizer.convert_tokens_to_ids(IMG_CONTEXT_TOKEN)
+        self.img_start_token_id = tokenizer.convert_tokens_to_ids(IMG_START_TOKEN)
+        self.config.t_eps = t_eps
+
+        if isinstance(image_size, tuple):
+            image_size_list = [image_size] * max_images
+        elif isinstance(image_size, list) and isinstance(image_size[0], tuple):
+            image_size_list = image_size
+            if len(image_size) < max_images:
+                image_size_list += [image_size_list[-1]] * (max_images - len(image_size_list))
+        else:
+            assert False, "image size should be a tuple or a list of tuple"
+
+        if generation_config and hasattr(generation_config, 'max_new_tokens') and generation_config.max_new_tokens is not None:
+            max_new_tokens = generation_config.max_new_tokens
+        else:
+            max_new_tokens = 8192
+
+        current_generated_tokens = 0
+
+        if images is None:
+            images = []
+
+        template = get_conv_template(self.template)
+        template.system_message = self.system_message
+        eos_token_id = tokenizer.convert_tokens_to_ids(template.sep.strip())
+
+        image_token_count = prompt.count('<image>')
+        assert len(images) >= image_token_count
+        if len(images) > image_token_count:
+            prompt = "<image>\n" * (len(images) - image_token_count) + prompt
+
+        pixel_values =[]
+        grid_hw =[]
+        for image in images:
+            cur_pixel_values, cur_grid_hw = load_image_native(image, self.patch_size, self.downsample_ratio, min_pixels=512*512, max_pixels=min(2048*2048, (4096*4096)//max(1, len(images))), upscale=False)
+            grid_hw.append(cur_grid_hw.to(self.device))
+            pixel_values.append(cur_pixel_values.to(self.device).to(torch.bfloat16))
+
+        merge_size = int(1 / self.downsample_ratio)
+        pv_tensor = torch.cat(pixel_values) if pixel_values else None
+        ghw_tensor = torch.cat(grid_hw) if grid_hw else None
+
+        # Condition
+        template_cond = get_conv_template(self.template)
+        template_cond.system_message = system_message
+        template_cond.append_message(template_cond.roles[0], prompt)
+        template_cond.append_message(template_cond.roles[1], None)
+        query_cond = template_cond.get_prompt()
+
+        if not think_mode:
+            query_cond = query_cond + '<think>\n\n</think>\n\n'
+
+        def replace_image_tokens(query, grid_hw_list):
+            for i in range(len(grid_hw_list)):
+                num_patch_token = int(grid_hw_list[i][0, 0] * grid_hw_list[i][0, 1] * self.downsample_ratio**2)
+                image_tokens = IMG_START_TOKEN + IMG_CONTEXT_TOKEN * num_patch_token + IMG_END_TOKEN
+                query = query.replace('<image>', image_tokens, 1)
+            return query
+
+        query_cond = replace_image_tokens(query_cond, grid_hw)
+        input_embeds_cond, indexes_cond, attention_mask_cond = self._build_it2i_inputs(tokenizer, query_cond, pv_tensor, ghw_tensor)
+        
+        outputs_cond = self.language_model(inputs_embeds=input_embeds_cond, indexes=indexes_cond, attention_mask=attention_mask_cond, use_cache=True)
+        past_key_values_cond = outputs_cond.past_key_values
+        t_index_cond = indexes_cond[0].max().item()
+
+        # Initialize Text Uncondition Cache
+        question_text_uncondition = '<image>' * len(images)
+        template_tu = get_conv_template(self.template)
+        template_tu.system_message = self.system_message
+        template_tu.append_message(template_tu.roles[0], question_text_uncondition)
+        template_tu.append_message(template_tu.roles[1], None)
+        query_text_uncond = template_tu.get_prompt()
+        query_text_uncond = replace_image_tokens(query_text_uncond, grid_hw)
+
+        input_embeds_tu, indexes_tu, attention_mask_tu = self._build_it2i_inputs(tokenizer, query_text_uncond, pv_tensor, ghw_tensor)
+        outputs_tu = self.language_model(inputs_embeds=input_embeds_tu, indexes=indexes_tu, attention_mask=attention_mask_tu, use_cache=True)
+        past_key_values_tu = outputs_tu.past_key_values
+        t_index_tu = indexes_tu[0].max().item()
+
+        # Initialize Img (ALL) Uncondition Cache
+        query_img_uncond = self._build_t2i_query("", append_text=IMG_START_TOKEN)
+        input_embeds_iu, indexes_iu, attention_mask_iu = self._build_it2i_inputs(tokenizer, query_img_uncond)
+        outputs_iu = self.language_model(inputs_embeds=input_embeds_iu, indexes=indexes_iu, attention_mask=attention_mask_iu, use_cache=True)
+        past_key_values_iu = outputs_iu.past_key_values
+
+
+        generated_text = ""
+        generated_images =[]
+        max_images = 10
+        img_count = 0
+
+        next_token = torch.argmax(outputs_cond.logits[:, -1, :], dim=-1)
+
+        generator = torch.Generator(self.device).manual_seed(seed)
+        while True:
+            # text generation
+            gen_tokens = []
+            hit_max_tokens = False
+            last_decoded = 0
+            while True:
+                token_item = next_token.item()
+                if token_item == eos_token_id or token_item == self.img_start_token_id:
+                    break
+                gen_tokens.append(token_item)
+                current_generated_tokens += 1
+
+                self.language_model.model.current_index = t_index_cond
+                outputs_cond = self.language_model(
+                    input_ids=next_token.unsqueeze(0),
+                    past_key_values=past_key_values_cond,
+                    use_cache=True
+                )
+                past_key_values_cond = outputs_cond.past_key_values
+                t_index_cond += 1
+                next_token = torch.argmax(outputs_cond.logits[:, -1, :], dim=-1)
+
+                # Stream partial text so users see liveness during long runs
+                # (e.g. low VRAM offload). Decode in 16-token chunks.
+                if verbose and len(gen_tokens) - last_decoded >= 16:
+                    partial = tokenizer.decode(gen_tokens[last_decoded:], skip_special_tokens=True)
+                    print(partial, end='', flush=True)
+                    last_decoded = len(gen_tokens)
+
+                if current_generated_tokens >= max_new_tokens:
+                    hit_max_tokens = True
+                    break
+
+            if len(gen_tokens) > 0:
+                chunk_text = tokenizer.decode(gen_tokens, skip_special_tokens=True)
+                generated_text += chunk_text
+                if verbose:
+                    remaining = tokenizer.decode(gen_tokens[last_decoded:], skip_special_tokens=True)
+                    if remaining:
+                        print(remaining, end='', flush=True)
+
+            if next_token.item() == eos_token_id or hit_max_tokens:
+                break
+
+            if next_token.item() == self.img_start_token_id:
+                if img_count >= max_images:
+                    break
+
+                generated_text += "<image>"
+                if verbose:
+                    print(f"\n[image {img_count + 1}] preparing diffusion...", flush=True)
+
+                # Add the img_start_token for condition and text_uncondition branch
+                self.language_model.model.current_index = t_index_cond
+                outputs_cond = self.language_model(input_ids=next_token.unsqueeze(0), past_key_values=past_key_values_cond, use_cache=True)
+                past_key_values_cond = outputs_cond.past_key_values
+                t_index_cond += 1
+
+                self.language_model.model.current_index = t_index_tu
+                outputs_tu = self.language_model(input_ids=next_token.unsqueeze(0), past_key_values=past_key_values_tu, use_cache=True)
+                past_key_values_tu = outputs_tu.past_key_values
+                t_index_tu += 1
+
+                image_size = image_size_list[img_count]
+                # Image Generation
+                token_h = image_size[1] // (self.patch_size * merge_size)
+                token_w = image_size[0] // (self.patch_size * merge_size)
+                device = self.device
+
+                indexes_image_condition = self._build_t2i_image_indexes(token_h, token_w, t_index_cond + 1, device=device)
+                indexes_image_text_uncondition = self._build_t2i_image_indexes(token_h, token_w, t_index_tu + 1, device=device)
+                indexes_image_img_uncondition = self._build_t2i_image_indexes(token_h, token_w, indexes_iu[0].max() + 1, device=device)
+
+                grid_h = image_size[1] // self.patch_size
+                grid_w = image_size[0] // self.patch_size
+                gen_grid_hw = torch.tensor([[grid_h, grid_w]], device=device)
+
+                noise_scale = self.noise_scale
+                if self.noise_scale_mode in ("resolution", "dynamic", 'dynamic_sqrt'):
+                    base = float(self.noise_scale_base_image_seq_len)
+                    noise_scale = math.sqrt((grid_h*grid_w)/(merge_size**2)/base) * float(self.noise_scale)
+                    if self.noise_scale_mode == 'dynamic_sqrt':
+                        noise_scale = math.sqrt(noise_scale)
+                noise_scale = min(noise_scale, self.noise_scale_max_value)
+                image_prediction = noise_scale * torch.randn((1, 3, image_size[1], image_size[0]), device=device, dtype=outputs_cond.logits.dtype, generator=generator)
+
+                past_key_values_cond_cfg = past_key_values_cond
+                past_key_values_tu_cfg = past_key_values_tu
+                past_key_values_iu_cfg = past_key_values_iu
+
+                attention_mask_condition = {"full_attention": None}
+                attention_mask_text_uncondition = {"full_attention": None}
+                attention_mask_img_uncondition = {"full_attention": None}
+
+                prepare_flash_kv_cache(
+                    past_key_values_cond_cfg,
+                    current_len=token_h * token_w,
+                    batch_size=1,
+                )
+                prepare_flash_kv_cache(
+                    past_key_values_tu_cfg,
+                    current_len=token_h * token_w,
+                    batch_size=1,
+                )
+                prepare_flash_kv_cache(
+                    past_key_values_iu_cfg,
+                    current_len=token_h * token_w,
+                    batch_size=1,
+                )
+
+                timesteps = torch.linspace(0.0, 1.0, num_steps+1, device=device)
+                if enable_timestep_shift:
+                    timesteps = self._apply_time_schedule(timesteps, token_h*token_w, timestep_shift)
+
+                step_iter = range(num_steps)
+                if verbose:
+                    try:
+                        from tqdm import tqdm as _tqdm
+                        step_iter = _tqdm(
+                            step_iter,
+                            desc=f"image {img_count + 1} ({image_size[0]}x{image_size[1]})",
+                            total=num_steps,
+                            leave=False,
+                        )
+                    except ImportError:
+                        pass
+                for step_i in step_iter:
+                    t = timesteps[step_i]
+                    t_next = timesteps[step_i + 1]
+
+                    z = self.patchify(image_prediction, self.patch_size * merge_size)
+                    image_input = self.patchify(image_prediction, self.patch_size, channel_first=True)
+                    image_embeds = self.extract_feature(image_input.view(1 * grid_h*grid_w, -1), gen_model=True, grid_hw=gen_grid_hw).view(1, token_h*token_w, -1)
+                    t_expanded = t.expand(token_h*token_w)
+                    timestep_embeddings = self.fm_modules['timestep_embedder'](t_expanded).view(1, token_h*token_w, -1)
+                    if self.add_noise_scale_embedding:
+                        noise_scale_tensor = torch.full_like(t_expanded, noise_scale/self.noise_scale_max_value)
+                        noise_embeddings = self.fm_modules['noise_scale_embedder'](noise_scale_tensor).view(1, token_h*token_w, -1)
+                        timestep_embeddings += noise_embeddings
+                    image_embeds = image_embeds + timestep_embeddings
+
+                    use_cfg = (t > cfg_interval[0] and t < cfg_interval[1]) or cfg_interval[0] == 0
+                    out_cond = self._t2i_predict_v(image_embeds, indexes_image_condition, attention_mask_condition, past_key_values_cond_cfg, t, z, image_token_num=token_h*token_w, timestep_embeddings=timestep_embeddings)
+                    if not use_cfg:
+                        v_pred = out_cond
+                    elif cfg_scale == 1 and img_cfg_scale == 1:
+                        v_pred = out_cond
+                    elif img_cfg_scale == 1:
+                        out_img_cond = self._t2i_predict_v(image_embeds, indexes_image_text_uncondition, attention_mask_text_uncondition, past_key_values_tu_cfg, t, z, image_token_num=token_h*token_w, timestep_embeddings=timestep_embeddings)
+                        v_pred = out_img_cond + cfg_scale * (out_cond - out_img_cond)
+                    elif cfg_scale == img_cfg_scale:
+                        out_uncond = self._t2i_predict_v(image_embeds, indexes_image_img_uncondition, attention_mask_img_uncondition, past_key_values_iu_cfg, t, z, image_token_num=token_h*token_w, timestep_embeddings=timestep_embeddings)
+                        v_pred = out_uncond + cfg_scale * (out_cond - out_uncond)
+                    else:
+                        out_img_cond = self._t2i_predict_v(image_embeds, indexes_image_text_uncondition, attention_mask_text_uncondition, past_key_values_tu_cfg, t, z, image_token_num=token_h*token_w, timestep_embeddings=timestep_embeddings)
+                        out_uncond = self._t2i_predict_v(image_embeds, indexes_image_img_uncondition, attention_mask_img_uncondition, past_key_values_iu_cfg, t, z, image_token_num=token_h*token_w, timestep_embeddings=timestep_embeddings)
+                        v_pred = (
+                            out_uncond
+                            + cfg_scale * (out_cond - out_img_cond)
+                            + img_cfg_scale * (out_img_cond - out_uncond)
+                        )
+                    if (cfg_scale > 1 or img_cfg_scale > 1 and use_cfg):
+                        if cfg_norm == 'global':
+                            norm_v_condition = torch.norm(out_cond, dim=(1,2), keepdim=True)
+                            norm_v_cfg = torch.norm(v_pred, dim=(1,2), keepdim=True)
+                            scale = (norm_v_condition / (norm_v_cfg + 1e-8)).clamp(min=0, max=1.0)
+                            v_pred = v_pred * scale
+                        elif cfg_norm == 'channel':
+                            norm_v_condition = torch.norm(out_cond, dim=-1, keepdim=True)
+                            norm_v_cfg = torch.norm(v_pred, dim=-1, keepdim=True)
+                            scale = (norm_v_condition / (norm_v_cfg + 1e-8)).clamp(min=0, max=1.0)
+                            v_pred = v_pred * scale
+
+                    z = z + (t_next - t) * v_pred
+                    image_prediction = self.unpatchify(z, self.patch_size * merge_size, image_size[1], image_size[0])
+
+                generated_images.append(image_prediction)
+
+                clear_flash_kv_cache(past_key_values_cond_cfg)
+                clear_flash_kv_cache(past_key_values_tu_cfg)
+                clear_flash_kv_cache(past_key_values_iu_cfg)
+
+                img_count += 1
+
+                # re-encode the generated image using the und-branch
+                pred_img = image_prediction[0].unsqueeze(0).to(torch.bfloat16)
+                # re-normalize the image
+                raw_img = pred_img * 0.5 + 0.5
+                img_mean = torch.tensor([0.485, 0.456, 0.406], dtype=raw_img.dtype, device=device).view(1, 3, 1, 1)
+                img_std = torch.tensor([0.229, 0.224, 0.225], dtype=raw_img.dtype, device=device).view(1, 3, 1, 1)
+                und_img = (raw_img - img_mean) / img_std
+                c, h, w = und_img[0].shape
+                ps = self.patch_size
+                p_grid_h = h // ps
+                p_grid_w = w // ps
+                flatten_pixel_values = (
+                    und_img[0].view(c, p_grid_h, ps, p_grid_w, ps)
+                    .permute(1, 3, 0, 2, 4)  # [grid_h, grid_w, c, patch_size, patch_size]
+                    .reshape(p_grid_h * p_grid_w, c * ps ** 2)
+                )
+                vit_embeds = self.extract_feature(flatten_pixel_values, grid_hw=gen_grid_hw[:1]).unsqueeze(0)
+                
+                img_end_id = tokenizer.convert_tokens_to_ids(IMG_END_TOKEN)
+                img_end_embed = self.language_model.get_input_embeddings()(torch.tensor([[img_end_id]], device=device))
+                inputs_embeds_img = torch.cat([vit_embeds, img_end_embed], dim=1) # (1, N + 1, C)
+                
+                N_img_tokens = vit_embeds.shape[1]
+                abs_pos_w, abs_pos_h = build_abs_positions_from_grid_hw(gen_grid_hw[:1] // int(1 / self.downsample_ratio), device=device)
+
+                def append_image_to_cache(cache, t_idx):
+                    past_len = cache.get_seq_length()
+                    tgt_len = N_img_tokens + 1
+                    
+                    t_indexes = torch.zeros(tgt_len, dtype=torch.long, device=device)
+                    t_indexes[:N_img_tokens] = t_idx + 1
+                    t_indexes[N_img_tokens] = t_idx + 2
+                    
+                    h_indexes = torch.zeros(tgt_len, dtype=torch.long, device=device)
+                    w_indexes = torch.zeros(tgt_len, dtype=torch.long, device=device)
+                    h_indexes[:N_img_tokens] = abs_pos_h
+                    w_indexes[:N_img_tokens] = abs_pos_w
+                    
+                    indexes = torch.stack([t_indexes, h_indexes, w_indexes], dim=0)
+                    
+                    mask = torch.zeros(1, 1, tgt_len, past_len + tgt_len, device=device)
+                    mask[0, 0, :N_img_tokens, past_len + N_img_tokens] = float('-inf')
+                    attention_mask_dict = {"full_attention": mask}
+                    
+                    outputs = self.language_model(
+                        inputs_embeds=inputs_embeds_img,
+                        indexes=indexes,
+                        attention_mask=attention_mask_dict,
+                        past_key_values=cache,
+                        use_cache=True
+                    )
+                    return outputs, t_idx + 2
+
+                outputs_cond, t_index_cond = append_image_to_cache(past_key_values_cond, t_index_cond)
+                outputs_tu, t_index_tu = append_image_to_cache(past_key_values_tu, t_index_tu)
+
+                next_token = torch.argmax(outputs_cond.logits[:, -1, :], dim=-1)
+
+        return generated_text, generated_images
+
+    @torch.no_grad()
+    def it2i_generate(self, tokenizer, prompt, images, cfg_scale=1, img_cfg_scale=1, cfg_norm='none', enable_timestep_shift=True, timestep_shift=1, image_size=(256, 256), num_steps=30, IMG_START_TOKEN='<img>', IMG_END_TOKEN='</img>', IMG_CONTEXT_TOKEN='<IMG_CONTEXT>', method='euler', cfg_interval=(0, 1), batch_size=1, t_eps=0.02, think_mode=False, seed=0):
+        assert cfg_norm in ['none', 'global', 'channel']
+        self._notify_layer_offload_phase("prefix")
+
+        self.img_context_token_id = tokenizer.convert_tokens_to_ids(IMG_CONTEXT_TOKEN)
+        self.config.t_eps = t_eps
+
+        image_token_count = prompt.count('<image>')
+        assert len(images) >= image_token_count
+        if len(images) > image_token_count:
+            if image_token_count == 0 and len(images) > 1:
+                prompt = "".join(f"Image-{i + 1}:<image>\n" for i in range(len(images))) + prompt
+            else:
+                prompt = "<image>\n" * (len(images) - image_token_count) + prompt
+
+        pixel_values = []
+        grid_hw = []
+        for image in images:
+            cur_pixel_values, cur_grid_hw = load_image_native(
+                image,
+                self.patch_size,
+                self.downsample_ratio,
+                min_pixels=512 * 512,
+                max_pixels=min(2048*2048, (4096 * 4096) // len(images)),
+                upscale=False,
+            )
+            cur_grid_hw = cur_grid_hw.to(self.device)
+            cur_pixel_values = cur_pixel_values.to(self.device).to(torch.bfloat16)
+            pixel_values.append(cur_pixel_values)
+            grid_hw.append(cur_grid_hw)
+        pixel_values = torch.cat(pixel_values)
+        grid_hw = torch.cat(grid_hw)
+
+        merge_size = int(1 / self.downsample_ratio)
+        question_condition = f"{prompt}"
+        think_text = ""
+        needs_cfg = not (cfg_scale == 1 and img_cfg_scale == 1)
+        needs_img_condition = needs_cfg and (img_cfg_scale == 1 or cfg_scale != img_cfg_scale)
+        needs_uncondition = needs_cfg and img_cfg_scale != 1
+
+        think_content = '<think>\n' if think_mode else '<think>\n\n</think>\n\n' + IMG_START_TOKEN
+        query_condition = self._build_t2i_query(question_condition, system_message=SYSTEM_MESSAGE_FOR_GEN, append_text=think_content)
+        query_img_condition = (
+            self._build_t2i_query('<image>' * len(images), append_text=IMG_START_TOKEN)
+            if needs_img_condition
+            else None
+        )
+        query_uncondition = self._build_t2i_query("", append_text=IMG_START_TOKEN) if needs_uncondition else None
+
+        for i in range(grid_hw.shape[0]):
+            num_patch_token = int(grid_hw[i, 0] * grid_hw[i, 1] * self.downsample_ratio**2)
+            image_tokens = IMG_START_TOKEN + IMG_CONTEXT_TOKEN * num_patch_token + IMG_END_TOKEN
+            query_condition = query_condition.replace('<image>', image_tokens, 1)
+            if query_img_condition is not None:
+                query_img_condition = query_img_condition.replace('<image>', image_tokens, 1)
+
+        input_embeds_condition, indexes_condition, attention_mask_condition_prefix = self._build_it2i_inputs(
+            tokenizer, query_condition, pixel_values, grid_hw
+        )
+        if query_img_condition is not None:
+            input_embeds_img_condition, indexes_img_condition, attention_mask_img_condition_prefix = self._build_it2i_inputs(
+                tokenizer, query_img_condition, pixel_values, grid_hw
+            )
+        else:
+            input_embeds_img_condition = indexes_img_condition = attention_mask_img_condition_prefix = None
+        if query_uncondition is not None:
+            input_embeds_uncondition, indexes_uncondition, attention_mask_uncondition_prefix = self._build_it2i_inputs(
+                tokenizer, query_uncondition
+            )
+        else:
+            input_embeds_uncondition = indexes_uncondition = attention_mask_uncondition_prefix = None
+
+        token_h = image_size[1] // (self.patch_size * merge_size)
+        token_w = image_size[0] // (self.patch_size * merge_size)
+
+        indexes_image_condition = self._build_t2i_image_indexes(
+            token_h, token_w, indexes_condition[0].max() + 1, device=input_embeds_condition.device
+        )
+        indexes_image_img_condition = (
+            self._build_t2i_image_indexes(
+                token_h, token_w, indexes_img_condition[0].max() + 1, device=input_embeds_img_condition.device
+            )
+            if indexes_img_condition is not None
+            else None
+        )
+        indexes_image_uncondition = (
+            self._build_t2i_image_indexes(
+                token_h, token_w, indexes_uncondition[0].max() + 1, device=input_embeds_uncondition.device
+            )
+            if indexes_uncondition is not None
+            else None
+        )
+
+        if think_mode:
+            outputs_condition = self._think_prefix_forward(
+                inputs_embeds=input_embeds_condition,
+                indexes=indexes_condition,
+                attention_mask=attention_mask_condition_prefix,
+            )
+            past_key_values_condition = outputs_condition.past_key_values
+            device = outputs_condition.logits.device
+            dtype = outputs_condition.logits.dtype
+            t_index_condition = indexes_condition[0].max().item()
+            past_key_values_condition, t_index_condition, think_text = self._generate_think(
+                tokenizer,
+                outputs_condition,
+                past_key_values_condition,
+                t_index_condition,
+                IMG_START_TOKEN,
+            )
+            indexes_image_condition = self._build_t2i_image_indexes(
+                token_h, token_w, t_index_condition + 1, device=input_embeds_condition.device
+            )
+            del outputs_condition
+        else:
+            past_key_values_condition, prefix_hidden_states = self._it2i_prefix_forward(
+                input_embeds_condition, indexes_condition, attention_mask_condition_prefix
+            )
+            device = prefix_hidden_states.device
+            dtype = prefix_hidden_states.dtype
+            del prefix_hidden_states
+        past_key_values_img_condition = None
+        if input_embeds_img_condition is not None:
+            past_key_values_img_condition, _ = self._it2i_prefix_forward(
+                input_embeds_img_condition, indexes_img_condition, attention_mask_img_condition_prefix
+            )
+        past_key_values_uncondition = None
+        if input_embeds_uncondition is not None:
+            past_key_values_uncondition, _ = self._it2i_prefix_forward(
+                input_embeds_uncondition, indexes_uncondition, attention_mask_uncondition_prefix
+            )
+
+        del pixel_values, grid_hw
+        del input_embeds_condition, indexes_condition, attention_mask_condition_prefix
+        if input_embeds_img_condition is not None:
+            del input_embeds_img_condition, indexes_img_condition, attention_mask_img_condition_prefix
+        if input_embeds_uncondition is not None:
+            del input_embeds_uncondition, indexes_uncondition, attention_mask_uncondition_prefix
+        self._notify_layer_offload_phase("denoise")
+
+        for layer_idx in range(len(past_key_values_condition.layers)):
+            past_key_values_condition.layers[layer_idx].keys = past_key_values_condition.layers[layer_idx].keys.expand(
+                batch_size, *past_key_values_condition.layers[layer_idx].keys.shape[1:]
+            )
+            past_key_values_condition.layers[layer_idx].values = past_key_values_condition.layers[layer_idx].values.expand(
+                batch_size, *past_key_values_condition.layers[layer_idx].values.shape[1:]
+            )
+            if past_key_values_img_condition is not None:
+                past_key_values_img_condition.layers[layer_idx].keys = past_key_values_img_condition.layers[layer_idx].keys.expand(
+                    batch_size, *past_key_values_img_condition.layers[layer_idx].keys.shape[1:]
+                )
+                past_key_values_img_condition.layers[layer_idx].values = past_key_values_img_condition.layers[layer_idx].values.expand(
+                    batch_size, *past_key_values_img_condition.layers[layer_idx].values.shape[1:]
+                )
+            if past_key_values_uncondition is not None:
+                past_key_values_uncondition.layers[layer_idx].keys = past_key_values_uncondition.layers[layer_idx].keys.expand(
+                    batch_size, *past_key_values_uncondition.layers[layer_idx].keys.shape[1:]
+                )
+                past_key_values_uncondition.layers[layer_idx].values = past_key_values_uncondition.layers[layer_idx].values.expand(
+                    batch_size, *past_key_values_uncondition.layers[layer_idx].values.shape[1:]
+                )
+
+        prepare_flash_kv_cache(
+            past_key_values_condition,
+            current_len=token_h * token_w,
+            batch_size=batch_size,
+        )
+        if past_key_values_img_condition is not None:
+            prepare_flash_kv_cache(
+                past_key_values_img_condition,
+                current_len=token_h * token_w,
+                batch_size=batch_size,
+            )
+        if past_key_values_uncondition is not None:
+            prepare_flash_kv_cache(
+                past_key_values_uncondition,
+                current_len=token_h * token_w,
+                batch_size=batch_size,
+            )
+
+        grid_h = image_size[1] // self.patch_size
+        grid_w = image_size[0] // self.patch_size
+        grid_hw = torch.tensor([[grid_h, grid_w]] * batch_size, device=device)
+
+        noise_scale = self.noise_scale
+        if self.noise_scale_mode in ("resolution", "dynamic", "dynamic_sqrt"):
+            base = float(self.noise_scale_base_image_seq_len)
+            scale = math.sqrt((grid_h * grid_w) / (merge_size**2) / base)
+            noise_scale = scale * float(self.noise_scale)
+            if self.noise_scale_mode == 'dynamic_sqrt':
+                noise_scale = math.sqrt(noise_scale)
+        noise_scale = min(noise_scale, self.noise_scale_max_value)
+        generator = torch.Generator(device).manual_seed(seed)
+        image_prediction = noise_scale * torch.randn(
+            (batch_size, 3, image_size[1], image_size[0]), device=device, dtype=dtype, generator=generator
+        )
+
+        attention_mask_condition = {"full_attention": None}
+        attention_mask_img_condition = {"full_attention": None}
+        attention_mask_uncondition = {"full_attention": None}
+
+        timesteps = torch.linspace(0.0, 1.0, num_steps + 1, device=device)
+        if enable_timestep_shift:
+            timesteps = self._apply_time_schedule(timesteps, token_h * token_w, timestep_shift)
+
+        for step_i in range(num_steps):
+            t = timesteps[step_i]
+            t_next = timesteps[step_i + 1]
+            use_cfg = (t > cfg_interval[0] and t < cfg_interval[1]) or cfg_interval[0] == 0
+
+            z = self.patchify(image_prediction, self.patch_size * merge_size)
+            image_input = self.patchify(image_prediction, self.patch_size, channel_first=True)
+            image_embeds = self.extract_feature(
+                image_input.view(batch_size * grid_h * grid_w, -1),
+                gen_model=True,
+                grid_hw=grid_hw,
+            ).view(batch_size, token_h * token_w, -1)
+            t_expanded = t.expand(batch_size * token_h * token_w)
+            timestep_embeddings = self.fm_modules['timestep_embedder'](t_expanded).view(batch_size, token_h * token_w, -1)
+            if self.add_noise_scale_embedding:
+                noise_scale_tensor = torch.full_like(t_expanded, noise_scale / self.noise_scale_max_value)
+                noise_embeddings = self.fm_modules['noise_scale_embedder'](noise_scale_tensor).view(batch_size, token_h * token_w, -1)
+                timestep_embeddings += noise_embeddings
+            image_embeds = image_embeds + timestep_embeddings
+
+            out_cond = self._t2i_predict_v(
+                image_embeds,
+                indexes_image_condition,
+                attention_mask_condition,
+                past_key_values_condition,
+                t,
+                z,
+                image_token_num=token_h * token_w,
+                timestep_embeddings=timestep_embeddings,
+                image_size=image_size,
+            )
+
+            if not use_cfg:
+                v_pred = out_cond
+            elif cfg_scale == 1 and img_cfg_scale == 1:
+                v_pred = out_cond
+            elif img_cfg_scale == 1:
+                out_img_cond = self._t2i_predict_v(
+                    image_embeds,
+                    indexes_image_img_condition,
+                    attention_mask_img_condition,
+                    past_key_values_img_condition,
+                    t,
+                    z,
+                    image_token_num=token_h * token_w,
+                    timestep_embeddings=timestep_embeddings,
+                    image_size=image_size,
+                )
+                v_pred = out_img_cond + cfg_scale * (out_cond - out_img_cond)
+            elif cfg_scale == img_cfg_scale:
+                out_uncond = self._t2i_predict_v(
+                    image_embeds,
+                    indexes_image_uncondition,
+                    attention_mask_uncondition,
+                    past_key_values_uncondition,
+                    t,
+                    z,
+                    image_token_num=token_h * token_w,
+                    timestep_embeddings=timestep_embeddings,
+                    image_size=image_size,
+                )
+                v_pred = out_uncond + cfg_scale * (out_cond - out_uncond)
+            else:
+                out_img_cond = self._t2i_predict_v(
+                    image_embeds,
+                    indexes_image_img_condition,
+                    attention_mask_img_condition,
+                    past_key_values_img_condition,
+                    t,
+                    z,
+                    image_token_num=token_h * token_w,
+                    timestep_embeddings=timestep_embeddings,
+                    image_size=image_size,
+                )
+                out_uncond = self._t2i_predict_v(
+                    image_embeds,
+                    indexes_image_uncondition,
+                    attention_mask_uncondition,
+                    past_key_values_uncondition,
+                    t,
+                    z,
+                    image_token_num=token_h * token_w,
+                    timestep_embeddings=timestep_embeddings,
+                    image_size=image_size,
+                )
+                v_pred = (
+                    out_uncond
+                    + cfg_scale * (out_cond - out_img_cond)
+                    + img_cfg_scale * (out_img_cond - out_uncond)
+                )
+            if (cfg_scale > 1 or img_cfg_scale > 1) and use_cfg:
+                if cfg_norm == 'global':
+                    norm_v_condition = torch.norm(out_cond, dim=(1, 2), keepdim=True)
+                    norm_v_cfg = torch.norm(v_pred, dim=(1, 2), keepdim=True)
+                    scale = (norm_v_condition / (norm_v_cfg + 1e-8)).clamp(min=0, max=1.0)
+                    v_pred = v_pred * scale
+                elif cfg_norm == 'channel':
+                    norm_v_condition = torch.norm(out_cond, dim=-1, keepdim=True)
+                    norm_v_cfg = torch.norm(v_pred, dim=-1, keepdim=True)
+                    scale = (norm_v_condition / (norm_v_cfg + 1e-8)).clamp(min=0, max=1.0)
+                    v_pred = v_pred * scale
+
+            z = z + (t_next - t) * v_pred
+            image_prediction = self.unpatchify(z, self.patch_size * merge_size, image_size[1], image_size[0])
+
+        clear_flash_kv_cache(past_key_values_condition)
+        if past_key_values_img_condition is not None:
+            clear_flash_kv_cache(past_key_values_img_condition)
+        if past_key_values_uncondition is not None:
+            clear_flash_kv_cache(past_key_values_uncondition)
+
+        self.last_think_content = think_text
+        if think_mode:
+            return image_prediction, think_text
+        return image_prediction
+
+    @torch.no_grad()
+    def t2i_generate(self, tokenizer, prompt, cfg_scale=1, timestep_shift=1, enable_timestep_shift=True, cfg_norm='none', image_size=(256, 256), num_steps=30, IMG_START_TOKEN='<img>', IMG_END_TOKEN='</img>', IMG_CONTEXT_TOKEN='<IMG_CONTEXT>', method='euler', cfg_interval=(0, 1), batch_size=1, t_eps=0.02, think_mode=False, seed=0):
+        assert self.concat_time_token_num == 0
+        assert cfg_norm in ['cfg_zero_star', 'global', 'none', 'channel']
+        self._notify_layer_offload_phase("prefix")
+        merge_size = int(1 / self.downsample_ratio)
+
+        self.config.t_eps = t_eps
+        # question_condition = f"Please generate an image based on the following description: {prompt}"
+        question_condition = f"{prompt}"
+        # question_condition += f"\nThe resolution of the image should be {image_size}"
+
+        think_text = ""
+        needs_cfg = cfg_scale > 1
+
+        think_content = '<think>\n' if think_mode else '<think>\n\n</think>\n\n' + IMG_START_TOKEN
+        query_condition = self._build_t2i_query(question_condition, system_message=SYSTEM_MESSAGE_FOR_GEN, append_text=think_content)
+        query_uncondition = self._build_t2i_query("", append_text=IMG_START_TOKEN) if needs_cfg else None
+
+        input_ids_condition, indexes_condition, attention_mask_condition_prefix = self._build_t2i_text_inputs(tokenizer, query_condition)
+        if query_uncondition is not None:
+            input_ids_uncondition, indexes_uncondition, attention_mask_uncondition_prefix = self._build_t2i_text_inputs(tokenizer, query_uncondition)
+        else:
+            input_ids_uncondition = indexes_uncondition = attention_mask_uncondition_prefix = None
+       
+        token_h = image_size[1] // (self.patch_size * merge_size)
+        token_w = image_size[0] // (self.patch_size * merge_size)
+
+        indexes_image_condition = self._build_t2i_image_indexes(token_h, token_w, indexes_condition.shape[1], device=input_ids_condition.device)
+        indexes_image_uncondition = (
+            self._build_t2i_image_indexes(token_h, token_w, indexes_uncondition.shape[1], device=input_ids_uncondition.device)
+            if indexes_uncondition is not None
+            else None
+        )
+
+        if think_mode:
+            outputs_condition = self._think_prefix_forward(
+                input_ids=input_ids_condition,
+                indexes=indexes_condition,
+                attention_mask=attention_mask_condition_prefix,
+            )
+            past_key_values_condition = outputs_condition.past_key_values
+            device = outputs_condition.logits.device
+            dtype = outputs_condition.logits.dtype
+            t_index_condition = indexes_condition[0].max().item()
+            past_key_values_condition, t_index_condition, think_text = self._generate_think(
+                tokenizer,
+                outputs_condition,
+                past_key_values_condition,
+                t_index_condition,
+                IMG_START_TOKEN,
+            )
+            indexes_image_condition = self._build_t2i_image_indexes(
+                token_h, token_w, t_index_condition + 1, device=input_ids_condition.device
+            )
+            del outputs_condition
+        else:
+            past_key_values_condition, prefix_hidden_states = self._t2i_prefix_forward(input_ids_condition, indexes_condition, attention_mask_condition_prefix)
+            device = prefix_hidden_states.device
+            dtype = prefix_hidden_states.dtype
+            del prefix_hidden_states
+        past_key_values_uncondition = None
+        if input_ids_uncondition is not None:
+            past_key_values_uncondition, _ = self._t2i_prefix_forward(input_ids_uncondition, indexes_uncondition, attention_mask_uncondition_prefix)
+
+        del input_ids_condition, indexes_condition, attention_mask_condition_prefix
+        if input_ids_uncondition is not None:
+            del input_ids_uncondition, indexes_uncondition, attention_mask_uncondition_prefix
+        self._notify_layer_offload_phase("denoise")
+
+        for layer_idx in range(len(past_key_values_condition.layers)):
+            past_key_values_condition.layers[layer_idx].keys = past_key_values_condition.layers[layer_idx].keys.expand(batch_size, *past_key_values_condition.layers[layer_idx].keys.shape[1:])
+            past_key_values_condition.layers[layer_idx].values = past_key_values_condition.layers[layer_idx].values.expand(batch_size, *past_key_values_condition.layers[layer_idx].values.shape[1:])
+            if past_key_values_uncondition is not None:
+                past_key_values_uncondition.layers[layer_idx].keys = past_key_values_uncondition.layers[layer_idx].keys.expand(batch_size, *past_key_values_uncondition.layers[layer_idx].keys.shape[1:])
+                past_key_values_uncondition.layers[layer_idx].values = past_key_values_uncondition.layers[layer_idx].values.expand(batch_size, *past_key_values_uncondition.layers[layer_idx].values.shape[1:])
+
+        # prepare flash cache once
+        prepare_flash_kv_cache(
+            past_key_values_condition,
+            current_len=token_h * token_w,
+            batch_size=batch_size,
+        )
+        if past_key_values_uncondition is not None:
+            prepare_flash_kv_cache(
+                past_key_values_uncondition,
+                current_len=token_h * token_w,
+                batch_size=batch_size,
+            )
+
+        # init noise image tokens
+        grid_h = image_size[1] // self.patch_size
+        grid_w = image_size[0] // self.patch_size
+        grid_hw = torch.tensor([[grid_h, grid_w]]*batch_size, device=device)
+
+        noise_scale = self.noise_scale
+        if self.noise_scale_mode in ("resolution", "dynamic", 'dynamic_sqrt'):
+            base = float(self.noise_scale_base_image_seq_len)
+            scale = math.sqrt((grid_h*grid_w)/(merge_size**2)/base)
+            noise_scale = scale * float(self.noise_scale)
+            if self.noise_scale_mode == 'dynamic_sqrt':
+                noise_scale = math.sqrt(noise_scale)
+        noise_scale = min(noise_scale, self.noise_scale_max_value)
+        generator = torch.Generator(device).manual_seed(seed)
+        image_prediction = noise_scale * torch.randn((batch_size, 3, image_size[1], image_size[0]), device=device, dtype=dtype, generator=generator)
+
+        attention_mask_condition = {"full_attention": None}
+        attention_mask_uncondition = {"full_attention": None}
+
+        timesteps = torch.linspace(0.0, 1.0, num_steps+1, device=device)
+        if enable_timestep_shift:
+            timesteps = self._apply_time_schedule(timesteps, token_h*token_w, timestep_shift)
+
+        for step_i in range(num_steps):
+            t = timesteps[step_i]
+            t_next = timesteps[step_i + 1]
+
+            z = self.patchify(image_prediction, self.patch_size * merge_size)
+            image_input = self.patchify(image_prediction, self.patch_size, channel_first=True)
+            image_embeds = self.extract_feature(image_input.view(batch_size * grid_h*grid_w, -1), gen_model=True, grid_hw=grid_hw).view(batch_size, token_h*token_w, -1)
+            t_expanded = t.expand(batch_size*token_h*token_w)
+            timestep_embeddings = self.fm_modules['timestep_embedder'](t_expanded).view(batch_size, token_h*token_w, -1)
+            if self.add_noise_scale_embedding:
+                noise_scale_tensor = torch.full_like(t_expanded, noise_scale / self.noise_scale_max_value)
+                noise_embeddings = self.fm_modules['noise_scale_embedder'](noise_scale_tensor).view(batch_size, token_h*token_w, -1)
+                timestep_embeddings += noise_embeddings
+            image_embeds = image_embeds + timestep_embeddings
+
+            v_pred_condition = self._t2i_predict_v(image_embeds, indexes_image_condition, attention_mask_condition, past_key_values_condition, t, z, image_token_num=token_h*token_w, timestep_embeddings=timestep_embeddings, image_size=image_size)
+            
+            if t >= cfg_interval[0] and t <= cfg_interval[1] and cfg_scale > 1:
+                v_pred_uncondition = self._t2i_predict_v(image_embeds, indexes_image_uncondition, attention_mask_uncondition, past_key_values_uncondition, t, z, image_token_num=token_h*token_w, timestep_embeddings=timestep_embeddings, image_size=image_size)
+                if cfg_norm == 'cfg_zero_star':
+                    positive_flat = v_pred_condition.view(batch_size, -1)  
+                    negative_flat = v_pred_uncondition.view(batch_size, -1)  
+
+                    alpha = optimized_scale(positive_flat,negative_flat)
+                    alpha = alpha.view(batch_size, *([1] * (len(v_pred_condition.shape) - 1)))
+                    alpha = alpha.to(positive_flat.dtype)
+
+                    if (step_i <= 0):
+                        v_pred = v_pred_condition*0.
+                    else:
+                        v_pred = v_pred_uncondition * alpha + cfg_scale * (v_pred_condition - v_pred_uncondition * alpha)
+                else: 
+                    v_pred = v_pred_uncondition + cfg_scale * (v_pred_condition - v_pred_uncondition)
+                    if cfg_norm == 'global':
+                        norm_v_condition = torch.norm(v_pred_condition, dim=(1,2), keepdim=True)
+                        norm_v_cfg = torch.norm(v_pred, dim=(1,2), keepdim=True)
+                        scale = (norm_v_condition / (norm_v_cfg + 1e-8)).clamp(min=0, max=1.0)
+                        v_pred = v_pred * scale
+                    elif cfg_norm == 'channel':
+                        norm_v_condition = torch.norm(v_pred_condition, dim=-1, keepdim=True)
+                        norm_v_cfg = torch.norm(v_pred, dim=-1, keepdim=True)
+                        scale = (norm_v_condition / (norm_v_cfg + 1e-8)).clamp(min=0, max=1.0)
+                        v_pred = v_pred * scale
+            else:
+                v_pred = v_pred_condition
+
+            z = z + (t_next - t) * v_pred
+
+            image_prediction = self.unpatchify(z, self.patch_size * merge_size, image_size[1], image_size[0])
+
+        clear_flash_kv_cache(past_key_values_condition)
+        if past_key_values_uncondition is not None:
+            clear_flash_kv_cache(past_key_values_uncondition)
+
+        self.last_think_content = think_text
+        if think_mode:
+            return image_prediction, think_text
+        return image_prediction
+
+    def chat(self, tokenizer, pixel_values, question, generation_config, history=None, return_history=False, grid_hw=None, 
+             IMG_START_TOKEN='<img>', IMG_END_TOKEN='</img>', IMG_CONTEXT_TOKEN='<IMG_CONTEXT>', verbose=False):
+
+        if history is None and pixel_values is not None and '<image>' not in question:
+            question = '<image>\n' + question
+
+        img_context_token_id = tokenizer.convert_tokens_to_ids(IMG_CONTEXT_TOKEN)
+        self.img_context_token_id = img_context_token_id
+        self.img_start_token_id = tokenizer.convert_tokens_to_ids(IMG_START_TOKEN)
+
+        template = get_conv_template(self.template)
+        template.system_message = self.system_message
+        eos_token_id = tokenizer.convert_tokens_to_ids(template.sep.strip())
+
+        history = [] if history is None else history
+        for (old_question, old_answer) in history:
+            template.append_message(template.roles[0], old_question)
+            template.append_message(template.roles[1], old_answer)
+        template.append_message(template.roles[0], question)
+        template.append_message(template.roles[1], None)
+        query = template.get_prompt()
+
+        if verbose and pixel_values is not None:
+            print(f'dynamic image size: {grid_hw[0] * self.patch_size}')
+
+        for i in range(grid_hw.shape[0]):
+            num_patch_token = int(grid_hw[i, 0] * grid_hw[i, 1] * self.downsample_ratio**2)
+            image_tokens = IMG_START_TOKEN + IMG_CONTEXT_TOKEN * num_patch_token + IMG_END_TOKEN
+            query = query.replace('<image>', image_tokens, 1)
+
+        model_inputs = tokenizer(query, return_tensors='pt')
+        input_ids = model_inputs['input_ids'].to(self.device)
+        attention_mask = model_inputs['attention_mask'].to(self.device)
+        generation_config['eos_token_id'] = eos_token_id
+        generation_output = self.generate(
+            pixel_values=pixel_values,
+            input_ids=input_ids,
+            grid_hw=grid_hw,
+            attention_mask=attention_mask,
+            **generation_config
+        )
+        response = tokenizer.batch_decode(generation_output, skip_special_tokens=True)[0]
+        response = response.split(template.sep.strip())[0].strip()
+        history.append((question, response))
+        if return_history:
+            return response, history
+        else:
+            query_to_print = query.replace(IMG_CONTEXT_TOKEN, '')
+            query_to_print = query_to_print.replace(f'{IMG_START_TOKEN}{IMG_END_TOKEN}', '<image>')
+            if verbose:
+                print(query_to_print, response)
+            return response
+
+    @torch.no_grad()
+    def generate(
+            self,
+            pixel_values: Optional[torch.FloatTensor] = None,
+            input_ids: Optional[torch.FloatTensor] = None,
+            grid_hw: Optional[torch.LongTensor] = None,
+            attention_mask: Optional[torch.LongTensor] = None,
+            visual_features: Optional[torch.FloatTensor] = None,
+            generation_config: Optional[GenerationConfig] = None,
+            output_hidden_states: Optional[bool] = None,
+            **generate_kwargs,
+    ) -> torch.LongTensor:
+        assert input_ids.shape[0] == 1
+        assert self.img_context_token_id is not None
+        indexes = self.get_thw_indexes(input_ids[0], grid_hw)
+        if pixel_values is not None:
+            if visual_features is not None:
+                vit_embeds = visual_features
+            else:
+                vit_embeds = self.extract_feature(pixel_values, grid_hw=grid_hw)
+        
+            input_embeds = self.language_model.get_input_embeddings()(input_ids)
+            B, N, C = input_embeds.shape
+            input_embeds = input_embeds.reshape(B * N, C)
+
+            input_ids = input_ids.reshape(B * N)
+            selected = (input_ids == self.img_context_token_id)
+            assert selected.sum() != 0
+            input_embeds[selected] = vit_embeds.reshape(-1, C).to(input_embeds.device)
+
+            input_embeds = input_embeds.reshape(B, N, C)
+        else:
+            input_embeds = self.language_model.get_input_embeddings()(input_ids)
+
+        outputs = self.language_model.generate(
+            inputs_embeds=input_embeds,
+            indexes=indexes,
+            attention_mask=attention_mask,
+            generation_config=generation_config,
+            output_hidden_states=output_hidden_states,
+            use_cache=True,
+            **generate_kwargs,
+        )
+
+        return outputs
+
+    @property
+    def lm_head(self):
+        return self.language_model.get_output_embeddings()
+
+    def get_output_embeddings(self):
+        return self.language_model.get_output_embeddings()
+
+    def get_input_embeddings(self):
+        return self.language_model.get_input_embeddings()
+
+    def set_input_embeddings(self, value):
+        return self.language_model.set_input_embeddings(value)
+
+    def set_output_embeddings(self, value):
+        return self.language_model.set_output_embeddings(value)
+    
+    def get_thw_indexes(self, input_ids, grid_hw=None):
+        img_start_shift = torch.cat([torch.zeros(1, dtype=torch.long).to(input_ids.device), 
+                                     (input_ids == self.img_start_token_id).long()], dim=0)[:-1]
+        not_img_token = (input_ids != self.img_context_token_id).long()
+        t_indexes = ((img_start_shift + not_img_token).cumsum(0) - 1)
+        h_indexes = torch.zeros_like(t_indexes).to(t_indexes.device)
+        w_indexes = torch.zeros_like(t_indexes).to(t_indexes.device)
+
+        if grid_hw is not None:
+            selected = (input_ids == self.img_context_token_id)
+            if selected.long().sum() > 0:
+                abs_pos_w, abs_pos_h = build_abs_positions_from_grid_hw(
+                    grid_hw // int(1 / self.downsample_ratio), device=t_indexes.device)
+                h_indexes[selected] = abs_pos_h.to(t_indexes.device, t_indexes.dtype)
+                w_indexes[selected] = abs_pos_w.to(t_indexes.device, t_indexes.dtype)
+        return torch.stack([t_indexes, h_indexes, w_indexes], dim=0)

--- a/xinference/thirdparty/sensenova_u1/models/neo_unify/modeling_neo_vit.py
+++ b/xinference/thirdparty/sensenova_u1/models/neo_unify/modeling_neo_vit.py
@@ -1,0 +1,248 @@
+from typing import Optional, Tuple, Union
+
+import torch
+import torch.utils.checkpoint
+from torch import nn
+from transformers.modeling_outputs import BaseModelOutputWithPooling
+from transformers.modeling_utils import PreTrainedModel
+
+from .configuration_neo_vit import NEOVisionConfig
+
+
+def precompute_rope_freqs_sincos(
+    dim: int, max_position: int, base: float = 10000.0, device=None
+):
+    """预计算 RoPE 的 cos 和 sin 值 (1D)。"""
+    inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2, device=device).float() / dim))
+    t = torch.arange(max_position, device=device).type_as(inv_freq)
+    freqs = torch.outer(t, inv_freq)
+    return torch.cos(freqs), torch.sin(freqs)
+
+
+def build_abs_positions_from_grid_hw(grid_hw: torch.Tensor, device=None):
+    """
+    Compute patch coordinates (x, y)
+
+    Args:
+        grid_hw: (B, 2) tensor representing (H, W) per image
+    """
+    device = grid_hw.device
+    B = grid_hw.shape[0]
+
+    # Get the number of patches per image
+    H = grid_hw[:, 0]
+    W = grid_hw[:, 1]
+    N = H * W
+    N_total = N.sum()
+
+    # Create the batch index for each patch (B x patch count)
+    patch_to_sample = torch.repeat_interleave(torch.arange(B, device=device), N)  # (N_total,)
+
+    # Generate intra-image patch index (row-major order)
+    patch_id_within_image = torch.arange(N_total, device=device)
+    patch_id_within_image = patch_id_within_image - torch.cumsum(
+        torch.cat([torch.tensor([0], device=device), N[:-1]]), dim=0
+    )[patch_to_sample]
+
+    # Get H/W for each patch according to its image
+    W_per_patch = W[patch_to_sample]
+    abs_x = patch_id_within_image % W_per_patch
+    abs_y = patch_id_within_image // W_per_patch
+
+    return abs_x, abs_y
+
+
+def apply_rotary_emb_1d(
+    x: torch.Tensor,
+    cos_cached: torch.Tensor,
+    sin_cached: torch.Tensor,
+    positions: torch.Tensor,
+):
+    """对输入张量的一部分应用1D RoPE。"""
+    # x: (..., seq_len, dim_part)
+    # positions: (..., seq_len)
+    # cos_cached: (max_pos, dim_part / 2)
+    
+    cos = cos_cached[positions] # Shape: (positions.shape, dim_part / 2)
+    sin = sin_cached[positions] # Shape: (positions.shape, dim_part / 2)
+    
+    x1 = x[..., 0::2]
+    x2 = x[..., 1::2]
+    
+    rotated_x1 = x1 * cos - x2 * sin
+    rotated_x2 = x1 * sin + x2 * cos
+    
+    x_rotated = torch.empty_like(x)
+    x_rotated[..., 0::2] = rotated_x1
+    x_rotated[..., 1::2] = rotated_x2
+    return x_rotated
+
+
+def apply_2d_rotary_pos_emb(
+    x: torch.Tensor,
+    cos_cached_x: torch.Tensor,
+    sin_cached_x: torch.Tensor,
+    cos_cached_y: torch.Tensor,
+    sin_cached_y: torch.Tensor,
+    abs_positions_x: torch.Tensor,
+    abs_positions_y: torch.Tensor
+):
+    """应用2D RoPE到输入张量x。"""
+    dim = x.shape[-1]
+    dim_half = dim // 2
+
+    # 假设我们将embedding的前半部分用于一个方向的RoPE，后半部分用于另一个方向
+    # 例如，前一半给X坐标，后一半给Y坐标 (或者反过来，但要保持一致)
+    x_part_1 = x[..., :dim_half]
+    x_part_2 = x[..., dim_half:]
+
+    # 将与 abs_positions_x 相关的旋转应用于 x_part_1
+    rotated_part_1 = apply_rotary_emb_1d(
+        x_part_1, cos_cached_x, sin_cached_x, abs_positions_x
+    )
+    # 将与 abs_positions_y 相关的旋转应用于 x_part_2
+    rotated_part_2 = apply_rotary_emb_1d(
+        x_part_2, cos_cached_y, sin_cached_y, abs_positions_y
+    )
+    
+    # 将它们重新拼接起来。确保顺序与你分割时一致。
+    return torch.cat((rotated_part_1, rotated_part_2), dim=-1)
+
+
+class NEOVisionEmbeddings(nn.Module):
+    """
+    Embedding Module for Vision.
+    """
+
+    def __init__(self, config: NEOVisionConfig):
+        super().__init__()
+        self.config = config
+        self.embed_dim = config.hidden_size
+        self.llm_embed_dim = config.llm_hidden_size[0]
+        self.downsample_factor = int(1 / config.downsample_ratio[0])
+        self.patch_size = config.patch_size
+
+        self.patch_embedding = nn.Conv2d(
+            in_channels=config.num_channels, out_channels=self.embed_dim, kernel_size=self.patch_size, stride=self.patch_size
+        )
+        self.dense_embedding = nn.Conv2d(
+            in_channels=self.embed_dim, out_channels=self.llm_embed_dim, kernel_size=self.downsample_factor, stride=self.downsample_factor
+        )
+        self.gelu = nn.GELU()
+
+        self.rope_dim_part = self.embed_dim // 2
+        self.max_position_embeddings_vision = config.max_position_embeddings_vision
+        self.rope_theta_vision = config.rope_theta_vision
+
+        # These deterministic caches are not checkpoint state.  In
+        # Transformers 5, ``from_pretrained`` constructs models on the meta
+        # device; tensors computed here would later be materialized as
+        # uninitialized memory because persistent=False buffers are absent
+        # from the checkpoint.  Build them lazily on the first real device.
+        self.register_buffer("cos_cached_x", None, persistent=False)
+        self.register_buffer("sin_cached_x", None, persistent=False)
+        self.register_buffer("cos_cached_y", None, persistent=False)
+        self.register_buffer("sin_cached_y", None, persistent=False)
+
+    def _ensure_rope_cache(self, device: torch.device) -> None:
+        if self.cos_cached_x is not None and self.cos_cached_x.device == device:
+            return
+
+        cos, sin = precompute_rope_freqs_sincos(
+            self.rope_dim_part,
+            self.max_position_embeddings_vision,
+            base=self.rope_theta_vision,
+            device=device,
+        )
+        self.cos_cached_x = cos
+        self.sin_cached_x = sin
+        self.cos_cached_y = cos.clone()
+        self.sin_cached_y = sin.clone()
+
+    def _apply_2d_rotary_pos_emb(self, patch_embeds, grid_hw):
+        """
+        Apply 2D Rotary Position Embedding to the patch embeddings.
+        """
+        abs_pos_x, abs_pos_y = build_abs_positions_from_grid_hw(grid_hw, device=patch_embeds.device)
+        embeddings = apply_2d_rotary_pos_emb(
+            patch_embeds.to(torch.float32), # RoPE calculations are often more stable in float32
+            self.cos_cached_x, self.sin_cached_x,
+            self.cos_cached_y, self.sin_cached_y,
+            abs_pos_x,
+            abs_pos_y
+        ).to(self.patch_embedding.weight.dtype)
+        return embeddings
+        
+    def forward(self, pixel_values: torch.FloatTensor, grid_hw=None) -> torch.Tensor:
+        
+        pixel_values = pixel_values.view(  # 
+            -1,
+            3,
+            self.patch_size,
+            self.patch_size,
+        )   #  [28072, 768] -> [28072, 3, 16, 16]
+        patch_embeds = self.gelu(self.patch_embedding(pixel_values)).view(-1, self.embed_dim)
+        self._ensure_rope_cache(patch_embeds.device)
+        patch_embeds = self._apply_2d_rotary_pos_emb(patch_embeds, grid_hw) # [28072, 1024]
+        assert (grid_hw[:,0] * grid_hw[:,1]).sum() == patch_embeds.shape[0]
+
+        patches_list = []
+        cur_position = 0
+        for i in range(grid_hw.shape[0]):
+            h, w = grid_hw[i]
+            patches_per_img = patch_embeds[cur_position : cur_position + h * w].view(h, w, -1).unsqueeze(0)
+            patches_per_img = self.dense_embedding(patches_per_img.permute(0, 3, 1, 2))
+            patches_per_img = patches_per_img.permute(0, 2, 3, 1)
+            patches_list.append(patches_per_img.view(-1, patches_per_img.shape[-1]))
+            cur_position += h * w
+
+        embeddings = torch.cat(patches_list, dim=0)  # (N_total // downsample_factor**2, C)
+
+        assert cur_position == patch_embeds.shape[0]
+        assert embeddings.shape[0] == int(patch_embeds.shape[0] / self.downsample_factor**2)
+
+        return embeddings
+
+
+class NEOVisionModel(PreTrainedModel):
+    main_input_name = 'pixel_values'
+    _supports_flash_attn_2 = True
+    supports_gradient_checkpointing = True
+    config_class = NEOVisionConfig
+    # support transformers 4.51.+
+    _tp_plan = ''
+
+    def __init__(self, config: NEOVisionConfig):
+        super().__init__(config)
+        self.config = config
+
+        self.embeddings = NEOVisionEmbeddings(config)
+
+    def forward(
+            self,
+            pixel_values: Optional[torch.FloatTensor] = None,
+            output_hidden_states: Optional[bool] = None,
+            return_dict: Optional[bool] = None,
+            pixel_embeds: Optional[torch.FloatTensor] = None,
+            grid_hw: Optional[torch.Tensor] = None
+    ) -> Union[Tuple, BaseModelOutputWithPooling]:
+        output_hidden_states = (
+            output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
+        )
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+
+        if pixel_values is None and pixel_embeds is None:
+            raise ValueError('You have to specify pixel_values or pixel_embeds')
+
+        if pixel_embeds is not None:
+            hidden_states = pixel_embeds
+        else:
+            assert pixel_values.dim() == 2, f"pixel_values must be 2D for native resolution, got: {pixel_values.dim()}"
+            hidden_states = self.embeddings(pixel_values, grid_hw=grid_hw)
+
+        return BaseModelOutputWithPooling(
+            last_hidden_state=hidden_states,
+            pooler_output=None,
+            hidden_states=None,
+            attentions=None,
+        )

--- a/xinference/thirdparty/sensenova_u1/models/neo_unify/modeling_qwen3.py
+++ b/xinference/thirdparty/sensenova_u1/models/neo_unify/modeling_qwen3.py
@@ -1,0 +1,1298 @@
+from typing import Callable, Optional, Union
+
+import torch
+import torch._dynamo
+from torch import nn
+
+import copy
+import math
+from transformers.activations import ACT2FN
+from transformers.cache_utils import Cache, DynamicCache
+from transformers.generation import GenerationMixin
+from transformers.integrations import use_kernel_forward_from_hub
+from transformers.masking_utils import create_causal_mask
+from transformers.modeling_flash_attention_utils import FlashAttentionKwargs
+from transformers.modeling_layers import (
+    GenericForQuestionAnswering,
+    GenericForSequenceClassification,
+    GenericForTokenClassification,
+    GradientCheckpointingLayer,
+)
+from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
+from transformers.modeling_rope_utils import ROPE_INIT_FUNCTIONS, dynamic_rope_update
+from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
+from transformers.processing_utils import Unpack
+from transformers.utils import TransformersKwargs, can_return_tuple
+from transformers.utils.deprecation import deprecate_kwarg
+from transformers import Qwen3Config
+
+from .transformers_compat import causal_mask_kwargs, model_input_compat, tied_weights_keys
+
+try:
+    from flash_attn import flash_attn_func  # type: ignore
+
+    _HAS_FLASH_ATTN = True
+except ImportError:  # pragma: no cover - exercised only in CPU-only / no-flash envs
+    flash_attn_func = None  # type: ignore
+    _HAS_FLASH_ATTN = False
+
+
+# Attention backend dispatch.
+#
+# Set via :func:`set_attn_backend`. Three modes are accepted:
+#   * ``"auto"``  - use flash-attn if available, otherwise SDPA (default).
+#   * ``"flash"`` - force flash-attn; raise if ``flash_attn`` is not installed.
+#   * ``"sdpa"``  - force torch SDPA (useful for reproducibility tests and
+#                    debugging, even when flash-attn is available).
+_VALID_ATTN_BACKENDS = ("auto", "flash", "sdpa")
+_ATTN_BACKEND: str = "auto"
+
+
+def set_attn_backend(backend: str) -> str:
+    """Choose the attention kernel used by the Qwen3 layers at runtime.
+
+    Returns the backend string that was set. Raises ``ValueError`` for an
+    unknown name and ``RuntimeError`` if ``flash`` is requested but the
+    ``flash_attn`` package isn't importable.
+    """
+    global _ATTN_BACKEND
+    backend = backend.lower()
+    if backend not in _VALID_ATTN_BACKENDS:
+        raise ValueError(
+            f"Unknown attention backend {backend!r}. "
+            f"Expected one of {_VALID_ATTN_BACKENDS}."
+        )
+    if backend == "flash" and not _HAS_FLASH_ATTN:
+        raise RuntimeError(
+            "Requested attn_backend='flash' but `flash_attn` is not installed. "
+            "Install it (e.g. `uv pip install <flash_attn-*.whl>`) or use "
+            "'auto' / 'sdpa'."
+        )
+    _ATTN_BACKEND = backend
+    return _ATTN_BACKEND
+
+
+def get_attn_backend() -> str:
+    """Return the currently active attention backend name."""
+    return _ATTN_BACKEND
+
+
+def effective_attn_backend() -> str:
+    """Resolve ``'auto'`` to the kernel that will actually run."""
+    if _ATTN_BACKEND != "auto":
+        return _ATTN_BACKEND
+    return "flash" if _HAS_FLASH_ATTN else "sdpa"
+
+
+def _sdpa_attn_func(q, k, v, dropout_p: float = 0.0, softmax_scale=None, causal: bool = False):
+    """Drop-in SDPA fallback for ``flash_attn_func``.
+
+    ``flash_attn_func`` expects q/k/v in layout ``[B, S, H, D]`` and returns
+    ``[B, S_q, H_q, D]``. ``torch.nn.functional.scaled_dot_product_attention``
+    expects ``[B, H, S, D]``; we transpose in and out.
+
+    ``flash_attn_func`` natively handles Grouped-Query Attention (GQA) where
+    ``H_q > H_kv``. Plain ``scaled_dot_product_attention`` only supports that
+    via the ``enable_gqa=True`` kwarg (torch >= 2.5). For broader compatibility
+    we just materialize the repeat manually when needed.
+    """
+    q_bhsd = q.transpose(1, 2)
+    k_bhsd = k.transpose(1, 2)
+    v_bhsd = v.transpose(1, 2)
+
+    h_q = q_bhsd.shape[1]
+    h_kv = k_bhsd.shape[1]
+    if h_q != h_kv:
+        if h_q % h_kv != 0:
+            raise ValueError(
+                f"Cannot broadcast key/value heads ({h_kv}) to query heads ({h_q}): not divisible."
+            )
+        n_rep = h_q // h_kv
+        k_bhsd = k_bhsd.repeat_interleave(n_rep, dim=1)
+        v_bhsd = v_bhsd.repeat_interleave(n_rep, dim=1)
+
+    # SDPA does not support an explicit `scale` argument on older torch
+    # versions; fall back to the manual path in that case.
+    try:
+        out = torch.nn.functional.scaled_dot_product_attention(
+            q_bhsd,
+            k_bhsd,
+            v_bhsd,
+            dropout_p=dropout_p,
+            is_causal=causal,
+            scale=softmax_scale,
+        )
+    except TypeError:
+        if softmax_scale is not None:
+            q_bhsd = q_bhsd * softmax_scale
+            out = torch.nn.functional.scaled_dot_product_attention(
+                q_bhsd,
+                k_bhsd,
+                v_bhsd,
+                dropout_p=dropout_p,
+                is_causal=causal,
+            )
+        else:
+            out = torch.nn.functional.scaled_dot_product_attention(
+                q_bhsd,
+                k_bhsd,
+                v_bhsd,
+                dropout_p=dropout_p,
+                is_causal=causal,
+            )
+    return out.transpose(1, 2).contiguous()
+
+
+def _flash_or_sdpa(q, k, v, dropout_p: float = 0.0, softmax_scale=None, causal: bool = False):
+    backend = effective_attn_backend()
+    # flash-attn ships CUDA kernels only. On XPU / CPU we transparently fall
+    # back to SDPA even if the user asked for ``flash`` — the alternative
+    # (crashing on first forward) is worse, and ``set_attn_backend('flash')``
+    # already guarded against the "package missing" case.
+    if backend == "flash" and q.device.type == "cuda":
+        return flash_attn_func(q, k, v, dropout_p=dropout_p, softmax_scale=softmax_scale, causal=causal)
+    return _sdpa_attn_func(q, k, v, dropout_p=dropout_p, softmax_scale=softmax_scale, causal=causal)
+
+
+def create_block_causal_mask(index: torch.Tensor):
+    """
+    index: (L)
+    return: (1, 1, L, L) block-wise causal attention mask
+    """
+    L = index.size(0)
+    idx_i = index.unsqueeze(1).expand(L, L)
+    idx_j = index.unsqueeze(0).expand(L, L)
+
+    arange = torch.arange(L, device=index.device)
+    mask = (idx_j == idx_i) | (arange.unsqueeze(0) <= arange.unsqueeze(1))
+
+    return torch.where(mask[None, None, :, :] > 0, torch.tensor(0.0), torch.tensor(float('-inf')))
+
+
+def visualize_mask(mask: torch.Tensor, i: int = 0, j: int = 12):
+    """
+    mask: (1,1, L, L)
+    """
+    submask = torch.where(mask[0, 0, :, :] == 0, torch.tensor(1.0), torch.tensor(0.0))
+    submask = mask[i:j, i:j].int().cpu().numpy()
+    for row in submask:
+        print(" ".join(map(str, row)))
+
+
+@use_kernel_forward_from_hub("RMSNorm")
+class Qwen3RMSNorm(nn.Module):
+    def __init__(self, hidden_size, eps: float = 1e-6) -> None:
+        """
+        Qwen3RMSNorm is equivalent to T5LayerNorm
+        """
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(hidden_size))
+        self.variance_epsilon = eps
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        input_dtype = hidden_states.dtype
+        hidden_states = hidden_states.to(torch.float32)
+        variance = hidden_states.pow(2).mean(-1, keepdim=True)
+        hidden_states = hidden_states * torch.rsqrt(variance + self.variance_epsilon)
+        return self.weight * hidden_states.to(input_dtype)
+
+    def extra_repr(self):
+        return f"{tuple(self.weight.shape)}, eps={self.variance_epsilon}"
+
+
+class Qwen3MLP(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        self.config = config
+        self.hidden_size = config.hidden_size
+        self.intermediate_size = config.intermediate_size
+        self.gate_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=False)
+        self.up_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=False)
+        self.down_proj = nn.Linear(self.intermediate_size, self.hidden_size, bias=False)
+        self.act_fn = ACT2FN[config.hidden_act]
+
+    def forward(self, x):
+        down_proj = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))
+        return down_proj
+
+
+def rotate_half(x):
+    """Rotates half the hidden dims of the input."""
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2 :]
+    return torch.cat((-x2, x1), dim=-1)
+
+
+def apply_rotary_pos_emb(q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
+    """Applies Rotary Position Embedding to the query and key tensors.
+
+    Args:
+        q (`torch.Tensor`): The query tensor.
+        k (`torch.Tensor`): The key tensor.
+        cos (`torch.Tensor`): The cosine part of the rotary embedding.
+        sin (`torch.Tensor`): The sine part of the rotary embedding.
+        position_ids (`torch.Tensor`, *optional*):
+            Deprecated and unused.
+        unsqueeze_dim (`int`, *optional*, defaults to 1):
+            The 'unsqueeze_dim' argument specifies the dimension along which to unsqueeze cos[position_ids] and
+            sin[position_ids] so that they can be properly broadcasted to the dimensions of q and k. For example, note
+            that cos[position_ids] and sin[position_ids] have the shape [batch_size, seq_len, head_dim]. Then, if q and
+            k have the shape [batch_size, heads, seq_len, head_dim], then setting unsqueeze_dim=1 makes
+            cos[position_ids] and sin[position_ids] broadcastable to the shapes of q and k. Similarly, if q and k have
+            the shape [batch_size, seq_len, heads, head_dim], then set unsqueeze_dim=2.
+    Returns:
+        `tuple(torch.Tensor)` comprising of the query and key tensors rotated using the Rotary Position Embedding.
+    """
+    cos = cos.unsqueeze(unsqueeze_dim)
+    sin = sin.unsqueeze(unsqueeze_dim)
+    q_embed = (q * cos) + (rotate_half(q) * sin)
+    k_embed = (k * cos) + (rotate_half(k) * sin)
+    return q_embed, k_embed
+
+
+def repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
+    """
+    This is the equivalent of torch.repeat_interleave(x, dim=1, repeats=n_rep). The hidden states go from (batch,
+    num_key_value_heads, seqlen, head_dim) to (batch, num_attention_heads, seqlen, head_dim)
+    """
+    batch, num_key_value_heads, slen, head_dim = hidden_states.shape
+    if n_rep == 1:
+        return hidden_states
+    hidden_states = hidden_states[:, :, None, :, :].expand(batch, num_key_value_heads, n_rep, slen, head_dim)
+    return hidden_states.reshape(batch, num_key_value_heads * n_rep, slen, head_dim)
+
+
+def eager_attention_forward(
+    module: nn.Module,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attention_mask: Optional[torch.Tensor],
+    scaling: float,
+    dropout: float = 0.0,
+    **kwargs: Unpack[TransformersKwargs],
+):
+    key_states = repeat_kv(key, module.num_key_value_groups)
+    value_states = repeat_kv(value, module.num_key_value_groups)
+
+    attn_weights = torch.matmul(query, key_states.transpose(2, 3)) * scaling
+    if attention_mask is not None:
+        causal_mask = attention_mask[:, :, :, : key_states.shape[-2]]
+        attn_weights = attn_weights + causal_mask
+
+    attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query.dtype)
+    attn_weights = nn.functional.dropout(attn_weights, p=dropout, training=module.training)
+    attn_output = torch.matmul(attn_weights, value_states)
+    attn_output = attn_output.transpose(1, 2).contiguous()
+
+    return attn_output, attn_weights
+
+
+def _compute_default_rope_parameters(config, device=None, **_kwargs):
+    """Default RoPE frequencies, inlined to avoid breakage across transformers versions.
+
+    transformers <=4.x exposes this as ``ROPE_INIT_FUNCTIONS["default"]``, but
+    5.x dropped the ``"default"`` key from that table. Having a local copy keeps
+    ``Qwen3RotaryEmbedding`` working on both.
+    """
+    base = config.rope_theta
+    partial_rotary_factor = getattr(config, "partial_rotary_factor", 1.0)
+    head_dim = getattr(config, "head_dim", config.hidden_size // config.num_attention_heads)
+    dim = int(head_dim * partial_rotary_factor)
+    attention_factor = 1.0
+    inv_freq = 1.0 / (
+        base ** (torch.arange(0, dim, 2, dtype=torch.int64).float().to(device) / dim)
+    )
+    return inv_freq, attention_factor
+
+
+class Qwen3RotaryEmbedding(nn.Module):
+    inv_freq: torch.Tensor  # fix linting for `register_buffer`
+
+    compute_default_rope_parameters = staticmethod(_compute_default_rope_parameters)
+
+    def __init__(self, config: Qwen3Config, device=None):
+        super().__init__()
+        # BC: "rope_type" was originally "type"
+        if hasattr(config, "rope_scaling") and isinstance(config.rope_scaling, dict):
+            self.rope_type = config.rope_scaling.get("rope_type", config.rope_scaling.get("type"))
+        else:
+            self.rope_type = "default"
+        self.max_seq_len_cached = config.max_position_embeddings
+        self.original_max_seq_len = config.max_position_embeddings
+
+        self.config = config
+        if self.rope_type == "default" or self.rope_type is None:
+            base_rope_init_fn = _compute_default_rope_parameters
+        else:
+            base_rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type]
+
+        def _rope_init_fn_keep_freq_range(cfg: Qwen3Config, dev=None):
+            inv_freq, attention_scaling = base_rope_init_fn(cfg, dev)
+
+            cfg2 = copy.deepcopy(cfg)
+            head_dim = getattr(cfg2, "head_dim", None)
+            if head_dim is None:
+                head_dim = cfg2.hidden_size // cfg2.num_attention_heads
+                setattr(cfg2, "head_dim", head_dim)
+            cfg2.head_dim = int(head_dim) * 2
+
+            inv_freq_full, _ = base_rope_init_fn(cfg2, dev)
+            inv_freq = inv_freq_full[::2]
+
+            return inv_freq, attention_scaling
+
+        self.rope_init_fn = _rope_init_fn_keep_freq_range
+
+        inv_freq, self.attention_scaling = self.rope_init_fn(self.config, device)
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self.original_inv_freq = self.inv_freq
+
+    @torch.no_grad()
+    @dynamic_rope_update  # power user: used with advanced RoPE types (e.g. dynamic rope)
+    def forward(self, x, position_ids):
+        inv_freq_expanded = self.inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)
+        position_ids_expanded = position_ids[:, None, :].float()
+
+        device_type = x.device.type if isinstance(x.device.type, str) and x.device.type != "mps" else "cpu"
+        with torch.autocast(device_type=device_type, enabled=False):  # Force float32
+            freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)
+            emb = torch.cat((freqs, freqs), dim=-1)
+            cos = emb.cos() * self.attention_scaling
+            sin = emb.sin() * self.attention_scaling
+
+        return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)
+
+
+class Qwen3Attention(nn.Module):
+    """Multi-headed attention from 'Attention Is All You Need' paper"""
+
+    def __init__(self, config: Qwen3Config, layer_idx: int):
+        super().__init__()
+        self.config = config
+        self.layer_idx = layer_idx
+        self.head_dim = getattr(config, "head_dim", config.hidden_size // config.num_attention_heads)
+        self.num_key_value_groups = config.num_attention_heads // config.num_key_value_heads
+        self.scaling = self.head_dim**-0.5
+        self.attention_dropout = config.attention_dropout
+        self.is_causal = True
+
+        self.q_proj = nn.Linear(
+            config.hidden_size, config.num_attention_heads * self.head_dim, bias=config.attention_bias
+        )
+        self.q_proj_mot_gen = nn.Linear(
+            config.hidden_size, config.num_attention_heads * self.head_dim, bias=config.attention_bias
+        )
+
+        self.k_proj = nn.Linear(
+            config.hidden_size, config.num_key_value_heads * self.head_dim, bias=config.attention_bias
+        )
+        self.k_proj_mot_gen = nn.Linear(
+            config.hidden_size, config.num_key_value_heads * self.head_dim, bias=config.attention_bias
+        )
+
+        self.v_proj = nn.Linear(
+            config.hidden_size, config.num_key_value_heads * self.head_dim, bias=config.attention_bias
+        )
+        self.v_proj_mot_gen = nn.Linear(
+            config.hidden_size, config.num_key_value_heads * self.head_dim, bias=config.attention_bias
+        )
+        self.o_proj = nn.Linear(
+            config.num_attention_heads * self.head_dim, config.hidden_size, bias=config.attention_bias
+        )
+        self.o_proj_mot_gen = nn.Linear(
+            config.num_attention_heads * self.head_dim, config.hidden_size, bias=config.attention_bias
+        )
+
+        self.q_norm = Qwen3RMSNorm(self.head_dim // 2, eps=config.rms_norm_eps)  # unlike olmo, only on the head dim!
+        self.q_norm_mot_gen = Qwen3RMSNorm(self.head_dim // 2, eps=config.rms_norm_eps)
+        self.q_norm_hw = Qwen3RMSNorm(self.head_dim // 2, eps=config.rms_norm_eps)
+        self.q_norm_hw_mot_gen = Qwen3RMSNorm(self.head_dim // 2, eps=config.rms_norm_eps)
+
+        self.k_norm = Qwen3RMSNorm(self.head_dim // 2, eps=config.rms_norm_eps)  # thus post q_norm does not need reshape
+        self.k_norm_mot_gen = Qwen3RMSNorm(self.head_dim // 2, eps=config.rms_norm_eps)
+        self.k_norm_hw = Qwen3RMSNorm(self.head_dim // 2, eps=config.rms_norm_eps)  # thus post q_norm does not need reshape
+        self.k_norm_hw_mot_gen = Qwen3RMSNorm(self.head_dim // 2, eps=config.rms_norm_eps)
+
+        self.sliding_window = config.sliding_window if config.layer_types[layer_idx] == "sliding_attention" else None
+
+        t_config = copy.deepcopy(config)
+        t_config.head_dim = config.head_dim // 2
+        self.rotary_emb = Qwen3RotaryEmbedding(config=t_config)
+
+        hw_config = copy.deepcopy(config)
+        hw_config.head_dim = config.head_dim // 4
+        hw_config.rope_theta = config.rope_theta_hw
+        if isinstance(getattr(hw_config, "rope_parameters", None), dict):
+            hw_config.rope_parameters = {**hw_config.rope_parameters, "rope_theta": config.rope_theta_hw}
+        hw_config.max_position_embeddings = config.max_position_embeddings_hw
+        self.rotary_emb_hw = Qwen3RotaryEmbedding(config=hw_config)
+    
+    def forward_und(
+        self,
+        hidden_states: torch.Tensor,
+        indexes: Optional[torch.LongTensor],
+        attention_mask: Optional[torch.Tensor],
+        past_key_values: Optional[Cache] = None,
+        cache_position: Optional[torch.LongTensor] = None,
+        **kwargs: Unpack[FlashAttentionKwargs],
+    ) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
+        assert self.config._attn_implementation == "eager"
+        input_shape = hidden_states.shape[:-1]
+        hidden_shape = (*input_shape, -1, self.head_dim)
+
+        query_states = self.q_proj(hidden_states).view(hidden_shape)
+        query_states_t, query_states_hw = query_states.chunk(2, dim=-1)
+        query_states_t = self.q_norm(query_states_t).transpose(1, 2)
+        query_states_hw = self.q_norm_hw(query_states_hw).transpose(1, 2)
+        query_states_h, query_states_w = query_states_hw.chunk(2, dim=-1)
+
+        key_states = self.k_proj(hidden_states).view(hidden_shape)
+        key_states_t, key_states_hw = key_states.chunk(2, dim=-1)
+        key_states_t = self.k_norm(key_states_t).transpose(1, 2)
+        key_states_hw = self.k_norm_hw(key_states_hw).transpose(1, 2)
+        key_states_h, key_states_w = key_states_hw.chunk(2, dim=-1)
+
+        value_states = self.v_proj(hidden_states).view(hidden_shape).transpose(1, 2)
+
+        cos_t, sin_t = self.rotary_emb(hidden_states, indexes[0].unsqueeze(0))
+        query_states_t, key_states_t = apply_rotary_pos_emb(query_states_t, key_states_t, cos_t, sin_t)
+
+        cos_h, sin_h = self.rotary_emb_hw(hidden_states, indexes[1].unsqueeze(0))
+        query_states_h, key_states_h = apply_rotary_pos_emb(query_states_h, key_states_h, cos_h, sin_h)
+
+        cos_w, sin_w = self.rotary_emb_hw(hidden_states, indexes[2].unsqueeze(0))
+        query_states_w, key_states_w = apply_rotary_pos_emb(query_states_w, key_states_w, cos_w, sin_w)
+
+        query_states = torch.cat([query_states_t, query_states_h, query_states_w], dim=-1)
+        key_states = torch.cat([key_states_t, key_states_h, key_states_w], dim=-1)
+
+
+        if past_key_values is not None:
+            # sin and cos are specific to RoPE models; cache_position needed for the static cache
+            # cache_kwargs = {"sin": sin, "cos": cos, "cache_position": cache_position}
+            # key_states, value_states = past_key_values.update(key_states, value_states, self.layer_idx, cache_kwargs)
+            update_cache = kwargs.get("update_cache", True)
+            if update_cache:
+                key_states, value_states = past_key_values.update(key_states, value_states, self.layer_idx, cache_kwargs=None)
+            else:
+                # only use the past key values but do not append the current one
+                layer = past_key_values.layers[self.layer_idx]
+                past_k, past_v = layer.keys, layer.values
+
+                if past_k is not None:
+                    key_states   = torch.cat([past_k, key_states], dim=2)   # concat on seq_len
+                    value_states = torch.cat([past_v, value_states], dim=2)
+
+        attention_interface: Callable = eager_attention_forward
+        if self.config._attn_implementation != "eager":
+            attention_interface = ALL_ATTENTION_FUNCTIONS[self.config._attn_implementation]
+
+        attn_output, attn_weights = attention_interface(
+            self,
+            query_states,
+            key_states,
+            value_states,
+            attention_mask,
+            dropout=0.0 if not self.training else self.attention_dropout,
+            scaling=self.scaling,
+            sliding_window=self.sliding_window,  # diff with Llama
+            **kwargs,
+        )
+
+        attn_output = attn_output.reshape(*input_shape, -1).contiguous()
+        attn_output = self.o_proj(attn_output)
+        return attn_output, attn_weights
+
+    # def forward_gen(
+    #     self,
+    #     hidden_states: torch.Tensor,
+    #     indexes: Optional[torch.LongTensor],
+    #     attention_mask: Optional[torch.Tensor],
+    #     past_key_values: Optional[Cache] = None,
+    #     cache_position: Optional[torch.LongTensor] = None,
+    #     **kwargs: Unpack[FlashAttentionKwargs],
+    # ) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
+    #     assert self.config._attn_implementation == "eager"
+    #     input_shape = hidden_states.shape[:-1]
+    #     hidden_shape = (*input_shape, -1, self.head_dim)
+
+    #     query_states = self.q_proj_mot_gen(hidden_states).view(hidden_shape)
+    #     query_states_t, query_states_hw = query_states.chunk(2, dim=-1)
+    #     query_states_t = self.q_norm_mot_gen(query_states_t).transpose(1, 2)
+    #     query_states_hw = self.q_norm_hw_mot_gen(query_states_hw).transpose(1, 2)
+    #     query_states_h, query_states_w = query_states_hw.chunk(2, dim=-1)
+
+    #     key_states = self.k_proj_mot_gen(hidden_states).view(hidden_shape)
+    #     key_states_t, key_states_hw = key_states.chunk(2, dim=-1)
+    #     key_states_t = self.k_norm_mot_gen(key_states_t).transpose(1, 2)
+    #     key_states_hw = self.k_norm_hw_mot_gen(key_states_hw).transpose(1, 2)
+    #     key_states_h, key_states_w = key_states_hw.chunk(2, dim=-1)
+
+    #     value_states = self.v_proj_mot_gen(hidden_states).view(hidden_shape).transpose(1, 2)
+
+    #     cos_t, sin_t = self.rotary_emb(hidden_states, indexes[0].unsqueeze(0))
+    #     query_states_t, key_states_t = apply_rotary_pos_emb(query_states_t, key_states_t, cos_t, sin_t)
+
+    #     cos_h, sin_h = self.rotary_emb_hw(hidden_states, indexes[1].unsqueeze(0))
+    #     query_states_h, key_states_h = apply_rotary_pos_emb(query_states_h, key_states_h, cos_h, sin_h)
+
+    #     cos_w, sin_w = self.rotary_emb_hw(hidden_states, indexes[2].unsqueeze(0))
+    #     query_states_w, key_states_w = apply_rotary_pos_emb(query_states_w, key_states_w, cos_w, sin_w)
+
+    #     query_states = torch.cat([query_states_t, query_states_h, query_states_w], dim=-1)
+    #     key_states = torch.cat([key_states_t, key_states_h, key_states_w], dim=-1)
+
+
+    #     if past_key_values is not None:
+    #         # sin and cos are specific to RoPE models; cache_position needed for the static cache
+    #         # cache_kwargs = {"sin": sin, "cos": cos, "cache_position": cache_position}
+    #         # key_states, value_states = past_key_values.update(key_states, value_states, self.layer_idx, cache_kwargs)
+    #         update_cache = kwargs.get("update_cache", True)
+    #         if update_cache:
+    #             key_states, value_states = past_key_values.update(key_states, value_states, self.layer_idx, cache_kwargs=None)
+    #         else:
+    #             # only use the past key values but do not append the current one
+    #             layer = past_key_values.layers[self.layer_idx]
+    #             past_k, past_v = layer.keys, layer.values
+
+    #             if past_k is not None:
+    #                 key_states   = torch.cat([past_k, key_states], dim=2)   # concat on seq_len
+    #                 value_states = torch.cat([past_v, value_states], dim=2)
+
+    #     attention_interface: Callable = eager_attention_forward
+    #     if self.config._attn_implementation != "eager":
+    #         attention_interface = ALL_ATTENTION_FUNCTIONS[self.config._attn_implementation]
+
+    #     attn_output, attn_weights = attention_interface(
+    #         self,
+    #         query_states,
+    #         key_states,
+    #         value_states,
+    #         attention_mask,
+    #         dropout=0.0 if not self.training else self.attention_dropout,
+    #         scaling=self.scaling,
+    #         sliding_window=self.sliding_window,  # diff with Llama
+    #         **kwargs,
+    #     )
+
+    #     attn_output = attn_output.reshape(*input_shape, -1).contiguous()
+    #     attn_output = self.o_proj_mot_gen(attn_output)
+    #     return attn_output, attn_weights
+
+    def forward_gen(
+        self,
+        hidden_states: torch.Tensor,
+        indexes: Optional[torch.LongTensor],
+        attention_mask: Optional[torch.Tensor],
+        past_key_values: Optional[Cache] = None,
+        cache_position: Optional[torch.LongTensor] = None,
+        **kwargs: Unpack[FlashAttentionKwargs],
+    ) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
+        input_shape = hidden_states.shape[:-1]
+        hidden_shape = (*input_shape, -1, self.head_dim)
+
+        # -----------------------------
+        # Build q / k / v for current tokens
+        # Internal layout before flash:
+        #   q/k/v: [B, H, S, D]
+        # Flash layout:
+        #   q/k/v: [B, S, H, D]
+        # -----------------------------
+        query_states = self.q_proj_mot_gen(hidden_states).view(hidden_shape)
+        query_states_t, query_states_hw = query_states.chunk(2, dim=-1)
+        query_states_t = self.q_norm_mot_gen(query_states_t).transpose(1, 2)   # [B,H,S,D/2]
+        query_states_hw = self.q_norm_hw_mot_gen(query_states_hw).transpose(1, 2)
+        query_states_h, query_states_w = query_states_hw.chunk(2, dim=-1)
+
+        key_states = self.k_proj_mot_gen(hidden_states).view(hidden_shape)
+        key_states_t, key_states_hw = key_states.chunk(2, dim=-1)
+        key_states_t = self.k_norm_mot_gen(key_states_t).transpose(1, 2)       # [B,H,S,D/2]
+        key_states_hw = self.k_norm_hw_mot_gen(key_states_hw).transpose(1, 2)
+        key_states_h, key_states_w = key_states_hw.chunk(2, dim=-1)
+
+        value_states = self.v_proj_mot_gen(hidden_states).view(hidden_shape).transpose(1, 2)  # [B,H,S,D]
+
+        # RoPE
+        cos_t, sin_t = self.rotary_emb(hidden_states, indexes[0].unsqueeze(0))
+        query_states_t, key_states_t = apply_rotary_pos_emb(query_states_t, key_states_t, cos_t, sin_t)
+
+        cos_h, sin_h = self.rotary_emb_hw(hidden_states, indexes[1].unsqueeze(0))
+        query_states_h, key_states_h = apply_rotary_pos_emb(query_states_h, key_states_h, cos_h, sin_h)
+
+        cos_w, sin_w = self.rotary_emb_hw(hidden_states, indexes[2].unsqueeze(0))
+        query_states_w, key_states_w = apply_rotary_pos_emb(query_states_w, key_states_w, cos_w, sin_w)
+
+        # concat along head_dim
+        # query/key current layout: [B, H, S, D]
+        query_states = torch.cat([query_states_t, query_states_h, query_states_w], dim=-1)
+        key_states = torch.cat([key_states_t, key_states_h, key_states_w], dim=-1)
+
+        update_cache = kwargs.get("update_cache", True)
+
+        # ------------------------------------------------------------------
+        # Flash path:
+        # Only use when there is no explicit dense mask.
+        # This is exactly the t2i denoising use case:
+        #   current image tokens attend to [prefix + current image tokens]
+        #   fully bidirectional inside current block => causal=False
+        # ------------------------------------------------------------------
+        if attention_mask is None:
+            # Convert current q/k/v to flash layout [B, S, H, D]
+            q = query_states.transpose(1, 2).contiguous()
+            k_cur = key_states.transpose(1, 2).contiguous()
+            v_cur = value_states.transpose(1, 2).contiguous()
+
+            if past_key_values is not None:
+                if update_cache:
+                    # Rare path, keep compatibility.
+                    # past_key_values.update expects [B,H,S,D]
+                    key_states, value_states = past_key_values.update(
+                        key_states, value_states, self.layer_idx, cache_kwargs=None
+                    )
+                    k = key_states.transpose(1, 2).contiguous()
+                    v = value_states.transpose(1, 2).contiguous()
+                else:
+                    # Optimized path:
+                    # use preallocated flash_k_cache / flash_v_cache
+                    layer = past_key_values.layers[self.layer_idx]
+
+                    if (
+                        hasattr(layer, "flash_k_cache")
+                        and layer.flash_k_cache is not None
+                        and hasattr(layer, "flash_v_cache")
+                        and layer.flash_v_cache is not None
+                    ):
+                        prefix_len = layer.flash_prefix_len
+                        cur_len = k_cur.shape[1]
+
+                        # overwrite current segment in-place
+                        layer.flash_k_cache[:, prefix_len:prefix_len + cur_len].copy_(k_cur)
+                        layer.flash_v_cache[:, prefix_len:prefix_len + cur_len].copy_(v_cur)
+
+                        k = layer.flash_k_cache[:, :prefix_len + cur_len]
+                        v = layer.flash_v_cache[:, :prefix_len + cur_len]
+                    else:
+                        # fallback if user forgot to prepare flash cache
+                        layer = past_key_values.layers[self.layer_idx]
+                        past_k, past_v = layer.keys, layer.values
+
+                        if past_k is not None:
+                            past_k = past_k.transpose(1, 2).contiguous()
+                            past_v = past_v.transpose(1, 2).contiguous()
+                            k = torch.cat([past_k, k_cur], dim=1)
+                            v = torch.cat([past_v, v_cur], dim=1)
+                        else:
+                            k = k_cur
+                            v = v_cur
+            else:
+                k = k_cur
+                v = v_cur
+
+            # sanity checks
+            assert q.ndim == 4 and k.ndim == 4 and v.ndim == 4
+            assert q.shape[0] == k.shape[0] == v.shape[0], (q.shape, k.shape, v.shape)
+            assert k.shape[1] == v.shape[1], (k.shape, v.shape)
+            assert k.shape[2] == v.shape[2], (k.shape, v.shape)
+            assert q.shape[3] == k.shape[3] == v.shape[3], (q.shape, k.shape, v.shape)
+
+            attn_output = _flash_or_sdpa(
+                q,
+                k,
+                v,
+                dropout_p=0.0 if not self.training else self.attention_dropout,
+                softmax_scale=self.scaling,
+                causal=False,
+            )  # [B, S_q, H_q, D]
+
+            attn_output = attn_output.reshape(*input_shape, -1).contiguous()
+            attn_output = self.o_proj_mot_gen(attn_output)
+            return attn_output, None
+
+        # ------------------------------------------------------------------
+        # Original eager fallback path
+        # ------------------------------------------------------------------
+        if past_key_values is not None:
+            if update_cache:
+                key_states, value_states = past_key_values.update(
+                    key_states, value_states, self.layer_idx, cache_kwargs=None
+                )
+            else:
+                layer = past_key_values.layers[self.layer_idx]
+                past_k, past_v = layer.keys, layer.values
+                if past_k is not None:
+                    key_states = torch.cat([past_k, key_states], dim=2)
+                    value_states = torch.cat([past_v, value_states], dim=2)
+
+        attention_interface: Callable = eager_attention_forward
+        if self.config._attn_implementation != "eager":
+            attention_interface = ALL_ATTENTION_FUNCTIONS[self.config._attn_implementation]
+
+        attn_output, attn_weights = attention_interface(
+            self,
+            query_states,
+            key_states,
+            value_states,
+            attention_mask,
+            dropout=0.0 if not self.training else self.attention_dropout,
+            scaling=self.scaling,
+            sliding_window=self.sliding_window,
+            **kwargs,
+        )
+
+        attn_output = attn_output.reshape(*input_shape, -1).contiguous()
+        attn_output = self.o_proj_mot_gen(attn_output)
+        return attn_output, attn_weights
+
+    @deprecate_kwarg("past_key_value", new_name="past_key_values", version="4.58")
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        image_gen_indicators: torch.Tensor,
+        exist_non_image_gen_tokens: bool,
+        exist_image_gen_tokens: bool,
+        indexes: Optional[torch.LongTensor],
+        attention_mask: Optional[torch.Tensor],
+        past_key_values: Optional[Cache] = None,
+        cache_position: Optional[torch.LongTensor] = None,
+        **kwargs: Unpack[FlashAttentionKwargs],
+    ) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
+        if exist_non_image_gen_tokens and not exist_image_gen_tokens:
+            return self.forward_und(hidden_states, indexes, attention_mask, past_key_values, cache_position, **kwargs)
+        if not exist_non_image_gen_tokens and exist_image_gen_tokens:
+            return self.forward_gen(hidden_states, indexes, attention_mask, past_key_values, cache_position, **kwargs)
+
+        # Mixed und/gen path: mirrors forward_und / forward_gen per token type.
+        # (Fixed per issue #207: the time-dim qk-norm, the `.view(hidden_shape)` before
+        # chunking, and the transpose on the time chunk were previously missing.)
+        # Note: Remove this raise once fully tested.
+        raise NotImplementedError(
+            "The mixed und/gen forward path is not yet validated (issue #207): known "
+            "issues are fixed, but it has no parity test and no production caller. "
+            "Split the sequence at token-type boundaries and use forward_und / forward_gen."
+        )
+
+        assert self.config._attn_implementation == "eager"
+        input_shape = hidden_states.shape[:-1]
+        hidden_shape = (*input_shape, -1, self.head_dim)
+
+        query_states = hidden_states.new_zeros((*input_shape, self.config.num_attention_heads*self.head_dim))
+        if exist_non_image_gen_tokens:
+            query_states[~image_gen_indicators] = self.q_proj(hidden_states[~image_gen_indicators])
+        if exist_image_gen_tokens:
+            query_states[image_gen_indicators] = self.q_proj_mot_gen(hidden_states[image_gen_indicators])
+        query_states = query_states.view(hidden_shape)  # [B, S, H, D]
+        query_states_t, query_states_hw = query_states.chunk(2, dim=-1)
+
+        _query_states_t = query_states_t.new_zeros(query_states_t.shape)
+        if exist_non_image_gen_tokens:
+            _query_states_t[~image_gen_indicators] = self.q_norm(query_states_t[~image_gen_indicators])
+        if exist_image_gen_tokens:
+            _query_states_t[image_gen_indicators] = self.q_norm_mot_gen(query_states_t[image_gen_indicators])
+        query_states_t = _query_states_t.transpose(1, 2)  # [B, H, S, D/2]
+
+        _query_states_hw = query_states_hw.new_zeros(query_states_hw.shape)
+        if exist_non_image_gen_tokens:
+            _query_states_hw[~image_gen_indicators] = self.q_norm_hw(query_states_hw[~image_gen_indicators])
+        if exist_image_gen_tokens:
+            _query_states_hw[image_gen_indicators] = self.q_norm_hw_mot_gen(query_states_hw[image_gen_indicators])
+        query_states_hw = _query_states_hw.transpose(1, 2)
+        query_states_h, query_states_w = query_states_hw.chunk(2, dim=-1)
+
+        key_states = hidden_states.new_zeros((*input_shape, self.config.num_key_value_heads*self.head_dim))
+        if exist_non_image_gen_tokens:
+            key_states[~image_gen_indicators] = self.k_proj(hidden_states[~image_gen_indicators])
+        if exist_image_gen_tokens:
+            key_states[image_gen_indicators] = self.k_proj_mot_gen(hidden_states[image_gen_indicators])
+        key_states = key_states.view(hidden_shape)  # [B, S, H_kv, D]
+        key_states_t, key_states_hw = key_states.chunk(2, dim=-1)
+
+        _key_states_t = key_states_t.new_zeros(key_states_t.shape)
+        if exist_non_image_gen_tokens:
+            _key_states_t[~image_gen_indicators] = self.k_norm(key_states_t[~image_gen_indicators])
+        if exist_image_gen_tokens:
+            _key_states_t[image_gen_indicators] = self.k_norm_mot_gen(key_states_t[image_gen_indicators])
+        key_states_t = _key_states_t.transpose(1, 2)  # [B, H_kv, S, D/2]
+
+        _key_states_hw = key_states_hw.new_zeros(key_states_hw.shape)
+        if exist_non_image_gen_tokens:
+            _key_states_hw[~image_gen_indicators] = self.k_norm_hw(key_states_hw[~image_gen_indicators])
+        if exist_image_gen_tokens:
+            _key_states_hw[image_gen_indicators] = self.k_norm_hw_mot_gen(key_states_hw[image_gen_indicators])
+        key_states_hw = _key_states_hw.transpose(1, 2)
+        key_states_h, key_states_w = key_states_hw.chunk(2, dim=-1)
+
+        value_states = hidden_states.new_zeros((*input_shape, self.config.num_key_value_heads*self.head_dim))
+        if exist_non_image_gen_tokens:
+            value_states[~image_gen_indicators] = self.v_proj(hidden_states[~image_gen_indicators])
+        if exist_image_gen_tokens:
+            value_states[image_gen_indicators] = self.v_proj_mot_gen(hidden_states[image_gen_indicators])
+        value_states = value_states.view(hidden_shape).transpose(1, 2)
+
+        cos_t, sin_t = self.rotary_emb(hidden_states, indexes[0].unsqueeze(0))
+        query_states_t, key_states_t = apply_rotary_pos_emb(query_states_t, key_states_t, cos_t, sin_t)
+
+        cos_h, sin_h = self.rotary_emb_hw(hidden_states, indexes[1].unsqueeze(0))
+        query_states_h, key_states_h = apply_rotary_pos_emb(query_states_h, key_states_h, cos_h, sin_h)
+
+        cos_w, sin_w = self.rotary_emb_hw(hidden_states, indexes[2].unsqueeze(0))
+        query_states_w, key_states_w = apply_rotary_pos_emb(query_states_w, key_states_w, cos_w, sin_w)
+
+        query_states = torch.cat([query_states_t, query_states_h, query_states_w], dim=-1)
+        key_states = torch.cat([key_states_t, key_states_h, key_states_w], dim=-1)
+
+
+        if past_key_values is not None:
+            # sin and cos are specific to RoPE models; cache_position needed for the static cache
+            # cache_kwargs = {"sin": sin, "cos": cos, "cache_position": cache_position}
+            # key_states, value_states = past_key_values.update(key_states, value_states, self.layer_idx, cache_kwargs)
+            update_cache = kwargs.get("update_cache", True)
+            if update_cache:
+                key_states, value_states = past_key_values.update(key_states, value_states, self.layer_idx, cache_kwargs=None)
+            else:
+                # only use the past key values but do not append the current one
+                layer = past_key_values.layers[self.layer_idx]
+                past_k, past_v = layer.keys, layer.values
+
+                if past_k is not None:
+                    key_states   = torch.cat([past_k, key_states], dim=2)   # concat on seq_len
+                    value_states = torch.cat([past_v, value_states], dim=2)
+
+        attention_interface: Callable = eager_attention_forward
+        if self.config._attn_implementation != "eager":
+            attention_interface = ALL_ATTENTION_FUNCTIONS[self.config._attn_implementation]
+
+        attn_output, attn_weights = attention_interface(
+            self,
+            query_states,
+            key_states,
+            value_states,
+            attention_mask,
+            dropout=0.0 if not self.training else self.attention_dropout,
+            scaling=self.scaling,
+            sliding_window=self.sliding_window,  # diff with Llama
+            **kwargs,
+        )
+
+        attn_output = attn_output.reshape(*input_shape, -1).contiguous()
+
+        _attn_output = attn_output.new_zeros((*input_shape, self.config.hidden_size))
+        if exist_non_image_gen_tokens:
+            _attn_output[~image_gen_indicators] = self.o_proj(attn_output[~image_gen_indicators])
+        if exist_image_gen_tokens:
+            _attn_output[image_gen_indicators] = self.o_proj_mot_gen(attn_output[image_gen_indicators])
+
+        attn_output = _attn_output
+        return attn_output, attn_weights
+
+
+class Qwen3DecoderLayer(GradientCheckpointingLayer):
+    def __init__(self, config: Qwen3Config, layer_idx: int):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+
+        self.self_attn = Qwen3Attention(config=config, layer_idx=layer_idx)
+
+        self.mlp = Qwen3MLP(config)
+        self.mlp_mot_gen = Qwen3MLP(config)
+        self.input_layernorm = Qwen3RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.input_layernorm_mot_gen = Qwen3RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = Qwen3RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm_mot_gen = Qwen3RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.attention_type = config.layer_types[layer_idx]
+
+    def forward_und(
+        self,
+        hidden_states: torch.Tensor,
+        image_gen_indicators: torch.Tensor,
+        exist_non_image_gen_tokens: bool,
+        exist_image_gen_tokens: bool,
+        indexes: Optional[torch.LongTensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_values: Optional[Cache] = None,
+        use_cache: Optional[bool] = False,
+        cache_position: Optional[torch.LongTensor] = None,
+        **kwargs: Unpack[TransformersKwargs],
+    ) -> torch.Tensor:
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+        # Self Attention
+        hidden_states, _ = self.self_attn(
+            hidden_states=hidden_states,
+            image_gen_indicators=image_gen_indicators,
+            exist_non_image_gen_tokens=exist_non_image_gen_tokens,
+            exist_image_gen_tokens=exist_image_gen_tokens,
+            indexes=indexes,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            use_cache=use_cache,
+            cache_position=cache_position,
+            **kwargs,
+        )
+        hidden_states = residual + hidden_states
+
+        # Fully Connected
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = residual + hidden_states
+        return hidden_states
+
+    def forward_gen(
+        self,
+        hidden_states: torch.Tensor,
+        image_gen_indicators: torch.Tensor,
+        exist_non_image_gen_tokens: bool,
+        exist_image_gen_tokens: bool,
+        indexes: Optional[torch.LongTensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_values: Optional[Cache] = None,
+        use_cache: Optional[bool] = False,
+        cache_position: Optional[torch.LongTensor] = None,
+        **kwargs: Unpack[TransformersKwargs],
+    ) -> torch.Tensor:
+        residual = hidden_states
+        hidden_states = self.input_layernorm_mot_gen(hidden_states)
+        # Self Attention
+        hidden_states, _ = self.self_attn(
+            hidden_states=hidden_states,
+            image_gen_indicators=image_gen_indicators,
+            exist_non_image_gen_tokens=exist_non_image_gen_tokens,
+            exist_image_gen_tokens=exist_image_gen_tokens,
+            indexes=indexes,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            use_cache=use_cache,
+            cache_position=cache_position,
+            **kwargs,
+        )
+        hidden_states = residual + hidden_states
+
+        # Fully Connected
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm_mot_gen(hidden_states)
+        hidden_states = self.mlp_mot_gen(hidden_states)
+        hidden_states = residual + hidden_states
+        return hidden_states
+
+    @deprecate_kwarg("past_key_value", new_name="past_key_values", version="4.58")
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        image_gen_indicators: torch.Tensor,
+        exist_non_image_gen_tokens: bool,
+        exist_image_gen_tokens: bool,
+        indexes: Optional[torch.LongTensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_values: Optional[Cache] = None,
+        use_cache: Optional[bool] = False,
+        cache_position: Optional[torch.LongTensor] = None,
+        **kwargs: Unpack[TransformersKwargs],
+    ) -> torch.Tensor:
+        if exist_non_image_gen_tokens and not exist_image_gen_tokens:
+            return self.forward_und(hidden_states, image_gen_indicators, exist_non_image_gen_tokens, exist_image_gen_tokens, indexes, attention_mask, position_ids, past_key_values, use_cache, cache_position, **kwargs)
+        if not exist_non_image_gen_tokens and exist_image_gen_tokens:
+            return self.forward_gen(hidden_states, image_gen_indicators, exist_non_image_gen_tokens, exist_image_gen_tokens, indexes, attention_mask, position_ids, past_key_values, use_cache, cache_position, **kwargs)
+
+        # Mixed und/gen path — see the NOTE in Qwen3Attention.forward for caveats.
+        raise NotImplementedError(
+            "Mixed und/gen decoder-layer forward is not yet validated (issue #207). "
+            "Split the sequence at token-type boundaries and use forward_und / forward_gen."
+        )
+
+        residual = hidden_states
+
+        _hidden_states = hidden_states.new_zeros(hidden_states.shape)
+        if exist_non_image_gen_tokens:
+            _hidden_states[~image_gen_indicators] = self.input_layernorm(hidden_states[~image_gen_indicators])
+        if exist_image_gen_tokens:
+            _hidden_states[image_gen_indicators] = self.input_layernorm_mot_gen(hidden_states[image_gen_indicators])
+        hidden_states = _hidden_states
+
+        # Self Attention
+        hidden_states, _ = self.self_attn(
+            hidden_states=hidden_states,
+            image_gen_indicators=image_gen_indicators,
+            exist_non_image_gen_tokens=exist_non_image_gen_tokens,
+            exist_image_gen_tokens=exist_image_gen_tokens,
+            indexes=indexes,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            use_cache=use_cache,
+            cache_position=cache_position,
+            **kwargs,
+        )
+        hidden_states = residual + hidden_states
+
+        # Fully Connected
+        residual = hidden_states
+
+        _hidden_states = hidden_states.new_zeros(hidden_states.shape)
+        if exist_non_image_gen_tokens:
+            _hidden_states[~image_gen_indicators] = self.mlp(self.post_attention_layernorm(hidden_states[~image_gen_indicators]))
+
+        if exist_image_gen_tokens:
+            _hidden_states[image_gen_indicators] = self.mlp_mot_gen(self.post_attention_layernorm_mot_gen(hidden_states[image_gen_indicators]))
+
+        hidden_states = _hidden_states
+        hidden_states = residual + hidden_states
+        return hidden_states
+
+
+class Qwen3PreTrainedModel(PreTrainedModel):
+    config: Qwen3Config
+    base_model_prefix = "model"
+    supports_gradient_checkpointing = True
+    _no_split_modules = ["Qwen3DecoderLayer"]
+    _skip_keys_device_placement = ["past_key_values"]
+    _supports_flash_attn = True
+    _supports_sdpa = True
+    _supports_flex_attn = True
+
+    _can_compile_fullgraph = True
+    _supports_attention_backend = True
+    _can_record_outputs = {
+        "hidden_states": Qwen3DecoderLayer,
+        "attentions": Qwen3Attention,
+    }
+
+
+class Qwen3Model(Qwen3PreTrainedModel):
+    def __init__(self, config: Qwen3Config):
+        super().__init__(config)
+        self.padding_idx = config.pad_token_id
+        self.vocab_size = config.vocab_size
+
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size, self.padding_idx)
+        self.layers = nn.ModuleList(
+            [Qwen3DecoderLayer(config, layer_idx) for layer_idx in range(config.num_hidden_layers)]
+        )
+        self.norm = Qwen3RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.norm_mot_gen = Qwen3RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        
+        self.gradient_checkpointing = False
+        self.has_sliding_layers = "sliding_attention" in self.config.layer_types
+        self.current_index = -1
+
+        # Initialize weights and apply final processing
+        self.post_init()
+
+    @model_input_compat
+    def forward(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        image_gen_indicators: Optional[torch.Tensor] = None,
+        indexes: Optional[torch.LongTensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_values: Optional[Cache] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        use_cache: Optional[bool] = None,
+        cache_position: Optional[torch.LongTensor] = None,
+        **kwargs: Unpack[TransformersKwargs],
+    ) -> BaseModelOutputWithPast:
+        
+        # assert position_ids is not None
+        # assert cache_position is not None
+        # assert past_key_values is not None 
+
+        if image_gen_indicators is None:
+            exist_non_image_gen_tokens = True
+            exist_image_gen_tokens = False
+        else:
+            # Normalize once before the decoder loop. Leaving these as CUDA
+            # scalar tensors makes every layer's Python branch read them back
+            # to the host, serializing the compute stream and defeating weight
+            # prefetch overlap.
+            exist_non_image_gen_tokens = bool((~image_gen_indicators).any().item())
+            exist_image_gen_tokens = bool(image_gen_indicators.any().item())
+        
+        if (input_ids is None) ^ (inputs_embeds is not None):
+            raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
+
+        if inputs_embeds is None:
+            inputs_embeds = self.embed_tokens(input_ids)
+
+        if use_cache and past_key_values is None:
+            past_key_values = DynamicCache(config=self.config)
+
+        if cache_position is None:
+            past_seen_tokens = past_key_values.get_seq_length() if past_key_values is not None else 0
+            cache_position = torch.arange(
+                past_seen_tokens, past_seen_tokens + inputs_embeds.shape[1], device=inputs_embeds.device
+            )
+
+        if position_ids is None:
+            position_ids = cache_position.unsqueeze(0)
+
+        # It may already have been prepared by e.g. `generate`
+        if not isinstance(causal_mask_mapping := attention_mask, dict):
+            # Prepare mask arguments
+            if input_ids is not None:
+                mask_kwargs = causal_mask_kwargs(
+                    create_causal_mask,
+                    config=self.config,
+                    inputs_embeds=inputs_embeds,
+                    attention_mask=attention_mask,
+                    cache_position=cache_position,
+                    past_key_values=past_key_values,
+                    position_ids=position_ids,
+                )
+                # Create the masks
+                causal_mask_mapping = {
+                    "full_attention": create_causal_mask(**mask_kwargs),
+                }
+                self.current_index += 1
+                indexes = torch.LongTensor([[self.current_index], [0], [0]]).to(input_ids.device)
+            else:
+                causal_mask_mapping = {
+                    "full_attention": create_block_causal_mask(indexes[0]),
+                }
+                self.current_index = indexes[0].max()
+        else:
+            self.current_index = indexes[0].max()
+            # raise NotImplementedError('not isinstance(causal_mask_mapping := attention_mask, dict)')
+
+            # The sliding window alternating layers are not always activated depending on the config
+            # if self.has_sliding_layers:
+            #     causal_mask_mapping["sliding_attention"] = create_sliding_window_causal_mask(**mask_kwargs)
+
+        hidden_states = inputs_embeds
+
+        for decoder_layer in self.layers[: self.config.num_hidden_layers]:
+            hidden_states = decoder_layer(
+                hidden_states,
+                image_gen_indicators=image_gen_indicators,
+                exist_non_image_gen_tokens=exist_non_image_gen_tokens,
+                exist_image_gen_tokens=exist_image_gen_tokens,
+                indexes=indexes,
+                attention_mask=causal_mask_mapping[decoder_layer.attention_type],
+                position_ids=position_ids,
+                past_key_values=past_key_values,
+                use_cache=use_cache,
+                cache_position=cache_position,
+                **kwargs,
+            )
+        if not exist_image_gen_tokens:
+            hidden_states = self.norm(hidden_states)
+        elif not exist_non_image_gen_tokens:
+            hidden_states = self.norm_mot_gen(hidden_states)
+        else:
+            _hidden_states = hidden_states.new_zeros(hidden_states.shape)
+            _hidden_states[~image_gen_indicators] = self.norm(hidden_states[~image_gen_indicators])
+            _hidden_states[image_gen_indicators] = self.norm_mot_gen(hidden_states[image_gen_indicators])
+            hidden_states = _hidden_states
+        return BaseModelOutputWithPast(
+            last_hidden_state=hidden_states,
+            past_key_values=past_key_values if use_cache else None,
+        )
+
+
+class Qwen3ForCausalLM(Qwen3PreTrainedModel, GenerationMixin):
+    _tied_weights_keys = tied_weights_keys("lm_head.weight", "model.embed_tokens.weight")
+    _tp_plan = {"lm_head": "colwise_rep"}
+    _pp_plan = {"lm_head": (["hidden_states"], ["logits"])}
+
+    def __init__(self, config):
+        super().__init__(config)
+        self.model = Qwen3Model(config)
+        self.vocab_size = config.vocab_size
+        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+
+        # Initialize weights and apply final processing
+        self.post_init()
+
+    @can_return_tuple
+    def forward(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        indexes: Optional[torch.LongTensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_values: Optional[Cache] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        labels: Optional[torch.LongTensor] = None,
+        use_cache: Optional[bool] = None,
+        cache_position: Optional[torch.LongTensor] = None,
+        logits_to_keep: Union[int, torch.Tensor] = 0,
+        **kwargs: Unpack[TransformersKwargs],
+    ) -> CausalLMOutputWithPast:
+        r"""
+        labels (`torch.LongTensor` of shape `(batch_size, sequence_length)`, *optional*):
+            Labels for computing the masked language modeling loss. Indices should either be in `[0, ...,
+            config.vocab_size]` or -100 (see `input_ids` docstring). Tokens with indices set to `-100` are ignored
+            (masked), the loss is only computed for the tokens with labels in `[0, ..., config.vocab_size]`.
+
+        Example:
+
+        ```python
+        >>> from transformers import AutoTokenizer, Qwen3ForCausalLM
+
+        >>> model = Qwen3ForCausalLM.from_pretrained("Qwen/Qwen3-8B")
+        >>> tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3-8B")
+
+        >>> prompt = "Hey, are you conscious? Can you talk to me?"
+        >>> inputs = tokenizer(prompt, return_tensors="pt")
+
+        >>> # Generate
+        >>> generate_ids = model.generate(inputs.input_ids, max_length=30)
+        >>> tokenizer.batch_decode(generate_ids, skip_special_tokens=True, clean_up_tokenization_spaces=False)[0]
+        "Hey, are you conscious? Can you talk to me?\nI'm not conscious, but I can talk to you."
+        ```"""
+
+        outputs: BaseModelOutputWithPast = self.model(
+            input_ids=input_ids,
+            indexes=indexes,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            inputs_embeds=inputs_embeds,
+            use_cache=use_cache,
+            cache_position=cache_position,
+            **kwargs,
+        )
+
+        hidden_states = outputs.last_hidden_state
+        # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
+        slice_indices = slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep
+        logits = self.lm_head(hidden_states[:, slice_indices, :])
+
+        loss = None
+        if labels is not None:
+            loss = self.loss_function(logits=logits, labels=labels, vocab_size=self.config.vocab_size, **kwargs)
+
+        return CausalLMOutputWithPast(
+            loss=loss,
+            logits=logits,
+            past_key_values=outputs.past_key_values,
+            hidden_states=outputs.hidden_states,
+            attentions=outputs.attentions,
+        )
+
+
+class Qwen3ForSequenceClassification(GenericForSequenceClassification, Qwen3PreTrainedModel):
+    pass
+
+
+class Qwen3ForTokenClassification(GenericForTokenClassification, Qwen3PreTrainedModel):
+    pass
+
+
+class Qwen3ForQuestionAnswering(GenericForQuestionAnswering, Qwen3PreTrainedModel):
+    base_model_prefix = "transformer"  # For BC, where `transformer` was used instead of `model`
+
+
+__all__ = [
+    "Qwen3ForCausalLM",
+    "Qwen3ForQuestionAnswering",
+    "Qwen3PreTrainedModel",
+    "Qwen3Model",
+    "Qwen3ForSequenceClassification",
+    "Qwen3ForTokenClassification",
+]

--- a/xinference/thirdparty/sensenova_u1/models/neo_unify/modeling_qwen3_moe.py
+++ b/xinference/thirdparty/sensenova_u1/models/neo_unify/modeling_qwen3_moe.py
@@ -1,0 +1,548 @@
+from typing import Callable, Optional, Union
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+from transformers.cache_utils import Cache, DynamicCache
+from transformers.generation import GenerationMixin
+from transformers.masking_utils import create_causal_mask
+from transformers.modeling_flash_attention_utils import FlashAttentionKwargs
+from transformers.modeling_layers import GradientCheckpointingLayer
+from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
+from transformers.modeling_utils import PreTrainedModel
+from transformers.processing_utils import Unpack
+from transformers.utils import TransformersKwargs, can_return_tuple
+from transformers.utils.deprecation import deprecate_kwarg
+
+from .configuration_neo_chat import NEOMoELLMConfig
+from .modeling_qwen3 import (
+    Qwen3Attention,
+    Qwen3RMSNorm,
+    create_block_causal_mask,
+)
+from .transformers_compat import causal_mask_kwargs, model_input_compat, tied_weights_keys
+
+
+class Qwen3MoeMLP(nn.Module):
+    """Single expert FFN. Same structure as :class:`Qwen3MLP` but the
+    intermediate size is parameterised so it can be ``moe_intermediate_size``
+    (per-expert) for experts and ``intermediate_size`` for any dense fallback.
+    """
+
+    def __init__(self, config, intermediate_size: Optional[int] = None):
+        super().__init__()
+        from transformers.activations import ACT2FN
+
+        self.config = config
+        self.hidden_size = config.hidden_size
+        self.intermediate_size = (
+            intermediate_size if intermediate_size is not None else config.intermediate_size
+        )
+        self.gate_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=False)
+        self.up_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=False)
+        self.down_proj = nn.Linear(self.intermediate_size, self.hidden_size, bias=False)
+        self.act_fn = ACT2FN[config.hidden_act]
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))
+
+
+class Qwen3MoeSparseMoeBlock(nn.Module):
+    """Top-k softmax-routed MoE block matching HuggingFace's Qwen3-MoE layout.
+
+    Parameter names (``gate.weight``, ``experts.{i}.gate_proj/up_proj/down_proj``)
+    are kept identical so converted A3B checkpoints load directly via the
+    ``mlp.*`` / ``mlp_mot_gen.*`` keys. The block is parameterised explicitly
+    so the same class can serve both the understanding branch (``num_experts``
+    experts, top-k = ``num_experts_per_tok``, width ``moe_intermediate_size``)
+    and the image-generation branch (``gen_num_experts`` etc.).
+    """
+
+    def __init__(
+        self,
+        config: NEOMoELLMConfig,
+        num_experts: Optional[int] = None,
+        num_experts_per_tok: Optional[int] = None,
+        moe_intermediate_size: Optional[int] = None,
+    ):
+        super().__init__()
+        self.num_experts = int(num_experts) if num_experts is not None else int(config.num_experts)
+        self.top_k = int(
+            num_experts_per_tok if num_experts_per_tok is not None else config.num_experts_per_tok
+        )
+        self.norm_topk_prob = bool(getattr(config, "norm_topk_prob", True))
+        self.hidden_size = config.hidden_size
+
+        expert_intermediate_size = int(
+            moe_intermediate_size
+            if moe_intermediate_size is not None
+            else config.moe_intermediate_size
+        )
+
+        self.gate = nn.Linear(config.hidden_size, self.num_experts, bias=False)
+        self.experts = nn.ModuleList(
+            [
+                Qwen3MoeMLP(config, intermediate_size=expert_intermediate_size)
+                for _ in range(self.num_experts)
+            ]
+        )
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        orig_shape = hidden_states.shape
+        hidden_dim = orig_shape[-1]
+        flat = hidden_states.view(-1, hidden_dim)
+        n_tokens = flat.shape[0]
+
+        router_logits = self.gate(flat)
+        routing_weights = F.softmax(router_logits, dim=1, dtype=torch.float32)
+        routing_weights, selected_experts = torch.topk(routing_weights, self.top_k, dim=-1)
+        if self.norm_topk_prob:
+            routing_weights = routing_weights / routing_weights.sum(dim=-1, keepdim=True)
+        routing_weights = routing_weights.to(flat.dtype)
+
+        output = torch.zeros(
+            (n_tokens, hidden_dim), dtype=flat.dtype, device=flat.device
+        )
+        # (num_experts, top_k, num_tokens)
+        expert_mask = F.one_hot(selected_experts, num_classes=self.num_experts).permute(2, 1, 0)
+
+        for expert_idx in range(self.num_experts):
+            idx, top_x = torch.where(expert_mask[expert_idx])
+            if top_x.numel() == 0:
+                continue
+            expert_layer = self.experts[expert_idx]
+            current_state = flat.index_select(0, top_x)
+            current_out = expert_layer(current_state) * routing_weights[top_x, idx, None]
+            output.index_add_(0, top_x, current_out.to(flat.dtype))
+
+        return output.view(*orig_shape)
+
+
+class Qwen3MoeDecoderLayer(GradientCheckpointingLayer):
+    """A Qwen3-MoE decoder block with the NEO-Unify two-branch structure.
+
+    Mirrors ``Qwen3DecoderLayer`` from :mod:`modeling_qwen3` but uses sparse
+    MoE blocks on *both* branches:
+
+      * ``self.mlp``         - understanding-path MoE
+                               (``num_experts`` / ``num_experts_per_tok`` /
+                               ``moe_intermediate_size``)
+      * ``self.mlp_mot_gen`` - image-generation-path MoE
+                               (``gen_num_experts`` / ``gen_num_experts_per_tok`` /
+                               ``gen_moe_intermediate_size``)
+
+    Layers listed in ``mlp_only_layers`` or those not aligned with
+    ``decoder_sparse_step`` fall back to a dense :class:`Qwen3MoeMLP` on the
+    understanding branch (matching upstream Qwen3-MoE), while the
+    generation branch still uses a sparse MoE.
+    """
+
+    def __init__(self, config: NEOMoELLMConfig, layer_idx: int):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.self_attn = Qwen3Attention(config=config, layer_idx=layer_idx)
+
+        mlp_only_layers = list(getattr(config, "mlp_only_layers", []) or [])
+        decoder_sparse_step = int(getattr(config, "decoder_sparse_step", 1) or 1)
+        is_sparse = (
+            int(config.num_experts) > 0
+            and layer_idx not in mlp_only_layers
+            and (layer_idx + 1) % decoder_sparse_step == 0
+        )
+
+        if is_sparse:
+            self.mlp = Qwen3MoeSparseMoeBlock(
+                config,
+                num_experts=config.num_experts,
+                num_experts_per_tok=config.num_experts_per_tok,
+                moe_intermediate_size=config.moe_intermediate_size,
+            )
+        else:
+            self.mlp = Qwen3MoeMLP(config, intermediate_size=config.intermediate_size)
+
+        # Image-generation branch: in the A3B checkpoint this is *also* a sparse
+        # MoE block (``gen_num_experts`` experts, typically smaller than the und
+        # branch's ``num_experts``). ``NEOMoELLMConfig`` defaults the gen-path
+        # knobs to their und-path counterparts so legacy single-pool configs
+        # keep working.
+        self.mlp_mot_gen = Qwen3MoeSparseMoeBlock(
+            config,
+            num_experts=getattr(config, "gen_num_experts", config.num_experts),
+            num_experts_per_tok=getattr(
+                config, "gen_num_experts_per_tok", config.num_experts_per_tok
+            ),
+            moe_intermediate_size=getattr(
+                config, "gen_moe_intermediate_size", config.moe_intermediate_size
+            ),
+        )
+
+        self.input_layernorm = Qwen3RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.input_layernorm_mot_gen = Qwen3RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = Qwen3RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm_mot_gen = Qwen3RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.attention_type = config.layer_types[layer_idx]
+
+    def forward_und(
+        self,
+        hidden_states: torch.Tensor,
+        image_gen_indicators: torch.Tensor,
+        exist_non_image_gen_tokens: bool,
+        exist_image_gen_tokens: bool,
+        indexes: Optional[torch.LongTensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_values: Optional[Cache] = None,
+        use_cache: Optional[bool] = False,
+        cache_position: Optional[torch.LongTensor] = None,
+        **kwargs: Unpack[TransformersKwargs],
+    ) -> torch.Tensor:
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+        hidden_states, _ = self.self_attn(
+            hidden_states=hidden_states,
+            image_gen_indicators=image_gen_indicators,
+            exist_non_image_gen_tokens=exist_non_image_gen_tokens,
+            exist_image_gen_tokens=exist_image_gen_tokens,
+            indexes=indexes,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            use_cache=use_cache,
+            cache_position=cache_position,
+            **kwargs,
+        )
+        hidden_states = residual + hidden_states
+
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = residual + hidden_states
+        return hidden_states
+
+    def forward_gen(
+        self,
+        hidden_states: torch.Tensor,
+        image_gen_indicators: torch.Tensor,
+        exist_non_image_gen_tokens: bool,
+        exist_image_gen_tokens: bool,
+        indexes: Optional[torch.LongTensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_values: Optional[Cache] = None,
+        use_cache: Optional[bool] = False,
+        cache_position: Optional[torch.LongTensor] = None,
+        **kwargs: Unpack[TransformersKwargs],
+    ) -> torch.Tensor:
+        residual = hidden_states
+        hidden_states = self.input_layernorm_mot_gen(hidden_states)
+        hidden_states, _ = self.self_attn(
+            hidden_states=hidden_states,
+            image_gen_indicators=image_gen_indicators,
+            exist_non_image_gen_tokens=exist_non_image_gen_tokens,
+            exist_image_gen_tokens=exist_image_gen_tokens,
+            indexes=indexes,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            use_cache=use_cache,
+            cache_position=cache_position,
+            **kwargs,
+        )
+        hidden_states = residual + hidden_states
+
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm_mot_gen(hidden_states)
+        hidden_states = self.mlp_mot_gen(hidden_states)
+        hidden_states = residual + hidden_states
+        return hidden_states
+
+    @deprecate_kwarg("past_key_value", new_name="past_key_values", version="4.58")
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        image_gen_indicators: torch.Tensor,
+        exist_non_image_gen_tokens: bool,
+        exist_image_gen_tokens: bool,
+        indexes: Optional[torch.LongTensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_values: Optional[Cache] = None,
+        use_cache: Optional[bool] = False,
+        cache_position: Optional[torch.LongTensor] = None,
+        **kwargs: Unpack[TransformersKwargs],
+    ) -> torch.Tensor:
+        if exist_non_image_gen_tokens and not exist_image_gen_tokens:
+            return self.forward_und(
+                hidden_states, image_gen_indicators, exist_non_image_gen_tokens,
+                exist_image_gen_tokens, indexes, attention_mask, position_ids,
+                past_key_values, use_cache, cache_position, **kwargs,
+            )
+        if not exist_non_image_gen_tokens and exist_image_gen_tokens:
+            return self.forward_gen(
+                hidden_states, image_gen_indicators, exist_non_image_gen_tokens,
+                exist_image_gen_tokens, indexes, attention_mask, position_ids,
+                past_key_values, use_cache, cache_position, **kwargs,
+            )
+
+        # Mixed und/gen path — see the NOTE in Qwen3Attention.forward (modeling_qwen3.py).
+        raise NotImplementedError(
+            "Mixed und/gen decoder-layer forward is not yet validated (issue #207). "
+            "Split the sequence at token-type boundaries and use forward_und / forward_gen."
+        )
+
+        # Mixed batch: dispatch tokens per branch then merge back. Matches the
+        # dense ``Qwen3DecoderLayer.forward`` mixed-path implementation.
+        residual = hidden_states
+
+        _hidden_states = hidden_states.new_zeros(hidden_states.shape)
+        if exist_non_image_gen_tokens:
+            _hidden_states[~image_gen_indicators] = self.input_layernorm(
+                hidden_states[~image_gen_indicators]
+            )
+        if exist_image_gen_tokens:
+            _hidden_states[image_gen_indicators] = self.input_layernorm_mot_gen(
+                hidden_states[image_gen_indicators]
+            )
+        hidden_states = _hidden_states
+
+        hidden_states, _ = self.self_attn(
+            hidden_states=hidden_states,
+            image_gen_indicators=image_gen_indicators,
+            exist_non_image_gen_tokens=exist_non_image_gen_tokens,
+            exist_image_gen_tokens=exist_image_gen_tokens,
+            indexes=indexes,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            use_cache=use_cache,
+            cache_position=cache_position,
+            **kwargs,
+        )
+        hidden_states = residual + hidden_states
+
+        residual = hidden_states
+
+        _hidden_states = hidden_states.new_zeros(hidden_states.shape)
+        if exist_non_image_gen_tokens:
+            und_hidden = self.post_attention_layernorm(
+                hidden_states[~image_gen_indicators]
+            )
+            # MoE expects a 3D input (batch, seq, hidden); promote then squeeze.
+            if und_hidden.dim() == 2:
+                und_hidden = und_hidden.unsqueeze(0)
+                _hidden_states[~image_gen_indicators] = self.mlp(und_hidden).squeeze(0)
+            else:
+                _hidden_states[~image_gen_indicators] = self.mlp(und_hidden)
+        if exist_image_gen_tokens:
+            _hidden_states[image_gen_indicators] = self.mlp_mot_gen(
+                self.post_attention_layernorm_mot_gen(hidden_states[image_gen_indicators])
+            )
+
+        hidden_states = _hidden_states
+        hidden_states = residual + hidden_states
+        return hidden_states
+
+
+class Qwen3MoePreTrainedModel(PreTrainedModel):
+    config: NEOMoELLMConfig
+    base_model_prefix = "model"
+    supports_gradient_checkpointing = True
+    _no_split_modules = ["Qwen3MoeDecoderLayer"]
+    _skip_keys_device_placement = ["past_key_values"]
+    _supports_flash_attn = True
+    _supports_sdpa = True
+    _supports_flex_attn = True
+
+    _can_compile_fullgraph = False  # MoE routing has data-dependent control flow.
+    _supports_attention_backend = True
+    _can_record_outputs = {
+        "hidden_states": Qwen3MoeDecoderLayer,
+        "attentions": Qwen3Attention,
+    }
+
+
+class Qwen3MoeModel(Qwen3MoePreTrainedModel):
+    def __init__(self, config: NEOMoELLMConfig):
+        super().__init__(config)
+        self.padding_idx = config.pad_token_id
+        self.vocab_size = config.vocab_size
+
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size, self.padding_idx)
+        self.layers = nn.ModuleList(
+            [Qwen3MoeDecoderLayer(config, layer_idx) for layer_idx in range(config.num_hidden_layers)]
+        )
+        self.norm = Qwen3RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.norm_mot_gen = Qwen3RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+        self.gradient_checkpointing = False
+        self.has_sliding_layers = "sliding_attention" in self.config.layer_types
+        self.current_index = -1
+
+        self.post_init()
+
+    @model_input_compat
+    def forward(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        image_gen_indicators: Optional[torch.Tensor] = None,
+        indexes: Optional[torch.LongTensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_values: Optional[Cache] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        use_cache: Optional[bool] = None,
+        cache_position: Optional[torch.LongTensor] = None,
+        **kwargs: Unpack[TransformersKwargs],
+    ) -> BaseModelOutputWithPast:
+        if image_gen_indicators is None:
+            exist_non_image_gen_tokens = True
+            exist_image_gen_tokens = False
+        else:
+            # Convert the CUDA reductions once before the decoder loop. If the
+            # scalar tensors reach every layer, each Python branch can force a
+            # host-device synchronization and collapse async weight prefetch.
+            exist_non_image_gen_tokens = bool((~image_gen_indicators).any().item())
+            exist_image_gen_tokens = bool(image_gen_indicators.any().item())
+
+        if (input_ids is None) ^ (inputs_embeds is not None):
+            raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
+
+        if inputs_embeds is None:
+            inputs_embeds = self.embed_tokens(input_ids)
+
+        if use_cache and past_key_values is None:
+            past_key_values = DynamicCache(config=self.config)
+
+        if cache_position is None:
+            past_seen_tokens = past_key_values.get_seq_length() if past_key_values is not None else 0
+            cache_position = torch.arange(
+                past_seen_tokens, past_seen_tokens + inputs_embeds.shape[1], device=inputs_embeds.device
+            )
+
+        if position_ids is None:
+            position_ids = cache_position.unsqueeze(0)
+
+        if not isinstance(causal_mask_mapping := attention_mask, dict):
+            if input_ids is not None:
+                mask_kwargs = causal_mask_kwargs(
+                    create_causal_mask,
+                    config=self.config,
+                    inputs_embeds=inputs_embeds,
+                    attention_mask=attention_mask,
+                    cache_position=cache_position,
+                    past_key_values=past_key_values,
+                    position_ids=position_ids,
+                )
+                causal_mask_mapping = {
+                    "full_attention": create_causal_mask(**mask_kwargs),
+                }
+                self.current_index += 1
+                indexes = torch.LongTensor([[self.current_index], [0], [0]]).to(input_ids.device)
+            else:
+                causal_mask_mapping = {
+                    "full_attention": create_block_causal_mask(indexes[0]),
+                }
+                self.current_index = indexes[0].max()
+        else:
+            self.current_index = indexes[0].max()
+
+        hidden_states = inputs_embeds
+
+        for decoder_layer in self.layers[: self.config.num_hidden_layers]:
+            hidden_states = decoder_layer(
+                hidden_states,
+                image_gen_indicators=image_gen_indicators,
+                exist_non_image_gen_tokens=exist_non_image_gen_tokens,
+                exist_image_gen_tokens=exist_image_gen_tokens,
+                indexes=indexes,
+                attention_mask=causal_mask_mapping[decoder_layer.attention_type],
+                position_ids=position_ids,
+                past_key_values=past_key_values,
+                use_cache=use_cache,
+                cache_position=cache_position,
+                **kwargs,
+            )
+
+        if not exist_image_gen_tokens:
+            hidden_states = self.norm(hidden_states)
+        elif not exist_non_image_gen_tokens:
+            hidden_states = self.norm_mot_gen(hidden_states)
+        else:
+            _hidden_states = hidden_states.new_zeros(hidden_states.shape)
+            _hidden_states[~image_gen_indicators] = self.norm(hidden_states[~image_gen_indicators])
+            _hidden_states[image_gen_indicators] = self.norm_mot_gen(hidden_states[image_gen_indicators])
+            hidden_states = _hidden_states
+
+        return BaseModelOutputWithPast(
+            last_hidden_state=hidden_states,
+            past_key_values=past_key_values if use_cache else None,
+        )
+
+
+class Qwen3MoeForCausalLM(Qwen3MoePreTrainedModel, GenerationMixin):
+    _tied_weights_keys = tied_weights_keys("lm_head.weight", "model.embed_tokens.weight")
+    _tp_plan = {"lm_head": "colwise_rep"}
+    _pp_plan = {"lm_head": (["hidden_states"], ["logits"])}
+
+    def __init__(self, config: NEOMoELLMConfig):
+        super().__init__(config)
+        self.model = Qwen3MoeModel(config)
+        self.vocab_size = config.vocab_size
+        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+        self.post_init()
+
+    @can_return_tuple
+    def forward(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        indexes: Optional[torch.LongTensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_values: Optional[Cache] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        labels: Optional[torch.LongTensor] = None,
+        use_cache: Optional[bool] = None,
+        cache_position: Optional[torch.LongTensor] = None,
+        logits_to_keep: Union[int, torch.Tensor] = 0,
+        **kwargs: Unpack[TransformersKwargs],
+    ) -> CausalLMOutputWithPast:
+        outputs: BaseModelOutputWithPast = self.model(
+            input_ids=input_ids,
+            indexes=indexes,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            inputs_embeds=inputs_embeds,
+            use_cache=use_cache,
+            cache_position=cache_position,
+            **kwargs,
+        )
+
+        hidden_states = outputs.last_hidden_state
+        slice_indices = slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep
+        logits = self.lm_head(hidden_states[:, slice_indices, :])
+
+        loss = None
+        if labels is not None:
+            loss = self.loss_function(
+                logits=logits, labels=labels, vocab_size=self.config.vocab_size, **kwargs
+            )
+
+        return CausalLMOutputWithPast(
+            loss=loss,
+            logits=logits,
+            past_key_values=outputs.past_key_values,
+            hidden_states=outputs.hidden_states,
+            attentions=outputs.attentions,
+        )
+
+
+__all__ = [
+    "Qwen3MoeForCausalLM",
+    "Qwen3MoeModel",
+    "Qwen3MoePreTrainedModel",
+    "Qwen3MoeDecoderLayer",
+    "Qwen3MoeSparseMoeBlock",
+    "Qwen3MoeMLP",
+]

--- a/xinference/thirdparty/sensenova_u1/models/neo_unify/transformers_compat.py
+++ b/xinference/thirdparty/sensenova_u1/models/neo_unify/transformers_compat.py
@@ -1,0 +1,67 @@
+"""Small compatibility seams for the supported Transformers 4/5 window."""
+
+from __future__ import annotations
+
+import inspect
+from functools import lru_cache
+from typing import Any, Callable
+
+import torch
+from packaging.version import Version
+
+try:
+    from transformers.utils.generic import merge_with_config_defaults
+    from transformers.utils.output_capturing import capture_outputs
+
+    def model_input_compat(func: Callable[..., Any]) -> Callable[..., Any]:
+        return merge_with_config_defaults(capture_outputs(func))
+
+except ImportError:  # Transformers 4.x
+    from transformers.utils.generic import check_model_inputs as model_input_compat
+
+
+@lru_cache(maxsize=None)
+def _parameter_names(callable_: Callable[..., Any]) -> frozenset[str]:
+    return frozenset(inspect.signature(callable_).parameters)
+
+
+def causal_mask_kwargs(
+    mask_factory: Callable[..., Any],
+    *,
+    config: Any,
+    inputs_embeds: torch.Tensor,
+    attention_mask: torch.Tensor | None,
+    cache_position: torch.Tensor,
+    past_key_values: Any,
+    position_ids: torch.Tensor,
+) -> dict[str, Any]:
+    """Build arguments accepted by the installed ``create_causal_mask``.
+
+    Transformers 4.57 uses ``input_embeds`` and ``cache_position`` while newer
+    5.x releases use ``inputs_embeds`` and derive the cache position internally.
+    """
+    parameters = _parameter_names(mask_factory)
+    embedding_parameter = "inputs_embeds" if "inputs_embeds" in parameters else "input_embeds"
+    candidates = {
+        "config": config,
+        embedding_parameter: inputs_embeds,
+        "attention_mask": attention_mask,
+        "cache_position": cache_position,
+        "past_key_values": past_key_values,
+        "position_ids": position_ids,
+    }
+    return {name: value for name, value in candidates.items() if name in parameters}
+
+
+def pretrained_dtype_kwargs(dtype: torch.dtype) -> dict[str, torch.dtype]:
+    """Use the public dtype keyword supported throughout Transformers 4.57+."""
+    return {"dtype": dtype}
+
+
+def tied_weights_keys(output_key: str, input_key: str) -> list[str] | dict[str, str]:
+    """Return the `_tied_weights_keys` shape expected by Transformers 4 or 5."""
+    import transformers
+
+    if Version(transformers.__version__).major >= 5:
+        return {output_key: input_key}
+    return [output_key]

--- a/xinference/thirdparty/sensenova_u1/models/neo_unify/utils.py
+++ b/xinference/thirdparty/sensenova_u1/models/neo_unify/utils.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import math
+
+import torch
+import torchvision.transforms as T
+from PIL import Image
+
+SYSTEM_MESSAGE_FOR_GEN = (
+    "You are an image generation and editing assistant that accurately understands and executes "
+    "user intent.\n\nYou support two modes:\n\n1. Think Mode:\nIf the task requires reasoning, you "
+    "MUST start with a <think></think> block. Put all reasoning inside the block using plain text. "
+    "DO NOT include any image tags. Keep it reasonable and directly useful for producing the final "
+    "image.\n\n2. Non-Think Mode:\nIf no reasoning is needed, directly produce the final image.\n\n"
+    "Task Types:\n\nA. Text-to-Image Generation:\n"
+    "- Generate a high-quality image based on the user's description.\n"
+    "- Ensure visual clarity, semantic consistency, and completeness.\n"
+    "- DO NOT introduce elements that contradict or override the user's intent.\n\n"
+    "B. Image Editing:\n"
+    "- Use the provided image(s) as input or reference for modification or transformation.\n"
+    "- The result can be an edited image or a new image based on the reference(s).\n"
+    "- Preserve all unspecified attributes unless explicitly changed.\n\n"
+    "General Rules:\n"
+    "- For any visible text in the image, follow the language specified for the rendered text in "
+    "the user's description, not the language of the prompt. If no language is specified, use the "
+    "user's input language."
+)
+
+IMAGENET_MEAN = (0.485, 0.456, 0.406)
+IMAGENET_STD = (0.229, 0.224, 0.225)
+
+
+def round_by_factor(number: float, factor: int) -> int:
+    """Returns the closest integer to `number` that is divisible by `factor`."""
+    return round(number / factor) * factor
+
+
+def ceil_by_factor(number: float, factor: int) -> int:
+    """Returns the smallest integer >= `number` that is divisible by `factor`."""
+    return math.ceil(number / factor) * factor
+
+
+def floor_by_factor(number: float, factor: int) -> int:
+    """Returns the largest integer <= `number` that is divisible by `factor`."""
+    return math.floor(number / factor) * factor
+
+
+def smart_resize(
+    height: int,
+    width: int,
+    factor: int = 32,
+    min_pixels: int = 65536,
+    max_pixels: int = 4194304,
+) -> tuple[int, int]:
+    """Rescale so that H/W are divisible by `factor` and total pixels ∈ [min, max].
+
+    Copied from https://github.com/QwenLM/Qwen2.5-VL/blob/main/qwen-vl-utils/src/qwen_vl_utils/vision_process.py#L60
+    """
+    if max(height, width) / min(height, width) > 200:
+        raise ValueError(
+            f"absolute aspect ratio must be smaller than 200, got {max(height, width) / min(height, width)}"
+        )
+    h_bar = max(factor, round_by_factor(height, factor))
+    w_bar = max(factor, round_by_factor(width, factor))
+    if h_bar * w_bar > max_pixels:
+        beta = math.sqrt((height * width) / max_pixels)
+        h_bar = max(factor, floor_by_factor(height / beta, factor))
+        w_bar = max(factor, floor_by_factor(width / beta, factor))
+    elif h_bar * w_bar < min_pixels:
+        beta = math.sqrt(min_pixels / (height * width))
+        h_bar = ceil_by_factor(height * beta, factor)
+        w_bar = ceil_by_factor(width * beta, factor)
+    return h_bar, w_bar
+
+
+def dynamic_preprocess_native_resolution(
+    image: Image.Image,
+    size_factor: int = 32,
+    min_pixels: int = 65536,
+    max_pixels: int = 4194304,
+    **_kwargs,
+) -> Image.Image:
+    width, height = image.size
+    resized_height, resized_width = smart_resize(
+        height,
+        width,
+        factor=size_factor,
+        min_pixels=min_pixels,
+        max_pixels=max_pixels,
+    )
+    return image.resize((resized_width, resized_height))
+
+
+def preprocess_pixel_values(pixel_values: torch.Tensor, patch_size: int = 16):
+    c, h, w = pixel_values.shape
+    grid_h = h // patch_size
+    grid_w = w // patch_size
+
+    flatten_pixel_values = (
+        pixel_values.view(c, grid_h, patch_size, grid_w, patch_size)
+        .permute(1, 3, 0, 2, 4)  # [grid_h, grid_w, c, patch_size, patch_size]
+        .reshape(grid_h * grid_w, c * patch_size ** 2)
+    )
+
+    grid_hw = torch.tensor([[grid_h, grid_w]], device=pixel_values.device)
+    return flatten_pixel_values, grid_hw
+
+
+def get_contrasting_background(image: Image.Image):
+    """Return a background color for RGBA->RGB conversion, or ``None`` to use default.
+
+    The original Neo_Unify implementation computed a contrasting background
+    from the alpha channel. For this open-source release we fall back to a
+    plain white background; callers that need the smarter behavior can override
+    this function.
+    """
+    del image
+    return (255, 255, 255)
+
+
+def load_image_native(
+    image,
+    patch_size: int = 16,
+    downsample_ratio: float = 0.5,
+    min_pixels: int = 65536,
+    max_pixels: int = 4194304,
+    upscale: bool = False,
+):
+    """Load and preprocess an image: RGB convert, smart-resize, normalize, patchify."""
+    if not isinstance(image, Image.Image):
+        image = Image.open(image)
+    if image.mode == "RGBA":
+        bg_color = get_contrasting_background(image)
+        if bg_color:
+            background = Image.new("RGB", image.size, bg_color)
+            background.paste(image, mask=image.split()[3])
+            image = background.convert("RGB")
+        else:
+            image = image.convert("RGB")
+    else:
+        image = image.convert("RGB")
+
+    if upscale:
+        image = image.resize((image.width * 2, image.height * 2), Image.BILINEAR)
+
+    transform = T.Compose(
+        [
+            T.Lambda(lambda img: img.convert("RGB") if img.mode != "RGB" else img),
+            T.ToTensor(),
+            T.Normalize(mean=IMAGENET_MEAN, std=IMAGENET_STD),
+        ]
+    )
+
+    new_image = dynamic_preprocess_native_resolution(
+        image,
+        size_factor=int(patch_size // downsample_ratio),
+        min_pixels=min_pixels,
+        max_pixels=max_pixels,
+    )
+    pixel_values, grid_hw = preprocess_pixel_values(
+        transform(new_image).to(torch.float32), patch_size=patch_size
+    )
+    return pixel_values, grid_hw

--- a/xinference/thirdparty/sensenova_u1/prompt_enhance/__init__.py
+++ b/xinference/thirdparty/sensenova_u1/prompt_enhance/__init__.py
@@ -1,0 +1,17 @@
+from .enhancer import (
+    DEFAULT_BACKEND,
+    DEFAULT_ENDPOINT,
+    DEFAULT_MODEL,
+    DEFAULT_STYLE,
+    PromptEnhancer,
+    make_adapter_from_env,
+)
+
+__all__ = [
+    "DEFAULT_BACKEND",
+    "DEFAULT_ENDPOINT",
+    "DEFAULT_MODEL",
+    "DEFAULT_STYLE",
+    "PromptEnhancer",
+    "make_adapter_from_env",
+]

--- a/xinference/thirdparty/sensenova_u1/prompt_enhance/_templates.py
+++ b/xinference/thirdparty/sensenova_u1/prompt_enhance/_templates.py
@@ -1,0 +1,31 @@
+"""System-prompt templates for LLM-based prompt enhancement.
+
+Templates live as ``.md`` files under ``sensenova_u1/prompt_enhance/templates/``
+(makes them easy to edit, diff and swap out without touching Python). They are
+loaded once at import time via ``importlib.resources``.
+
+Adding a new style is a two-step change:
+
+1. Drop a new ``*.md`` under ``templates/``.
+2. Add its stem to :data:`AVAILABLE_STYLES` below.
+"""
+
+from __future__ import annotations
+
+from importlib import resources
+
+AVAILABLE_STYLES = ("infographic",)
+"""Styles currently shipped with the package."""
+
+_TEMPLATES_PACKAGE = "sensenova_u1.prompt_enhance.templates"
+
+
+def load_system_prompt(style: str) -> str:
+    """Load the system-prompt ``.md`` for ``style`` from package data.
+
+    Raises:
+        ValueError: If ``style`` is not in :data:`AVAILABLE_STYLES`.
+    """
+    if style not in AVAILABLE_STYLES:
+        raise ValueError(f"Unknown enhance style {style!r}; supported: {AVAILABLE_STYLES}")
+    return resources.files(_TEMPLATES_PACKAGE).joinpath(f"{style}_system.md").read_text(encoding="utf-8")

--- a/xinference/thirdparty/sensenova_u1/prompt_enhance/adapters/__init__.py
+++ b/xinference/thirdparty/sensenova_u1/prompt_enhance/adapters/__init__.py
@@ -1,0 +1,5 @@
+from .anthropic_adapter import AnthropicVlmAdapter
+from .chat_completions_adapter import ChatCompletionsVlmAdapter
+from .vlm_adapter import VlmAdapter
+
+__all__ = ["AnthropicVlmAdapter", "ChatCompletionsVlmAdapter", "VlmAdapter"]

--- a/xinference/thirdparty/sensenova_u1/prompt_enhance/adapters/anthropic_adapter.py
+++ b/xinference/thirdparty/sensenova_u1/prompt_enhance/adapters/anthropic_adapter.py
@@ -1,0 +1,225 @@
+"""Anthropic Messages API adapter for VLM (async only, vision support).
+
+Supports Anthropic's /v1/messages endpoint with image inputs.
+
+Usage:
+    from vlm.anthropic_adapter import AnthropicVlmAdapter
+
+    adapter = AnthropicVlmAdapter(
+        endpoint_url="https://api.anthropic.com/v1/messages",
+        api_key="sk-ant-xxx",
+        model="claude-sonnet-4-6",
+    )
+    result = await adapter.vision_completion(
+        user_prompt="Describe this image",
+        images=["path/to/image.png"],
+        system_prompt="You are a helpful assistant.",
+    )
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+from .utils import image_to_base64
+from .vlm_adapter import VlmAdapter
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_REQUEST_TIMEOUT = 150.0
+DEFAULT_MAX_TOKENS = 4096
+
+
+class AnthropicVlmAdapter(VlmAdapter):
+    """VLM adapter for Anthropic Messages API.
+
+    Features:
+
+    * Vision support via ``image`` content blocks (base64 encoded).
+    * Shared or internally-created :class:`httpx.AsyncClient` for connection
+      pooling.
+    * Model name can be overridden per-call or at initialization.
+
+    This adapter is intentionally generic. No preset base_url, model, or system prompt.
+    All required parameters must be provided by the caller.
+    """
+
+    def __init__(
+        self,
+        endpoint_url: str,
+        api_key: str,
+        model: str,
+        *,
+        max_tokens: int = DEFAULT_MAX_TOKENS,
+        timeout: float = DEFAULT_REQUEST_TIMEOUT,
+        async_client: httpx.AsyncClient | None = None,
+    ) -> None:
+        """Initialize the Anthropic Messages VLM adapter.
+
+        Args:
+            endpoint_url: Full ``/v1/messages`` endpoint URL
+                (e.g. ``https://api.anthropic.com/v1/messages``).
+            api_key: Bearer token for the ``Authorization`` header.
+            model: Default model name sent in the request payload.
+            max_tokens: Maximum tokens to generate. Defaults to 4096.
+            timeout: Request timeout in seconds. Defaults to 150.
+            async_client (httpx.AsyncClient | None, optional):
+                Shared HTTP client supplied by the caller. When
+                provided the adapter reuses it and will *not* close it in
+                :meth:`aclose`. Defaults to None.
+        """
+        self._url = endpoint_url
+        self._api_key = api_key
+        self._default_model = model
+        self._max_tokens = max_tokens
+        self._timeout = timeout
+        self._external_client = async_client
+        self._client: httpx.AsyncClient | None = async_client
+        logger.info(
+            "AnthropicVlmAdapter: endpoint=%s model=%s max_tokens=%s",
+            self._url,
+            self._default_model,
+            self._max_tokens,
+        )
+
+    def _get_client(self) -> httpx.AsyncClient:
+        """Return the async HTTP client, creating it lazily if needed."""
+        if self._client is None:
+            self._client = httpx.AsyncClient(timeout=self._timeout)
+        return self._client
+
+    def _build_content_blocks(
+        self,
+        user_prompt: str,
+        images: list[str | bytes],
+    ) -> list[dict[str, Any]]:
+        """Build Anthropic-style content blocks with text and image blocks.
+
+        Args:
+            user_prompt: The text instruction.
+            images: Images to include in the user turn.
+
+        Returns:
+            list[dict[str, Any]]: Anthropic-style content blocks.
+        """
+        blocks: list[dict[str, Any]] = [{"type": "text", "text": user_prompt}]
+        for img in images:
+            mime, b64 = image_to_base64(img)
+            blocks.append(
+                {
+                    "type": "image",
+                    "source": {
+                        "type": "base64",
+                        "media_type": mime,
+                        "data": b64,
+                    },
+                }
+            )
+        return blocks
+
+    def _build_payload(
+        self,
+        user_prompt: str,
+        images: list[str | bytes],
+        system_prompt: str,
+        model: str | None,
+    ) -> dict[str, Any]:
+        """Assemble the full JSON request payload for Anthropic Messages API.
+
+        Args:
+            user_prompt: User-facing text instruction.
+            images: Images for the user turn.
+            system_prompt: System instruction (may be empty).
+            model: Model name to use (overrides default if provided).
+
+        Returns:
+            dict[str, Any]: JSON-serialisable request body.
+        """
+        messages: list[dict[str, Any]] = []
+        if system_prompt:
+            messages.append({"role": "user", "content": system_prompt})
+        messages.append(
+            {
+                "role": "user",
+                "content": self._build_content_blocks(user_prompt, images),
+            }
+        )
+
+        payload: dict[str, Any] = {
+            "model": model or self._default_model,
+            "messages": messages,
+            "max_tokens": self._max_tokens,
+        }
+        return payload
+
+    @staticmethod
+    def _parse_response(data: dict[str, Any]) -> str:
+        """Extract the assistant message text from Anthropic Messages response.
+
+        Handles responses with or without content blocks, and extracts text
+        from content blocks when available.
+
+        Args:
+            data: Parsed JSON response body.
+
+        Returns:
+            str: Assistant text content.
+
+        Raises:
+            RuntimeError: If the response contains no extractable content.
+        """
+        content = data.get("content", [])
+        if content:
+            for block in content:
+                if isinstance(block, dict) and block.get("type") == "text":
+                    return block.get("text", "")
+
+        thinking = data.get("thinking")
+        if thinking:
+            return f"[Think] {thinking}"
+
+        raise RuntimeError("Anthropic Messages response has no extractable content.")
+
+    async def vision_completion(
+        self,
+        user_prompt: str,
+        images: list[str | bytes],
+        system_prompt: str = "",
+        model: str | None = None,
+    ) -> str:
+        """Call the ``/v1/messages`` endpoint with vision content.
+
+        Args:
+            user_prompt: User-facing text instruction.
+            images: Images to include in the user turn.
+            system_prompt: System-level instruction. Defaults to ''.
+            model: Model name to use. Defaults to the model set at init.
+
+        Returns:
+            str: Assistant message text extracted from the API response.
+
+        Raises:
+            httpx.HTTPStatusError: On non-2xx HTTP responses.
+            RuntimeError: If the response contains no content.
+        """
+        payload = self._build_payload(user_prompt, images, system_prompt, model)
+        headers = {
+            "Authorization": f"Bearer {self._api_key}",
+            "Content-Type": "application/json",
+            "x-api-key": self._api_key,
+        }
+        resp = await self._get_client().post(self._url, json=payload, headers=headers)
+        resp.raise_for_status()
+        return self._parse_response(resp.json())
+
+    async def aclose(self) -> None:
+        """Close the internal async HTTP client if we own it.
+
+        Has no effect when the client was injected from outside.
+        """
+        if self._external_client is None and self._client is not None:
+            await self._client.aclose()
+            self._client = None

--- a/xinference/thirdparty/sensenova_u1/prompt_enhance/adapters/chat_completions_adapter.py
+++ b/xinference/thirdparty/sensenova_u1/prompt_enhance/adapters/chat_completions_adapter.py
@@ -1,0 +1,222 @@
+"""OpenAI-compatible chat/completions VLM adapter (async only).
+
+Supports any backend that follows the standard ``POST /chat/completions``
+request/response schema with vision support (image_url content blocks).
+
+Usage:
+    from vlm.chat_completions_adapter import ChatCompletionsVlmAdapter
+
+    adapter = ChatCompletionsVlmAdapter(
+        endpoint_url="https://api.openai.com/v1/chat/completions",
+        api_key="sk-xxx",
+        model="gpt-4o",
+    )
+    result = await adapter.vision_completion(
+        user_prompt="Describe this image",
+        images=["path/to/image.png"],
+        system_prompt="You are a helpful assistant.",
+    )
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+from .utils import image_to_data_url
+from .vlm_adapter import VlmAdapter
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_REQUEST_TIMEOUT = 1500.0
+
+
+class ChatCompletionsVlmAdapter(VlmAdapter):
+    """VLM adapter for any OpenAI-compatible ``/chat/completions`` endpoint.
+
+    Features:
+
+    * Multimodal ``image_url`` vision content (images encoded as data URLs).
+    * Optional ``reasoning_effort`` request field (Cloudsway extension).
+    * Shared or internally-created :class:`httpx.AsyncClient` for connection
+      pooling.
+    * Model name can be overridden per-call or at initialization.
+
+    This adapter is intentionally generic. No preset base_url, model, or system prompt.
+    All required parameters must be provided by the caller.
+    """
+
+    def __init__(
+        self,
+        endpoint_url: str,
+        api_key: str,
+        model: str,
+        *,
+        timeout: float = DEFAULT_REQUEST_TIMEOUT,
+        async_client: httpx.AsyncClient | None = None,
+        reasoning_effort: str | None = None,
+    ) -> None:
+        """Initialize the chat/completions VLM adapter.
+
+        Args:
+            endpoint_url: Full ``/chat/completions`` endpoint URL
+                (e.g. ``https://api.openai.com/v1/chat/completions``).
+            api_key: Bearer token for the ``Authorization`` header.
+            model: Default model name sent in the request payload.
+            timeout: Request timeout in seconds. Defaults to 1500.
+            async_client (httpx.AsyncClient | None, optional):
+                Shared HTTP client supplied by the caller. When
+                provided the adapter reuses it and will *not* close it in
+                :meth:`aclose`. Defaults to None.
+            reasoning_effort (str | None, optional):
+                Optional ``reasoning_effort`` field appended
+                to the JSON body (e.g. ``'high'``). Pass ``None`` or ``''``
+                to omit the field. Defaults to None.
+        """
+        self._url = endpoint_url
+        self._api_key = api_key
+        self._default_model = model
+        self._timeout = timeout
+        self._reasoning_effort = reasoning_effort or None
+        self._external_client = async_client
+        self._client: httpx.AsyncClient | None = async_client
+        logger.info(
+            "ChatCompletionsVlmAdapter: endpoint=%s model=%s reasoning_effort=%s",
+            self._url,
+            self._default_model,
+            self._reasoning_effort,
+        )
+
+    def _get_client(self) -> httpx.AsyncClient:
+        """Return the async HTTP client, creating it lazily if needed."""
+        if self._client is None:
+            self._client = httpx.AsyncClient(timeout=self._timeout)
+        return self._client
+
+    @staticmethod
+    def _build_user_content(
+        user_prompt: str,
+        images: list[str | bytes],
+    ) -> list[dict[str, Any]]:
+        """Build the ``user`` turn content list with text + image_url blocks.
+
+        Args:
+            user_prompt: The text instruction.
+            images: Images encoded as data URLs.
+
+        Returns:
+            list[dict[str, Any]]: OpenAI-style multimodal content blocks.
+        """
+        content: list[dict[str, Any]] = [{"type": "text", "text": user_prompt}]
+        content.extend(
+            {"type": "image_url", "image_url": {"url": image_to_data_url(img)}} for img in images
+        )
+        return content
+
+    def _build_payload(
+        self,
+        user_prompt: str,
+        images: list[str | bytes],
+        system_prompt: str,
+        model: str | None,
+    ) -> dict[str, Any]:
+        """Assemble the full JSON request payload for a vision call.
+
+        Args:
+            user_prompt: User-facing text instruction.
+            images: Images for the user turn.
+            system_prompt: System instruction (may be empty).
+            model: Model name to use (overrides default if provided).
+
+        Returns:
+            dict[str, Any]: JSON-serialisable request body.
+        """
+        messages: list[dict[str, Any]] = [
+            {
+                "role": "user",
+                "content": self._build_user_content(user_prompt, images),
+            },
+        ]
+        if system_prompt:
+            messages.insert(0, {"role": "system", "content": system_prompt})
+        payload: dict[str, Any] = {
+            "model": model or self._default_model,
+            "messages": messages,
+        }
+        if self._reasoning_effort:
+            payload["reasoning_effort"] = self._reasoning_effort
+        return payload
+
+    @staticmethod
+    def _parse_response(data: dict[str, Any]) -> str:
+        """Extract the assistant message text from a chat/completions response.
+
+        Handles both plain-string and list-of-content-blocks message formats.
+
+        Args:
+            data: Parsed JSON response body.
+
+        Returns:
+            str: Concatenated assistant text.
+
+        Raises:
+            RuntimeError: If the response contains no ``choices``.
+        """
+        choice = (data.get("choices") or [None])[0]
+        if not choice:
+            raise RuntimeError("chat/completions response has no choices.")
+        msg = choice.get("message", {})
+        content_val = msg.get("content")
+        if isinstance(content_val, str):
+            return content_val
+        if isinstance(content_val, list):
+            parts: list[str] = []
+            for block in content_val:
+                if isinstance(block, dict) and block.get("type") == "text":
+                    text = block.get("text")
+                    if isinstance(text, str):
+                        parts.append(text)
+            return "".join(parts)
+        return str(content_val or "")
+
+    async def vision_completion(
+        self,
+        user_prompt: str,
+        images: list[str | bytes],
+        system_prompt: str = "",
+        model: str | None = None,
+    ) -> str:
+        """Call the ``/chat/completions`` endpoint with vision content.
+
+        Args:
+            user_prompt: User-facing text instruction.
+            images: Images to include in the user turn.
+            system_prompt: System-level instruction. Defaults to ''.
+            model: Model name to use. Defaults to the model set at init.
+
+        Returns:
+            str: Assistant message text extracted from the API response.
+
+        Raises:
+            httpx.HTTPStatusError: On non-2xx HTTP responses.
+            RuntimeError: If the response contains no ``choices``.
+        """
+        payload = self._build_payload(user_prompt, images, system_prompt, model)
+        headers = {
+            "Authorization": f"Bearer {self._api_key}",
+            "Content-Type": "application/json",
+        }
+        resp = await self._get_client().post(self._url, json=payload, headers=headers)
+        resp.raise_for_status()
+        return self._parse_response(resp.json())
+
+    async def aclose(self) -> None:
+        """Close the internal async HTTP client if we own it.
+
+        Has no effect when the client was injected from outside.
+        """
+        if self._external_client is None and self._client is not None:
+            await self._client.aclose()
+            self._client = None

--- a/xinference/thirdparty/sensenova_u1/prompt_enhance/adapters/utils.py
+++ b/xinference/thirdparty/sensenova_u1/prompt_enhance/adapters/utils.py
@@ -1,0 +1,120 @@
+"""Image encoding / decoding utilities for VLM."""
+
+from __future__ import annotations
+
+import base64
+import io
+from pathlib import Path
+
+from PIL import Image
+
+
+def read_image_bytes(image: str | bytes) -> bytes:
+    """Read raw image bytes from a path or return bytes unchanged.
+
+    Args:
+        image: File path to an image, or raw image bytes.
+
+    Returns:
+        bytes: Raw image bytes.
+
+    Raises:
+        FileNotFoundError: If image is a path and the file does not exist.
+    """
+    if isinstance(image, bytes):
+        return image
+    path = Path(image)
+    if not path.is_file():
+        raise FileNotFoundError(f"Image file not found: {image}")
+    return path.read_bytes()
+
+
+def detect_mime(data: bytes) -> str:
+    """Infer MIME type from image magic bytes.
+
+    Args:
+        data: Raw image bytes (at least 8 bytes for PNG check).
+
+    Returns:
+        str: 'image/png', 'image/jpeg', or 'image/png' as fallback.
+    """
+    if data[:8] == b"\x89PNG\r\n\x1a\n":
+        return "image/png"
+    if data[:3] == b"\xff\xd8\xff":
+        return "image/jpeg"
+    return "image/png"
+
+
+def detect_suffix(data: bytes) -> str:
+    """Infer file suffix from image magic bytes.
+
+    Args:
+        data: Raw image bytes.
+
+    Returns:
+        str: '.png', '.jpg', or '.bin' as fallback.
+    """
+    if data[:8] == b"\x89PNG\r\n\x1a\n":
+        return ".png"
+    if data[:3] == b"\xff\xd8\xff":
+        return ".jpg"
+    return ".bin"
+
+
+def image_to_mime_and_bytes(image: str | bytes) -> tuple[str, bytes]:
+    """Get MIME type and raw bytes; convert to PNG if format is not PNG/JPEG.
+
+    Args:
+        image: File path or raw image bytes.
+
+    Returns:
+        tuple[str, bytes]: (mime_type, raw_bytes). Unknown formats become PNG.
+    """
+    raw = read_image_bytes(image)
+    mime = detect_mime(raw)
+    if mime in ("image/png", "image/jpeg"):
+        return mime, raw
+    img = Image.open(io.BytesIO(raw)).convert("RGBA")
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return "image/png", buf.getvalue()
+
+
+def image_to_base64(image: str | bytes) -> tuple[str, str]:
+    """Encode image to MIME type and base64 string.
+
+    Args:
+        image: File path or raw image bytes.
+
+    Returns:
+        tuple[str, str]: (mime_type, base64_encoded_string).
+    """
+    mime, raw = image_to_mime_and_bytes(image)
+    return mime, base64.b64encode(raw).decode("utf-8")
+
+
+def image_to_data_url(image: str | bytes) -> str:
+    """Build a data URL (data:mime;base64,...) for the image.
+
+    Args:
+        image: File path or raw image bytes.
+
+    Returns:
+        str: Data URL string.
+    """
+    mime, b64 = image_to_base64(image)
+    return f"data:{mime};base64,{b64}"
+
+
+def mask_secret(secret: str) -> str:
+    """Mask a secret for logging (e.g. show first 6 and last 4 chars).
+
+    Args:
+        secret: Raw secret string.
+
+    Returns:
+        str: Masked string (e.g. 'abcdef...ghij' or all '*' if length <= 8).
+    """
+    if len(secret) <= 8:
+        return "*" * len(secret)
+    return f"{secret[:6]}...{secret[-4:]}"

--- a/xinference/thirdparty/sensenova_u1/prompt_enhance/adapters/vlm_adapter.py
+++ b/xinference/thirdparty/sensenova_u1/prompt_enhance/adapters/vlm_adapter.py
@@ -1,0 +1,55 @@
+"""Abstract base class for VLM (Vision Language Model) adapters."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+
+class VlmAdapter(ABC):
+    """Uniform async interface for a single Vision Language Model backend.
+
+    Each concrete adapter wraps one LLM endpoint + model combination and
+    exposes a single :meth:`vision_completion` coroutine.  Synchronous
+    calling is intentionally **not** supported; callers must run inside an
+    asyncio event loop.
+
+    **Client ownership contract** — when a shared
+    :class:`httpx.AsyncClient` is supplied at construction time the adapter
+    *reuses* it and must **not** close it; the caller retains full ownership
+    of the client's lifecycle.  When no external client is provided the
+    adapter creates and owns an internal client and must close it in
+    :meth:`aclose`.
+    """
+
+    @abstractmethod
+    async def vision_completion(
+        self,
+        user_prompt: str,
+        images: list[str | bytes],
+        system_prompt: str = "",
+        model: str | None = None,
+    ) -> str:
+        """Send image(s) and a text prompt to the model; return the reply.
+
+        Args:
+            user_prompt: User-facing text instruction.
+            images: One or more images to pass to the model.  Each element
+                is either a file-path string or raw image bytes.
+            system_prompt: System-level instruction prepended to the
+                conversation.  Defaults to ''.
+            model: Model name to use. If None, uses the default set at
+                initialization.
+
+        Returns:
+            str: Raw text response from the model (may contain JSON or
+                markdown-wrapped JSON depending on the model and prompt).
+        """
+
+    @abstractmethod
+    async def aclose(self) -> None:
+        """Release async resources owned by this adapter.
+
+        Must be called when the adapter is no longer needed.  Adapters that
+        were given an external shared client must implement this as a no-op;
+        adapters that created their own internal client must close it here.
+        """

--- a/xinference/thirdparty/sensenova_u1/prompt_enhance/enhancer.py
+++ b/xinference/thirdparty/sensenova_u1/prompt_enhance/enhancer.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import asyncio
+import os
+
+from ._templates import AVAILABLE_STYLES, load_system_prompt
+from .adapters import AnthropicVlmAdapter, ChatCompletionsVlmAdapter, VlmAdapter
+
+DEFAULT_STYLE = "infographic"
+DEFAULT_BACKEND = "chat_completions"
+DEFAULT_ENDPOINT = "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions"
+DEFAULT_MODEL = "gemini-3.1-pro"
+
+_ENV_PREFIX = "U1_ENHANCE_"
+_SUPPORTED_BACKENDS = ("chat_completions", "anthropic")
+
+
+def make_adapter_from_env(
+    *,
+    backend: str | None = None,
+    endpoint: str | None = None,
+    api_key: str | None = None,
+    model: str | None = None,
+) -> VlmAdapter:
+    """Construct a :class:`VlmAdapter` from env + explicit overrides.
+
+    Resolution order (highest priority first):
+
+    1. Explicit kwargs passed to this function.
+    2. ``U1_ENHANCE_BACKEND`` / ``U1_ENHANCE_ENDPOINT`` / ``U1_ENHANCE_API_KEY``
+       / ``U1_ENHANCE_MODEL`` environment variables.
+    3. Defaults (Gemini 3.1 Pro via its OpenAI-compatible endpoint).
+
+    Args:
+        backend: ``'chat_completions'`` (any OpenAI-compatible, Gemini,
+            Kimi etc.) or ``'anthropic'``.
+        endpoint: Full URL of the ``/chat/completions`` or ``/v1/messages``
+            endpoint.
+        api_key: Bearer token.
+        model: Model name string sent in the request body.
+
+    Raises:
+        RuntimeError: If no API key can be resolved.
+        ValueError: If ``backend`` is unsupported.
+    """
+    backend = (backend or os.environ.get(f"{_ENV_PREFIX}BACKEND") or DEFAULT_BACKEND).lower()
+    endpoint = endpoint or os.environ.get(f"{_ENV_PREFIX}ENDPOINT") or DEFAULT_ENDPOINT
+    model = model or os.environ.get(f"{_ENV_PREFIX}MODEL") or DEFAULT_MODEL
+    api_key = api_key or os.environ.get(f"{_ENV_PREFIX}API_KEY")
+    if not api_key:
+        raise RuntimeError(
+            f"Prompt enhancement requires an API key. Set {_ENV_PREFIX}API_KEY or pass api_key= explicitly."
+        )
+
+    if backend == "chat_completions":
+        return ChatCompletionsVlmAdapter(endpoint_url=endpoint, api_key=api_key, model=model)
+    if backend == "anthropic":
+        return AnthropicVlmAdapter(endpoint_url=endpoint, api_key=api_key, model=model)
+    raise ValueError(f"Unsupported enhance backend {backend!r}; supported: {_SUPPORTED_BACKENDS}")
+
+
+class PromptEnhancer:
+    """Thin facade that turns a :class:`VlmAdapter` into a one-shot enhancer.
+
+    Both entry points call the adapter with ``images=[]`` so this works with
+    any text-only chat-style LLM; vision-capable backends simply ignore the
+    empty image list.
+    The enhancer does not own the adapter's HTTP client's lifecycle –
+    call :meth:`aclose` explicitly (or rely on the sync :meth:`enhance` path
+    which spins up / tears down a fresh event loop and closes the client for you).
+    """
+
+    def __init__(self, adapter: VlmAdapter, *, style: str = DEFAULT_STYLE) -> None:
+        if style not in AVAILABLE_STYLES:
+            raise ValueError(f"Unknown enhance style {style!r}; supported: {AVAILABLE_STYLES}")
+        self._adapter = adapter
+        self._style = style
+        self._system_prompt = load_system_prompt(style)
+
+    @classmethod
+    def from_env(
+        cls,
+        *,
+        style: str = DEFAULT_STYLE,
+        backend: str | None = None,
+        endpoint: str | None = None,
+        api_key: str | None = None,
+        model: str | None = None,
+    ) -> PromptEnhancer:
+        """Convenience constructor that reads the ``U1_ENHANCE_*`` env vars."""
+        adapter = make_adapter_from_env(backend=backend, endpoint=endpoint, api_key=api_key, model=model)
+        return cls(adapter, style=style)
+
+    @property
+    def style(self) -> str:
+        return self._style
+
+    async def aenhance(self, user_prompt: str) -> str:
+        """Async entry point: expand ``user_prompt`` into a long T2I prompt."""
+        return await self._adapter.vision_completion(
+            user_prompt=user_prompt,
+            images=[],
+            system_prompt=self._system_prompt,
+        )
+
+    def enhance(self, user_prompt: str) -> str:
+        """Sync wrapper around :meth:`aenhance`.
+
+        Creates and tears down its own event loop on every call – fine for a
+        CLI that enhances a handful of prompts, but do not use inside an
+        already-running event loop (call :meth:`aenhance` directly there).
+        """
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            pass
+        else:
+            raise RuntimeError(
+                "PromptEnhancer.enhance() is sync; you're already inside an asyncio loop. "
+                "Use `await enhancer.aenhance(...)` instead."
+            )
+
+        async def _once() -> str:
+            try:
+                return await self.aenhance(user_prompt)
+            finally:
+                await self._adapter.aclose()
+
+        return asyncio.run(_once())
+
+    async def aclose(self) -> None:
+        """Release HTTP resources owned by the underlying adapter."""
+        await self._adapter.aclose()

--- a/xinference/thirdparty/sensenova_u1/utils/__init__.py
+++ b/xinference/thirdparty/sensenova_u1/utils/__init__.py
@@ -1,0 +1,66 @@
+from .accel import (
+    best_available_device,
+)
+from .accel import (
+    manual_seed_all as seed_all_accelerators,
+)
+from .checkpoint_loading import (
+    add_offload_args,
+    infer_input_device,
+    load_model_and_tokenizer,
+    parse_max_memory,
+)
+from .comparison import save_compare
+from .gguf_loader import load_gguf_checkpoint, match_state_dict, set_gguf2meta_model
+from .lora import load_and_merge_lora_weight_from_safetensors
+from .offload import (
+    DEFAULT_FAST_ACTIVATION_RESERVE_GIB,
+    DEFAULT_FAST_VRAM_FRACTION,
+    DEFAULT_FAST_VRAM_HEADROOM_GIB,
+    DEFAULT_LAYERS_ATTR,
+    DEFAULT_VRAM_MODE,
+    VRAM_MODE_OPTIONS,
+    make_offload_ctx,
+    offload_layers_async,
+    offload_layers_sync,
+    vram_mode_keeps_generation_resident,
+    vram_mode_to_prefetch_count,
+)
+from .param_count import (
+    ModelParamInspector,
+    build_rules,
+    format_bytes,
+    format_param_count,
+)
+from .profiler import DEFAULT_IMAGE_PATCH_SIZE, InferenceProfiler
+
+__all__ = [
+    "DEFAULT_FAST_ACTIVATION_RESERVE_GIB",
+    "DEFAULT_FAST_VRAM_FRACTION",
+    "DEFAULT_FAST_VRAM_HEADROOM_GIB",
+    "DEFAULT_IMAGE_PATCH_SIZE",
+    "DEFAULT_LAYERS_ATTR",
+    "DEFAULT_VRAM_MODE",
+    "InferenceProfiler",
+    "ModelParamInspector",
+    "VRAM_MODE_OPTIONS",
+    "add_offload_args",
+    "best_available_device",
+    "build_rules",
+    "format_bytes",
+    "format_param_count",
+    "infer_input_device",
+    "load_and_merge_lora_weight_from_safetensors",
+    "load_gguf_checkpoint",
+    "load_model_and_tokenizer",
+    "make_offload_ctx",
+    "match_state_dict",
+    "offload_layers_async",
+    "offload_layers_sync",
+    "parse_max_memory",
+    "save_compare",
+    "seed_all_accelerators",
+    "set_gguf2meta_model",
+    "vram_mode_keeps_generation_resident",
+    "vram_mode_to_prefetch_count",
+]

--- a/xinference/thirdparty/sensenova_u1/utils/accel.py
+++ b/xinference/thirdparty/sensenova_u1/utils/accel.py
@@ -1,0 +1,91 @@
+"""Accelerator-agnostic helpers for CUDA / XPU.
+
+The codebase used to hard-code ``torch.cuda.*`` for device-availability checks,
+cache management, and stream APIs. This module centralises the small amount of
+namespace switching needed so the same code paths work on both CUDA (incl.
+ROCm via the ``cuda`` namespace) and Intel XPU.
+
+CPU / MPS are intentionally out of scope: the layer-offload / inference path
+needs pinned host memory and dedicated transfer streams, which neither of
+those backends exposes uniformly. Targets PyTorch >= 2.5 where ``torch.xpu``
+is in-tree.
+"""
+
+from __future__ import annotations
+
+import torch
+
+SUPPORTED_DEVICE_TYPES: tuple[str, ...] = ("cuda", "xpu")
+
+
+def accel_module(device: torch.device):
+    """Return ``torch.cuda`` or ``torch.xpu`` matching ``device.type``."""
+    if device.type == "cuda":
+        return torch.cuda
+    if device.type == "xpu":
+        return torch.xpu
+    raise NotImplementedError(f"No accelerator namespace for device {device!r}; supported: {SUPPORTED_DEVICE_TYPES}.")
+
+
+def require_accelerator(device: torch.device) -> None:
+    """Raise unless ``device`` is a backend the inference path actually supports."""
+    if device.type not in SUPPORTED_DEVICE_TYPES:
+        raise NotImplementedError(
+            f"Inference requires a CUDA or XPU device (got {device!r}). "
+            "CPU / MPS lack the pinned-memory and stream primitives used here."
+        )
+
+
+def is_available(device_type: str) -> bool:
+    """``True`` if the backend module reports an available device."""
+    if device_type == "cuda":
+        return torch.cuda.is_available()
+    if device_type == "xpu":
+        return torch.xpu.is_available()
+    return False
+
+
+def best_available_device() -> torch.device:
+    """Pick the best available accelerator, preferring CUDA over XPU over CPU."""
+    if torch.cuda.is_available():
+        return torch.device("cuda")
+    if torch.xpu.is_available():
+        return torch.device("xpu")
+    return torch.device("cpu")
+
+
+def empty_cache(device: torch.device | None = None) -> None:
+    """Release the accelerator's caching-allocator blocks.
+
+    With ``device=None`` runs the equivalent of "for every backend that has a
+    device available, drop its cache" — used at teardown where we just want
+    the global state cleaned up regardless of which backend we ran on.
+    """
+    if device is None:
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+        if torch.xpu.is_available():
+            torch.xpu.empty_cache()
+        return
+    if device.type in SUPPORTED_DEVICE_TYPES and is_available(device.type):
+        accel_module(device).empty_cache()
+
+
+def synchronize(device: torch.device | None = None) -> None:
+    """Block until pending work on the accelerator completes."""
+    if device is None:
+        if torch.cuda.is_available():
+            torch.cuda.synchronize()
+        if torch.xpu.is_available():
+            torch.xpu.synchronize()
+        return
+    if device.type in SUPPORTED_DEVICE_TYPES and is_available(device.type):
+        accel_module(device).synchronize(device)
+
+
+def manual_seed_all(seed: int) -> None:
+    """Seed all available accelerator devices (CUDA + XPU)."""
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+    if torch.xpu.is_available():
+        torch.xpu.manual_seed_all(seed)

--- a/xinference/thirdparty/sensenova_u1/utils/checkpoint_loading.py
+++ b/xinference/thirdparty/sensenova_u1/utils/checkpoint_loading.py
@@ -1,0 +1,323 @@
+"""Shared model + tokenizer loader for SenseNova-U1.
+
+Centralises the ``AutoConfig`` / ``AutoTokenizer`` / ``AutoModel`` calls used
+by the example scripts and the ComfyUI app, and adds an optional GGUF
+checkpoint override.
+
+Usage:
+
+    from sensenova_u1.utils import load_model_and_tokenizer
+
+    model, tokenizer = load_model_and_tokenizer(
+        model_path="sensenova/SenseNova-U1-8B-MoT",
+        dtype=torch.bfloat16,
+        # device=None auto-picks CUDA > XPU > CPU. Pass an explicit
+        # "cuda" / "cuda:0" / "xpu" / "xpu:0" to override.
+    )
+
+    # GGUF override (config / tokenizer still come from `model_path`):
+    model, tokenizer = load_model_and_tokenizer(
+        model_path="sensenova/SenseNova-U1-8B-MoT",
+        dtype=torch.bfloat16,
+        gguf_checkpoint="/path/to/SenseNova-U1-8B-MoT-Q5_K_M.gguf",
+    )
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import json
+import logging
+import math
+from pathlib import Path
+from typing import Any
+
+import torch
+from torch import nn
+
+from . import accel
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _default_device() -> torch.device:
+    """Pick CUDA, then XPU, then CPU. Used as the default ``device`` for loaders."""
+    return accel.best_available_device()
+
+
+def add_offload_args(parser: argparse.ArgumentParser) -> None:
+    """Add Transformers/Accelerate device-map and layer-offload flags to an example CLI."""
+    from .offload import (
+        DEFAULT_FAST_ACTIVATION_RESERVE_GIB,
+        DEFAULT_FAST_VRAM_FRACTION,
+        DEFAULT_FAST_VRAM_HEADROOM_GIB,
+        DEFAULT_VRAM_MODE,
+        VRAM_MODE_OPTIONS,
+    )
+
+    def fraction(value: str) -> float:
+        parsed = float(value)
+        if not math.isfinite(parsed) or not 0 < parsed <= 1:
+            raise argparse.ArgumentTypeError("must satisfy 0 < value <= 1")
+        return parsed
+
+    def nonnegative_gib(value: str) -> float:
+        parsed = float(value)
+        if not math.isfinite(parsed) or parsed < 0:
+            raise argparse.ArgumentTypeError("must be >= 0")
+        return parsed
+
+    def positive_gib(value: str) -> float:
+        parsed = float(value)
+        if not math.isfinite(parsed) or parsed <= 0:
+            raise argparse.ArgumentTypeError("must be > 0")
+        return parsed
+
+    parser.add_argument(
+        "--device_map",
+        default=None,
+        help=(
+            "Optional Transformers device_map, e.g. 'auto', 'balanced', "
+            "'balanced_low_0', or 'sequential'. When set, the model is loaded "
+            "with Accelerate dispatch and is not moved again with .to(device). "
+            "Use this for multi-GPU split; for low-VRAM single-card, prefer --vram_mode."
+        ),
+    )
+    parser.add_argument(
+        "--max_memory",
+        default=None,
+        help=(
+            "Optional per-device memory limits for --device_map, either JSON "
+            "or comma-separated KEY=VALUE pairs, e.g. '0=20GiB,1=20GiB'."
+        ),
+    )
+    parser.add_argument(
+        "--vram_mode",
+        choices=list(VRAM_MODE_OPTIONS),
+        default=DEFAULT_VRAM_MODE,
+        help=(
+            "Single-GPU layer-offload mode. "
+            "'full' = no offload, whole model on GPU, fastest (default). "
+            "'fast' = async prefetch, then retain generation layers within the GPU memory budget. "
+            "'low' = synchronous per-layer CPU<->GPU swap, smallest weight footprint. "
+            "'balanced' = async prefetch, overlaps H2D with compute, faster than 'low'. "
+            "Mutually exclusive with --device_map (layer offload requires the model on CPU)."
+        ),
+    )
+    parser.add_argument(
+        "--fast_vram_fraction",
+        type=fraction,
+        default=DEFAULT_FAST_VRAM_FRACTION,
+        help="Fast-mode automatic VRAM budget as a fraction of physical memory (default: 0.90).",
+    )
+    parser.add_argument(
+        "--fast_vram_headroom_gib",
+        type=nonnegative_gib,
+        default=DEFAULT_FAST_VRAM_HEADROOM_GIB,
+        help="Fast-mode reusable VRAM headroom reserved after projected activation growth (default: 2 GiB).",
+    )
+    parser.add_argument(
+        "--fast_activation_reserve_gib",
+        type=nonnegative_gib,
+        default=DEFAULT_FAST_ACTIVATION_RESERVE_GIB,
+        help="Fast-mode allowance for activations allocated after decoder layers (default: 4 GiB).",
+    )
+    parser.add_argument(
+        "--fast_vram_budget_gib",
+        type=positive_gib,
+        default=None,
+        help="Optional absolute fast-mode VRAM budget in GiB; overrides --fast_vram_fraction.",
+    )
+
+
+def infer_input_device(model: nn.Module, fallback: str | torch.device | None = None) -> torch.device:
+    """Pick a usable device for tensors passed into a dispatched model.
+
+    When ``fallback`` is ``None`` (the default), auto-detects the best
+    accelerator (CUDA > XPU > CPU).
+    """
+    for param in model.parameters():
+        if param.device.type not in {"cpu", "meta"}:
+            return param.device
+    if fallback is None:
+        return _default_device()
+    return torch.device(fallback) if isinstance(fallback, str) else fallback
+
+
+def _resolve_local_model_path(model_path: str) -> str:
+    """Resolve a HF id to a complete cached snapshot directory when offline.
+
+    Mirrors transformers' fall-back behaviour but skips the up-front HEAD
+    request that times out on offline machines. A partially cached snapshot
+    must not shadow the Hub id, because Transformers would then treat it as a
+    local directory and lose the opportunity to fetch its missing weights.
+    """
+    if Path(model_path).exists():
+        return model_path
+    try:
+        from huggingface_hub import snapshot_download
+
+        snapshot = Path(snapshot_download(model_path, local_files_only=True))
+    except Exception:
+        return model_path
+    if _has_complete_model_weights(snapshot):
+        return str(snapshot)
+    return model_path
+
+
+def _has_complete_model_weights(snapshot: Path) -> bool:
+    for index_name in ("model.safetensors.index.json", "pytorch_model.bin.index.json"):
+        index_path = snapshot / index_name
+        if not index_path.is_file():
+            continue
+        try:
+            shard_names = set(json.loads(index_path.read_text())["weight_map"].values())
+        except (KeyError, TypeError, OSError, json.JSONDecodeError):
+            return False
+        return bool(shard_names) and all((snapshot / shard_name).is_file() for shard_name in shard_names)
+    return (snapshot / "model.safetensors").is_file() or (snapshot / "pytorch_model.bin").is_file()
+
+
+def load_model_and_tokenizer(
+    model_path: str,
+    *,
+    dtype: torch.dtype,
+    device: str | torch.device | None = None,
+    gguf_checkpoint: str | None = None,
+    device_map: str | None = None,
+    max_memory: str | dict[int | str, str] | None = None,
+    for_offload: bool = False,
+) -> tuple[nn.Module, Any]:
+    """Build a SenseNova-U1 model + tokenizer pair.
+
+    ``model_path`` always provides the config and tokenizer (HF id or local
+    directory containing ``config.json``).
+
+    Weight loading branches on ``gguf_checkpoint``:
+
+    - ``None``: standard ``AutoModel.from_pretrained(model_path, ...)``.
+      The ``device_map`` / ``max_memory`` accelerate kwargs apply on this
+      path; when ``device_map`` is ``None`` the model is ``.to(device)``
+      after loading.
+    - ``"*.gguf"``: build a meta-init model from the config and inject
+      dequantizing weights from the GGUF file via the diffusers quantizer.
+      The accelerate kwargs are ignored on this path.
+
+    When ``for_offload=True`` the loaded model stays on CPU (no ``.to(device)``)
+    so a downstream layer-offload wrapper can manage CPU<->GPU movement
+    itself. ``device_map`` is forced to ``None`` in this mode (with a warning)
+    because accelerate's static placement is incompatible with dynamic offload.
+    """
+    from transformers import AutoConfig, AutoModel, AutoTokenizer
+
+    from .. import check_checkpoint_compatibility
+    from ..models.neo_unify.transformers_compat import pretrained_dtype_kwargs
+
+    if for_offload and device_map:
+        LOGGER.warning(
+            "for_offload=True overrides device_map=%r (accelerate placement is incompatible with layer offload).",
+            device_map,
+        )
+        device_map = None
+
+    if device is None and not device_map and not for_offload:
+        device = _default_device()
+
+    model_path = _resolve_local_model_path(model_path)
+    config = AutoConfig.from_pretrained(model_path)
+    check_checkpoint_compatibility(config)
+    tokenizer = AutoTokenizer.from_pretrained(model_path)
+
+    if gguf_checkpoint is not None:
+        gguf_device = torch.device("cpu") if for_offload else device
+        model = _load_from_gguf(config, gguf_checkpoint, dtype=dtype, device=gguf_device)
+    else:
+        model_kwargs: dict[str, Any] = {"config": config, **pretrained_dtype_kwargs(dtype)}
+        if device_map:
+            model_kwargs["device_map"] = device_map
+            parsed_max_memory = _normalize_max_memory(max_memory)
+            if parsed_max_memory:
+                model_kwargs["max_memory"] = parsed_max_memory
+
+        model = AutoModel.from_pretrained(model_path, **model_kwargs).eval()
+        if not device_map and device is not None and not for_offload:
+            model = model.to(device)
+
+    return model, tokenizer
+
+
+def _normalize_max_memory(value: str | dict | None) -> dict[int | str, str]:
+    """Accept a parsed mapping, JSON object, or comma-separated CLI form ``"0=20GiB,cpu=64GiB"``."""
+    if value is None or value == "":
+        return {}
+    if isinstance(value, dict):
+        return {_coerce_memory_key(k): str(v) for k, v in value.items()}
+    stripped = value.strip()
+    if stripped.startswith("{"):
+        raw = json.loads(stripped)
+        if not isinstance(raw, dict):
+            raise RuntimeError("max_memory JSON must be an object")
+        return {_coerce_memory_key(k): str(v) for k, v in raw.items()}
+    result: dict[int | str, str] = {}
+    for item in stripped.split(","):
+        item = item.strip()
+        if not item:
+            continue
+        if "=" not in item:
+            raise RuntimeError("max_memory entries must look like 0=20GiB,cpu=64GiB.")
+        key, memory = item.split("=", 1)
+        key = key.strip()
+        memory = memory.strip()
+        if not key or not memory:
+            raise RuntimeError("max_memory entries must include both device and memory.")
+        result[_coerce_memory_key(key)] = memory
+    return result
+
+
+def _coerce_memory_key(key: object) -> int | str:
+    if isinstance(key, int):
+        return key
+    key_str = str(key)
+    return int(key_str) if key_str.isdigit() else key_str
+
+
+parse_max_memory = _normalize_max_memory
+
+
+def _load_from_gguf(
+    config,
+    gguf_checkpoint: str,
+    *,
+    dtype: torch.dtype,
+    device: str | torch.device | None,
+) -> nn.Module:
+    try:
+        from accelerate import init_empty_weights
+    except ImportError as exc:
+        raise RuntimeError("GGUF loading requires `accelerate`; install it in your environment.") from exc
+
+    from transformers import AutoModel
+
+    from .gguf_loader import load_gguf_checkpoint, set_gguf2meta_model
+
+    print(f"[gguf] loading quantized checkpoint from {gguf_checkpoint}")
+    with init_empty_weights():
+        model = AutoModel.from_config(config)
+
+    state_dict = load_gguf_checkpoint(gguf_checkpoint)
+    print(f"[gguf] parsed {len(state_dict)} tensors")
+    target_device = torch.device(device) if isinstance(device, str) else device
+    # set_gguf2meta_model places weights on `target_device` while injecting;
+    # callers that ultimately want a different device can `.to()` afterwards.
+    set_gguf2meta_model(model, state_dict, dtype, target_device)
+
+    n_gguf_linear = sum(1 for m in model.modules() if type(m).__name__ == "GGUFLinear")
+    print(f"[gguf] {n_gguf_linear} GGUFLinear modules active (dequantized at forward time)")
+    if n_gguf_linear == 0:
+        print("[gguf] WARNING: no GGUFLinear modules found — quantizer hook did not run as expected")
+
+    del state_dict
+    gc.collect()
+    accel.empty_cache()
+    return model.eval()

--- a/xinference/thirdparty/sensenova_u1/utils/comparison.py
+++ b/xinference/thirdparty/sensenova_u1/utils/comparison.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import re
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Sequence
+
+from PIL import Image, ImageDraw, ImageFont
+
+__all__ = ["ensure_cjk_font", "make_comparison", "save_compare"]
+
+# Tokens for pixel-aware wrap: ASCII word, whitespace run, or a single CJK char.
+_WRAP_TOKEN_RE = re.compile(r"\s+|[\u4e00-\u9fff]|[^\s\u4e00-\u9fff]+")
+_CJK_RE = re.compile(r"[\u4e00-\u9fff]")
+
+# Font search order: CJK-capable first so Chinese prompts render properly.
+_CJK_FONTS = (
+    "/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc",
+    "/usr/share/fonts/noto-cjk/NotoSansCJK-Regular.ttc",
+    "/usr/share/fonts/google-noto-cjk-vf-fonts/NotoSansCJK-VF.otf.ttc",
+    "/usr/share/fonts/truetype/wqy/wqy-microhei.ttc",
+    "/usr/share/fonts/truetype/wqy/wqy-zenhei.ttc",
+    "./fonts/Noto_Sans_SC/static/NotoSansSC-Regular.ttf",
+)
+_LATIN_FONTS = (
+    "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+    "/usr/share/fonts/dejavu/DejaVuSans.ttf",
+    "DejaVuSans.ttf",
+)
+_CJK_FONT_CACHE_DIR = Path.home() / ".cache" / "sensenova_u1" / "fonts"
+_CJK_FONT_CACHE_PATH = _CJK_FONT_CACHE_DIR / "NotoSansCJKsc-Regular.otf"
+_CJK_FONT_URLS = (
+    "https://github.com/notofonts/noto-cjk/raw/main/Sans/OTF/SimplifiedChinese/NotoSansCJKsc-Regular.otf",
+    "https://raw.githubusercontent.com/notofonts/noto-cjk/main/Sans/OTF/SimplifiedChinese/NotoSansCJKsc-Regular.otf",
+)
+
+_warned_missing_cjk = False
+_warned_download_cjk = False
+
+
+def _try_load_truetype(path: str | Path, size: int) -> ImageFont.FreeTypeFont | None:
+    try:
+        return ImageFont.truetype(str(path), size=size)
+    except OSError:
+        return None
+
+
+def ensure_cjk_font(*, timeout: float = 30.0) -> Path | None:
+    """Return a local CJK font path, downloading Noto Sans CJK SC if needed.
+
+    The font is stored under the user's cache directory so this works in
+    non-root containers and does not mutate system font directories.
+    """
+    for path in _CJK_FONTS:
+        if _try_load_truetype(path, size=16) is not None:
+            return Path(path)
+
+    if _try_load_truetype(_CJK_FONT_CACHE_PATH, size=16) is not None:
+        return _CJK_FONT_CACHE_PATH
+
+    tmp_path = _CJK_FONT_CACHE_PATH.with_suffix(".tmp")
+    _CJK_FONT_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    for url in _CJK_FONT_URLS:
+        try:
+            with urllib.request.urlopen(url, timeout=timeout) as response:
+                tmp_path.write_bytes(response.read())
+            if _try_load_truetype(tmp_path, size=16) is None:
+                tmp_path.unlink(missing_ok=True)
+                continue
+            tmp_path.replace(_CJK_FONT_CACHE_PATH)
+            return _CJK_FONT_CACHE_PATH
+        except (OSError, urllib.error.URLError):
+            tmp_path.unlink(missing_ok=True)
+            continue
+    return None
+
+
+def _load_font(size: int, *, need_cjk: bool = False) -> tuple[ImageFont.ImageFont | ImageFont.FreeTypeFont, bool]:
+    """Return (font, has_cjk_coverage). Falls back to PIL default if nothing usable."""
+    for path in _CJK_FONTS:
+        font = _try_load_truetype(path, size)
+        if font is not None:
+            return font, True
+    if need_cjk:
+        path = ensure_cjk_font()
+        if path is not None:
+            font = _try_load_truetype(path, size)
+            if font is not None:
+                return font, True
+    for path in _LATIN_FONTS:
+        font = _try_load_truetype(path, size)
+        if font is not None:
+            return font, False
+    try:
+        return ImageFont.load_default(size=size), False
+    except TypeError:
+        return ImageFont.load_default(), False
+
+
+def _wrap_text(text: str, font, max_width: int) -> list[str]:
+    """Greedy pixel-aware wrap. Keeps ASCII words intact, splits CJK per-char."""
+    lines: list[str] = []
+    for paragraph in text.split("\n"):
+        cur = ""
+        for tok in _WRAP_TOKEN_RE.findall(paragraph):
+            candidate = cur + tok
+            if font.getlength(candidate.rstrip()) <= max_width:
+                cur = candidate
+                continue
+            if cur.strip():
+                lines.append(cur.rstrip())
+            cur = "" if tok.isspace() else tok
+        if cur.rstrip():
+            lines.append(cur.rstrip())
+    return lines or [""]
+
+
+def make_comparison(
+    inputs: Sequence[Image.Image],
+    output: Image.Image,
+    prompt: str,
+    *,
+    pad: int = 16,
+    bg: tuple[int, int, int] = (255, 255, 255),
+) -> Image.Image:
+    """Return ``[inputs... | output]`` stacked horizontally with ``prompt`` below.
+
+    Inputs are letterboxed to match the output's height so the row lines up
+    cleanly regardless of aspect ratio.
+    """
+    row_h = output.size[1]
+    row_imgs: list[Image.Image] = []
+    for im in inputs:
+        if im.size[1] != row_h:
+            new_w = max(1, round(im.size[0] * row_h / im.size[1]))
+            im = im.resize((new_w, row_h), Image.LANCZOS)
+        row_imgs.append(im)
+    row_imgs.append(output)
+    row_w = sum(im.size[0] for im in row_imgs) + pad * (len(row_imgs) + 1)
+
+    prompt_has_cjk = bool(_CJK_RE.search(prompt))
+    font, has_cjk = _load_font(max(18, row_h // 30), need_cjk=prompt_has_cjk)
+    global _warned_download_cjk, _warned_missing_cjk
+    if prompt_has_cjk and has_cjk and not _warned_download_cjk:
+        print("[compare] using a CJK-capable font for prompt rendering.")
+        _warned_download_cjk = True
+    if prompt_has_cjk and not has_cjk and not _warned_missing_cjk:
+        print(
+            "[compare] prompt contains CJK but no CJK-capable font was found; "
+            "automatic font download failed and Chinese characters will render as tofu. "
+            "Install e.g. `fonts-noto-cjk` (Debian/Ubuntu), `google-noto-cjk-fonts` "
+            "(RHEL-family) for proper rendering."
+        )
+        _warned_missing_cjk = True
+
+    lines = _wrap_text(prompt, font, row_w - pad * 2)
+    bbox = font.getbbox("Ag中")
+    line_h = max(1, int((bbox[3] - bbox[1]) * 1.3))
+    text_h = line_h * len(lines) + pad * 2
+
+    canvas = Image.new("RGB", (row_w, row_h + pad * 2 + text_h), bg)
+    x = pad
+    for im in row_imgs:
+        canvas.paste(im, (x, pad))
+        x += im.size[0] + pad
+    draw = ImageDraw.Draw(canvas)
+    y = row_h + pad * 2
+    for line in lines:
+        draw.text((pad, y), line, fill=(0, 0, 0), font=font)
+        y += line_h
+    return canvas
+
+
+def save_compare(
+    out_path: Path,
+    inputs: Sequence[Image.Image],
+    output: Image.Image,
+    prompt: str,
+) -> None:
+    """Save a comparison next to ``out_path`` as ``<stem>_compare<suffix>``."""
+    cmp_path = out_path.with_name(f"{out_path.stem}_compare{out_path.suffix}")
+    make_comparison(inputs, output, prompt).save(cmp_path)
+    print(f"[saved] {cmp_path}")

--- a/xinference/thirdparty/sensenova_u1/utils/gguf_loader.py
+++ b/xinference/thirdparty/sensenova_u1/utils/gguf_loader.py
@@ -1,0 +1,114 @@
+"""GGUF checkpoint loader for transformers/diffusers-style models.
+
+Public API:
+    load_gguf_checkpoint(path) -> dict[str, Tensor | GGUFParameter]
+    set_gguf2meta_model(meta_model, state_dict, dtype, device) -> nn.Module
+    match_state_dict(meta_model, state_dict, show_num=10) -> dict  # debug helper
+"""
+
+from __future__ import annotations
+
+import gc
+
+import torch
+from torch import nn
+
+
+def load_gguf_checkpoint(gguf_checkpoint_path: str) -> dict:
+    """Parse a .gguf file into a state-dict-compatible mapping.
+
+    F32 / F16 tensors come back as plain torch tensors; everything else is
+    wrapped in ``GGUFParameter`` so the diffusers quantizer can dequantize on
+    the fly during forward.
+    """
+    from diffusers.utils import is_gguf_available, is_torch_available
+
+    if not (is_gguf_available() and is_torch_available()):
+        raise ImportError("Please install torch and gguf>=0.10.0 to load a GGUF checkpoint.")
+
+    import gguf
+    from diffusers.quantizers.gguf.utils import SUPPORTED_GGUF_QUANT_TYPES, GGUFParameter
+    from gguf import GGUFReader
+
+    reader = GGUFReader(gguf_checkpoint_path)
+    parsed: dict = {}
+    for tensor in reader.tensors:
+        name = tensor.name
+        quant_type = tensor.tensor_type
+        is_quant = quant_type not in (gguf.GGMLQuantizationType.F32, gguf.GGMLQuantizationType.F16)
+        if is_quant and quant_type not in SUPPORTED_GGUF_QUANT_TYPES:
+            supported = "\n".join(str(t) for t in SUPPORTED_GGUF_QUANT_TYPES)
+            raise ValueError(f"{name} has unsupported quant type {quant_type}.\nSupported:\n{supported}")
+        weights = torch.from_numpy(tensor.data.copy())
+        parsed[name] = GGUFParameter(weights, quant_type=quant_type) if is_quant else weights
+        del tensor, weights
+    del reader
+    gc.collect()
+    return parsed
+
+
+def set_gguf2meta_model(
+    meta_model: nn.Module,
+    model_state_dict: dict,
+    dtype: torch.dtype,
+    device: torch.device | None,
+) -> nn.Module:
+    """Inject GGUF weights into a meta-initialized model.
+
+    The model **must** have been built with ``accelerate.init_empty_weights()``
+    so its parameters live on the meta device. This function:
+      1. Replaces ``nn.Linear`` modules with ``GGUFLinear`` (via the quantizer hook).
+      2. Loads the parsed state-dict into those modules.
+      3. Returns the model cast to ``dtype`` (non-quant params only).
+    """
+    from diffusers import GGUFQuantizationConfig
+    from diffusers.models.model_loading_utils import load_model_dict_into_meta
+    from diffusers.quantizers.gguf import GGUFQuantizer
+
+    g_config = GGUFQuantizationConfig(compute_dtype=dtype or torch.bfloat16)
+    hf_quantizer = GGUFQuantizer(quantization_config=g_config)
+    hf_quantizer.pre_quantized = True  # required: weights are already quantized
+
+    device_map = {"": device} if device is not None else None
+    hf_quantizer._process_model_before_weight_loading(meta_model, device_map=device_map, state_dict=model_state_dict)
+    load_model_dict_into_meta(
+        meta_model,
+        model_state_dict,
+        hf_quantizer=hf_quantizer,
+        device_map=device_map,
+        dtype=dtype,
+    )
+    hf_quantizer._process_model_after_weight_loading(meta_model)
+
+    del model_state_dict
+    gc.collect()
+    return meta_model.to(dtype=dtype)
+
+
+def match_state_dict(meta_model: nn.Module, sd: dict, show_num: int = 10) -> dict:
+    """Debug helper: report how well a parsed state-dict matches a model.
+
+    Returns a dict with counts/sets for programmatic checks.
+    """
+    model_keys = set(meta_model.state_dict().keys())
+    sd_keys = set(sd.keys())
+    matching = model_keys & sd_keys
+    extra = sd_keys - model_keys
+    missing = model_keys - sd_keys
+
+    print(f"[gguf] matching keys: {len(matching)}")
+    if extra:
+        print(f"[gguf] extra in state_dict (not in model): {len(extra)}")
+        for k in list(extra)[:show_num]:
+            print(f"  + {k}")
+    if missing:
+        print(f"[gguf] missing in state_dict (in model only): {len(missing)}")
+        for k in list(missing)[:show_num]:
+            print(f"  - {k}")
+    print(f"[gguf] sample matches: {list(matching)[:5]}")
+
+    return {
+        "matching": len(matching),
+        "extra": extra,
+        "missing": missing,
+    }

--- a/xinference/thirdparty/sensenova_u1/utils/layer_offload.py
+++ b/xinference/thirdparty/sensenova_u1/utils/layer_offload.py
@@ -1,0 +1,998 @@
+"""Layer offload wrapper for memory-efficient inference.
+
+Keeps each layer of an ``nn.ModuleList`` in CPU pinned memory and moves it
+onto an accelerator device (CUDA or XPU) on demand. Two modes share a single
+:class:`LayerOffloadWrapper`:
+
+- ``prefetch_count == 0`` — synchronous: load before forward, evict after.
+- ``prefetch_count >= 1`` — asynchronous: a dedicated CUDA stream prefetches
+  the next ``prefetch_count`` layers so the H2D copy overlaps compute.
+
+General-purpose: works with any ``nn.Module`` whose forward iterates over a
+``nn.ModuleList`` attribute (``transformer_blocks``, ``layers``, …). Each
+layer is evicted back to CPU immediately after its forward completes; in
+async mode prefetch wraps around modulo the layer count so the last layer's
+prefetch warms up early layers for the next forward pass.
+
+Inference-only — the eviction-after-forward design destroys gradient flow,
+so :meth:`__init__` rejects models in training mode.
+
+Origin: adapted from `Lightricks/LTX-2 <https://github.com/Lightricks/LTX-2>`_.
+
+Example
+-------
+>>> model = build_my_model(device=torch.device("cpu")).eval()
+>>> model = LayerOffloadWrapper(
+...     model,
+...     layers_attr="transformer_blocks",
+...     target_device=torch.device("cuda:0"),
+...     prefetch_count=2,
+... )
+>>> out = model(inputs)
+>>> model.teardown()
+"""
+
+from __future__ import annotations
+
+import functools
+import itertools
+import logging
+import math
+from typing import Any
+
+import torch
+from torch import nn
+
+from .accel import accel_module as _accel
+from .accel import require_accelerator as _require_accelerator
+
+logger = logging.getLogger(__name__)
+
+_GROUP_SHARED = "shared"
+_GROUP_UNDERSTANDING = "understanding"
+_GROUP_GENERATION = "generation"
+_ALL_TENSOR_GROUPS = frozenset({_GROUP_SHARED, _GROUP_UNDERSTANDING, _GROUP_GENERATION})
+_GIB = 1024**3
+DEFAULT_FAST_VRAM_FRACTION = 0.90
+DEFAULT_FAST_VRAM_HEADROOM_GIB = 2.0
+DEFAULT_FAST_ACTIVATION_RESERVE_GIB = 4.0
+_PHASE_CALLBACK_ATTR = "_layer_offload_phase_callback"
+_MISSING = object()
+# The prefix understanding path uses eager attention with a float32 additive
+# mask.  At its peak, BF16 scores, promoted/masked scores, and float32 softmax
+# workspace overlap.  Twelve bytes per score is deliberately conservative and
+# matched the measured 8,442-token H100 peak with roughly 10% safety margin.
+_EAGER_ATTENTION_BYTES_PER_SCORE = 12
+
+
+def _resident_memory_limit(
+    total_memory_bytes: int,
+    *,
+    memory_fraction: float = DEFAULT_FAST_VRAM_FRACTION,
+    headroom_bytes: int = int(DEFAULT_FAST_VRAM_HEADROOM_GIB * _GIB),
+    budget_bytes: int | None = None,
+) -> int:
+    """Return the allocator watermark used by generation-weight residency.
+
+    An explicit ``budget_bytes`` overrides the fraction-derived budget. Both
+    paths still preserve ``headroom_bytes`` below physical device capacity.
+    """
+    if total_memory_bytes < 0:
+        raise ValueError("total_memory_bytes must be >= 0")
+    if not math.isfinite(memory_fraction) or not 0 < memory_fraction <= 1:
+        raise ValueError("memory_fraction must satisfy 0 < value <= 1")
+    if headroom_bytes < 0:
+        raise ValueError("headroom_bytes must be >= 0")
+    if budget_bytes is not None and budget_bytes <= 0:
+        raise ValueError("budget_bytes must be > 0 when set")
+    if total_memory_bytes <= headroom_bytes:
+        return 0
+    requested_limit = budget_bytes if budget_bytes is not None else int(total_memory_bytes * memory_fraction)
+    return min(requested_limit, total_memory_bytes - headroom_bytes)
+
+
+def _log_vram(label: str, target_device: torch.device, *, reset_peak: bool = False) -> None:
+    """Cheap VRAM snapshot for diagnosing offload-mode leaks across repeated
+    runs (notably under ComfyUI). Never raises; logs at INFO so it shows up
+    without explicit DEBUG opt-in.
+    """
+    try:
+        accel = _accel(target_device)
+        if not accel.is_available():
+            return
+        alloc = accel.memory_allocated(target_device) / (1024**3)
+        reserved = accel.memory_reserved(target_device) / (1024**3)
+        peak = accel.max_memory_allocated(target_device) / (1024**3)
+        logger.info(
+            "[layer_offload vram] %-40s | alloc=%6.2f GiB  reserved=%6.2f GiB  peak=%6.2f GiB",
+            label,
+            alloc,
+            reserved,
+            peak,
+        )
+        if reset_peak:
+            accel.reset_peak_memory_stats(target_device)
+    except Exception as exc:  # pragma: no cover - diagnostic only
+        logger.debug("vram log %r failed: %s", label, exc)
+
+
+def _resolve_attr(module: nn.Module, dotted_path: str) -> nn.ModuleList:
+    """Resolve a dotted attribute path like ``'model.language_model.layers'``."""
+    obj: Any = module
+    for part in dotted_path.split("."):
+        obj = getattr(obj, part)
+    if not isinstance(obj, nn.ModuleList):
+        raise TypeError(f"Expected nn.ModuleList at '{dotted_path}', got {type(obj).__name__}")
+    return obj
+
+
+def _resolve_modules(module: nn.Module, dotted_paths: tuple[str, ...]) -> tuple[nn.Module, ...]:
+    """Resolve model-declared module paths used by inference phase offload."""
+    resolved: list[nn.Module] = []
+    for dotted_path in dotted_paths:
+        obj: Any = module
+        for part in dotted_path.split("."):
+            obj = getattr(obj, part)
+        if not isinstance(obj, nn.Module):
+            raise TypeError(f"Expected nn.Module at '{dotted_path}', got {type(obj).__name__}")
+        resolved.append(obj)
+    return tuple(resolved)
+
+
+def _unique_module_parameters(modules: tuple[nn.Module, ...]) -> tuple[nn.Parameter, ...]:
+    """Return parameters from ``modules`` once, preserving declaration order."""
+    parameters: list[nn.Parameter] = []
+    seen: set[int] = set()
+    for module in modules:
+        for parameter in module.parameters():
+            if id(parameter) in seen:
+                continue
+            seen.add(id(parameter))
+            parameters.append(parameter)
+    return tuple(parameters)
+
+
+class _PrefixWeightStore:
+    """Keep pinned CPU backing for weights needed only before denoising."""
+
+    def __init__(self, modules: tuple[nn.Module, ...], target_device: torch.device) -> None:
+        self._target_device = target_device
+        self._parameters = _unique_module_parameters(modules)
+        self._pinned: dict[int, torch.Tensor] = {}
+        self._on_target = False
+        # Allocate every backing tensor before rebinding any Parameter.  A
+        # pinning failure must leave the model in its original state.
+        for parameter in self._parameters:
+            pinned = parameter.data.pin_memory(device=target_device.type)
+            self._pinned[id(parameter)] = pinned
+        for parameter in self._parameters:
+            parameter.data = self._pinned[id(parameter)]
+
+    def move_to_target(self) -> None:
+        if self._on_target:
+            return
+        for parameter in self._parameters:
+            parameter.data = self._pinned[id(parameter)].to(self._target_device, non_blocking=True)
+        self._on_target = True
+
+    def evict_to_cpu(self) -> None:
+        if not self._on_target:
+            return
+        for parameter in self._parameters:
+            parameter.data = self._pinned[id(parameter)]
+        self._on_target = False
+
+    def parameter_ids(self) -> set[int]:
+        return {id(parameter) for parameter in self._parameters}
+
+    def cleanup(self) -> None:
+        # Parameter.data intentionally keeps the pinned CPU tensor.  A later
+        # wrapper can reuse it without paying the pinning copy again.
+        self._parameters = ()
+        self._pinned.clear()
+
+
+def _partition_layer_tensor_names(layer: nn.Module) -> dict[str, str]:
+    """Classify layer tensors into shared, understanding, and generation groups.
+
+    NEO-Unify stores the two task branches side by side. Generation modules
+    carry a ``_mot_gen`` suffix while their understanding counterparts use the
+    same path without the suffix. A tensor without such a paired counterpart
+    (for example RoPE buffers) is shared by both branches.
+
+    For ordinary transformer blocks with no ``_mot_gen`` names every tensor is
+    classified as shared, preserving the wrapper's general-purpose behaviour.
+    """
+    names = {name for name, _tensor in itertools.chain(layer.named_parameters(), layer.named_buffers())}
+    groups: dict[str, str] = {}
+    for name in names:
+        parts = name.split(".")
+        if any(part.endswith("_mot_gen") for part in parts[:-1]):
+            groups[name] = _GROUP_GENERATION
+            continue
+
+        has_generation_pair = False
+        for idx in range(len(parts) - 1):
+            candidate = parts.copy()
+            candidate[idx] = f"{candidate[idx]}_mot_gen"
+            if ".".join(candidate) in names:
+                has_generation_pair = True
+                break
+        groups[name] = _GROUP_UNDERSTANDING if has_generation_pair else _GROUP_SHARED
+    return groups
+
+
+def _required_tensor_groups(kwargs: dict[str, Any]) -> frozenset[str]:
+    """Return the weight groups required by one decoder-layer invocation.
+
+    The model normalises the two branch flags to Python ``bool`` values before
+    entering the layer loop. Unknown/custom callers fall back to all groups so
+    branch-aware streaming can never omit a weight merely because a module has
+    a different forward signature.
+    """
+    use_understanding = kwargs.get("exist_non_image_gen_tokens")
+    use_generation = kwargs.get("exist_image_gen_tokens")
+    if not isinstance(use_understanding, bool) or not isinstance(use_generation, bool):
+        return _ALL_TENSOR_GROUPS
+    if use_understanding and not use_generation:
+        return frozenset({_GROUP_SHARED, _GROUP_UNDERSTANDING})
+    if use_generation and not use_understanding:
+        return frozenset({_GROUP_SHARED, _GROUP_GENERATION})
+    return _ALL_TENSOR_GROUPS
+
+
+def _is_cuda_malloc_async_backend() -> bool:
+    """Detect whether the active CUDA caching allocator is ``cudaMallocAsync``.
+
+    The native caching allocator and ``cudaMallocAsync`` differ on a point
+    that matters for our cross-stream prefetch: ``cudaMallocAsync`` keeps a
+    pool *per stream* and never reuses freed blocks across streams without
+    explicit ordering, so allocating on the prefetch stream and freeing on
+    the compute stream causes the reserved pool to grow without bound. The
+    native allocator handles this case with ``record_stream`` and reuses
+    blocks freely.
+
+    ComfyUI launchers commonly set
+    ``PYTORCH_CUDA_ALLOC_CONF=backend:cudaMallocAsync``; standalone Python
+    runs typically don't.
+    """
+    try:
+        return torch.cuda.is_available() and torch.cuda.get_allocator_backend() == "cudaMallocAsync"
+    except Exception:
+        return False
+
+
+def _audit_lazy_state(
+    model: nn.Module,
+    target_device: torch.device,
+    managed_tensor_ids: set[int],
+) -> int:
+    """Move any params/buffers stranded off ``target_device`` after the first
+    forward (lazy buffers materialised inside ``forward()``) onto it.
+
+    Returns the number of tensors moved. Tensors already managed by the
+    offload store are skipped — they are intentionally rotated between
+    pinned CPU and GPU. Anything else that ends up on the wrong device is
+    almost certainly a lazy buffer (e.g. an attention mask cache) that the
+    constructor could not see, and it lives on GPU permanently from here on.
+    """
+    moved = 0
+    for tensor in itertools.chain(model.parameters(), model.buffers()):
+        if id(tensor) in managed_tensor_ids:
+            continue
+        if tensor.device != target_device:
+            tensor.data = tensor.data.to(target_device)
+            moved += 1
+    return moved
+
+
+class _LayerStore:
+    """Holds CPU-pinned copies of every parameter/buffer of every offloaded layer.
+
+    Tracks which layers currently reside on GPU so the prefetcher and evictor
+    can make correct decisions in async mode. In sync mode the bookkeeping is
+    free overhead.
+    """
+
+    def __init__(self, layers: nn.ModuleList, target_device: torch.device) -> None:
+        self.target_device = target_device
+        self.num_layers = len(layers)
+
+        # ``Tensor.pin_memory()`` defaults to CUDA; XPU needs an explicit
+        # device kind so the host buffer is registered with the right driver.
+        self._pin_device = target_device.type
+
+        self._pinned: list[dict[str, torch.Tensor]] = []
+        self._tensor_groups: list[dict[str, str]] = []
+        self._resident_groups: list[set[str]] = []
+        self._on_gpu: set[int] = set()
+        self._managed_tensor_ids: set[int] = set()
+        self._bytes_moved = 0
+        self._bytes_moved_by_group = {group: 0 for group in _ALL_TENSOR_GROUPS}
+
+        for layer in layers:
+            pinned: dict[str, torch.Tensor] = {}
+            for name, tensor in itertools.chain(layer.named_parameters(), layer.named_buffers()):
+                self._managed_tensor_ids.add(id(tensor))
+                pinned_tensor = tensor.data.pin_memory(device=self._pin_device)
+                tensor.data = pinned_tensor
+                pinned[name] = pinned_tensor
+            self._pinned.append(pinned)
+            self._tensor_groups.append(_partition_layer_tensor_names(layer))
+            self._resident_groups.append(set())
+
+    def _check_idx(self, idx: int) -> None:
+        if idx < 0 or idx >= self.num_layers:
+            raise IndexError(f"Layer index {idx} out of range [0, {self.num_layers})")
+
+    def is_on_gpu(self, idx: int, groups: frozenset[str] | None = None) -> bool:
+        self._check_idx(idx)
+        if groups is None:
+            return idx in self._on_gpu
+        return groups.issubset(self._resident_groups[idx])
+
+    def move_to_gpu(
+        self,
+        idx: int,
+        layer: nn.Module,
+        *,
+        groups: frozenset[str] = _ALL_TENSOR_GROUPS,
+        non_blocking: bool = False,
+    ) -> None:
+        """Move layer *idx* parameters from pinned CPU to ``target_device``."""
+        self._check_idx(idx)
+        missing_groups = groups - self._resident_groups[idx]
+        if not missing_groups:
+            return
+        pinned = self._pinned[idx]
+        tensor_groups = self._tensor_groups[idx]
+        for name, param in itertools.chain(layer.named_parameters(), layer.named_buffers()):
+            group = tensor_groups.get(name, _GROUP_SHARED)
+            if name in pinned and group in missing_groups:
+                source = pinned[name]
+                param.data = source.to(self.target_device, non_blocking=non_blocking)
+                moved = source.numel() * source.element_size()
+                self._bytes_moved += moved
+                self._bytes_moved_by_group[group] += moved
+        self._resident_groups[idx].update(missing_groups)
+        self._on_gpu.add(idx)
+
+    def evict_to_cpu(
+        self,
+        idx: int,
+        layer: nn.Module,
+        *,
+        groups: frozenset[str] = _ALL_TENSOR_GROUPS,
+    ) -> None:
+        """Swap layer *idx* parameters back to their pinned CPU copies."""
+        self._check_idx(idx)
+        if idx not in self._on_gpu:
+            return
+        pinned = self._pinned[idx]
+        tensor_groups = self._tensor_groups[idx]
+        for name, param in itertools.chain(layer.named_parameters(), layer.named_buffers()):
+            if name in pinned and tensor_groups.get(name, _GROUP_SHARED) in groups:
+                param.data = pinned[name]
+        self._resident_groups[idx].difference_update(groups)
+        if not self._resident_groups[idx]:
+            self._on_gpu.discard(idx)
+
+    def tensors_for_groups(
+        self,
+        idx: int,
+        layer: nn.Module,
+        groups: frozenset[str],
+    ) -> list[torch.Tensor]:
+        """Return tensors belonging to ``groups`` for stream recording."""
+        self._check_idx(idx)
+        tensor_groups = self._tensor_groups[idx]
+        return [
+            tensor
+            for name, tensor in itertools.chain(layer.named_parameters(), layer.named_buffers())
+            if tensor_groups.get(name, _GROUP_SHARED) in groups
+        ]
+
+    def transfer_stats(self) -> tuple[int, dict[str, int]]:
+        return self._bytes_moved, dict(self._bytes_moved_by_group)
+
+    def group_nbytes(self, idx: int, group: str) -> int:
+        """Return the pinned bytes belonging to one tensor group in a layer."""
+        self._check_idx(idx)
+        tensor_groups = self._tensor_groups[idx]
+        return sum(
+            tensor.numel() * tensor.element_size()
+            for name, tensor in self._pinned[idx].items()
+            if tensor_groups.get(name, _GROUP_SHARED) == group
+        )
+
+    def managed_tensor_ids(self) -> set[int]:
+        return set(self._managed_tensor_ids)
+
+    def cleanup(self) -> None:
+        """Drop the pinned-tensor refs so they can be freed by the GC."""
+        for pinned_dict in self._pinned:
+            pinned_dict.clear()
+        self._pinned.clear()
+        self._tensor_groups.clear()
+        self._resident_groups.clear()
+        self._on_gpu.clear()
+        self._managed_tensor_ids.clear()
+
+
+class _AsyncPrefetcher:
+    """Issues H2D transfers on a dedicated CUDA stream.
+
+    Uses per-layer CUDA events so that the compute stream only waits for the
+    specific layer it needs, not all pending transfers.
+    """
+
+    def __init__(self, store: _LayerStore, layers: nn.ModuleList) -> None:
+        self._store = store
+        self._layers = layers
+        self._accel = _accel(store.target_device)
+        self._stream = self._accel.Stream(device=store.target_device)
+        self._events: dict[int, tuple[Any, frozenset[str]]] = {}
+
+    def prefetch(self, idx: int, groups: frozenset[str]) -> None:
+        """Begin async transfer of layer *idx* to GPU (no-op if already there)."""
+        if self._store.is_on_gpu(idx, groups) or idx in self._events:
+            return
+        with self._accel.stream(self._stream):
+            self._store.move_to_gpu(idx, self._layers[idx], groups=groups, non_blocking=True)
+            event = self._accel.Event()
+            event.record(self._stream)
+            self._events[idx] = (event, groups)
+
+    def wait(self, idx: int) -> None:
+        """Block the compute stream until layer *idx*'s transfer completes."""
+        pending = self._events.pop(idx, None)
+        if pending is not None:
+            event, _groups = pending
+            self._accel.current_stream(self._store.target_device).wait_event(event)
+
+    def clear_events(self) -> None:
+        self._events.clear()
+
+    def cleanup(self) -> None:
+        """Drain pending work and release accelerator stream/event resources."""
+        self._events.clear()
+        self._stream = None
+        self._layers = None
+        self._store = None
+        self._accel = None
+
+
+class LayerOffloadWrapper(nn.Module):
+    """Wraps a model to offload its sequential layers between CPU and GPU.
+
+    Each layer is evicted immediately after its forward completes. With
+    ``prefetch_count == 0`` the wrapper runs in synchronous mode (one layer
+    on GPU at a time, no extra stream). With ``prefetch_count >= 1`` it
+    pre-stages the next layers on a dedicated CUDA stream so H2D overlaps
+    compute, with up to ``1 + prefetch_count`` layers resident on GPU.
+
+    Parameters
+    ----------
+    model:
+        The model to wrap, with all parameters on **CPU** and in eval mode.
+    layers_attr:
+        Dotted attribute path to the ``nn.ModuleList`` of sequential layers
+        (e.g. ``"transformer_blocks"`` or ``"language_model.model.layers"``).
+    target_device:
+        The accelerator device to use for compute (CUDA or XPU). CPU / MPS
+        are rejected.
+    prefetch_count:
+        ``0`` = synchronous (per-layer load/evict, lowest VRAM, slowest).
+        ``>= 1`` = async prefetch this many layers ahead (faster, more VRAM).
+    keep_generation_resident:
+        Retain generation-branch weights across decoder forwards while they
+        fit the configured fast-mode budget.
+    fast_vram_fraction:
+        Automatic budget as a fraction of physical device memory.
+    fast_vram_headroom_gib:
+        Physical device memory that must remain available.
+    fast_activation_reserve_gib:
+        Projected allocation added to each residency decision for work that
+        happens after the decoder-layer hooks.
+    fast_vram_budget_gib:
+        Optional absolute budget overriding ``fast_vram_fraction``.
+    """
+
+    def __init__(
+        self,
+        model: nn.Module,
+        layers_attr: str,
+        target_device: torch.device,
+        prefetch_count: int = 0,
+        keep_generation_resident: bool = False,
+        fast_vram_fraction: float = DEFAULT_FAST_VRAM_FRACTION,
+        fast_vram_headroom_gib: float = DEFAULT_FAST_VRAM_HEADROOM_GIB,
+        fast_activation_reserve_gib: float = DEFAULT_FAST_ACTIVATION_RESERVE_GIB,
+        fast_vram_budget_gib: float | None = None,
+    ) -> None:
+        super().__init__()
+        _require_accelerator(target_device)
+        if prefetch_count < 0:
+            raise ValueError("prefetch_count must be >= 0")
+        if model.training:
+            raise RuntimeError(
+                "LayerOffloadWrapper only supports inference; the per-forward "
+                "evict-to-CPU step destroys gradient flow. Call model.eval() first."
+            )
+
+        self._model = model
+        self._layers = _resolve_attr(model, layers_attr)
+        self._target_device = target_device
+        self._accel = _accel(target_device)
+        # Clamp: no point prefetching more layers than (num_layers - 1).
+        max_prefetch = max(len(self._layers) - 1, 0)
+        self._prefetch_count = min(prefetch_count, max_prefetch)
+        self._async_mode = self._prefetch_count >= 1
+        self._keep_generation_resident = keep_generation_resident
+        self._resident_generation_layers: set[int] = set()
+        self._resident_generation_bytes = 0
+        self._resident_understanding_layers: set[int] = set()
+        self._resident_understanding_bytes = 0
+        self._inference_phase: str | None = None
+        self._prefix_attention_reserve_bytes = 0
+        self._prefix_residency_active = False
+        self._resident_memory_limit_bytes = 0
+        if not math.isfinite(fast_vram_headroom_gib) or fast_vram_headroom_gib < 0:
+            raise ValueError("fast_vram_headroom_gib must be finite and >= 0")
+        if not math.isfinite(fast_activation_reserve_gib) or fast_activation_reserve_gib < 0:
+            raise ValueError("fast_activation_reserve_gib must be finite and >= 0")
+        if fast_vram_budget_gib is not None and (not math.isfinite(fast_vram_budget_gib) or fast_vram_budget_gib <= 0):
+            raise ValueError("fast_vram_budget_gib must be finite and > 0 when set")
+        self._resident_headroom_bytes = int(fast_vram_headroom_gib * _GIB)
+        self._activation_reserve_bytes = int(fast_activation_reserve_gib * _GIB)
+        # ``cudaMallocAsync`` keeps per-stream memory pools and never reuses
+        # freed blocks across streams without explicit ordering. Detect the
+        # backend at construction time so the hooks can pick the right
+        # alloc/free pairing strategy: native allocator → record_stream
+        # (fast, frees go to whatever stream is current); cudaMallocAsync →
+        # wait_stream + free on prefetch stream (correct, slightly more
+        # serialized). Only meaningful for CUDA; XPU always uses the native
+        # caching allocator and takes the record_stream fast path.
+        self._cuda_malloc_async = target_device.type == "cuda" and _is_cuda_malloc_async_backend()
+        if self._async_mode:
+            logger.info(
+                "LayerOffloadWrapper: async prefetch enabled (prefetch_count=%d, allocator=%s, free_path=%s)",
+                self._prefetch_count,
+                "cudaMallocAsync" if self._cuda_malloc_async else "native",
+                "prefetch-stream + wait_stream" if self._cuda_malloc_async else "compute-stream + record_stream",
+            )
+        if self._keep_generation_resident:
+            try:
+                total_memory = int(self._accel.get_device_properties(target_device).total_memory)
+                budget_bytes = None if fast_vram_budget_gib is None else int(fast_vram_budget_gib * _GIB)
+                self._resident_memory_limit_bytes = _resident_memory_limit(
+                    total_memory,
+                    memory_fraction=fast_vram_fraction,
+                    headroom_bytes=self._resident_headroom_bytes,
+                    budget_bytes=budget_bytes,
+                )
+                if self._activation_reserve_bytes < 0:
+                    raise ValueError("fast_activation_reserve_gib must be >= 0")
+                logger.info(
+                    "LayerOffloadWrapper: generation residency budget=%.2f GiB "
+                    "(fraction=%.3f, headroom=%.2f GiB, activation_reserve=%.2f GiB, explicit_budget=%s)",
+                    self._resident_memory_limit_bytes / _GIB,
+                    fast_vram_fraction,
+                    self._resident_headroom_bytes / _GIB,
+                    self._activation_reserve_bytes / _GIB,
+                    "auto" if budget_bytes is None else f"{budget_bytes / _GIB:.2f} GiB",
+                )
+            except Exception as exc:  # pragma: no cover - backend-specific fallback
+                raise ValueError(f"Invalid generation residency configuration: {exc}") from exc
+        self._hooks: list[torch.utils.hooks.RemovableHandle] = []
+        self._audit_handle: torch.utils.hooks.RemovableHandle | None = None
+        self._prefetcher: _AsyncPrefetcher | None = None
+        self._active_groups: frozenset[str] | None = None
+        self._prefix_weight_store: _PrefixWeightStore | None = None
+        self._previous_phase_callback: Any = _MISSING
+        self._phase_callback_installed = False
+
+        _log_vram("wrapper.__init__: pre-setup", target_device, reset_peak=True)
+        self._setup()
+        _log_vram(
+            f"wrapper.__init__: post-setup (async={self._async_mode}, "
+            f"prefetch={self._prefetch_count}, layers={len(self._layers)})",
+            target_device,
+        )
+
+    # ------------------------------------------------------------------
+    # Setup / teardown
+    # ------------------------------------------------------------------
+
+    def _setup(self) -> None:
+        # 1. Pin all layer tensors in CPU memory.
+        self._store = _LayerStore(self._layers, self._target_device)
+
+        denoise_module_paths = getattr(self._model, "_denoise_offload_module_paths", ())
+        if denoise_module_paths:
+            denoise_modules = _resolve_modules(self._model, tuple(denoise_module_paths))
+            self._prefix_weight_store = _PrefixWeightStore(denoise_modules, self._target_device)
+
+        # 2. Move all NON-layer params/buffers to GPU permanently.
+        layer_tensor_ids: set[int] = set()
+        for layer in self._layers:
+            for t in itertools.chain(layer.parameters(), layer.buffers()):
+                layer_tensor_ids.add(id(t))
+
+        denoise_parameter_ids = (
+            self._prefix_weight_store.parameter_ids() if self._prefix_weight_store is not None else set()
+        )
+
+        for p in self._model.parameters():
+            if id(p) not in layer_tensor_ids and id(p) not in denoise_parameter_ids:
+                p.data = p.data.to(self._target_device)
+        for b in self._model.buffers():
+            if id(b) not in layer_tensor_ids:
+                b.data = b.data.to(self._target_device)
+        if self._prefix_weight_store is not None:
+            self._prefix_weight_store.move_to_target()
+
+        # 3. In async mode spin up the prefetch stream. The first weights are
+        #    loaded lazily because the layer kwargs tell us whether this pass
+        #    needs the understanding branch or the generation branch.
+        if self._async_mode:
+            self._prefetcher = _AsyncPrefetcher(self._store, self._layers)
+
+        # 4. Register layer load/evict hooks.
+        self._register_hooks()
+
+        # 5. One-shot audit: catch lazy params/buffers materialised inside the
+        #    first forward (RoPE caches, attention masks, etc.) that escaped
+        #    the construction-time scan.
+        self._audit_handle = self._model.register_forward_hook(self._audit_first_forward)
+        if self._prefix_weight_store is not None:
+            # Install last so a setup failure cannot leave the model pointing
+            # at a partially initialized wrapper.
+            self._install_phase_callback()
+
+    def _switch_async_groups(self, groups: frozenset[str], *, force: bool = False) -> None:
+        """Reset stale prefetch state when inference changes task branch."""
+        if self._active_groups == groups and not force:
+            return
+        if self._active_groups is not None:
+            # Branch transitions are infrequent (typically prefix -> denoise).
+            # A one-time drain is preferable to carrying the unused branch's
+            # prefetched weights through every subsequent layer.
+            logger.info(
+                "LayerOffloadWrapper: branch transition %s -> %s "
+                "(understanding_resident=%.2f GiB, generation_resident=%.2f GiB)",
+                sorted(self._active_groups),
+                sorted(groups),
+                self._resident_understanding_bytes / _GIB,
+                self._resident_generation_bytes / _GIB,
+            )
+            self._accel.synchronize(device=self._target_device)
+            self._prefetcher.clear_events()  # type: ignore[union-attr]
+            if self._cuda_malloc_async:
+                with self._accel.stream(self._prefetcher._stream):  # type: ignore[union-attr]
+                    for idx, layer in enumerate(self._layers):
+                        self._store.evict_to_cpu(idx, layer)
+            else:
+                for idx, layer in enumerate(self._layers):
+                    self._store.evict_to_cpu(idx, layer)
+            self._resident_generation_layers.clear()
+            self._resident_generation_bytes = 0
+            self._resident_understanding_layers.clear()
+            self._resident_understanding_bytes = 0
+        self._active_groups = groups
+
+    def _can_keep_resident(self, activation_reserve_bytes: int) -> bool:
+        """Return whether current allocations plus workspace fit the fast watermark."""
+        allocated = int(self._accel.memory_allocated(self._target_device))
+        required_free_memory = self._resident_headroom_bytes + activation_reserve_bytes
+        try:
+            driver_free_memory = int(self._accel.mem_get_info(self._target_device)[0])
+            # cudaMallocAsync owns separate pools per stream in this wrapper;
+            # cached blocks from the prefetch stream cannot be assumed usable
+            # by attention work on the compute stream.
+            reclaimable_cache = 0
+            if not self._cuda_malloc_async:
+                reserved = int(self._accel.memory_reserved(self._target_device))
+                reclaimable_cache = max(reserved - allocated, 0)
+            effective_free_memory = driver_free_memory + reclaimable_cache
+        except Exception:  # pragma: no cover - backend-specific fallback
+            effective_free_memory = required_free_memory
+        projected_peak = allocated + activation_reserve_bytes
+        return projected_peak <= self._resident_memory_limit_bytes and effective_free_memory >= required_free_memory
+
+    def _generation_groups_to_evict(self, idx: int, groups: frozenset[str]) -> frozenset[str]:
+        """Keep generation weights resident while below the VRAM watermark."""
+        if not self._keep_generation_resident or _GROUP_GENERATION not in groups:
+            return groups
+
+        keep_resident = self._can_keep_resident(self._activation_reserve_bytes)
+        group_bytes = self._store.group_nbytes(idx, _GROUP_GENERATION)
+        if keep_resident:
+            if idx not in self._resident_generation_layers:
+                self._resident_generation_layers.add(idx)
+                self._resident_generation_bytes += group_bytes
+            return groups - {_GROUP_GENERATION}
+        if idx in self._resident_generation_layers:
+            self._resident_generation_layers.remove(idx)
+            self._resident_generation_bytes -= group_bytes
+        return groups
+
+    def _observe_prefix_forward(
+        self,
+        *,
+        query_length: int,
+        key_length: int,
+        batch_size: int,
+        num_heads: int,
+    ) -> None:
+        """Record the long-prefix workspace before retaining Think weights."""
+        if not self._keep_generation_resident or self._inference_phase != "prefix":
+            return
+        if min(query_length, key_length, batch_size, num_heads) <= 0:
+            return
+        if query_length > 1:
+            score_count = batch_size * num_heads * query_length * key_length
+            reserve = score_count * _EAGER_ATTENTION_BYTES_PER_SCORE
+            self._prefix_attention_reserve_bytes = max(self._prefix_attention_reserve_bytes, reserve)
+            return
+        if self._prefix_attention_reserve_bytes > 0:
+            self._prefix_residency_active = True
+
+    def _understanding_groups_to_evict(self, idx: int, groups: frozenset[str]) -> frozenset[str]:
+        """Retain Think-path weights when the measured prefix budget permits."""
+        if (
+            not self._keep_generation_resident
+            or self._inference_phase != "prefix"
+            or not self._prefix_residency_active
+            or _GROUP_UNDERSTANDING not in groups
+        ):
+            return groups
+
+        activation_reserve = max(self._activation_reserve_bytes, self._prefix_attention_reserve_bytes)
+        keep_resident = self._can_keep_resident(activation_reserve)
+        group_bytes = self._store.group_nbytes(idx, _GROUP_UNDERSTANDING)
+        if keep_resident:
+            if idx not in self._resident_understanding_layers:
+                self._resident_understanding_layers.add(idx)
+                self._resident_understanding_bytes += group_bytes
+            return groups - {_GROUP_UNDERSTANDING}
+        if idx in self._resident_understanding_layers:
+            self._resident_understanding_layers.remove(idx)
+            self._resident_understanding_bytes -= group_bytes
+        return groups
+
+    def _register_hooks(self) -> None:
+        idx_map: dict[int, int] = {id(layer): idx for idx, layer in enumerate(self._layers)}
+        num_layers = len(self._layers)
+
+        active_groups_by_layer: dict[int, frozenset[str]] = {}
+
+        def _pre_hook(module: nn.Module, args: Any, kwargs: dict[str, Any], *, idx: int) -> None:
+            groups = _required_tensor_groups(kwargs)
+            active_groups_by_layer[idx] = groups
+            if idx == 0 and _GROUP_UNDERSTANDING in groups and args and isinstance(args[0], torch.Tensor):
+                hidden_states = args[0]
+                attention_mask = kwargs.get("attention_mask")
+                key_length = (
+                    int(attention_mask.shape[-1])
+                    if isinstance(attention_mask, torch.Tensor) and attention_mask.ndim >= 2
+                    else int(hidden_states.shape[-2])
+                )
+                attention_config = getattr(getattr(module, "self_attn", None), "config", None)
+                num_heads = int(getattr(attention_config, "num_attention_heads", 0))
+                self._observe_prefix_forward(
+                    query_length=int(hidden_states.shape[-2]),
+                    key_length=key_length,
+                    batch_size=int(hidden_states.shape[0]),
+                    num_heads=num_heads,
+                )
+            if self._async_mode:
+                self._switch_async_groups(groups)
+                # Wait only for THIS layer's H2D transfer.
+                self._prefetcher.wait(idx)  # type: ignore[union-attr]
+                if not self._store.is_on_gpu(idx, groups):
+                    self._store.move_to_gpu(idx, module, groups=groups)
+
+                if not self._cuda_malloc_async:
+                    # Native caching allocator fast path: tell the allocator
+                    # the compute stream will read these weights so it does
+                    # not reuse the blocks while the kernel is still running.
+                    # Frees in _post_hook go to whatever stream is current
+                    # (compute stream) and the allocator handles cross-stream
+                    # reuse internally — no prefetch-stream barrier needed.
+                    compute_stream = self._accel.current_stream(self._target_device)
+                    for param in self._store.tensors_for_groups(idx, module, groups):
+                        param.data.record_stream(compute_stream)
+
+                # Kick off prefetch for upcoming layers (wraps around for next pass).
+                for offset in range(1, self._prefetch_count + 1):
+                    self._prefetcher.prefetch((idx + offset) % num_layers, groups)  # type: ignore[union-attr]
+            else:
+                # Sync mode: the H2D dispatches on the compute stream itself,
+                # which serialises naturally with the kernel that follows.
+                self._store.move_to_gpu(idx, module, groups=groups, non_blocking=True)
+
+        def _post_hook(module: nn.Module, _args: Any, _output: Any, *, idx: int) -> None:
+            groups = active_groups_by_layer.pop(idx, _ALL_TENSOR_GROUPS)
+            groups_to_evict = self._understanding_groups_to_evict(idx, groups)
+            groups_to_evict = self._generation_groups_to_evict(idx, groups_to_evict)
+            if self._async_mode and self._cuda_malloc_async:
+                # cudaMallocAsync slow-but-safe path: per-stream pools
+                # require alloc and free on the same stream. Since
+                # `_AsyncPrefetcher` allocates layer weights on the prefetch
+                # stream, we must also free them there. Wait for the compute
+                # stream to finish reading the weights first; wait_stream is
+                # host-async so it does not stall Python. The cost is that
+                # subsequent prefetches queued on the prefetch stream are
+                # ordered after this wait, slightly reducing pipeline depth.
+                prefetch_stream = self._prefetcher._stream  # type: ignore[union-attr]
+                compute_stream = self._accel.current_stream(self._target_device)
+                prefetch_stream.wait_stream(compute_stream)
+                with self._accel.stream(prefetch_stream):
+                    self._store.evict_to_cpu(idx, module, groups=groups_to_evict)
+            else:
+                # Native allocator path: just drop the GPU tensor refs on
+                # the compute stream. record_stream in _pre_hook ensures the
+                # blocks are not reused before the kernel finishes.
+                self._store.evict_to_cpu(idx, module, groups=groups_to_evict)
+
+        for layer in self._layers:
+            idx = idx_map[id(layer)]
+            h1 = layer.register_forward_pre_hook(functools.partial(_pre_hook, idx=idx), with_kwargs=True)
+            h2 = layer.register_forward_hook(functools.partial(_post_hook, idx=idx))
+            self._hooks.extend([h1, h2])
+
+    def _audit_first_forward(self, _module: nn.Module, _inputs: Any, _outputs: Any) -> None:
+        _log_vram("wrapper.audit: pre", self._target_device)
+        managed_tensor_ids = self._store.managed_tensor_ids()
+        if self._prefix_weight_store is not None:
+            managed_tensor_ids.update(self._prefix_weight_store.parameter_ids())
+        moved = _audit_lazy_state(self._model, self._target_device, managed_tensor_ids)
+        if moved:
+            logger.warning(
+                "LayerOffloadWrapper: moved %d lazy param(s)/buffer(s) onto %s after "
+                "the first forward. These will stay on GPU; they are not offloaded.",
+                moved,
+                self._target_device,
+            )
+        _log_vram(f"wrapper.audit: post (moved={moved})", self._target_device)
+        if self._audit_handle is not None:
+            self._audit_handle.remove()
+            self._audit_handle = None
+
+    def set_inference_phase(self, phase: str) -> None:
+        """Swap branch and prefix-only weights for the next inference phase."""
+        if phase not in {"prefix", "denoise"}:
+            raise ValueError(f"Unsupported inference phase: {phase!r}")
+        self._inference_phase = phase
+        if phase == "prefix":
+            self._prefix_attention_reserve_bytes = 0
+            self._prefix_residency_active = False
+            if self._async_mode:
+                # A previous generation may have been cancelled during Think,
+                # before its denoise phase had a chance to release resident
+                # understanding weights. Always drain at a new run boundary.
+                self._switch_async_groups(
+                    frozenset({_GROUP_SHARED, _GROUP_UNDERSTANDING}),
+                    force=True,
+                )
+            else:
+                self._accel.synchronize(device=self._target_device)
+                for idx, layer in enumerate(self._layers):
+                    self._store.evict_to_cpu(idx, layer)
+                self._resident_generation_layers.clear()
+                self._resident_generation_bytes = 0
+                self._resident_understanding_layers.clear()
+                self._resident_understanding_bytes = 0
+            if self._prefix_weight_store is not None:
+                self._prefix_weight_store.move_to_target()
+            return
+        if self._async_mode:
+            self._switch_async_groups(frozenset({_GROUP_SHARED, _GROUP_GENERATION}))
+        else:
+            self._accel.synchronize(device=self._target_device)
+            for idx, layer in enumerate(self._layers):
+                self._store.evict_to_cpu(
+                    idx,
+                    layer,
+                    groups=frozenset({_GROUP_UNDERSTANDING}),
+                )
+        self._resident_understanding_layers.clear()
+        self._resident_understanding_bytes = 0
+        if self._prefix_weight_store is not None:
+            self._prefix_weight_store.evict_to_cpu()
+
+    def _install_phase_callback(self) -> None:
+        self._previous_phase_callback = self._model.__dict__.get(_PHASE_CALLBACK_ATTR, _MISSING)
+        setattr(self._model, _PHASE_CALLBACK_ATTR, self.set_inference_phase)
+        self._phase_callback_installed = True
+
+    def _restore_phase_callback(self) -> None:
+        if not self._phase_callback_installed:
+            return
+        if self._previous_phase_callback is _MISSING:
+            if _PHASE_CALLBACK_ATTR in self._model.__dict__:
+                delattr(self._model, _PHASE_CALLBACK_ATTR)
+        else:
+            setattr(self._model, _PHASE_CALLBACK_ATTR, self._previous_phase_callback)
+        self._previous_phase_callback = _MISSING
+        self._phase_callback_installed = False
+
+    def teardown(self) -> None:
+        """Remove hooks, release pinned memory, and move parameters back to CPU.
+
+        After this call the wrapper is inert: hooks are removed, the prefetch
+        stream is drained and destroyed, all parameters reside on CPU, and
+        the stores release their references. Parameters retain pinned CPU
+        backing so a later wrapper can reuse it without another pinning copy.
+        """
+        _log_vram(
+            f"wrapper.teardown: enter (on_gpu={len(self._store._on_gpu)}, "
+            f"events={len(self._prefetcher._events) if self._prefetcher is not None else 0}, "
+            f"resident_understanding_layers={len(self._resident_understanding_layers)}, "
+            f"resident_understanding_gib={self._resident_understanding_bytes / _GIB:.2f}, "
+            f"resident_generation_layers={len(self._resident_generation_layers)}, "
+            f"resident_generation_gib={self._resident_generation_bytes / _GIB:.2f})",
+            self._target_device,
+        )
+        for h in self._hooks:
+            h.remove()
+        self._hooks.clear()
+        if self._audit_handle is not None:
+            self._audit_handle.remove()
+            self._audit_handle = None
+        self._restore_phase_callback()
+
+        # Drain in-flight H2D copies before tearing down stream resources, or
+        # the accelerator driver can hit use-after-free during cleanup.
+        self._accel.synchronize(device=self._target_device)
+        if self._prefetcher is not None:
+            self._prefetcher.cleanup()
+            self._prefetcher = None
+
+        if self._prefix_weight_store is not None:
+            self._prefix_weight_store.evict_to_cpu()
+
+        for idx, layer in enumerate(self._layers):
+            self._store.evict_to_cpu(idx, layer)
+        self._resident_generation_layers.clear()
+        self._resident_generation_bytes = 0
+        self._resident_understanding_layers.clear()
+        self._resident_understanding_bytes = 0
+
+        for p in self._model.parameters():
+            p.data = p.data.to("cpu")
+        for b in self._model.buffers():
+            b.data = b.data.to("cpu")
+
+        total_bytes, by_group = self._store.transfer_stats()
+        logger.info(
+            "LayerOffloadWrapper transfer totals: %.2f GiB (shared=%.2f, understanding=%.2f, generation=%.2f)",
+            total_bytes / (1024**3),
+            by_group[_GROUP_SHARED] / (1024**3),
+            by_group[_GROUP_UNDERSTANDING] / (1024**3),
+            by_group[_GROUP_GENERATION] / (1024**3),
+        )
+        self._store.cleanup()
+        if self._prefix_weight_store is not None:
+            self._prefix_weight_store.cleanup()
+            self._prefix_weight_store = None
+        _log_vram("wrapper.teardown: exit (pre-empty_cache)", self._target_device)
+
+    # ------------------------------------------------------------------
+    # Forward and attribute delegation
+    # ------------------------------------------------------------------
+
+    def forward(self, *args: Any, **kwargs: Any) -> Any:
+        return self._model(*args, **kwargs)
+
+    def __getattr__(self, name: str) -> Any:
+        """Proxy attribute access to the wrapped model.
+
+        ``nn.Module.__getattr__`` is only called when normal lookup fails, so
+        ``_model`` / ``_store`` etc. are still resolved via ``__dict__``.
+        """
+        try:
+            return super().__getattr__(name)
+        except AttributeError:
+            return getattr(self._model, name)

--- a/xinference/thirdparty/sensenova_u1/utils/lora.py
+++ b/xinference/thirdparty/sensenova_u1/utils/lora.py
@@ -1,0 +1,49 @@
+import torch
+import torch.nn as nn
+from safetensors.torch import safe_open
+
+
+def build_lora_names(key, lora_down_key, lora_up_key, is_native_weight):
+    base = "diffusion_model." if is_native_weight else ""
+    lora_down = base + key.replace(".weight", lora_down_key)
+    lora_up = base + key.replace(".weight", lora_up_key)
+    lora_alpha = base + key.replace(".weight", ".alpha")
+    return lora_down, lora_up, lora_alpha
+
+
+def load_and_merge_lora_weight(
+    model: nn.Module,
+    lora_state_dict: dict,
+    lora_down_key: str = ".lora_down.weight",
+    lora_up_key: str = ".lora_up.weight",
+):
+    is_native_weight = any("diffusion_model." in key for key in lora_state_dict)
+    for key, value in model.named_parameters():
+        lora_down_name, lora_up_name, lora_alpha_name = build_lora_names(
+            key, lora_down_key, lora_up_key, is_native_weight
+        )
+        if lora_down_name in lora_state_dict:
+            lora_down = lora_state_dict[lora_down_name]
+            lora_up = lora_state_dict[lora_up_name]
+            lora_alpha = float(lora_state_dict[lora_alpha_name])
+            rank = lora_down.shape[0]
+            scaling_factor = lora_alpha / rank
+            assert lora_up.dtype == torch.float32
+            assert lora_down.dtype == torch.float32
+            delta_W = scaling_factor * torch.matmul(lora_up, lora_down).to(value.device)
+            value.data = (value.data + delta_W).type_as(value.data)
+    return model
+
+
+def load_and_merge_lora_weight_from_safetensors(
+    model: nn.Module,
+    lora_weight_path: str,
+    lora_down_key: str = ".lora_down.weight",
+    lora_up_key: str = ".lora_up.weight",
+):
+    lora_state_dict = {}
+    with safe_open(lora_weight_path, framework="pt", device="cpu") as f:
+        for key in f.keys():
+            lora_state_dict[key] = f.get_tensor(key)
+    model = load_and_merge_lora_weight(model, lora_state_dict, lora_down_key, lora_up_key)
+    return model

--- a/xinference/thirdparty/sensenova_u1/utils/offload.py
+++ b/xinference/thirdparty/sensenova_u1/utils/offload.py
@@ -1,0 +1,253 @@
+"""Context managers for CPU<->GPU layer offload during inference.
+
+Wraps :class:`LayerOffloadWrapper` from :mod:`.layer_offload` so callers can
+enter a ``with`` block, run generation through the wrapped model, and have
+the wrapper torn down + host pinned-memory cache released on exit.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import gc
+import logging
+from collections.abc import Iterator
+from contextlib import AbstractContextManager, contextmanager
+from typing import TypeVar
+
+import torch
+from torch import nn
+
+from . import accel
+from .layer_offload import (
+    DEFAULT_FAST_ACTIVATION_RESERVE_GIB,
+    DEFAULT_FAST_VRAM_FRACTION,
+    DEFAULT_FAST_VRAM_HEADROOM_GIB,
+    LayerOffloadWrapper,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+_M = TypeVar("_M", bound=nn.Module)
+
+VRAM_MODE_OPTIONS: tuple[str, ...] = ("full", "fast", "balanced", "low")
+DEFAULT_VRAM_MODE: str = "full"
+_VRAM_MODE_TO_PREFETCH: dict[str, int] = {
+    "full": 0,
+    "fast": 2,
+    "low": 1,
+    "balanced": 2,
+}
+DEFAULT_LAYERS_ATTR: str = "language_model.model.layers"
+
+
+def vram_mode_to_prefetch_count(mode: str) -> int:
+    """Map a ``--vram_mode`` choice to the layer-offload ``prefetch_count``.
+
+    ``0`` means the model stays fully on GPU (no offload). ``1`` means
+    synchronous per-layer swap; ``>=2`` means async prefetch.
+    """
+    if mode not in _VRAM_MODE_TO_PREFETCH:
+        raise ValueError(f"Unsupported vram_mode={mode!r}. Choose one of {VRAM_MODE_OPTIONS}.")
+    return _VRAM_MODE_TO_PREFETCH[mode]
+
+
+def vram_mode_keeps_generation_resident(mode: str) -> bool:
+    """Whether ``mode`` retains generation-layer weights after first use."""
+    if mode not in _VRAM_MODE_TO_PREFETCH:
+        raise ValueError(f"Unsupported vram_mode={mode!r}. Choose one of {VRAM_MODE_OPTIONS}.")
+    return mode == "fast"
+
+
+def make_offload_ctx(
+    model: nn.Module,
+    prefetch_count: int,
+    target_device: str | torch.device,
+    layers_attr: str = DEFAULT_LAYERS_ATTR,
+    *,
+    keep_generation_resident: bool = False,
+    fast_vram_fraction: float = DEFAULT_FAST_VRAM_FRACTION,
+    fast_vram_headroom_gib: float = DEFAULT_FAST_VRAM_HEADROOM_GIB,
+    fast_activation_reserve_gib: float = DEFAULT_FAST_ACTIVATION_RESERVE_GIB,
+    fast_vram_budget_gib: float | None = None,
+) -> AbstractContextManager[nn.Module]:
+    """Pick the right offload context for ``prefetch_count``.
+
+    ``0`` returns a pass-through context yielding ``model`` unchanged.
+    ``1`` returns the synchronous offload context (one resident layer).
+    ``>=2`` returns the async prefetch context with that many layers ahead.
+    """
+    if prefetch_count == 0:
+        return contextlib.nullcontext(model)
+    target = target_device if isinstance(target_device, torch.device) else torch.device(target_device)
+    if prefetch_count == 1:
+        return offload_layers_sync(
+            model,
+            layers_attr,
+            target,
+            keep_generation_resident=keep_generation_resident,
+            fast_vram_fraction=fast_vram_fraction,
+            fast_vram_headroom_gib=fast_vram_headroom_gib,
+            fast_activation_reserve_gib=fast_activation_reserve_gib,
+            fast_vram_budget_gib=fast_vram_budget_gib,
+        )
+    return offload_layers_async(
+        model,
+        layers_attr,
+        target,
+        prefetch_count=prefetch_count,
+        keep_generation_resident=keep_generation_resident,
+        fast_vram_fraction=fast_vram_fraction,
+        fast_vram_headroom_gib=fast_vram_headroom_gib,
+        fast_activation_reserve_gib=fast_activation_reserve_gib,
+        fast_vram_budget_gib=fast_vram_budget_gib,
+    )
+
+
+def _cleanup_memory() -> None:
+    gc.collect()
+    accel.empty_cache()
+    accel.synchronize()
+
+
+def _log_vram(label: str, target_device: torch.device) -> None:
+    """Log allocated / reserved / peak VRAM with ``label``.
+
+    Used to diagnose the ComfyUI-only VRAM growth under
+    ``vram_mode='balanced'``. Best-effort; never raises.
+    """
+    try:
+        if target_device.type not in accel.SUPPORTED_DEVICE_TYPES or not accel.is_available(target_device.type):
+            return
+        mod = accel.accel_module(target_device)
+        alloc = mod.memory_allocated(target_device) / (1024**3)
+        reserved = mod.memory_reserved(target_device) / (1024**3)
+        peak = mod.max_memory_allocated(target_device) / (1024**3)
+        LOGGER.info(
+            "[offload vram] %-40s | alloc=%6.2f GiB  reserved=%6.2f GiB  peak=%6.2f GiB",
+            label,
+            alloc,
+            reserved,
+            peak,
+        )
+    except Exception as exc:  # pragma: no cover - diagnostic only
+        LOGGER.debug("offload vram log %r failed: %s", label, exc)
+
+
+def _empty_host_cache(target_device: torch.device) -> None:
+    """Release PyTorch's pinned host-memory cache.
+
+    Without this, repeated offload runs eventually exhaust host memory
+    because the CachingHostAllocator keeps freed pinned blocks cached. The
+    host cache is global (not per-backend); we still synchronize the active
+    accelerator first so in-flight H2D copies don't reference freed blocks.
+    """
+    if target_device.type not in accel.SUPPORTED_DEVICE_TYPES or not accel.is_available(target_device.type):
+        return
+    try:
+        accel.synchronize(target_device)
+        if hasattr(torch._C, "_host_emptyCache"):
+            torch._C._host_emptyCache()
+    except Exception as exc:  # pragma: no cover - best-effort cleanup
+        LOGGER.warning("offload: host cache release failed: %s", exc)
+
+
+@contextmanager
+def _offload_layers(
+    model: _M,
+    layers_attr: str,
+    target_device: torch.device,
+    prefetch_count: int,
+    keep_generation_resident: bool,
+    fast_vram_fraction: float,
+    fast_vram_headroom_gib: float,
+    fast_activation_reserve_gib: float,
+    fast_vram_budget_gib: float | None,
+) -> Iterator[nn.Module]:
+    wrapper = LayerOffloadWrapper(
+        model,
+        layers_attr=layers_attr,
+        target_device=target_device,
+        prefetch_count=prefetch_count,
+        keep_generation_resident=keep_generation_resident,
+        fast_vram_fraction=fast_vram_fraction,
+        fast_vram_headroom_gib=fast_vram_headroom_gib,
+        fast_activation_reserve_gib=fast_activation_reserve_gib,
+        fast_vram_budget_gib=fast_vram_budget_gib,
+    )
+    try:
+        yield wrapper
+    finally:
+        try:
+            wrapper.teardown()
+        except Exception as exc:  # pragma: no cover
+            LOGGER.warning("offload: teardown failed: %s", exc)
+        try:
+            model.to("cpu")
+        except Exception as exc:  # pragma: no cover
+            LOGGER.warning("offload: model.to('cpu') failed: %s", exc)
+        _log_vram("offload._offload_layers: pre-empty_cache", target_device)
+        _cleanup_memory()
+        _log_vram("offload._offload_layers: post-empty_cache", target_device)
+        _empty_host_cache(target_device)
+        _log_vram("offload._offload_layers: post-host_empty_cache", target_device)
+
+
+def offload_layers_sync(
+    model: _M,
+    layers_attr: str,
+    target_device: torch.device,
+    *,
+    keep_generation_resident: bool = False,
+    fast_vram_fraction: float = DEFAULT_FAST_VRAM_FRACTION,
+    fast_vram_headroom_gib: float = DEFAULT_FAST_VRAM_HEADROOM_GIB,
+    fast_activation_reserve_gib: float = DEFAULT_FAST_ACTIVATION_RESERVE_GIB,
+    fast_vram_budget_gib: float | None = None,
+) -> AbstractContextManager[nn.Module]:
+    """Synchronous CPU<->GPU layer offload. Lower memory, slower.
+
+    Each offloaded layer is loaded just before its forward and evicted right
+    after; exactly one layer's weights are resident on GPU.
+    """
+    return _offload_layers(
+        model,
+        layers_attr,
+        target_device,
+        prefetch_count=0,
+        keep_generation_resident=keep_generation_resident,
+        fast_vram_fraction=fast_vram_fraction,
+        fast_vram_headroom_gib=fast_vram_headroom_gib,
+        fast_activation_reserve_gib=fast_activation_reserve_gib,
+        fast_vram_budget_gib=fast_vram_budget_gib,
+    )
+
+
+def offload_layers_async(
+    model: _M,
+    layers_attr: str,
+    target_device: torch.device,
+    prefetch_count: int = 2,
+    *,
+    keep_generation_resident: bool = False,
+    fast_vram_fraction: float = DEFAULT_FAST_VRAM_FRACTION,
+    fast_vram_headroom_gib: float = DEFAULT_FAST_VRAM_HEADROOM_GIB,
+    fast_activation_reserve_gib: float = DEFAULT_FAST_ACTIVATION_RESERVE_GIB,
+    fast_vram_budget_gib: float | None = None,
+) -> AbstractContextManager[nn.Module]:
+    """Async-prefetch layer offload. Higher memory, faster.
+
+    ``prefetch_count`` is how many layers ahead to prefetch on a dedicated
+    CUDA stream; must be >= 1.
+    """
+    if prefetch_count < 1:
+        raise ValueError("prefetch_count must be >= 1 for async offload")
+    return _offload_layers(
+        model,
+        layers_attr,
+        target_device,
+        prefetch_count=prefetch_count,
+        keep_generation_resident=keep_generation_resident,
+        fast_vram_fraction=fast_vram_fraction,
+        fast_vram_headroom_gib=fast_vram_headroom_gib,
+        fast_activation_reserve_gib=fast_activation_reserve_gib,
+        fast_vram_budget_gib=fast_vram_budget_gib,
+    )

--- a/xinference/thirdparty/sensenova_u1/utils/param_count.py
+++ b/xinference/thirdparty/sensenova_u1/utils/param_count.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Iterable
+
+import torch
+from transformers import AutoConfig, AutoModel
+
+from sensenova_u1 import check_checkpoint_compatibility
+from sensenova_u1.models.neo_unify.transformers_compat import pretrained_dtype_kwargs
+
+
+@dataclass(frozen=True)
+class GroupRule:
+    name: str
+    prefixes: tuple[str, ...] = ()
+    contains: tuple[str, ...] = ()
+    excludes: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class ParamEntry:
+    name: str
+    numel: int
+    dtype: str
+    bytes: int
+
+
+@dataclass(frozen=True)
+class ParamGroupStat:
+    name: str
+    params: int
+    trainable_params: int
+    bytes: int
+    entries: tuple[ParamEntry, ...]
+
+
+@dataclass(frozen=True)
+class ParamCountResult:
+    model_path: str
+    total_params: int
+    trainable_params: int
+    total_bytes: int
+    groups: tuple[ParamGroupStat, ...]
+
+
+# NOTE on architecture (SenseNova-U1, MoT):
+#   * vision_model.*                       -> visual und.
+#   * fm_modules.*                         -> generation-only (visual gen., fm_head, timestep/noise embedders)
+#   * language_model.* w/ "_mot_gen"       -> generation expert inside the LLM backbone
+#   * language_model.* w/o "_mot_gen"      -> understanding expert inside the LLM backbone
+#   * language_model.model.embed_tokens.*  -> token input embedding, used by every text token in both
+#                                             pathways (image-gen still embeds the text prompt)
+#   * language_model.lm_head.*             -> text-token output projection. Also exercised by the
+#                                             generation pathway because t2i-reasoning runs a
+#                                             thinking phase that emits text tokens before image
+#                                             tokens. Hence both belong to the "shared" group.
+DEFAULT_GROUPS: tuple[GroupRule, ...] = (
+    GroupRule("generation_transformer", prefixes=("fm_modules",)),
+    GroupRule(
+        "generation_transformer",
+        prefixes=("language_model",),
+        contains=("_mot_gen",),
+    ),
+    GroupRule(
+        "shared",
+        prefixes=(
+            "language_model.model.embed_tokens",
+            "language_model.lm_head",
+        ),
+    ),
+    GroupRule("understanding_transformer", prefixes=("vision_model",)),
+    GroupRule("understanding_transformer", prefixes=("language_model",)),
+)
+
+
+def format_param_count(n: int) -> str:
+    """Format a parameter count using SI suffixes (B = Billion = 1e9)."""
+    units = (("B", 1_000_000_000), ("M", 1_000_000), ("K", 1_000))
+    for suffix, base in units:
+        if abs(n) >= base:
+            return f"{n / base:.3f}{suffix}"
+    return str(n)
+
+
+def format_bytes(n: int) -> str:
+    """Format a byte count in decimal units (GB = 1e9 bytes), matching SI."""
+    units = (("GB", 1_000_000_000), ("MB", 1_000_000), ("KB", 1_000))
+    for suffix, base in units:
+        if abs(n) >= base:
+            return f"{n / base:.3f}{suffix}"
+    return f"{n}B"
+
+
+def build_rules(custom_groups_json: str | None = None) -> tuple[GroupRule, ...]:
+    if not custom_groups_json:
+        return DEFAULT_GROUPS
+
+    with open(custom_groups_json, "r", encoding="utf-8") as f:
+        raw = json.load(f)
+    if not isinstance(raw, dict):
+        raise ValueError("custom group config must be a JSON object")
+
+    rules: list[GroupRule] = []
+    for group_name, prefixes in raw.items():
+        if not isinstance(group_name, str):
+            raise ValueError("group name must be string")
+        if not isinstance(prefixes, list) or not all(isinstance(x, str) for x in prefixes):
+            raise ValueError(f"group '{group_name}' prefixes must be list[str]")
+        rules.append(GroupRule(group_name, tuple(prefixes)))
+    return tuple(rules)
+
+
+def _rule_matches(rule: GroupRule, param_name: str) -> bool:
+    if rule.prefixes and not any(param_name.startswith(p) for p in rule.prefixes):
+        return False
+    if rule.contains and not any(c in param_name for c in rule.contains):
+        return False
+    if rule.excludes and any(e in param_name for e in rule.excludes):
+        return False
+    return bool(rule.prefixes or rule.contains)
+
+
+def infer_group(param_name: str, rules: Iterable[GroupRule]) -> str:
+    for rule in rules:
+        if _rule_matches(rule, param_name):
+            return rule.name
+
+    lowered = param_name.lower()
+    if "embed" in lowered or "embedding" in lowered:
+        return "embedding_misc"
+    return "other"
+
+
+class ModelParamInspector:
+    def __init__(
+        self,
+        model_path: str,
+        *,
+        dtype: torch.dtype = torch.bfloat16,
+    ) -> None:
+        self.model_path = model_path
+        config = AutoConfig.from_pretrained(model_path)
+        check_checkpoint_compatibility(config)
+        self.model = AutoModel.from_pretrained(model_path, config=config, **pretrained_dtype_kwargs(dtype))
+
+    def count(self, rules: Iterable[GroupRule]) -> ParamCountResult:
+        total_params = 0
+        trainable_params = 0
+        total_bytes = 0
+        group_to_params: dict[str, int] = {}
+        group_to_trainable: dict[str, int] = {}
+        group_to_bytes: dict[str, int] = {}
+        group_to_entries: dict[str, list[ParamEntry]] = {}
+        seen_param_ids: set[int] = set()
+
+        for name, param in self.model.named_parameters():
+            param_id = id(param)
+            if param_id in seen_param_ids:
+                continue
+            seen_param_ids.add(param_id)
+
+            numel = int(param.numel())
+            # element_size() reflects the actual per-element byte width of this
+            # parameter, which is robust to mixed-dtype checkpoints (e.g. norms
+            # forced to fp32 even when the rest is loaded as bf16).
+            nbytes = numel * param.element_size()
+            total_params += numel
+            total_bytes += nbytes
+            if param.requires_grad:
+                trainable_params += numel
+
+            group = infer_group(name, rules)
+            group_to_params[group] = group_to_params.get(group, 0) + numel
+            group_to_bytes[group] = group_to_bytes.get(group, 0) + nbytes
+            group_to_entries.setdefault(group, []).append(
+                ParamEntry(
+                    name=name,
+                    numel=numel,
+                    dtype=str(param.dtype).replace("torch.", ""),
+                    bytes=nbytes,
+                )
+            )
+            if param.requires_grad:
+                group_to_trainable[group] = group_to_trainable.get(group, 0) + numel
+
+        groups = tuple(
+            ParamGroupStat(
+                name=k,
+                params=v,
+                trainable_params=group_to_trainable.get(k, 0),
+                bytes=group_to_bytes.get(k, 0),
+                entries=tuple(sorted(group_to_entries.get(k, []), key=lambda e: e.numel, reverse=True)),
+            )
+            for k, v in sorted(group_to_params.items(), key=lambda x: x[1], reverse=True)
+        )
+        return ParamCountResult(
+            model_path=self.model_path,
+            total_params=total_params,
+            trainable_params=trainable_params,
+            total_bytes=total_bytes,
+            groups=groups,
+        )

--- a/xinference/thirdparty/sensenova_u1/utils/profiler.py
+++ b/xinference/thirdparty/sensenova_u1/utils/profiler.py
@@ -1,0 +1,324 @@
+"""Inference timing profiler.
+
+Records model-load time and per-generation wall time (CUDA-synchronized so
+GPU launch overhead doesn't hide inside Python). ``report()`` prints a summary
+that also converts per-image time into per-token cost using a fixed image
+patch size (the model's generation patchification factor). For CUDA devices,
+it also records peak memory allocated/reserved during model load and each
+generation block.
+
+Intended for quick, human-readable profiling from CLI scripts under
+``examples/``. When ``enabled=False``, every context manager is a no-op and
+``report()`` prints nothing, so it can be wired in unconditionally.
+
+Typical usage::
+
+    from sensenova_u1.utils import InferenceProfiler
+
+    prof = InferenceProfiler(enabled=args.profile, device=args.device)
+    with prof.time_load():
+        engine = SenseNovaU1T2I(model_path)
+    with prof.time_generate(width=2048, height=2048, batch=1):
+        images = engine.generate(...)
+    prof.report()
+"""
+
+from __future__ import annotations
+
+import time
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Iterator, List, Mapping
+
+import torch
+
+try:
+    import resource as _resource  # POSIX-only; Windows falls back to 0
+except ImportError:  # pragma: no cover - non-POSIX
+    _resource = None  # type: ignore[assignment]
+
+DEFAULT_IMAGE_PATCH_SIZE = 32
+
+
+def _process_rss_peak() -> int:
+    """Return process-wide peak resident set size in bytes (0 if unavailable).
+
+    ``ru_maxrss`` is a monotonic high-water mark since process start: it cannot
+    be reset, so per-block values reflect cumulative peak, not delta.
+    """
+    if _resource is None:
+        return 0
+    rss = _resource.getrusage(_resource.RUSAGE_SELF).ru_maxrss
+    # Linux reports kB; macOS reports bytes. Heuristic: huge value => already bytes.
+    return rss * 1024 if rss < (1 << 40) else rss
+
+
+@dataclass
+class _MemoryPeak:
+    allocated: int = 0
+    reserved: int = 0
+    cpu_rss: int = 0
+    by_device: tuple[tuple[str, int, int], ...] = ()
+
+    @property
+    def available(self) -> bool:
+        return self.allocated > 0 or self.reserved > 0 or self.cpu_rss > 0
+
+
+@dataclass
+class _GenerationRecord:
+    width: int
+    height: int
+    batch: int
+    seconds: float
+    memory_peak: _MemoryPeak
+
+
+@dataclass
+class GenerationHandle:
+    """Mutable handle yielded by :meth:`InferenceProfiler.time_generate`.
+
+    Callers may overwrite ``batch`` (and width/height) after the generate
+    call returns when the true count is only known post-hoc — e.g. interleave
+    inference, where one call produces a variable number of images.
+    """
+
+    width: int
+    height: int
+    batch: int
+
+
+class InferenceProfiler:
+    """Minimal wall-clock profiler for model loading + generation.
+
+    Parameters
+    ----------
+    enabled : bool
+        If False, every method is a no-op (zero overhead).
+    device : str
+        E.g. ``"cuda"``, ``"cuda:0"``, ``"cpu"``. Used to decide whether to
+        ``torch.cuda.synchronize()`` around timed blocks.
+    patch_size : int, optional
+        Image-token grid factor used by :meth:`report` to translate wall time
+        into ms/token. Defaults to :data:`DEFAULT_IMAGE_PATCH_SIZE`.
+    """
+
+    def __init__(
+        self,
+        enabled: bool,
+        device: str = "cuda",
+        patch_size: int = DEFAULT_IMAGE_PATCH_SIZE,
+        config: Mapping[str, object] | None = None,
+    ) -> None:
+        self.enabled = enabled
+        self.device = device
+        self.patch_size = patch_size
+        self.load_time: float = 0.0
+        self.load_memory_peak = _MemoryPeak()
+        self.gen_records: List[_GenerationRecord] = []
+        self.config: dict[str, str] = {}
+        if config:
+            self.set_config(config)
+
+    def set_config(self, config: Mapping[str, object]) -> None:
+        """Attach run metadata (e.g. vram_mode, attn_backend, dtype) shown in report().
+
+        ``None`` values are dropped so callers can pass-through optional args
+        without filtering. Existing keys are overwritten.
+        """
+        for key, value in config.items():
+            if value is None:
+                continue
+            self.config[key] = str(value)
+
+    # ------------------------------------------------------------------
+    # timing
+    # ------------------------------------------------------------------
+
+    def _sync(self) -> None:
+        if self.enabled and self.device.startswith("cuda") and torch.cuda.is_available():
+            torch.cuda.synchronize()
+
+    def _has_cuda_memory_stats(self) -> bool:
+        return self.enabled and self.device.startswith("cuda") and torch.cuda.is_available()
+
+    def _cuda_devices(self) -> list[torch.device]:
+        device = torch.device(self.device)
+        if device.type != "cuda":
+            return []
+        if device.index is not None:
+            return [device]
+        return [torch.device(f"cuda:{idx}") for idx in range(torch.cuda.device_count())]
+
+    def _reset_memory_peak(self) -> None:
+        if self._has_cuda_memory_stats():
+            for device in self._cuda_devices():
+                torch.cuda.reset_peak_memory_stats(device)
+
+    def _memory_peak(self) -> _MemoryPeak:
+        cpu_rss = _process_rss_peak()
+        if not self._has_cuda_memory_stats():
+            return _MemoryPeak(cpu_rss=cpu_rss)
+        by_device = tuple(
+            (
+                str(device),
+                torch.cuda.max_memory_allocated(device),
+                torch.cuda.max_memory_reserved(device),
+            )
+            for device in self._cuda_devices()
+        )
+        return _MemoryPeak(
+            allocated=sum(allocated for _, allocated, _ in by_device),
+            reserved=sum(reserved for _, _, reserved in by_device),
+            cpu_rss=cpu_rss,
+            by_device=by_device,
+        )
+
+    @contextmanager
+    def time_load(self) -> Iterator[None]:
+        if not self.enabled:
+            yield
+            return
+        self._sync()
+        self._reset_memory_peak()
+        t0 = time.perf_counter()
+        try:
+            yield
+        finally:
+            self._sync()
+            self.load_time = time.perf_counter() - t0
+            self.load_memory_peak = self._memory_peak()
+
+    @contextmanager
+    def time_generate(self, width: int, height: int, batch: int = 1) -> Iterator[GenerationHandle]:
+        """Time a generation block. Yields a mutable handle so callers can
+        correct ``batch`` (or width/height) after the call when the true
+        count is only known post-hoc (e.g. interleave produces N images per
+        call). Existing callers that ignore the yielded value still work."""
+        handle = GenerationHandle(width=width, height=height, batch=batch)
+        if not self.enabled:
+            yield handle
+            return
+        self._sync()
+        self._reset_memory_peak()
+        t0 = time.perf_counter()
+        try:
+            yield handle
+        finally:
+            self._sync()
+            self.gen_records.append(
+                _GenerationRecord(
+                    width=handle.width,
+                    height=handle.height,
+                    batch=handle.batch,
+                    seconds=time.perf_counter() - t0,
+                    memory_peak=self._memory_peak(),
+                )
+            )
+
+    def update_last_batch(self, n: int) -> None:
+        """Correct the batch count of the most recent time_generate record.
+
+        Call this immediately after the context manager exits, once the actual
+        number of generated images is known (e.g. len(images) for interleaved
+        generation where one call produces a variable number of images).
+        """
+        if self.enabled and self.gen_records:
+            self.gen_records[-1].batch = n
+
+    # ------------------------------------------------------------------
+    # reporting
+    # ------------------------------------------------------------------
+
+    def report(self) -> None:
+        """Print a summary. No-op when ``enabled=False``."""
+        if not self.enabled:
+            return
+        print()
+        print("=" * 64)
+        print("Profile summary")
+        print("=" * 64)
+        if self.config:
+            config_str = ", ".join(f"{k}={v}" for k, v in self.config.items())
+            print(f"  config              : {config_str}")
+        print(f"  model load          : {self.load_time:8.3f} s")
+        if self.load_memory_peak.available:
+            print(f"  load peak memory    : {self._format_memory(self.load_memory_peak)}")
+        if not self.gen_records:
+            print("  (no generations were timed)")
+            return
+
+        total_images = sum(record.batch for record in self.gen_records)
+        total_time = sum(record.seconds for record in self.gen_records)
+        avg_per_image = total_time / total_images
+
+        total_tokens = sum(
+            (record.width // self.patch_size) * (record.height // self.patch_size) * record.batch
+            for record in self.gen_records
+        )
+        avg_tokens = total_tokens / total_images
+        tokens_per_sec = total_tokens / total_time
+
+        peak_generation_memory = self._max_memory_peak(record.memory_peak for record in self.gen_records)
+
+        print(
+            f"  generations         : {len(self.gen_records)} call(s), "
+            f"{total_images} image(s) total, {total_time:.3f} s wall"
+        )
+        print(f"  avg per image       : {avg_per_image:8.3f} s")
+        print(
+            f"  image tokens        : patch_size={self.patch_size}, "
+            f"avg {avg_tokens:.0f} tok/image ({int(avg_tokens):d})"
+        )
+        print(f"  throughput          : {tokens_per_sec:8.2f} tok/s")
+        if peak_generation_memory.available:
+            print(f"  generation peak mem : {self._format_memory(peak_generation_memory)}")
+
+        if len(self.gen_records) > 1:
+            print("  per-call breakdown  :")
+            for idx, record in enumerate(self.gen_records):
+                tokens = (record.width // self.patch_size) * (record.height // self.patch_size) * record.batch
+                memory = f", {self._format_memory(record.memory_peak)}" if record.memory_peak.available else ""
+                print(
+                    f"    [{idx + 1:>3}] {record.width}x{record.height} x{record.batch}  "
+                    f"{record.seconds:7.3f} s  ({tokens:>6d} tok, "
+                    f"{tokens / record.seconds:8.2f} tok/s{memory})"
+                )
+        print("=" * 64)
+
+    @staticmethod
+    def _format_bytes(num_bytes: int) -> str:
+        return f"{num_bytes / (1024**3):.2f} GiB"
+
+    @classmethod
+    def _format_memory(cls, memory_peak: _MemoryPeak) -> str:
+        parts: list[str] = []
+        if memory_peak.allocated > 0 or memory_peak.reserved > 0:
+            parts.append(
+                f"allocated {cls._format_bytes(memory_peak.allocated)}, "
+                f"reserved {cls._format_bytes(memory_peak.reserved)}"
+            )
+        if memory_peak.cpu_rss > 0:
+            parts.append(f"cpu RSS {cls._format_bytes(memory_peak.cpu_rss)}")
+        text = ", ".join(parts) if parts else "n/a"
+        if len(memory_peak.by_device) <= 1:
+            return text
+        details = ", ".join(
+            f"{name}: {cls._format_bytes(allocated)} alloc/{cls._format_bytes(reserved)} reserved"
+            for name, allocated, reserved in memory_peak.by_device
+        )
+        return f"{text} ({details})"
+
+    @staticmethod
+    def _max_memory_peak(memory_peaks: Iterator[_MemoryPeak]) -> _MemoryPeak:
+        max_peak = _MemoryPeak()
+        by_device: dict[str, tuple[int, int]] = {}
+        for memory_peak in memory_peaks:
+            max_peak.allocated = max(max_peak.allocated, memory_peak.allocated)
+            max_peak.reserved = max(max_peak.reserved, memory_peak.reserved)
+            max_peak.cpu_rss = max(max_peak.cpu_rss, memory_peak.cpu_rss)
+            for name, allocated, reserved in memory_peak.by_device:
+                prev_allocated, prev_reserved = by_device.get(name, (0, 0))
+                by_device[name] = (max(prev_allocated, allocated), max(prev_reserved, reserved))
+        max_peak.by_device = tuple((name, allocated, reserved) for name, (allocated, reserved) in by_device.items())
+        return max_peak


### PR DESCRIPTION
## Summary

- Add support for `SenseNova-U1.5-8B-MoT-Preview` using the Transformers backend.
- Support both model sources:
  - Hugging Face: `sensenova/SenseNova-U1.5-8B-MoT-Preview`, revision `main`
  - ModelScope: `SenseNova/SenseNova-U1.5-8B-MoT-Preview`, revision `master`
- Support text-to-image and single/multi-reference image editing.
- Vendor the official `src/sensenova_u1` runtime under `xinference/thirdparty`.
- Add virtualenv dependencies without requiring a Git checkout during model launch.

## Motivation

SenseNova-U1.5 uses its own Transformers-based runtime instead of Diffusers.

Installing that runtime through a VCS dependency makes model startup depend on GitHub access and a relatively large repository checkout. This can make virtualenv creation slow or fail in restricted deployment environments.

This change vendors the required upstream runtime from:

- Repository: https://github.com/OpenSenseNova/SenseNova-U1
- Commit: `35fb2fc520869aa09223a819882abdb3dc328ecd`
- License: Apache License 2.0

The vendored upstream source is kept unchanged.

## Implementation

- Add `SenseNovaU1Model` to adapt the official runtime to Xinference image APIs.
- Register SenseNova-U1.5 as a Transformers image engine.
- Exclude the model from Diffusers engine matching.
- Select the model's registered default engine when `model_engine` is omitted, instead of always defaulting to Diffusers.
- Add image size validation, automatic resizing, generation configuration handling, VRAM offloading, and LoRA integration.
- Load the vendored runtime lazily from `xinference/thirdparty`.
- Reuse system Torch, TorchVision, and NumPy packages in the model virtualenv.
