### PR TITLE
fix(vllm): handle engine death during async iteration

### DIFF
--- a/xinference/model/llm/utils.py
+++ b/xinference/model/llm/utils.py
@@ -810,37 +810,44 @@ class ChatModelMixin:
         full_text = ""
         is_first_chunk = True
         fallback_chunk: Optional[CompletionChunk] = None
-        # Process chunks
-        if reasoning_parser:
-            set_context()
-            chunks = reasoning_parser.prepare_reasoning_content_streaming(chunks)
-        async for chunk in chunks:
-            set_context()
-            choices = chunk.get("choices")
-            if not choices:
-                # usage
-                if chunk.get("usage") is not None:
-                    chat_chunk = cls._get_usage_chat_completion_chunk(
-                        chunk, fallback_chunk
-                    )
+        upstream_chunks = chunks
+        try:
+            # Process chunks
+            if reasoning_parser:
+                set_context()
+                chunks = reasoning_parser.prepare_reasoning_content_streaming(chunks)
+            async for chunk in chunks:
+                set_context()
+                choices = chunk.get("choices")
+                if not choices:
+                    # usage
+                    if chunk.get("usage") is not None:
+                        chat_chunk = cls._get_usage_chat_completion_chunk(
+                            chunk, fallback_chunk
+                        )
+                    else:
+                        chat_chunk = cls._get_final_chat_completion_chunk(
+                            chunk, fallback_chunk
+                        )
                 else:
-                    chat_chunk = cls._get_final_chat_completion_chunk(
-                        chunk, fallback_chunk
-                    )
-            else:
-                if choices[0].get("text"):
-                    full_text += choices[0]["text"]  # type: ignore
+                    if choices[0].get("text"):
+                        full_text += choices[0]["text"]  # type: ignore
 
-                chat_chunk = cls._to_chat_completion_chunk(
-                    chunk,
-                    reasoning_parser,
-                    previous_texts,
-                    ensure_role=is_first_chunk,
-                )
-                fallback_chunk = chunk
-            is_first_chunk = False
-            yield chat_chunk
-        logger.debug("Chat finished, output: %s", full_text)
+                    chat_chunk = cls._to_chat_completion_chunk(
+                        chunk,
+                        reasoning_parser,
+                        previous_texts,
+                        ensure_role=is_first_chunk,
+                    )
+                    fallback_chunk = chunk
+                is_first_chunk = False
+                yield chat_chunk
+            logger.debug("Chat finished, output: %s", full_text)
+        finally:
+            # async for does not close its iterator when this conversion
+            # generator is closed early.  Close the original model stream
+            # explicitly so engines can release the request immediately.
+            await upstream_chunks.aclose()
 
     @staticmethod
     def _to_chat_completion(
@@ -1331,45 +1338,55 @@ class ChatModelMixin:
         tool_call_state: Dict[str, Any] = {"seen": False}
         full_text = ""
         fallback_chunk: Optional[CompletionChunk] = None
-        if self.reasoning_parser:
-            set_context()
-            chunks = self.reasoning_parser.prepare_reasoning_content_streaming(chunks)
-        async for completion_chunk in chunks:
-            set_context()
-            if not completion_chunk.get("choices"):
-                if completion_chunk.get("usage") is not None:
-                    yield self._get_usage_chat_completion_chunk(
-                        completion_chunk, fallback_chunk
-                    )
-                else:
-                    yield self._get_final_chat_completion_chunk(
-                        completion_chunk, fallback_chunk
-                    )
-                continue
+        upstream_chunks = chunks
+        try:
+            if self.reasoning_parser:
+                set_context()
+                chunks = self.reasoning_parser.prepare_reasoning_content_streaming(
+                    chunks
+                )
+            async for completion_chunk in chunks:
+                set_context()
+                if not completion_chunk.get("choices"):
+                    if completion_chunk.get("usage") is not None:
+                        yield self._get_usage_chat_completion_chunk(
+                            completion_chunk, fallback_chunk
+                        )
+                    else:
+                        yield self._get_final_chat_completion_chunk(
+                            completion_chunk, fallback_chunk
+                        )
+                    continue
 
-            fallback_chunk = completion_chunk
-            chat_chunk = self._to_chat_completion_chunk(
-                completion_chunk,
-                self.reasoning_parser,
-                previous_texts,
-                ensure_role=i == 0,
-            )
-            reasoning_chunk, tool_chunk = self._split_reasoning_tool_chunk(chat_chunk)
-            if reasoning_chunk is not None:
-                yield reasoning_chunk
-            if tool_chunk is None:
-                continue
-            processed_chunk = self._post_process_completion_chunk(
-                self.model_family,
-                self.model_uid,
-                tool_chunk,
-                previous_texts=previous_tools_texts,
-                tool_call_state=tool_call_state,
-            )
-            if processed_chunk:
-                yield processed_chunk
-            i += 1
-        logger.debug("Chat finished, output: %s", full_text)
+                fallback_chunk = completion_chunk
+                chat_chunk = self._to_chat_completion_chunk(
+                    completion_chunk,
+                    self.reasoning_parser,
+                    previous_texts,
+                    ensure_role=i == 0,
+                )
+                reasoning_chunk, tool_chunk = self._split_reasoning_tool_chunk(
+                    chat_chunk
+                )
+                if reasoning_chunk is not None:
+                    yield reasoning_chunk
+                if tool_chunk is None:
+                    continue
+                processed_chunk = self._post_process_completion_chunk(
+                    self.model_family,
+                    self.model_uid,
+                    tool_chunk,
+                    previous_texts=previous_tools_texts,
+                    tool_call_state=tool_call_state,
+                )
+                if processed_chunk:
+                    yield processed_chunk
+                i += 1
+            logger.debug("Chat finished, output: %s", full_text)
+        finally:
+            # Keep request cleanup deterministic when the converted tool stream
+            # is closed before the model stream is exhausted.
+            await upstream_chunks.aclose()
 
 
 def get_model_version(

--- a/xinference/model/llm/vllm/tests/test_utils.py
+++ b/xinference/model/llm/vllm/tests/test_utils.py
@@ -1,0 +1,101 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from unittest.mock import MagicMock
+
+import pytest
+
+from .. import utils
+from ..utils import vllm_check
+
+
+class _Model:
+    def __init__(self):
+        self.stop = MagicMock()
+        self.iterator_closed = MagicMock()
+
+    @vllm_check
+    async def stream(self, fail: bool):
+        async def iterator():
+            yield "first"
+            if fail:
+                raise utils.VLLM_ENGINE_DEAD_ERRORS[0]("EngineCore died")
+            yield "second"
+
+        return iterator()
+
+    @vllm_check
+    async def fail_before_returning(self):
+        raise utils.VLLM_ENGINE_DEAD_ERRORS[0]("EngineCore died")
+
+    @vllm_check
+    async def closable_stream(self):
+        async def iterator():
+            try:
+                yield "first"
+                yield "second"
+            finally:
+                self.iterator_closed()
+
+        return iterator()
+
+
+@pytest.mark.asyncio
+async def test_vllm_check_guards_async_generator(monkeypatch):
+    model = _Model()
+    exit_process = MagicMock()
+    monkeypatch.setattr("xinference.model.llm.vllm.utils.os._exit", exit_process)
+
+    iterator = await model.stream(fail=True)
+    assert [item async for item in iterator] == ["first"]
+    model.stop.assert_called_once_with()
+    exit_process.assert_called_once_with(1)
+
+
+@pytest.mark.asyncio
+async def test_vllm_check_keeps_successful_async_generator(monkeypatch):
+    model = _Model()
+    exit_process = MagicMock()
+    monkeypatch.setattr("xinference.model.llm.vllm.utils.os._exit", exit_process)
+
+    iterator = await model.stream(fail=False)
+    assert [item async for item in iterator] == ["first", "second"]
+    model.stop.assert_not_called()
+    exit_process.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_vllm_check_handles_failure_before_generator_return(monkeypatch):
+    model = _Model()
+    exit_process = MagicMock()
+    monkeypatch.setattr("xinference.model.llm.vllm.utils.os._exit", exit_process)
+
+    assert await model.fail_before_returning() is None
+    model.stop.assert_called_once_with()
+    exit_process.assert_called_once_with(1)
+
+
+@pytest.mark.asyncio
+async def test_vllm_check_closes_wrapped_async_generator(monkeypatch):
+    model = _Model()
+    exit_process = MagicMock()
+    monkeypatch.setattr("xinference.model.llm.vllm.utils.os._exit", exit_process)
+
+    iterator = await model.closable_stream()
+    assert await anext(iterator) == "first"
+
+    await iterator.aclose()
+
+    model.iterator_closed.assert_called_once_with()
+    model.stop.assert_not_called()
+    exit_process.assert_not_called()

--- a/xinference/model/llm/vllm/tests/test_utils.py
+++ b/xinference/model/llm/vllm/tests/test_utils.py
@@ -19,6 +19,24 @@ from .. import utils
 from ..utils import vllm_check
 
 
+class _AsyncIterableOnly:
+    def __init__(self, model, fail: bool = False):
+        self._model = model
+        self._fail = fail
+
+    def __aiter__(self):
+        async def iterator():
+            try:
+                yield "first"
+                if self._fail:
+                    raise utils.VLLM_ENGINE_DEAD_ERRORS[0]("EngineCore died")
+                yield "second"
+            finally:
+                self._model.iterator_closed()
+
+        return iterator()
+
+
 class _Model:
     def __init__(self):
         self.stop = MagicMock()
@@ -48,6 +66,10 @@ class _Model:
                 self.iterator_closed()
 
         return iterator()
+
+    @vllm_check
+    async def async_iterable_stream(self, fail: bool = False):
+        return _AsyncIterableOnly(self, fail)
 
 
 @pytest.mark.asyncio
@@ -95,6 +117,34 @@ async def test_vllm_check_closes_wrapped_async_generator(monkeypatch):
     assert await anext(iterator) == "first"
 
     await iterator.aclose()
+
+    model.iterator_closed.assert_called_once_with()
+    model.stop.assert_not_called()
+    exit_process.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_vllm_check_guards_async_iterable(monkeypatch):
+    model = _Model()
+    exit_process = MagicMock()
+    monkeypatch.setattr("xinference.model.llm.vllm.utils.os._exit", exit_process)
+
+    iterable = await model.async_iterable_stream(fail=True)
+    assert [item async for item in iterable] == ["first"]
+    model.stop.assert_called_once_with()
+    exit_process.assert_called_once_with(1)
+
+
+@pytest.mark.asyncio
+async def test_vllm_check_closes_async_iterable_iterator(monkeypatch):
+    model = _Model()
+    exit_process = MagicMock()
+    monkeypatch.setattr("xinference.model.llm.vllm.utils.os._exit", exit_process)
+
+    iterable = await model.async_iterable_stream()
+    assert await anext(iterable) == "first"
+
+    await iterable.aclose()
 
     model.iterator_closed.assert_called_once_with()
     model.stop.assert_not_called()

--- a/xinference/model/llm/vllm/tests/test_utils.py
+++ b/xinference/model/llm/vllm/tests/test_utils.py
@@ -15,6 +15,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from ...utils import ChatModelMixin
 from .. import utils
 from ..utils import vllm_check
 
@@ -70,6 +71,48 @@ class _Model:
     @vllm_check
     async def async_iterable_stream(self, fail: bool = False):
         return _AsyncIterableOnly(self, fail)
+
+    @vllm_check
+    async def async_generate(self):
+        async def engine_stream():
+            try:
+                yield {
+                    "id": "completion-id",
+                    "model": "test-model",
+                    "created": 0,
+                    "object": "text_completion",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "text": "first",
+                            "logprobs": None,
+                            "finish_reason": None,
+                        }
+                    ],
+                }
+                yield {
+                    "id": "completion-id",
+                    "model": "test-model",
+                    "created": 0,
+                    "object": "text_completion",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "text": "second",
+                            "logprobs": None,
+                            "finish_reason": None,
+                        }
+                    ],
+                }
+            finally:
+                self.iterator_closed()
+
+        return engine_stream()
+
+    @vllm_check
+    async def async_chat(self):
+        chunks = await self.async_generate()
+        return ChatModelMixin._async_to_chat_completion_chunks(chunks)
 
 
 @pytest.mark.asyncio
@@ -145,6 +188,23 @@ async def test_vllm_check_closes_async_iterable_iterator(monkeypatch):
     assert await anext(iterable) == "first"
 
     await iterable.aclose()
+
+    model.iterator_closed.assert_called_once_with()
+    model.stop.assert_not_called()
+    exit_process.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_vllm_check_closes_nested_generate_stream(monkeypatch):
+    model = _Model()
+    exit_process = MagicMock()
+    monkeypatch.setattr("xinference.model.llm.vllm.utils.os._exit", exit_process)
+
+    stream = await model.async_chat()
+    first_chunk = await anext(stream)
+    assert first_chunk["choices"][0]["delta"]["content"] == "first"
+
+    await stream.aclose()
 
     model.iterator_closed.assert_called_once_with()
     model.stop.assert_not_called()

--- a/xinference/model/llm/vllm/utils.py
+++ b/xinference/model/llm/vllm/utils.py
@@ -60,9 +60,13 @@ def _stop_after_engine_death(model: Any) -> None:
     os._exit(1)
 
 
-async def _guard_async_iterator(model: Any, iterator: Any) -> AsyncIterator[Any]:
+async def _guard_async_iterator(model: Any, iterable: Any) -> AsyncIterator[Any]:
     completed = False
+    iterator = None
     try:
+        # AsyncIterable objects do not have to implement __anext__ themselves;
+        # close the concrete iterator returned by __aiter__ on cancellation.
+        iterator = aiter(iterable)
         async for item in iterator:
             yield item
         completed = True
@@ -70,10 +74,10 @@ async def _guard_async_iterator(model: Any, iterator: Any) -> AsyncIterator[Any]
         _stop_after_engine_death(model)
     finally:
         # Closing the wrapper (for example after a client disconnects) must
-        # also close the wrapped async generator so that vLLM can release the
+        # also close the wrapped async iterator so that vLLM can release the
         # request and run its cleanup handlers.  Avoid an unnecessary aclose
         # call after normal exhaustion.
-        if not completed:
+        if not completed and iterator is not None:
             aclose = getattr(iterator, "aclose", None)
             if aclose is not None:
                 try:
@@ -91,7 +95,7 @@ def vllm_check(fn: _F) -> _F:
             # from `async for` happen after the decorated coroutine has already
             # returned, so the outer try/except cannot see them unless the
             # iterator itself is wrapped.
-            if hasattr(result, "__aiter__") and hasattr(result, "__anext__"):
+            if hasattr(result, "__aiter__"):
                 return _guard_async_iterator(self, result)
             return result
         except VLLM_ENGINE_DEAD_ERRORS:

--- a/xinference/model/llm/vllm/utils.py
+++ b/xinference/model/llm/vllm/utils.py
@@ -15,35 +15,90 @@ import functools
 import ipaddress
 import logging
 import os
+from typing import Any, AsyncIterator, Awaitable, Callable, TypeVar, cast
 
 logger = logging.getLogger(__name__)
 
+# vLLM has moved the engine-dead exception between releases.  Import the
+# concrete exception where possible instead of falling back to RuntimeError
+# whenever vLLM is installed: a RuntimeError raised by request processing is
+# not, by itself, evidence that the EngineCore has died.
+_vllm_engine_dead_errors = []
 try:
     from vllm.engine.async_llm_engine import AsyncEngineDeadError
 except Exception:
     # vLLM 0.19.0+ removed AsyncEngineDeadError from this module.
-    # It is a subclass of RuntimeError, so except RuntimeError suffices.
-    # Use except Exception (not just ImportError) to handle partial/broken
-    # vllm installations where module init may raise non-ImportError errors.
-    AsyncEngineDeadError = RuntimeError  # type: ignore[assignment,misc]
+    AsyncEngineDeadError = None  # type: ignore[assignment,misc]
+else:
+    _vllm_engine_dead_errors.append(AsyncEngineDeadError)
+
+try:
+    from vllm.v1.engine.exceptions import EngineDeadError
+except Exception:
+    EngineDeadError = None  # type: ignore[assignment,misc]
+else:
+    _vllm_engine_dead_errors.append(EngineDeadError)
+
+VLLM_ENGINE_DEAD_ERRORS = tuple(_vllm_engine_dead_errors) or (RuntimeError,)
+
+_F = TypeVar("_F", bound=Callable[..., Awaitable[Any]])
 
 
-def vllm_check(fn):
+def _stop_after_engine_death(model: Any) -> None:
+    logger.exception("vLLM EngineCore is dead; terminating the model process")
+    try:
+        model.stop()
+    except Exception:
+        # Ignore errors while stopping a broken engine.
+        logger.debug(
+            "Failed to stop the vLLM model after EngineCore death", exc_info=True
+        )
+    # Let Xinference's process supervisor recover the model.  In particular,
+    # do not let the vLLM exception cross the xoscar Worker/Supervisor boundary:
+    # the Supervisor may not have vLLM installed and would replace the useful
+    # EngineDeadError with a misleading ModuleNotFoundError during unpickling.
+    os._exit(1)
+
+
+async def _guard_async_iterator(model: Any, iterator: Any) -> AsyncIterator[Any]:
+    completed = False
+    try:
+        async for item in iterator:
+            yield item
+        completed = True
+    except VLLM_ENGINE_DEAD_ERRORS:
+        _stop_after_engine_death(model)
+    finally:
+        # Closing the wrapper (for example after a client disconnects) must
+        # also close the wrapped async generator so that vLLM can release the
+        # request and run its cleanup handlers.  Avoid an unnecessary aclose
+        # call after normal exhaustion.
+        if not completed:
+            aclose = getattr(iterator, "aclose", None)
+            if aclose is not None:
+                try:
+                    await aclose()
+                except VLLM_ENGINE_DEAD_ERRORS:
+                    _stop_after_engine_death(model)
+
+
+def vllm_check(fn: _F) -> _F:
     @functools.wraps(fn)
     async def _async_wrapper(self, *args, **kwargs):
         try:
-            return await fn(self, *args, **kwargs)
-        except AsyncEngineDeadError:
-            logger.info("Detecting vLLM is not health, prepare to quit the process")
-            try:
-                self.stop()
-            except Exception:
-                # ignore error when stop
-                pass
-            # Just kill the process and let xinference auto-recover the model
-            os._exit(1)
+            result = await fn(self, *args, **kwargs)
+            # async_generate/async_chat return an async generator.  Exceptions
+            # from `async for` happen after the decorated coroutine has already
+            # returned, so the outer try/except cannot see them unless the
+            # iterator itself is wrapped.
+            if hasattr(result, "__aiter__") and hasattr(result, "__anext__"):
+                return _guard_async_iterator(self, result)
+            return result
+        except VLLM_ENGINE_DEAD_ERRORS:
+            _stop_after_engine_death(self)
+        return cast(Any, None)
 
-    return _async_wrapper
+    return cast(_F, _async_wrapper)
 
 
 def get_distributed_init_method(ip: str, port: int) -> str:


### PR DESCRIPTION
## Summary

- handle both the legacy `AsyncEngineDeadError` and the vLLM V1 `EngineDeadError`
- guard exceptions raised while consuming async generators, not only while creating them
- stop and terminate the broken model process before a vLLM-specific exception can cross the xoscar boundary
- close wrapped async iterators when streaming is cancelled, allowing vLLM request cleanup to run
- avoid treating every `RuntimeError` as an engine death when a concrete vLLM exception class is available

## Tests

- `pytest -q xinference/model/llm/vllm/tests/test_utils.py`
- `pre-commit run --files xinference/model/llm/vllm/utils.py xinference/model/llm/vllm/tests/test_utils.py`
