### PR TITLE
feat(llm): register DeepSeek V4 Flash 0731

### DIFF
--- a/doc/source/models/builtin/llm/deepseek-v4-flash-0731.rst
+++ b/doc/source/models/builtin/llm/deepseek-v4-flash-0731.rst
@@ -10,88 +10,21 @@ DeepSeek-V4-Flash-0731
 - **Abilities:** chat, reasoning, hybrid, tools
 - **Description:** Official DeepSeek-V4-Flash release with enhanced agentic capabilities and an attached DSpark speculative decoding module.
 
-This is a separate built-in model entry from the existing ``DeepSeek-V4-Flash``
-preview entry. It represents the native FP8 checkpoint and is intended to run
-with vLLM 0.20.1 or newer.
-
 Specifications
 ^^^^^^^^^^^^^^
 
+
 Model Spec 1 (fp8, 304 Billion)
-++++++++++++++++++++++++++++++++
+++++++++++++++++++++++++++++++++++++++++
 
 - **Model Format:** fp8
 - **Model Size (in billions):** 304
 - **Quantizations:** fp8
-- **Engines:** vLLM (vLLM >= 0.20.1)
-- **Architecture:** ``DeepseekV4ForCausalLM``
+- **Engines**: vLLM
 - **Model ID:** deepseek-ai/DeepSeek-V4-Flash-0731
-- **Model Hubs:** `Hugging Face <https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731>`__, `ModelScope <https://modelscope.cn/models/deepseek-ai/DeepSeek-V4-Flash-0731>`__
+- **Model Hubs**:  `Hugging Face <https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731>`__, `ModelScope <https://modelscope.cn/models/deepseek-ai/DeepSeek-V4-Flash-0731>`__
 
-Launch the model with the native FP8 format:
+Execute the following command to launch the model, remember to replace ``${quantization}`` with your
+chosen quantization method from the options listed above::
 
-.. code-block:: bash
-
-   xinference launch \
-       --model-engine vLLM \
-       --model-name DeepSeek-V4-Flash-0731 \
-       --size-in-billions 304 \
-       --model-format fp8 \
-       --quantization fp8
-
-The model repository supplies DeepSeek-V4-specific encoding code. For safety,
-Xinference only loads this repository code when the operator enables:
-
-.. code-block:: bash
-
-   export XINFERENCE_TRUST_REMOTE_CODE=1
-
-Reasoning and thinking mode
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-DeepSeek-V4 uses its repository ``encoding/encoding_dsv4.py`` implementation.
-The ``chat_template_kwargs`` option can select thinking mode and reasoning
-level, for example:
-
-.. code-block:: json
-
-   {
-     "chat_template_kwargs": {
-       "enable_thinking": true,
-       "reasoning_effort": "high"
-     }
-   }
-
-Set ``enable_thinking`` to ``false`` to request chat mode. Supported reasoning
-levels depend on the model repository encoding implementation; ``low``,
-``high`` and ``max`` are forwarded without Xinference rewriting them.
-
-DSpark speculative decoding (opt-in)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The checkpoint includes a DSpark speculative decoding module, but Xinference
-does not enable it automatically. Enable it explicitly through vLLM model
-configuration when the deployment hardware and installed vLLM version support
-it:
-
-.. code-block:: json
-
-   {
-     "speculative_config": {
-       "method": "dspark",
-       "num_speculative_tokens": 7,
-       "draft_sample_method": "greedy"
-     }
-   }
-
-The following parameters are an upstream example for a specific 4xGB200
-configuration and are **not** Xinference defaults:
-
-.. code-block:: bash
-
-   --kv-cache-dtype fp8 \
-   --block-size 256 \
-   --data-parallel-size 4 \
-   --enable-expert-parallel \
-   --moe-backend deep_gemm_mega_moe \
-   --attention-config '{"use_fp4_indexer_cache": true}'
+   xinference launch --model-engine ${engine} --model-name DeepSeek-V4-Flash-0731 --size-in-billions 304 --model-format fp8 --quantization ${quantization}

--- a/doc/source/models/builtin/llm/deepseek-v4-flash-0731.rst
+++ b/doc/source/models/builtin/llm/deepseek-v4-flash-0731.rst
@@ -1,0 +1,97 @@
+.. _models_llm_deepseek-v4-flash-0731:
+
+========================================
+DeepSeek-V4-Flash-0731
+========================================
+
+- **Context Length:** 1048576
+- **Model Name:** DeepSeek-V4-Flash-0731
+- **Languages:** en, zh
+- **Abilities:** chat, reasoning, hybrid, tools
+- **Description:** Official DeepSeek-V4-Flash release with enhanced agentic capabilities and an attached DSpark speculative decoding module.
+
+This is a separate built-in model entry from the existing ``DeepSeek-V4-Flash``
+preview entry. It represents the native FP8 checkpoint and is intended to run
+with vLLM 0.20.1 or newer.
+
+Specifications
+^^^^^^^^^^^^^^
+
+Model Spec 1 (fp8, 304 Billion)
+++++++++++++++++++++++++++++++++
+
+- **Model Format:** fp8
+- **Model Size (in billions):** 304
+- **Quantizations:** fp8
+- **Engines:** vLLM (vLLM >= 0.20.1)
+- **Architecture:** ``DeepseekV4ForCausalLM``
+- **Model ID:** deepseek-ai/DeepSeek-V4-Flash-0731
+- **Model Hubs:** `Hugging Face <https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731>`__, `ModelScope <https://modelscope.cn/models/deepseek-ai/DeepSeek-V4-Flash-0731>`__
+
+Launch the model with the native FP8 format:
+
+.. code-block:: bash
+
+   xinference launch \
+       --model-engine vLLM \
+       --model-name DeepSeek-V4-Flash-0731 \
+       --size-in-billions 304 \
+       --model-format fp8 \
+       --quantization fp8
+
+The model repository supplies DeepSeek-V4-specific encoding code. For safety,
+Xinference only loads this repository code when the operator enables:
+
+.. code-block:: bash
+
+   export XINFERENCE_TRUST_REMOTE_CODE=1
+
+Reasoning and thinking mode
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+DeepSeek-V4 uses its repository ``encoding/encoding_dsv4.py`` implementation.
+The ``chat_template_kwargs`` option can select thinking mode and reasoning
+level, for example:
+
+.. code-block:: json
+
+   {
+     "chat_template_kwargs": {
+       "enable_thinking": true,
+       "reasoning_effort": "high"
+     }
+   }
+
+Set ``enable_thinking`` to ``false`` to request chat mode. Supported reasoning
+levels depend on the model repository encoding implementation; ``low``,
+``high`` and ``max`` are forwarded without Xinference rewriting them.
+
+DSpark speculative decoding (opt-in)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The checkpoint includes a DSpark speculative decoding module, but Xinference
+does not enable it automatically. Enable it explicitly through vLLM model
+configuration when the deployment hardware and installed vLLM version support
+it:
+
+.. code-block:: json
+
+   {
+     "speculative_config": {
+       "method": "dspark",
+       "num_speculative_tokens": 7,
+       "draft_sample_method": "greedy"
+     }
+   }
+
+The following parameters are an upstream example for a specific 4xGB300
+configuration and are **not** Xinference defaults:
+
+.. code-block:: bash
+
+   --kv-cache-dtype fp8 \
+   --block-size 256 \
+   --data-parallel-size 4 \
+   --enable-expert-parallel \
+   --moe-backend deep_gemm_mega_moe \
+   --attention-config '{"use_fp4_indexer_cache": true}'

--- a/doc/source/models/builtin/llm/deepseek-v4-flash-0731.rst
+++ b/doc/source/models/builtin/llm/deepseek-v4-flash-0731.rst
@@ -84,7 +84,7 @@ it:
      }
    }
 
-The following parameters are an upstream example for a specific 4xGB300
+The following parameters are an upstream example for a specific 4xGB200
 configuration and are **not** Xinference defaults:
 
 .. code-block:: bash

--- a/doc/source/models/builtin/llm/index.rst
+++ b/doc/source/models/builtin/llm/index.rst
@@ -176,6 +176,11 @@ The following is a list of built-in LLM in Xinference:
      - 163840
      - We present a preview version of DeepSeek-V4 series, including two strong Mixture-of-Experts (MoE) language models — DeepSeek-V4-Pro with 1.6T parameters (49B activated) and DeepSeek-V4-Flash with 284B parameters (13B activated) — both supporting a context length of one million tokens.
 
+   * - :ref:`deepseek-v4-flash-0731 <models_llm_deepseek-v4-flash-0731>`
+     - chat, reasoning, hybrid, tools
+     - 1048576
+     - Official DeepSeek-V4-Flash release with enhanced agentic capabilities and an attached DSpark speculative decoding module.
+
    * - :ref:`deepseek-v4-pro <models_llm_deepseek-v4-pro>`
      - chat, reasoning, hybrid, tools
      - 163840
@@ -925,6 +930,8 @@ The following is a list of built-in LLM in Xinference:
   
    deepseek-v4-flash
   
+   deepseek-v4-flash-0731
+
    deepseek-v4-pro
   
    deepseek-vl2

--- a/doc/source/models/model_abilities/chat.rst
+++ b/doc/source/models/model_abilities/chat.rst
@@ -206,6 +206,73 @@ Usage examples:
     )
 
 
+DeepSeek-V4-Flash-0731
+~~~~~~~~~~~~~~~~~~~~~~
+
+``DeepSeek-V4-Flash-0731`` is a separate built-in model from the
+``DeepSeek-V4-Flash`` preview entry. It uses the native FP8 checkpoint and
+requires vLLM 0.20.1 or newer.
+
+Launch it with:
+
+.. code-block:: bash
+
+   xinference launch \
+       --model-engine vLLM \
+       --model-name DeepSeek-V4-Flash-0731 \
+       --size-in-billions 304 \
+       --model-format fp8 \
+       --quantization fp8
+
+The upstream repository supplies DeepSeek-V4-specific encoding code. Enable
+trusted repository code before launch:
+
+.. code-block:: bash
+
+   export XINFERENCE_TRUST_REMOTE_CODE=1
+
+The ``chat_template_kwargs`` option selects thinking mode and reasoning level:
+
+.. code-block:: json
+
+   {
+     "chat_template_kwargs": {
+       "enable_thinking": true,
+       "reasoning_effort": "high"
+     }
+   }
+
+Set ``enable_thinking`` to ``false`` for chat mode. Supported reasoning levels
+are provided by the model repository; ``low``, ``high``, and ``max`` are
+forwarded without Xinference rewriting them.
+
+The checkpoint includes a DSpark speculative decoding module, but Xinference
+does not enable it automatically. Enable it through vLLM model configuration
+when supported:
+
+.. code-block:: json
+
+   {
+     "speculative_config": {
+       "method": "dspark",
+       "num_speculative_tokens": 7,
+       "draft_sample_method": "greedy"
+     }
+   }
+
+The following parameters are the upstream example for a single 4xGB300 node
+and are not Xinference defaults:
+
+.. code-block:: bash
+
+   --kv-cache-dtype fp8 \
+   --block-size 256 \
+   --data-parallel-size 4 \
+   --enable-expert-parallel \
+   --moe-backend deep_gemm_mega_moe \
+   --attention-config '{"use_fp4_indexer_cache": true}'
+
+
 Generate Models
 ================
 

--- a/xinference/model/llm/llm_family.json
+++ b/xinference/model/llm/llm_family.json
@@ -33434,6 +33434,63 @@
     "updated_at": 1779522860
   },
   {
+    "model_name": "DeepSeek-V4-Flash-0731",
+    "model_description": "Official DeepSeek-V4-Flash release with enhanced agentic capabilities and an attached DSpark speculative decoding module.",
+    "context_length": 1048576,
+    "model_lang": [
+      "en",
+      "zh"
+    ],
+    "model_ability": [
+      "chat",
+      "reasoning",
+      "hybrid",
+      "tools"
+    ],
+    "model_specs": [
+      {
+        "model_size_in_billions": 304,
+        "model_format": "fp8",
+        "model_src": {
+          "huggingface": {
+            "model_id": "deepseek-ai/DeepSeek-V4-Flash-0731",
+            "quantizations": [
+              "fp8"
+            ]
+          },
+          "modelscope": {
+            "model_id": "deepseek-ai/DeepSeek-V4-Flash-0731",
+            "quantizations": [
+              "fp8"
+            ]
+          }
+        }
+      }
+    ],
+    "architectures": [
+      "DeepseekV4ForCausalLM"
+    ],
+    "chat_template": "",
+    "stop_token_ids": [
+      1
+    ],
+    "stop": [
+      "<｜end▁of▁sentence｜>"
+    ],
+    "reasoning_start_tag": "<think>",
+    "reasoning_end_tag": "</think>",
+    "tool_parser": "deepseek-v4",
+    "version": 2,
+    "virtualenv": {
+      "packages": [
+        "vllm>=0.20.1 ; #engine# == \"vllm\"",
+        "#system_numpy# ; #engine# == \"vllm\""
+      ]
+    },
+    "featured": false,
+    "updated_at": 1786099285
+  },
+  {
     "model_name": "DeepSeek-V4-Pro",
     "model_description": "We present a preview version of DeepSeek-V4 series, including two strong Mixture-of-Experts (MoE) language models — DeepSeek-V4-Pro with 1.6T parameters (49B activated) and DeepSeek-V4-Flash with 284B parameters (13B activated) — both supporting a context length of one million tokens.",
     "context_length": 163840,

--- a/xinference/model/llm/tests/test_llm_family.py
+++ b/xinference/model/llm/tests/test_llm_family.py
@@ -742,6 +742,59 @@ def test_match_llm():
         os.environ.pop(XINFERENCE_ENV_MODEL_SRC)
 
 
+def test_match_deepseek_v4_flash_0731():
+    family = match_llm(
+        "DeepSeek-V4-Flash-0731",
+        model_format="fp8",
+        model_size_in_billions=304,
+        quantization="fp8",
+        download_hub="huggingface",
+    )
+
+    assert family is not None
+    assert family.model_name == "DeepSeek-V4-Flash-0731"
+    assert family.context_length == 1048576
+    assert family.architectures == ["DeepseekV4ForCausalLM"]
+    assert family.tool_parser == "deepseek-v4"
+    assert len(family.model_specs) == 1
+    spec = family.model_specs[0]
+    assert spec.model_format == "fp8"
+    assert spec.model_size_in_billions == 304
+    assert spec.quantization == "fp8"
+    assert spec.model_hub == "huggingface"
+    assert spec.model_id == "deepseek-ai/DeepSeek-V4-Flash-0731"
+
+    modelscope_family = match_llm(
+        "DeepSeek-V4-Flash-0731",
+        model_format="fp8",
+        model_size_in_billions=304,
+        quantization="fp8",
+        download_hub="modelscope",
+    )
+    assert modelscope_family is not None
+    assert modelscope_family.model_specs[0].model_hub == "modelscope"
+    assert (
+        modelscope_family.model_specs[0].model_id
+        == "deepseek-ai/DeepSeek-V4-Flash-0731"
+    )
+
+    assert family.virtualenv is not None
+    packages = family.virtualenv.packages
+    assert 'vllm>=0.20.1 ; #engine# == "vllm"' in packages
+    assert not any('#engine# == "Transformers"' in package for package in packages)
+    assert not any('#engine# == "SGLang"' in package for package in packages)
+
+    preview = match_llm(
+        "DeepSeek-V4-Flash",
+        model_format="pytorch",
+        model_size_in_billions=284,
+        quantization="none",
+        download_hub="huggingface",
+    )
+    assert preview is not None
+    assert preview.model_specs[0].model_id == "deepseek-ai/DeepSeek-V4-Flash"
+
+
 def test_is_valid_file_uri():
     with tempfile.NamedTemporaryFile() as tmp_file:
         assert is_valid_model_uri(f"file://{tmp_file.name}") is True


### PR DESCRIPTION
## Summary

- register `DeepSeek-V4-Flash-0731` as a separate built-in model from the existing preview entry
- expose the native FP8 checkpoint from Hugging Face and ModelScope with its 1M-token context metadata
- reuse the existing DeepSeek V4 chat/tool integration and document launch, trust-remote-code, reasoning, and opt-in DSpark settings
- add coverage for model matching, hub selection, runtime dependency selection, and preview-entry compatibility

## Tests

- `pytest -q xinference/model/llm/tests/test_llm_family.py -k 'match_deepseek_v4_flash_0731 or match_llm'`
- `pre-commit run --files xinference/model/llm/llm_family.json xinference/model/llm/tests/test_llm_family.py doc/source/models/builtin/llm/index.rst doc/source/models/builtin/llm/deepseek-v4-flash-0731.rst`
