### PR TITLE
fix(vllm): use block size 256 for DeepSeek V4

### DIFF
--- a/xinference/model/llm/vllm/core.py
+++ b/xinference/model/llm/vllm/core.py
@@ -1111,7 +1111,11 @@ class VLLMModel(LLM):
             model_config.setdefault("master_addr", master_addr)  # type: ignore
             model_config.setdefault("master_port", get_next_port())  # type: ignore
         is_deepseek_v4 = "DeepseekV4ForCausalLM" in architectures
-        model_config.setdefault("block_size", 256 if is_deepseek_v4 else 16)
+        if is_deepseek_v4:
+            default_block_size = 128 if is_npu_available() else 256
+        else:
+            default_block_size = 16
+        model_config.setdefault("block_size", default_block_size)
         if VLLM_VERSION < version.parse("0.18.0"):
             model_config.setdefault("swap_space", 4)
         model_config.setdefault("gpu_memory_utilization", 0.90)

--- a/xinference/model/llm/vllm/core.py
+++ b/xinference/model/llm/vllm/core.py
@@ -1110,7 +1110,8 @@ class VLLMModel(LLM):
                 master_addr = self._address
             model_config.setdefault("master_addr", master_addr)  # type: ignore
             model_config.setdefault("master_port", get_next_port())  # type: ignore
-        model_config.setdefault("block_size", 16)
+        is_deepseek_v4 = "DeepseekV4ForCausalLM" in architectures
+        model_config.setdefault("block_size", 256 if is_deepseek_v4 else 16)
         if VLLM_VERSION < version.parse("0.18.0"):
             model_config.setdefault("swap_space", 4)
         model_config.setdefault("gpu_memory_utilization", 0.90)

--- a/xinference/model/llm/vllm/tests/test_speculative_config.py
+++ b/xinference/model/llm/vllm/tests/test_speculative_config.py
@@ -167,11 +167,15 @@ def _model_for_config(architecture="DeepseekV4ForCausalLM"):
     return model
 
 
+@pytest.mark.parametrize("npu_available", [False, True])
 @pytest.mark.parametrize("configured", [256, 128])
-def test_deepseek_v4_preserves_explicit_block_size(monkeypatch, configured):
+def test_deepseek_v4_preserves_explicit_block_size(
+    monkeypatch, npu_available, configured
+):
     from .. import core
 
     monkeypatch.setattr(core, "VLLM_VERSION", version.parse("0.22.0"))
+    monkeypatch.setattr(core, "is_npu_available", lambda: npu_available)
 
     model_config = _model_for_config()._sanitize_model_config(
         {"block_size": configured}
@@ -180,20 +184,29 @@ def test_deepseek_v4_preserves_explicit_block_size(monkeypatch, configured):
     assert model_config["block_size"] == configured
 
 
-def test_deepseek_v4_uses_block_size_256_by_default(monkeypatch):
+@pytest.mark.parametrize(
+    ("npu_available", "expected"),
+    [(False, 256), (True, 128)],
+)
+def test_deepseek_v4_uses_platform_block_size_by_default(
+    monkeypatch, npu_available, expected
+):
     from .. import core
 
     monkeypatch.setattr(core, "VLLM_VERSION", version.parse("0.22.0"))
+    monkeypatch.setattr(core, "is_npu_available", lambda: npu_available)
 
     model_config = _model_for_config()._sanitize_model_config({})
 
-    assert model_config["block_size"] == 256
+    assert model_config["block_size"] == expected
 
 
-def test_regular_model_keeps_block_size_16_default(monkeypatch):
+@pytest.mark.parametrize("npu_available", [False, True])
+def test_regular_model_keeps_block_size_16_default(monkeypatch, npu_available):
     from .. import core
 
     monkeypatch.setattr(core, "VLLM_VERSION", version.parse("0.22.0"))
+    monkeypatch.setattr(core, "is_npu_available", lambda: npu_available)
 
     model_config = _model_for_config("LlamaForCausalLM")._sanitize_model_config({})
 

--- a/xinference/model/llm/vllm/tests/test_speculative_config.py
+++ b/xinference/model/llm/vllm/tests/test_speculative_config.py
@@ -151,3 +151,50 @@ def test_no_drafter_is_a_noop(monkeypatch):
     _model()._apply_draft_model(model_config)
 
     assert model_config == {"gpu_memory_utilization": 0.9}
+
+
+def _model_for_config(architecture="DeepseekV4ForCausalLM"):
+    model = _model(model_name="DeepSeek-V4-Flash-0731", model_size=304)
+    model.model_family = SimpleNamespace(
+        model_name="DeepSeek-V4-Flash-0731",
+        architectures=[architecture],
+    )
+    model.model_spec = SimpleNamespace(model_size_in_billions=304, model_format="fp8")
+    model._device_count = 1
+    model._n_worker = 1
+    model._address = None
+    model._shard = 0
+    return model
+
+
+@pytest.mark.parametrize("configured", [256, 128])
+def test_deepseek_v4_preserves_explicit_block_size(monkeypatch, configured):
+    from .. import core
+
+    monkeypatch.setattr(core, "VLLM_VERSION", version.parse("0.22.0"))
+
+    model_config = _model_for_config()._sanitize_model_config(
+        {"block_size": configured}
+    )
+
+    assert model_config["block_size"] == configured
+
+
+def test_deepseek_v4_uses_block_size_256_by_default(monkeypatch):
+    from .. import core
+
+    monkeypatch.setattr(core, "VLLM_VERSION", version.parse("0.22.0"))
+
+    model_config = _model_for_config()._sanitize_model_config({})
+
+    assert model_config["block_size"] == 256
+
+
+def test_regular_model_keeps_block_size_16_default(monkeypatch):
+    from .. import core
+
+    monkeypatch.setattr(core, "VLLM_VERSION", version.parse("0.22.0"))
+
+    model_config = _model_for_config("LlamaForCausalLM")._sanitize_model_config({})
+
+    assert model_config["block_size"] == 16


### PR DESCRIPTION
Depends on #5371 for the `DeepSeek-V4-Flash-0731` built-in registration.

## Summary

- default vLLM `block_size` to `256` for the `DeepseekV4ForCausalLM` architecture
- preserve any explicit user-provided `block_size`
- keep the existing default of `16` for other model architectures
- use architecture detection so aliases and future DeepSeek V4 entries receive the same compatibility default

## Tests

- `pytest -q xinference/model/llm/vllm/tests/test_speculative_config.py`
- `pre-commit run --files xinference/model/llm/vllm/core.py xinference/model/llm/vllm/tests/test_speculative_config.py`


Please review now if convenient, but merge only after the dependency PRs have landed.
