### PR TITLE
feat(router): add token-aware virtual model routing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dependencies = [
     "python-multipart>=0.0.18",  # required by FastAPI's Form/File/UploadFile params; used to come in transitively via gradio
     "orjson",  # used by core.utils.json_dumps for all REST API JSON responses; used to come in transitively via gradio
     "uvicorn",
+    "PyYAML",
     "huggingface-hub>=0.19.4",
     "typing_extensions",
     "modelscope>=1.19.0",
@@ -76,6 +77,7 @@ xinference = "xinference.deploy.cmdline:cli"
 xinference-local = "xinference.deploy.cmdline:local"
 xinference-supervisor = "xinference.deploy.cmdline:supervisor"
 xinference-worker = "xinference.deploy.cmdline:worker"
+xinference-router = "xinference.deploy.router:main"
 xinference-migrate-auth = "xinference.api.oauth2.advanced.migrate:main"
 xinference-reset-auth-password = "xinference.api.oauth2.advanced.reset_password:main"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -352,7 +352,7 @@ follow_imports = "skip"
 exclude = "thirdparty"
 
 [tool.codespell]
-ignore-words-list = "hist,rcall,fpr,ser,nd,inout,ot,Ba,ba,asend,hart,coo,splitted,datas,fro"
+ignore-words-list = "hist,rcall,fpr,ser,nd,inout,ot,Ba,ba,asend,hart,coo,splitted,datas,fro,te"
 skip = ".idea,.git,./build,./docs/build,node_modules,static,generated,*.po,*.ts,*.json,*.c,*.cpp,*.cfg,thirdparty"
 
 [tool.ruff]

--- a/xinference/api/oauth2/advanced/audit.py
+++ b/xinference/api/oauth2/advanced/audit.py
@@ -62,6 +62,7 @@ _AUDIT_SKIP_ENDPOINTS = (
     "/v1/cluster/ui_config",
     "/status",
     "/v1/address",
+    "/v1/internal/token-router/",
 )
 
 # Endpoint prefixes for category classification

--- a/xinference/api/oauth2/advanced/auth_service.py
+++ b/xinference/api/oauth2/advanced/auth_service.py
@@ -87,6 +87,10 @@ INITIAL_ADMIN_PERMISSIONS = [
     "virtualenv:delete",
     "logs:list",
     "monitor:view",
+    "routers:list",
+    "routers:read",
+    "routers:write",
+    "routers:operate",
 ]
 
 try:

--- a/xinference/api/restful_api.py
+++ b/xinference/api/restful_api.py
@@ -24,8 +24,9 @@ import time
 import uuid
 import warnings
 from pathlib import Path
-from typing import Any, List, Optional, Union, get_type_hints
+from typing import Any, AsyncIterator, Dict, List, Optional, Union, get_type_hints
 
+import httpx
 import xoscar as xo
 from aioprometheus import REGISTRY, MetricsMiddleware
 from aioprometheus.asgi.starlette import metrics
@@ -43,7 +44,7 @@ from fastapi import (
 from fastapi.middleware.cors import CORSMiddleware
 from PIL import Image
 from sse_starlette.sse import EventSourceResponse
-from starlette.responses import PlainTextResponse
+from starlette.responses import PlainTextResponse, StreamingResponse
 from uvicorn import Config, Server
 from xoscar.utils import get_next_port
 
@@ -59,6 +60,7 @@ from ..constants import (
     XINFERENCE_LAUNCH_HISTORY_DB_PATH,
     XINFERENCE_MONITOR_CONFIG_DB_PATH,
     XINFERENCE_SSE_PING_ATTEMPTS_SECONDS,
+    XINFERENCE_TOKEN_ROUTER_ENABLED,
     get_auth_encryption_key,
     get_auth_jwt_secret_key,
     is_auth_advanced,
@@ -104,6 +106,46 @@ from .schemas import (
 from .utils import require_model
 
 logger = logging.getLogger(__name__)
+
+_TOKEN_ROUTER_HOP_BY_HOP_HEADERS = {
+    "connection",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "t" "e",
+    "trailer",
+    "transfer-encoding",
+    "upgrade",
+}
+_TOKEN_ROUTER_REQUEST_HEADERS = {
+    "accept",
+    "authorization",
+    "content-type",
+    "traceparent",
+    "tracestate",
+    "user-agent",
+    "x-request-id",
+}
+
+
+def _token_router_request_headers(request: Request, request_id: str) -> Dict[str, str]:
+    headers = {
+        key.lower(): value
+        for key, value in request.headers.items()
+        if key.lower() in _TOKEN_ROUTER_REQUEST_HEADERS
+    }
+    headers["content-type"] = "application/json"
+    headers["x-request-id"] = request_id
+    return headers
+
+
+def _token_router_response_headers(response: httpx.Response) -> Dict[str, str]:
+    excluded = _TOKEN_ROUTER_HOP_BY_HOP_HEADERS | {"content-length"}
+    return {
+        key: value
+        for key, value in response.headers.items()
+        if key.lower() not in excluded
+    }
 
 
 _AUDIO_RESPONSE_MEDIA_TYPES = {
@@ -508,6 +550,93 @@ class RESTfulAPI(CancelMixin):
                 "Report error event failed, model: %s, content: %s", model_uid, content
             )
 
+    async def _proxy_token_router_chat_completion(
+        self,
+        request: Request,
+        raw_body: Dict[str, Any],
+        runtime: Dict[str, Any],
+    ) -> Response:
+        request_id = request.headers.get("x-request-id") or f"xinf-{uuid.uuid4()}"
+        endpoint = runtime["endpoint"]
+        upstream_url = f"{endpoint}/v1/chat/completions"
+        client = httpx.AsyncClient(timeout=None, follow_redirects=False)
+        try:
+            upstream_request = client.build_request(
+                "POST",
+                upstream_url,
+                headers=_token_router_request_headers(request, request_id),
+                json=raw_body,
+            )
+            upstream_response = await client.send(upstream_request, stream=True)
+        except httpx.HTTPError as exc:
+            await client.aclose()
+            logger.warning(
+                "Token Router connection failed: virtual_model_uid=%s "
+                "router_uid=%s instance_id=%s error=%s",
+                runtime.get("virtual_model_uid"),
+                runtime.get("router_uid"),
+                runtime.get("instance_id"),
+                exc,
+            )
+            return JSONResponse(
+                content={
+                    "error": {
+                        "message": "Token Router runtime is temporarily unavailable",
+                        "type": "router_unavailable",
+                    }
+                },
+                status_code=502,
+                headers={"Retry-After": "1", "X-Request-ID": request_id},
+            )
+
+        is_stream = bool(raw_body.get("stream", False))
+        response_headers = _token_router_response_headers(upstream_response)
+        response_headers.setdefault("x-request-id", request_id)
+
+        if is_stream and upstream_response.status_code < 400:
+
+            async def body_stream() -> AsyncIterator[bytes]:
+                try:
+                    async for chunk in upstream_response.aiter_raw():
+                        if await request.is_disconnected():
+                            break
+                        yield chunk
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    logger.exception(
+                        "Token Router stream failed: virtual_model_uid=%s "
+                        "router_uid=%s instance_id=%s",
+                        runtime.get("virtual_model_uid"),
+                        runtime.get("router_uid"),
+                        runtime.get("instance_id"),
+                    )
+                    raise
+                finally:
+                    await upstream_response.aclose()
+                    await client.aclose()
+
+            response_headers.setdefault("cache-control", "no-cache")
+            response_headers.setdefault("x-accel-buffering", "no")
+            return StreamingResponse(
+                body_stream(),
+                status_code=upstream_response.status_code,
+                headers=response_headers,
+            )
+
+        try:
+            response_body = b"".join(
+                [chunk async for chunk in upstream_response.aiter_raw()]
+            )
+        finally:
+            await upstream_response.aclose()
+            await client.aclose()
+        return Response(
+            content=response_body,
+            status_code=upstream_response.status_code,
+            headers=response_headers,
+        )
+
     def serve(self, logging_conf: Optional[dict] = None):
         self._app.add_middleware(
             CORSMiddleware,
@@ -781,7 +910,10 @@ class RESTfulAPI(CancelMixin):
 
     async def list_models(self) -> JSONResponse:
         try:
-            models = await (await self._get_supervisor_ref()).list_models()
+            supervisor_ref = await self._get_supervisor_ref()
+            physical_models = await supervisor_ref.list_models()
+            virtual_models = await supervisor_ref.list_virtual_models()
+            models = {**physical_models, **virtual_models}
 
             model_list = []
             for model_id, model_info in models.items():
@@ -2683,6 +2815,31 @@ class RESTfulAPI(CancelMixin):
         self._set_trace_model(model_uid)
         self._set_trace_model_type("llm")
         self._check_model_access(request, model_uid, "LLM")
+
+        supervisor_ref = await self._get_supervisor_ref()
+        token_router_runtime = None
+        if XINFERENCE_TOKEN_ROUTER_ENABLED:
+            token_router_runtime = await supervisor_ref.resolve_token_router_runtime(
+                model_uid
+            )
+        if token_router_runtime is not None:
+            if not token_router_runtime.get("available"):
+                return JSONResponse(
+                    content={
+                        "error": {
+                            "message": (
+                                "No ready Token Router runtime is available for "
+                                f"virtual model {model_uid}"
+                            ),
+                            "type": "router_unavailable",
+                        }
+                    },
+                    status_code=503,
+                    headers={"Retry-After": "1"},
+                )
+            return await self._proxy_token_router_chat_completion(
+                request, raw_body, token_router_runtime
+            )
 
         model = await require_model(
             self._get_supervisor_ref, model_uid, self._report_error_event

--- a/xinference/api/restful_api.py
+++ b/xinference/api/restful_api.py
@@ -44,6 +44,7 @@ from fastapi import (
 from fastapi.middleware.cors import CORSMiddleware
 from PIL import Image
 from sse_starlette.sse import EventSourceResponse
+from starlette.background import BackgroundTask
 from starlette.responses import PlainTextResponse, StreamingResponse
 from uvicorn import Config, Server
 from xoscar.utils import get_next_port
@@ -146,6 +147,36 @@ def _token_router_response_headers(response: httpx.Response) -> Dict[str, str]:
         for key, value in response.headers.items()
         if key.lower() not in excluded
     }
+
+
+def _normalize_token_router_chat_payload(
+    raw_body: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Mirror Chat API normalization before forwarding to the Token Router."""
+    normalized = dict(raw_body)
+    enable_thinking = raw_body.get("enable_thinking")
+    if enable_thinking is None:
+        extra_body = raw_body.get("extra_body")
+        if isinstance(extra_body, dict):
+            enable_thinking = extra_body.get("enable_thinking")
+    if isinstance(enable_thinking, bool):
+        chat_template_kwargs = raw_body.get("chat_template_kwargs") or {}
+        if isinstance(chat_template_kwargs, str):
+            try:
+                chat_template_kwargs = json.loads(chat_template_kwargs)
+            except json.JSONDecodeError:
+                chat_template_kwargs = {}
+        if not isinstance(chat_template_kwargs, dict):
+            chat_template_kwargs = {}
+        chat_template_kwargs = dict(chat_template_kwargs)
+        chat_template_kwargs["enable_thinking"] = enable_thinking
+        chat_template_kwargs["thinking"] = enable_thinking
+        normalized["chat_template_kwargs"] = chat_template_kwargs
+
+    max_completion_tokens = raw_body.get("max_completion_tokens")
+    if max_completion_tokens is not None:
+        normalized["max_tokens"] = max_completion_tokens
+    return normalized
 
 
 _AUDIO_RESPONSE_MEDIA_TYPES = {
@@ -483,6 +514,38 @@ class RESTfulAPI(CancelMixin):
             auth_type="jwt",
         )
 
+    async def _audit_middleware(self, request: Request, call_next):
+        started = time.perf_counter()
+        response = await call_next(request)
+        model_uid = getattr(request.state, "_audit_model_uid", "")
+        if model_uid:
+            latency_s = time.perf_counter() - started
+            if response.status_code < 400:
+                audit_status = "success"
+            elif response.status_code == 404:
+                audit_status = "model_not_found"
+            else:
+                audit_status = "error"
+            model_type = getattr(request.state, "_audit_model_type", "")
+            self._record_audit(request, model_uid, model_type, audit_status, latency_s)
+        elif self._advanced_auth_service and request.url.path.startswith(
+            ("/v1/models", "/v1/admin", "/v1/token_routers")
+        ):
+            from .oauth2.advanced.audit import classify_endpoint
+
+            category = classify_endpoint(request.url.path)
+            if category == "admin":
+                latency_s = time.perf_counter() - started
+                audit_status = "success" if response.status_code < 400 else "error"
+                self._record_admin_audit(request, audit_status, latency_s)
+        elif self._advanced_auth_service and request.url.path.startswith(
+            ("/token", "/v1/auth/", "/v1/api_keys")
+        ):
+            latency_s = time.perf_counter() - started
+            audit_status = "success" if response.status_code < 400 else "login_failed"
+            self._record_admin_audit(request, audit_status, latency_s)
+        return response
+
     @staticmethod
     def handle_request_limit_error(e: Exception):
         if "Rate limit reached" in str(e):
@@ -608,6 +671,13 @@ class RESTfulAPI(CancelMixin):
         response_headers.setdefault("x-request-id", request_id)
 
         if is_stream and upstream_response.status_code < 400:
+            cleanup_task: asyncio.Task[None] | None = None
+
+            async def release_resources() -> None:
+                nonlocal cleanup_task
+                if cleanup_task is None:
+                    cleanup_task = asyncio.create_task(upstream_response.aclose())
+                await asyncio.shield(cleanup_task)
 
             async def body_stream() -> AsyncIterator[bytes]:
                 try:
@@ -627,7 +697,7 @@ class RESTfulAPI(CancelMixin):
                     )
                     raise
                 finally:
-                    await upstream_response.aclose()
+                    await release_resources()
 
             response_headers.setdefault("cache-control", "no-cache")
             response_headers.setdefault("x-accel-buffering", "no")
@@ -635,6 +705,7 @@ class RESTfulAPI(CancelMixin):
                 body_stream(),
                 status_code=upstream_response.status_code,
                 headers=response_headers,
+                background=BackgroundTask(release_resources),
             )
 
         try:
@@ -668,44 +739,7 @@ class RESTfulAPI(CancelMixin):
             response = await call_next(request)
             return response
 
-        @self._app.middleware("http")
-        async def audit_middleware(request: Request, call_next):
-            import time as _time
-
-            _start = _time.perf_counter()
-            response = await call_next(request)
-            model_uid = getattr(request.state, "_audit_model_uid", "")
-            if model_uid:
-                latency_s = _time.perf_counter() - _start
-                if response.status_code < 400:
-                    audit_status = "success"
-                elif response.status_code == 404:
-                    audit_status = "model_not_found"
-                else:
-                    audit_status = "error"
-                model_type = getattr(request.state, "_audit_model_type", "")
-                self._record_audit(
-                    request, model_uid, model_type, audit_status, latency_s
-                )
-            elif self._advanced_auth_service and request.url.path.startswith(
-                ("/v1/models", "/v1/admin")
-            ):
-                from .oauth2.advanced.audit import classify_endpoint
-
-                _category = classify_endpoint(request.url.path)
-                if _category == "admin":
-                    latency_s = _time.perf_counter() - _start
-                    audit_status = "success" if response.status_code < 400 else "error"
-                    self._record_admin_audit(request, audit_status, latency_s)
-            elif self._advanced_auth_service and request.url.path.startswith(
-                ("/token", "/v1/auth/", "/v1/api_keys")
-            ):
-                latency_s = _time.perf_counter() - _start
-                audit_status = (
-                    "success" if response.status_code < 400 else "login_failed"
-                )
-                self._record_admin_audit(request, audit_status, latency_s)
-            return response
+        self._app.middleware("http")(self._audit_middleware)
 
         # Initialise OpenTelemetry tracing & metrics (no-op when disabled)
         if XINFERENCE_ENABLE_OTEL:
@@ -924,8 +958,11 @@ class RESTfulAPI(CancelMixin):
         try:
             supervisor_ref = await self._get_supervisor_ref()
             physical_models = await supervisor_ref.list_models()
-            virtual_models = await supervisor_ref.list_virtual_models()
-            models = {**physical_models, **virtual_models}
+            if XINFERENCE_TOKEN_ROUTER_ENABLED:
+                virtual_models = await supervisor_ref.list_virtual_models()
+                models = {**physical_models, **virtual_models}
+            else:
+                models = physical_models
 
             model_list = []
             for model_id, model_info in models.items():
@@ -2767,6 +2804,7 @@ class RESTfulAPI(CancelMixin):
     async def create_chat_completion(self, request: Request) -> Response:
         raw_body = await request.json()
         body = CreateChatCompletion.parse_obj(raw_body)
+        raw_body = _normalize_token_router_chat_payload(raw_body)
         exclude = {
             "prompt",
             "model",

--- a/xinference/api/restful_api.py
+++ b/xinference/api/restful_api.py
@@ -23,6 +23,7 @@ import pprint
 import time
 import uuid
 import warnings
+from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any, AsyncIterator, Dict, List, Optional, Union, get_type_hints
 
@@ -292,6 +293,13 @@ class RESTfulAPI(CancelMixin):
     # Add new class attributes
     _allowed_ip_list: Optional[List[ipaddress.IPv4Network]] = None
 
+    @asynccontextmanager
+    async def _lifespan(self, _app: FastAPI) -> AsyncIterator[None]:
+        try:
+            yield
+        finally:
+            await self._close_token_router_client()
+
     def __init__(
         self,
         supervisor_address: str,
@@ -353,9 +361,8 @@ class RESTfulAPI(CancelMixin):
         )
 
         self._router = APIRouter()
-        self._app = FastAPI()
         self._token_router_client: Optional[httpx.AsyncClient] = None
-        self._app.add_event_handler("shutdown", self._close_token_router_client)
+        self._app = FastAPI(lifespan=self._lifespan)
         # Initialize allowed IP list once
         self._init_allowed_ip_list()
 

--- a/xinference/api/restful_api.py
+++ b/xinference/api/restful_api.py
@@ -112,7 +112,7 @@ _TOKEN_ROUTER_HOP_BY_HOP_HEADERS = {
     "keep-alive",
     "proxy-authenticate",
     "proxy-authorization",
-    "t" "e",
+    "te",
     "trailer",
     "transfer-encoding",
     "upgrade",
@@ -323,6 +323,8 @@ class RESTfulAPI(CancelMixin):
 
         self._router = APIRouter()
         self._app = FastAPI()
+        self._token_router_client: Optional[httpx.AsyncClient] = None
+        self._app.add_event_handler("shutdown", self._close_token_router_client)
         # Initialize allowed IP list once
         self._init_allowed_ip_list()
 
@@ -550,6 +552,19 @@ class RESTfulAPI(CancelMixin):
                 "Report error event failed, model: %s, content: %s", model_uid, content
             )
 
+    def _get_token_router_client(self) -> httpx.AsyncClient:
+        client = getattr(self, "_token_router_client", None)
+        if client is None or client.is_closed:
+            client = httpx.AsyncClient(timeout=None, follow_redirects=False)
+            self._token_router_client = client
+        return client
+
+    async def _close_token_router_client(self) -> None:
+        client = getattr(self, "_token_router_client", None)
+        if client is not None:
+            await client.aclose()
+            self._token_router_client = None
+
     async def _proxy_token_router_chat_completion(
         self,
         request: Request,
@@ -559,7 +574,7 @@ class RESTfulAPI(CancelMixin):
         request_id = request.headers.get("x-request-id") or f"xinf-{uuid.uuid4()}"
         endpoint = runtime["endpoint"]
         upstream_url = f"{endpoint}/v1/chat/completions"
-        client = httpx.AsyncClient(timeout=None, follow_redirects=False)
+        client = self._get_token_router_client()
         try:
             upstream_request = client.build_request(
                 "POST",
@@ -569,7 +584,6 @@ class RESTfulAPI(CancelMixin):
             )
             upstream_response = await client.send(upstream_request, stream=True)
         except httpx.HTTPError as exc:
-            await client.aclose()
             logger.warning(
                 "Token Router connection failed: virtual_model_uid=%s "
                 "router_uid=%s instance_id=%s error=%s",
@@ -614,7 +628,6 @@ class RESTfulAPI(CancelMixin):
                     raise
                 finally:
                     await upstream_response.aclose()
-                    await client.aclose()
 
             response_headers.setdefault("cache-control", "no-cache")
             response_headers.setdefault("x-accel-buffering", "no")
@@ -630,7 +643,6 @@ class RESTfulAPI(CancelMixin):
             )
         finally:
             await upstream_response.aclose()
-            await client.aclose()
         return Response(
             content=response_body,
             status_code=upstream_response.status_code,

--- a/xinference/api/routers/__init__.py
+++ b/xinference/api/routers/__init__.py
@@ -17,6 +17,7 @@ from . import (
     llm,
     models,
     rerank,
+    token_routers,
     videos,
 )
 
@@ -35,3 +36,7 @@ def register_all_routes(api: RESTfulAPI) -> None:
     images.register_routes(api)
     videos.register_routes(api)
     launch_history.register_routes(api)
+    from ...constants import XINFERENCE_TOKEN_ROUTER_ENABLED
+
+    if XINFERENCE_TOKEN_ROUTER_ENABLED:
+        token_routers.register_routes(api)

--- a/xinference/api/routers/token_routers.py
+++ b/xinference/api/routers/token_routers.py
@@ -1,0 +1,423 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+"""Token-aware Router control-plane REST endpoints."""
+
+from __future__ import annotations
+
+import hmac
+import os
+from typing import TYPE_CHECKING, Any, Callable, Dict, Optional
+
+from fastapi import Depends, Header, HTTPException, Query, Request, Security
+from fastapi.responses import Response
+
+from ..._compat import ValidationError
+from ..dependencies import get_api
+from ..responses import JSONResponse
+from ..schemas.router import (
+    RouterConfigAck,
+    RouterRuntimeHeartbeat,
+    RouterRuntimeRegister,
+    TokenRouterCreate,
+    TokenRouterUpdate,
+)
+
+if TYPE_CHECKING:
+    from ..restful_api import RESTfulAPI
+
+
+def _username(user: Optional[dict]) -> str:
+    return user.get("username", "") if user else ""
+
+
+def _internal_authorized(authorization: str) -> bool:
+    expected = os.environ.get("XINFERENCE_TOKEN_ROUTER_INTERNAL_TOKEN", "")
+    if not expected or not authorization.startswith("Bearer "):
+        return False
+    return hmac.compare_digest(authorization[7:], expected)
+
+
+def _require_internal(authorization: str = Header(default="")) -> None:
+    if not _internal_authorized(authorization):
+        raise HTTPException(status_code=401, detail="Invalid Token Router credential")
+
+
+async def _parse_payload(request: Request, payload_model: Any):
+    try:
+        body = await request.json()
+        return payload_model.parse_obj(body)
+    except ValidationError as exc:
+        raise HTTPException(status_code=422, detail=exc.errors()) from exc
+    except (TypeError, ValueError) as exc:
+        raise HTTPException(
+            status_code=422, detail="Request body must be valid JSON"
+        ) from exc
+
+
+async def _supervisor(api: "RESTfulAPI"):
+    return await api._get_supervisor_ref()
+
+
+async def list_routers(api: "RESTfulAPI") -> JSONResponse:
+    return JSONResponse(content=await (await _supervisor(api)).list_token_routers())
+
+
+async def list_backend_candidates(api: "RESTfulAPI") -> JSONResponse:
+    return JSONResponse(
+        content=await (await _supervisor(api)).list_token_router_backend_candidates()
+    )
+
+
+async def create_router(
+    payload: TokenRouterCreate, api: "RESTfulAPI", user: Optional[dict]
+) -> JSONResponse:
+    data = payload.dict()
+    router_uid = data.pop("router_uid")
+    try:
+        result = await (await _supervisor(api)).create_token_router(
+            router_uid, data, _username(user)
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    return JSONResponse(status_code=201, content=result)
+
+
+async def get_router(router_uid: str, api: "RESTfulAPI") -> JSONResponse:
+    result = await (await _supervisor(api)).get_token_router(router_uid)
+    if result is None:
+        raise HTTPException(status_code=404, detail="Token Router not found")
+    return JSONResponse(content=result)
+
+
+async def update_router(
+    router_uid: str,
+    payload: TokenRouterUpdate,
+    api: "RESTfulAPI",
+    user: Optional[dict],
+) -> JSONResponse:
+    try:
+        result = await (await _supervisor(api)).update_token_router(
+            router_uid, payload.dict(), _username(user)
+        )
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail="Token Router not found") from exc
+    except (RuntimeError, ValueError) as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    return JSONResponse(content=result)
+
+
+async def delete_router(router_uid: str, api: "RESTfulAPI") -> JSONResponse:
+    try:
+        deleted = await (await _supervisor(api)).delete_token_router(router_uid)
+    except ValueError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Token Router not found")
+    return JSONResponse(content={"status": "ok"})
+
+
+async def set_router_enabled(
+    router_uid: str, enabled: bool, api: "RESTfulAPI", user: Optional[dict]
+) -> JSONResponse:
+    try:
+        result = await (await _supervisor(api)).set_token_router_enabled(
+            router_uid, enabled, _username(user)
+        )
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail="Token Router not found") from exc
+    return JSONResponse(content=result)
+
+
+async def validate_router(router_uid: str, api: "RESTfulAPI") -> JSONResponse:
+    result = await (await _supervisor(api)).validate_token_router(router_uid)
+    if result is None:
+        raise HTTPException(status_code=404, detail="Token Router not found")
+    return JSONResponse(content=result)
+
+
+async def router_status(router_uid: str, api: "RESTfulAPI") -> JSONResponse:
+    result = await (await _supervisor(api)).get_token_router_status(router_uid)
+    if result is None:
+        raise HTTPException(status_code=404, detail="Token Router not found")
+    return JSONResponse(content=result)
+
+
+async def router_instances(router_uid: str, api: "RESTfulAPI") -> JSONResponse:
+    if await (await _supervisor(api)).get_token_router(router_uid) is None:
+        raise HTTPException(status_code=404, detail="Token Router not found")
+    return JSONResponse(
+        content=await (await _supervisor(api)).list_token_router_instances(router_uid)
+    )
+
+
+async def router_metrics(router_uid: str, api: "RESTfulAPI") -> JSONResponse:
+    result = await (await _supervisor(api)).get_token_router_metrics(router_uid)
+    if result is None:
+        raise HTTPException(status_code=404, detail="Token Router not found")
+    return JSONResponse(content=result)
+
+
+async def runtime_register(
+    payload: RouterRuntimeRegister, api: "RESTfulAPI"
+) -> JSONResponse:
+    if await (await _supervisor(api)).get_token_router(payload.router_uid) is None:
+        raise HTTPException(status_code=404, detail="Token Router not found")
+    data = payload.dict()
+    router_uid = data.pop("router_uid")
+    instance_id = data.pop("instance_id")
+    try:
+        result = await (await _supervisor(api)).register_token_router_instance(
+            router_uid, instance_id, data
+        )
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail="Token Router not found") from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    return JSONResponse(content=result)
+
+
+async def runtime_heartbeat(
+    instance_id: str, payload: RouterRuntimeHeartbeat, api: "RESTfulAPI"
+) -> JSONResponse:
+    try:
+        result = await (await _supervisor(api)).heartbeat_token_router_instance(
+            instance_id, payload.dict()
+        )
+    except KeyError as exc:
+        raise HTTPException(
+            status_code=404, detail="Router instance not found"
+        ) from exc
+    return JSONResponse(content=result)
+
+
+async def runtime_config(
+    router_uid: str, after_revision: int, api: "RESTfulAPI"
+) -> Response:
+    result = await (await _supervisor(api)).get_token_router_config_after(
+        router_uid, after_revision
+    )
+    if result is None:
+        return Response(status_code=204)
+    return JSONResponse(content=result)
+
+
+async def runtime_ack(
+    instance_id: str, payload: RouterConfigAck, api: "RESTfulAPI"
+) -> JSONResponse:
+    try:
+        result = await (await _supervisor(api)).ack_token_router_config(
+            instance_id, payload.router_uid, payload.revision, payload.error
+        )
+    except KeyError as exc:
+        raise HTTPException(
+            status_code=404, detail="Router instance not found"
+        ) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    return JSONResponse(content=result)
+
+
+async def runtime_unregister(instance_id: str, api: "RESTfulAPI") -> JSONResponse:
+    deleted = await (await _supervisor(api)).unregister_token_router_instance(
+        instance_id
+    )
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Router instance not found")
+    return JSONResponse(content={"status": "ok"})
+
+
+def register_routes(api: "RESTfulAPI") -> None:
+    router = api._router
+    auth = api._auth_service
+    is_auth = api.is_authenticated()
+
+    def route(
+        path: str,
+        endpoint: Callable[..., Any],
+        methods: list[str],
+        scope: str,
+        *,
+        payload_model: Optional[type] = None,
+        include_user: bool = False,
+        enabled: Optional[bool] = None,
+        query_params: tuple[str, ...] = (),
+    ) -> None:
+        async def invoke(
+            request: Request,
+            api_: "RESTfulAPI",
+            user: Optional[dict],
+        ) -> JSONResponse:
+            kwargs: Dict[str, Any] = dict(request.path_params)
+            for name in query_params:
+                kwargs[name] = request.query_params.get(name, "")
+            if payload_model is not None:
+                kwargs["payload"] = await _parse_payload(request, payload_model)
+            if enabled is not None:
+                kwargs["enabled"] = enabled
+            kwargs["api"] = api_
+            if include_user:
+                kwargs["user"] = user
+            return await endpoint(**kwargs)
+
+        if is_auth:
+
+            async def authed(
+                request: Request,
+                user: dict = Security(auth, scopes=[scope]),
+                api_: "RESTfulAPI" = Depends(get_api),
+            ) -> JSONResponse:
+                return await invoke(request, api_, user)
+
+            handler: Callable[..., Any] = authed
+        else:
+
+            async def anonymous(
+                request: Request,
+                api_: "RESTfulAPI" = Depends(get_api),
+            ) -> JSONResponse:
+                return await invoke(request, api_, None)
+
+            handler = anonymous
+        router.add_api_route(path, handler, methods=methods)
+
+    route("/v1/token_routers", list_routers, ["GET"], "routers:list")
+    route(
+        "/v1/token_routers/backend-candidates",
+        list_backend_candidates,
+        ["GET"],
+        "routers:list",
+    )
+    route(
+        "/v1/token_routers",
+        create_router,
+        ["POST"],
+        "routers:write",
+        payload_model=TokenRouterCreate,
+        include_user=True,
+    )
+    route("/v1/token_routers/{router_uid}", get_router, ["GET"], "routers:read")
+    route(
+        "/v1/token_routers/{router_uid}",
+        update_router,
+        ["PUT"],
+        "routers:write",
+        payload_model=TokenRouterUpdate,
+        include_user=True,
+    )
+    route(
+        "/v1/token_routers/{router_uid}",
+        delete_router,
+        ["DELETE"],
+        "routers:write",
+    )
+    route(
+        "/v1/token_routers/{router_uid}/validate",
+        validate_router,
+        ["POST"],
+        "routers:operate",
+    )
+    route(
+        "/v1/token_routers/{router_uid}/enable",
+        set_router_enabled,
+        ["POST"],
+        "routers:operate",
+        include_user=True,
+        enabled=True,
+    )
+    route(
+        "/v1/token_routers/{router_uid}/disable",
+        set_router_enabled,
+        ["POST"],
+        "routers:operate",
+        include_user=True,
+        enabled=False,
+    )
+    route(
+        "/v1/token_routers/{router_uid}/status",
+        router_status,
+        ["GET"],
+        "routers:read",
+    )
+    route(
+        "/v1/token_routers/{router_uid}/instances",
+        router_instances,
+        ["GET"],
+        "routers:read",
+    )
+    route(
+        "/v1/token_routers/{router_uid}/metrics-summary",
+        router_metrics,
+        ["GET"],
+        "routers:read",
+    )
+
+    async def register_runtime_handler(
+        request: Request,
+        _: None = Depends(_require_internal),
+        api_: "RESTfulAPI" = Depends(get_api),
+    ) -> JSONResponse:
+        payload = await _parse_payload(request, RouterRuntimeRegister)
+        return await runtime_register(payload, api_)
+
+    async def heartbeat_runtime_handler(
+        instance_id: str,
+        request: Request,
+        _: None = Depends(_require_internal),
+        api_: "RESTfulAPI" = Depends(get_api),
+    ) -> JSONResponse:
+        payload = await _parse_payload(request, RouterRuntimeHeartbeat)
+        return await runtime_heartbeat(instance_id, payload, api_)
+
+    async def get_runtime_config_handler(
+        router_uid: str,
+        after_revision: int = Query(default=0, ge=0),
+        _: None = Depends(_require_internal),
+        api_: "RESTfulAPI" = Depends(get_api),
+    ) -> Response:
+        try:
+            return await runtime_config(router_uid, after_revision, api_)
+        except KeyError as exc:
+            raise HTTPException(
+                status_code=404, detail="Token Router not found"
+            ) from exc
+
+    async def ack_runtime_handler(
+        instance_id: str,
+        request: Request,
+        _: None = Depends(_require_internal),
+        api_: "RESTfulAPI" = Depends(get_api),
+    ) -> JSONResponse:
+        payload = await _parse_payload(request, RouterConfigAck)
+        return await runtime_ack(instance_id, payload, api_)
+
+    async def unregister_runtime_handler(
+        instance_id: str,
+        _: None = Depends(_require_internal),
+        api_: "RESTfulAPI" = Depends(get_api),
+    ) -> JSONResponse:
+        return await runtime_unregister(instance_id, api_)
+
+    router.add_api_route(
+        "/v1/internal/token-router/instances/register",
+        register_runtime_handler,
+        methods=["POST"],
+    )
+    router.add_api_route(
+        "/v1/internal/token-router/instances/{instance_id}/heartbeat",
+        heartbeat_runtime_handler,
+        methods=["POST"],
+    )
+    router.add_api_route(
+        "/v1/internal/token-router/configs/{router_uid}",
+        get_runtime_config_handler,
+        methods=["GET"],
+    )
+    router.add_api_route(
+        "/v1/internal/token-router/instances/{instance_id}/config-ack",
+        ack_runtime_handler,
+        methods=["POST"],
+    )
+    router.add_api_route(
+        "/v1/internal/token-router/instances/{instance_id}/unregister",
+        unregister_runtime_handler,
+        methods=["POST"],
+    )

--- a/xinference/api/schemas/router.py
+++ b/xinference/api/schemas/router.py
@@ -1,0 +1,245 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+"""Schemas for Token-aware Router management and runtime APIs."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Literal, Optional, Union
+
+from ..._compat import BaseModel, Field, validator
+
+_BACKEND_ID_PATTERN = r"^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$"
+_RULE_ID_PATTERN = _BACKEND_ID_PATTERN
+
+
+class AdmissionConfig(BaseModel):
+    max_active: int = Field(default=1, ge=1)
+    max_queue: int = Field(default=0, ge=0)
+    queue_timeout_seconds: float = Field(default=5.0, ge=0)
+    retry_after_seconds: int = Field(default=1, ge=0)
+
+
+class RouterBackendConfig(BaseModel):
+    """Legacy V1 Short/Long backend."""
+
+    model_uid: str = Field(min_length=1)
+    max_context_tokens: int = Field(ge=1)
+    admission: AdmissionConfig = Field(default_factory=AdmissionConfig)
+
+
+class RouterBackendsConfig(BaseModel):
+    """Legacy V1 fixed backend map."""
+
+    short: RouterBackendConfig
+    long: RouterBackendConfig
+
+
+class DynamicRouterBackendConfig(RouterBackendConfig):
+    """V2 backend with a stable Router-local identifier."""
+
+    id: str = Field(min_length=1, max_length=64, regex=_BACKEND_ID_PATTERN)
+
+
+class RoutingConfig(BaseModel):
+    """Legacy V1 token threshold routing."""
+
+    short_threshold_tokens: int = Field(default=131072, ge=1)
+    context_reserve_tokens: int = Field(default=64, ge=0)
+    default_output_tokens: int = Field(default=512, ge=1)
+    thinking_policy: Literal["short", "long", "reject"] = "long"
+    overflow_policy: Literal["reject"] = "reject"
+
+
+class RoutingRuleMatch(BaseModel):
+    total_tokens_gte: Optional[int] = Field(default=None, ge=0)
+    total_tokens_lte: Optional[int] = Field(default=None, ge=0)
+    thinking: Optional[bool] = None
+    tools_present: Optional[bool] = None
+    stream: Optional[bool] = None
+
+    @validator("stream", always=True)
+    def validate_match(cls, value: Optional[bool], values: Dict[str, Any]):
+        fields = (
+            values.get("total_tokens_gte"),
+            values.get("total_tokens_lte"),
+            values.get("thinking"),
+            values.get("tools_present"),
+            value,
+        )
+        if all(item is None for item in fields):
+            raise ValueError("routing rule match cannot be empty")
+        lower = values.get("total_tokens_gte")
+        upper = values.get("total_tokens_lte")
+        if lower is not None and upper is not None and lower > upper:
+            raise ValueError("total_tokens_gte cannot exceed total_tokens_lte")
+        return value
+
+
+class RouteAction(BaseModel):
+    type: Literal["route"]
+    backend_id: str = Field(min_length=1, max_length=64, regex=_BACKEND_ID_PATTERN)
+
+
+class RejectAction(BaseModel):
+    type: Literal["reject"]
+    reason: str = Field(min_length=1, max_length=128)
+
+
+RoutingAction = Union[RouteAction, RejectAction]
+
+
+class RoutingRule(BaseModel):
+    id: str = Field(min_length=1, max_length=64, regex=_RULE_ID_PATTERN)
+    priority: int = Field(ge=1, le=10000)
+    match: RoutingRuleMatch
+    action: RoutingAction
+
+
+class TypedRoutingConfig(BaseModel):
+    evaluation_mode: Literal["first_match"] = "first_match"
+    context_reserve_tokens: int = Field(default=64, ge=0)
+    default_output_tokens: int = Field(default=512, ge=1)
+    rules: list[RoutingRule] = Field(min_items=1, max_items=64)
+    default_action: RoutingAction
+
+    @validator("rules")
+    def validate_rules(cls, value: list[RoutingRule]) -> list[RoutingRule]:
+        ids = [rule.id for rule in value]
+        if len(ids) != len(set(ids)):
+            raise ValueError("routing rule ids must be unique")
+        priorities = [rule.priority for rule in value]
+        if len(priorities) != len(set(priorities)):
+            raise ValueError("routing rule priorities must be unique")
+        return value
+
+
+class TokenizationConfig(BaseModel):
+    executor: Literal["process"] = "process"
+    multiprocessing_start_method: Literal["spawn"] = "spawn"
+    max_workers: int = Field(default=2, ge=1)
+    max_active: int = Field(default=2, ge=1)
+    max_queue: int = Field(default=8, ge=0)
+    queue_timeout_seconds: float = Field(default=5.0, ge=0)
+    retry_after_seconds: int = Field(default=1, ge=0)
+
+
+class TokenRouterConfigBase(BaseModel):
+    config_version: int = Field(default=1)
+    virtual_model_uid: str = Field(min_length=1)
+    model_type: Literal["LLM"] = "LLM"
+    route_profile: Literal["llm_chat"] = "llm_chat"
+    strategy: Literal["token_budget", "typed_rules"] = "token_budget"
+    tokenizer_path: str = Field(min_length=1)
+    backend_url: str = Field(min_length=1)
+    model_aliases: list[str] = Field(default_factory=list)
+    request_timeout_seconds: float = Field(default=10800.0, gt=0)
+    connect_timeout_seconds: float = Field(default=10.0, gt=0)
+    backends: Union[RouterBackendsConfig, list[DynamicRouterBackendConfig]]
+    routing: Union[TypedRoutingConfig, RoutingConfig]
+    tokenization: TokenizationConfig = Field(default_factory=TokenizationConfig)
+
+    @validator("config_version")
+    def validate_config_version(cls, value: int) -> int:
+        if value not in {1, 2}:
+            raise ValueError("config_version must be 1 or 2")
+        return value
+
+    @validator("backend_url")
+    def normalize_backend_url(cls, value: str) -> str:
+        value = value.rstrip("/")
+        if not value.startswith(("http://", "https://")):
+            raise ValueError("backend_url must start with http:// or https://")
+        return value
+
+    @validator("backends")
+    def validate_backends(
+        cls,
+        value: Union[RouterBackendsConfig, list[DynamicRouterBackendConfig]],
+        values: Dict[str, Any],
+    ):
+        version = values.get("config_version", 1)
+        if version == 1:
+            if not isinstance(value, RouterBackendsConfig):
+                raise ValueError("config_version 1 requires short/long backends")
+            if value.short.model_uid == value.long.model_uid:
+                raise ValueError("short and long backend model_uid must be different")
+            return value
+        if not isinstance(value, list):
+            raise ValueError("config_version 2 requires a dynamic backend list")
+        if not 1 <= len(value) <= 16:
+            raise ValueError("config_version 2 requires 1 to 16 backends")
+        ids = [backend.id for backend in value]
+        if len(ids) != len(set(ids)):
+            raise ValueError("backend ids must be unique")
+        return value
+
+    @validator("routing")
+    def validate_routing(
+        cls,
+        value: Union[TypedRoutingConfig, RoutingConfig],
+        values: Dict[str, Any],
+    ):
+        version = values.get("config_version", 1)
+        backends = values.get("backends")
+        strategy = values.get("strategy")
+        if version == 1:
+            if not isinstance(value, RoutingConfig) or not isinstance(
+                backends, RouterBackendsConfig
+            ):
+                raise ValueError("config_version 1 requires legacy routing")
+            if strategy != "token_budget":
+                raise ValueError("config_version 1 requires token_budget strategy")
+            if value.short_threshold_tokens > backends.short.max_context_tokens:
+                raise ValueError(
+                    "short_threshold_tokens cannot exceed short max_context_tokens"
+                )
+            if backends.short.max_context_tokens > backends.long.max_context_tokens:
+                raise ValueError(
+                    "short max_context_tokens cannot exceed long max_context_tokens"
+                )
+            return value
+        if not isinstance(value, TypedRoutingConfig) or not isinstance(backends, list):
+            raise ValueError("config_version 2 requires typed routing rules")
+        if strategy != "typed_rules":
+            raise ValueError("config_version 2 requires typed_rules strategy")
+        backend_ids = {backend.id for backend in backends}
+        actions = [rule.action for rule in value.rules] + [value.default_action]
+        unknown = sorted(
+            action.backend_id
+            for action in actions
+            if isinstance(action, RouteAction) and action.backend_id not in backend_ids
+        )
+        if unknown:
+            raise ValueError(
+                "routing actions reference unknown backends: " + ", ".join(unknown)
+            )
+        return value
+
+
+class TokenRouterCreate(TokenRouterConfigBase):
+    router_uid: str = Field(min_length=1)
+
+
+class TokenRouterUpdate(TokenRouterConfigBase):
+    revision: int = Field(ge=1)
+
+
+class RouterRuntimeRegister(BaseModel):
+    router_uid: str = Field(min_length=1)
+    instance_id: str = Field(min_length=1)
+    endpoint: str = Field(min_length=1)
+    version: str = ""
+    acked_revision: int = Field(default=0, ge=0)
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+
+class RouterRuntimeHeartbeat(BaseModel):
+    status: str = "ready"
+    metrics: Dict[str, Any] = Field(default_factory=dict)
+    backend_health: Dict[str, Any] = Field(default_factory=dict)
+    process: Dict[str, Any] = Field(default_factory=dict)
+
+
+class RouterConfigAck(BaseModel):
+    router_uid: str = Field(min_length=1)
+    revision: int = Field(ge=1)
+    error: str = ""

--- a/xinference/api/tests/test_token_router_api.py
+++ b/xinference/api/tests/test_token_router_api.py
@@ -1,0 +1,572 @@
+from copy import deepcopy
+from types import MethodType
+
+import httpx
+import pytest
+from fastapi import APIRouter, FastAPI, Header, HTTPException
+from fastapi.security import SecurityScopes
+
+from xinference.api.routers.token_routers import register_routes
+from xinference.core.router_config_store import RouterConfigStore
+from xinference.core.router_registry import RouterRuntimeRegistry
+from xinference.core.supervisor import SupervisorActor
+
+
+def router_payload() -> dict:
+    return {
+        "router_uid": "router-a",
+        "virtual_model_uid": "virtual-model",
+        "model_type": "LLM",
+        "strategy": "token_budget",
+        "tokenizer_path": "/models/tokenizer",
+        "backend_url": "http://xinference.internal:9997",
+        "model_aliases": ["virtual-alias"],
+        "request_timeout_seconds": 10800,
+        "connect_timeout_seconds": 10,
+        "backends": {
+            "short": {
+                "model_uid": "short-model",
+                "max_context_tokens": 131072,
+                "admission": {
+                    "max_active": 8,
+                    "max_queue": 32,
+                    "queue_timeout_seconds": 5,
+                    "retry_after_seconds": 1,
+                },
+            },
+            "long": {
+                "model_uid": "long-model",
+                "max_context_tokens": 1048576,
+                "admission": {
+                    "max_active": 1,
+                    "max_queue": 2,
+                    "queue_timeout_seconds": 30,
+                    "retry_after_seconds": 5,
+                },
+            },
+        },
+        "routing": {
+            "short_threshold_tokens": 131072,
+            "context_reserve_tokens": 64,
+            "default_output_tokens": 512,
+            "thinking_policy": "long",
+            "overflow_policy": "reject",
+        },
+        "tokenization": {
+            "executor": "process",
+            "multiprocessing_start_method": "spawn",
+            "max_workers": 2,
+            "max_active": 2,
+            "max_queue": 8,
+            "queue_timeout_seconds": 5,
+            "retry_after_seconds": 1,
+        },
+    }
+
+
+def typed_router_payload() -> dict:
+    payload = router_payload()
+    payload.update(
+        {
+            "config_version": 2,
+            "route_profile": "llm_chat",
+            "strategy": "typed_rules",
+            "backends": [
+                {
+                    "id": backend_id,
+                    "model_uid": model_uid,
+                    "max_context_tokens": context,
+                    "admission": {
+                        "max_active": max_active,
+                        "max_queue": 8,
+                        "queue_timeout_seconds": 5,
+                        "retry_after_seconds": 1,
+                    },
+                }
+                for backend_id, model_uid, context, max_active in (
+                    ("fast", "short-model", 131072, 8),
+                    ("tools", "tools-model", 131072, 4),
+                    ("reasoning", "reasoning-model", 262144, 2),
+                    ("long", "long-model", 1048576, 1),
+                )
+            ],
+            "routing": {
+                "evaluation_mode": "first_match",
+                "context_reserve_tokens": 64,
+                "default_output_tokens": 512,
+                "rules": [
+                    {
+                        "id": "tools-route",
+                        "priority": 400,
+                        "match": {"tools_present": True},
+                        "action": {"type": "route", "backend_id": "tools"},
+                    },
+                    {
+                        "id": "thinking-route",
+                        "priority": 300,
+                        "match": {"thinking": True},
+                        "action": {"type": "route", "backend_id": "reasoning"},
+                    },
+                    {
+                        "id": "short-route",
+                        "priority": 200,
+                        "match": {"total_tokens_lte": 131072},
+                        "action": {"type": "route", "backend_id": "fast"},
+                    },
+                    {
+                        "id": "long-route",
+                        "priority": 100,
+                        "match": {"total_tokens_gte": 131073},
+                        "action": {"type": "route", "backend_id": "long"},
+                    },
+                ],
+                "default_action": {
+                    "type": "reject",
+                    "reason": "no_compatible_backend",
+                },
+            },
+        }
+    )
+    return payload
+
+
+def make_supervisor(tmp_path):
+    supervisor = SupervisorActor.__new__(SupervisorActor)
+    supervisor._token_router_store = RouterConfigStore(str(tmp_path / "routers.db"))
+    supervisor._token_router_registry = RouterRuntimeRegistry()
+
+    async def list_models(_self):
+        return {
+            "short-model": {
+                "model_type": "LLM",
+                "model_engine": "vLLM",
+                "model_ability": ["chat"],
+                "context_length": 131072,
+            },
+            "tools-model": {
+                "model_type": "LLM",
+                "model_engine": "vLLM",
+                "model_ability": ["chat", "tools"],
+                "context_length": 131072,
+            },
+            "reasoning-model": {
+                "model_type": "LLM",
+                "model_engine": "vLLM",
+                "model_ability": ["chat", "reasoning"],
+                "context_length": 262144,
+            },
+            "long-model": {
+                "model_type": "LLM",
+                "model_engine": "vLLM",
+                "model_ability": ["chat"],
+                "context_length": 1048576,
+            },
+        }
+
+    supervisor.list_models = MethodType(list_models, supervisor)
+    return supervisor
+
+
+class FakeAPI:
+    def __init__(self, supervisor, *, authenticated: bool, auth_service) -> None:
+        self._router = APIRouter()
+        self._supervisor = supervisor
+        self._authenticated = authenticated
+        self._auth_service = auth_service
+
+    def is_authenticated(self) -> bool:
+        return self._authenticated
+
+    async def _get_supervisor_ref(self):
+        return self._supervisor
+
+
+async def unused_auth():
+    return {"username": "anonymous"}
+
+
+def create_app(supervisor, *, authenticated: bool = False, auth_service=unused_auth):
+    api = FakeAPI(
+        supervisor,
+        authenticated=authenticated,
+        auth_service=auth_service,
+    )
+    register_routes(api)  # type: ignore[arg-type]
+    app = FastAPI()
+    app.state.api = api
+    app.include_router(api._router)
+    return app
+
+
+@pytest.mark.asyncio
+async def test_management_crud_revision_and_validation(tmp_path) -> None:
+    app = create_app(make_supervisor(tmp_path))
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        payload = router_payload()
+        created = await client.post("/v1/token_routers", json=payload)
+        assert created.status_code == 201
+        assert created.json()["revision"] == 1
+        assert created.json()["enabled"] is False
+
+        repeated = await client.post("/v1/token_routers", json=payload)
+        assert repeated.status_code == 201
+        assert repeated.json()["revision"] == 1
+
+        listed = await client.get("/v1/token_routers")
+        assert listed.status_code == 200
+        assert [item["router_uid"] for item in listed.json()] == ["router-a"]
+
+        invalid = deepcopy(payload)
+        invalid["router_uid"] = "router-b"
+        invalid["backends"]["long"]["model_uid"] = "short-model"
+        response = await client.post("/v1/token_routers", json=invalid)
+        assert response.status_code == 422
+
+        update = deepcopy(payload)
+        update.pop("router_uid")
+        update["revision"] = 1
+        update["routing"]["default_output_tokens"] = 1024
+        updated = await client.put("/v1/token_routers/router-a", json=update)
+        assert updated.status_code == 200
+        assert updated.json()["revision"] == 2
+
+        conflict = await client.put("/v1/token_routers/router-a", json=update)
+        assert conflict.status_code == 409
+
+        validated = await client.post("/v1/token_routers/router-a/validate")
+        assert validated.status_code == 200
+        assert validated.json()["valid"] is True
+
+        enabled = await client.post("/v1/token_routers/router-a/enable")
+        assert enabled.status_code == 200
+        assert enabled.json()["enabled"] is True
+        assert (await client.delete("/v1/token_routers/router-a")).status_code == 409
+
+        disabled = await client.post("/v1/token_routers/router-a/disable")
+        assert disabled.status_code == 200
+        assert disabled.json()["enabled"] is False
+        assert (await client.delete("/v1/token_routers/router-a")).status_code == 200
+        assert (await client.get("/v1/token_routers/router-a")).status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_validation_checks_running_backend_type_and_context(tmp_path) -> None:
+    supervisor = make_supervisor(tmp_path)
+
+    async def list_models(_self):
+        return {
+            "short-model": {
+                "model_type": "embedding",
+                "context_length": 4096,
+            }
+        }
+
+    supervisor.list_models = MethodType(list_models, supervisor)
+    app = create_app(supervisor)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        assert (
+            await client.post("/v1/token_routers", json=router_payload())
+        ).status_code == 201
+        response = await client.post("/v1/token_routers/router-a/validate")
+
+    assert response.status_code == 200
+    result = response.json()
+    assert result["valid"] is False
+    assert "short backend model must be an LLM" in result["errors"][0]
+    assert any("short max_context_tokens" in error for error in result["errors"])
+    assert any(
+        "long backend model is not running" in error for error in result["errors"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_runtime_internal_api_and_empty_204(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("XINFERENCE_TOKEN_ROUTER_INTERNAL_TOKEN", "internal-secret")
+    app = create_app(make_supervisor(tmp_path))
+    headers = {"Authorization": "Bearer internal-secret"}
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        assert (
+            await client.get("/v1/internal/token-router/configs/router-a")
+        ).status_code == 401
+
+        assert (
+            await client.post("/v1/token_routers", json=router_payload())
+        ).status_code == 201
+        config = await client.get(
+            "/v1/internal/token-router/configs/router-a",
+            headers=headers,
+            params={"after_revision": 0},
+        )
+        assert config.status_code == 200
+        revision = config.json()["revision"]
+
+        no_change = await client.get(
+            "/v1/internal/token-router/configs/router-a",
+            headers=headers,
+            params={"after_revision": revision},
+        )
+        assert no_change.status_code == 204
+        assert no_change.content == b""
+
+        registered = await client.post(
+            "/v1/internal/token-router/instances/register",
+            headers=headers,
+            json={
+                "router_uid": "router-a",
+                "instance_id": "instance-a",
+                "endpoint": "http://router:10080",
+                "acked_revision": 0,
+            },
+        )
+        assert registered.status_code == 200
+
+        heartbeat = await client.post(
+            "/v1/internal/token-router/instances/instance-a/heartbeat",
+            headers=headers,
+            json={"status": "ready", "metrics": {"requests": 1}},
+        )
+        assert heartbeat.status_code == 200
+        assert heartbeat.json()["metrics"] == {"requests": 1}
+
+        ack = await client.post(
+            "/v1/internal/token-router/instances/instance-a/config-ack",
+            headers=headers,
+            json={"router_uid": "router-a", "revision": revision},
+        )
+        assert ack.status_code == 200
+        assert ack.json()["acked_revision"] == revision
+
+        instances = await client.get("/v1/token_routers/router-a/instances")
+        assert instances.status_code == 200
+        assert instances.json()[0]["instance_id"] == "instance-a"
+
+        future_ack = await client.post(
+            "/v1/internal/token-router/instances/instance-a/config-ack",
+            headers=headers,
+            json={"router_uid": "router-a", "revision": revision + 1},
+        )
+        assert future_ack.status_code == 409
+
+        stale_ack = await client.post(
+            "/v1/internal/token-router/instances/instance-a/config-ack",
+            headers=headers,
+            json={"router_uid": "router-a", "revision": revision - 1},
+        )
+        assert stale_ack.status_code == 422
+
+        unregistered = await client.post(
+            "/v1/internal/token-router/instances/instance-a/unregister",
+            headers=headers,
+        )
+        assert unregistered.status_code == 200
+        assert (
+            await client.post(
+                "/v1/internal/token-router/instances/instance-a/unregister",
+                headers=headers,
+            )
+        ).status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_management_scope_enforcement(tmp_path) -> None:
+    token_scopes = {
+        "reader": {"routers:list", "routers:read"},
+        "writer": {"routers:write"},
+        "admin-token": {"admin"},
+    }
+
+    async def auth_service(
+        security_scopes: SecurityScopes,
+        authorization: str = Header(default=""),
+    ) -> dict:
+        token = authorization.removeprefix("Bearer ")
+        scopes = token_scopes.get(token)
+        if scopes is None:
+            raise HTTPException(status_code=401, detail="Unauthorized")
+        if "admin" not in scopes and not set(security_scopes.scopes).issubset(scopes):
+            raise HTTPException(status_code=403, detail="Forbidden")
+        return {"username": token}
+
+    app = create_app(
+        make_supervisor(tmp_path), authenticated=True, auth_service=auth_service
+    )
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        assert (await client.get("/v1/token_routers")).status_code == 401
+        assert (
+            await client.get(
+                "/v1/token_routers", headers={"Authorization": "Bearer reader"}
+            )
+        ).status_code == 200
+        assert (
+            await client.post(
+                "/v1/token_routers",
+                headers={"Authorization": "Bearer reader"},
+                json=router_payload(),
+            )
+        ).status_code == 403
+        assert (
+            await client.post(
+                "/v1/token_routers",
+                headers={"Authorization": "Bearer admin-token"},
+                json=router_payload(),
+            )
+        ).status_code == 201
+
+
+@pytest.mark.asyncio
+async def test_v2_dynamic_router_crud_and_validation(tmp_path) -> None:
+    app = create_app(make_supervisor(tmp_path))
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        created = await client.post("/v1/token_routers", json=typed_router_payload())
+        assert created.status_code == 201
+        body = created.json()
+        assert body["config_version"] == 2
+        assert body["route_profile"] == "llm_chat"
+        assert body["strategy"] == "typed_rules"
+        assert [backend["id"] for backend in body["backends"]] == [
+            "fast",
+            "tools",
+            "reasoning",
+            "long",
+        ]
+        assert [rule["id"] for rule in body["routing"]["rules"]] == [
+            "tools-route",
+            "thinking-route",
+            "short-route",
+            "long-route",
+        ]
+
+        validation = await client.post("/v1/token_routers/router-a/validate")
+        assert validation.status_code == 200
+        assert validation.json()["valid"] is True
+        assert validation.json()["errors"] == []
+
+        fetched = await client.get("/v1/token_routers/router-a")
+        assert fetched.status_code == 200
+        assert fetched.json()["routing"]["default_action"] == {
+            "type": "reject",
+            "reason": "no_compatible_backend",
+        }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        lambda payload: payload.update(config_version=3),
+        lambda payload: payload["backends"][1].update(id="fast"),
+        lambda payload: payload["routing"]["rules"][1].update(id="tools-route"),
+        lambda payload: payload["routing"]["rules"][1].update(priority=400),
+        lambda payload: payload["routing"]["rules"][0].update(match={}),
+        lambda payload: payload["routing"]["rules"][0]["action"].update(
+            backend_id="missing"
+        ),
+    ],
+)
+async def test_v2_schema_rejects_invalid_dynamic_config(tmp_path, mutate) -> None:
+    payload = typed_router_payload()
+    mutate(payload)
+    app = create_app(make_supervisor(tmp_path))
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post("/v1/token_routers", json=payload)
+
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_backend_candidates_apply_profile_and_engine_filters(
+    tmp_path,
+) -> None:
+    supervisor = make_supervisor(tmp_path)
+
+    async def list_models(_self):
+        return {
+            "eligible-vllm": {
+                "model_type": "LLM",
+                "model_engine": "vLLM",
+                "model_ability": ["chat", "tools"],
+                "model_name": "DeepSeek-V4-Flash-0731",
+                "model_format": "pytorch",
+                "context_length": 131072,
+            },
+            "embedding": {
+                "model_type": "embedding",
+                "model_engine": "vLLM",
+                "model_ability": ["chat"],
+                "model_name": "DeepSeek-V4-Flash-0731",
+            },
+            "completion-only": {
+                "model_type": "LLM",
+                "model_engine": "vLLM",
+                "model_ability": ["generate"],
+                "model_name": "DeepSeek-V4-Flash-0731",
+            },
+            "nested-router": {
+                "model_type": "LLM",
+                "model_engine": "token_router",
+                "model_ability": ["chat"],
+                "model_name": "DeepSeek-V4-Flash-0731",
+            },
+            "unsupported-engine": {
+                "model_type": "LLM",
+                "model_engine": "SGLang",
+                "model_ability": ["chat"],
+                "model_name": "DeepSeek-V4-Flash-0731",
+            },
+            "asset-mismatch": {
+                "model_type": "LLM",
+                "model_engine": "vLLM",
+                "model_ability": ["chat"],
+                "model_name": "Another-Model",
+            },
+        }
+
+    supervisor.list_models = MethodType(list_models, supervisor)
+    app = create_app(supervisor)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/v1/token_routers/backend-candidates")
+
+    assert response.status_code == 200
+    candidates = {item["model_uid"]: item for item in response.json()["items"]}
+    assert candidates["eligible-vllm"]["eligible"] is True
+    assert candidates["eligible-vllm"]["compatibility_status"] == "Verified"
+    assert candidates["embedding"]["eligible"] is False
+    assert "model_type must be LLM" in candidates["embedding"]["ineligible_reasons"]
+    assert candidates["completion-only"]["eligible"] is False
+    assert candidates["nested-router"]["compatibility_status"] == "Unsupported"
+    assert candidates["unsupported-engine"]["eligible"] is False
+    assert candidates["asset-mismatch"]["eligible"] is True
+
+
+@pytest.mark.asyncio
+async def test_v2_validation_checks_tools_and_thinking_capabilities(tmp_path) -> None:
+    supervisor = make_supervisor(tmp_path)
+    original_list_models = supervisor.list_models
+
+    async def list_models(_self):
+        models = await original_list_models()
+        models["tools-model"]["model_ability"] = ["chat"]
+        models["reasoning-model"]["model_ability"] = ["chat"]
+        return models
+
+    supervisor.list_models = MethodType(list_models, supervisor)
+    app = create_app(supervisor)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        assert (
+            await client.post("/v1/token_routers", json=typed_router_payload())
+        ).status_code == 201
+        validation = await client.post("/v1/token_routers/router-a/validate")
+
+    assert validation.status_code == 200
+    result = validation.json()
+    assert result["valid"] is False
+    assert any("requires tools" in error for error in result["errors"])
+    assert any("requires thinking" in error for error in result["errors"])

--- a/xinference/api/tests/test_token_router_audit.py
+++ b/xinference/api/tests/test_token_router_audit.py
@@ -1,4 +1,11 @@
+from types import MethodType
+
+import httpx
+import pytest
+from fastapi import FastAPI, Response
+
 from xinference.api.oauth2.advanced.audit import classify_endpoint, should_skip_audit
+from xinference.api.restful_api import RESTfulAPI
 
 
 def test_internal_token_router_endpoints_skip_audit():
@@ -13,3 +20,40 @@ def test_token_router_management_endpoints_are_admin_audited():
     endpoint = "/v1/token_routers/router-1/enable"
     assert should_skip_audit(endpoint) is False
     assert classify_endpoint(endpoint) == "admin"
+
+
+@pytest.mark.asyncio
+async def test_token_router_management_request_records_final_audit_status():
+    api = RESTfulAPI.__new__(RESTfulAPI)
+    api._advanced_auth_service = object()
+    recorded = []
+
+    def record_admin_audit(self, request, status, latency_s=0.0):
+        recorded.append((request.url.path, status, latency_s))
+
+    api._record_admin_audit = MethodType(record_admin_audit, api)
+    app = FastAPI()
+    app.middleware("http")(api._audit_middleware)
+
+    @app.post("/v1/token_routers/{router_uid}/enable")
+    async def enable_router(router_uid: str) -> Response:
+        return Response(status_code=409)
+
+    @app.post("/v1/internal/token-router/instances/register")
+    async def register_runtime() -> Response:
+        return Response(status_code=200)
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        management_response = await client.post("/v1/token_routers/router-1/enable")
+        internal_response = await client.post(
+            "/v1/internal/token-router/instances/register"
+        )
+
+    assert management_response.status_code == 409
+    assert internal_response.status_code == 200
+    assert len(recorded) == 1
+    endpoint, status, latency_s = recorded[0]
+    assert endpoint == "/v1/token_routers/router-1/enable"
+    assert status == "error"
+    assert latency_s >= 0

--- a/xinference/api/tests/test_token_router_audit.py
+++ b/xinference/api/tests/test_token_router_audit.py
@@ -1,0 +1,15 @@
+from xinference.api.oauth2.advanced.audit import classify_endpoint, should_skip_audit
+
+
+def test_internal_token_router_endpoints_skip_audit():
+    assert should_skip_audit("/v1/internal/token-router/instances/register") is True
+    assert (
+        should_skip_audit("/v1/internal/token-router/instances/router-1/config-ack")
+        is True
+    )
+
+
+def test_token_router_management_endpoints_are_admin_audited():
+    endpoint = "/v1/token_routers/router-1/enable"
+    assert should_skip_audit(endpoint) is False
+    assert classify_endpoint(endpoint) == "admin"

--- a/xinference/api/tests/test_token_router_dispatch.py
+++ b/xinference/api/tests/test_token_router_dispatch.py
@@ -353,7 +353,9 @@ async def test_virtual_chat_non_stream_preserves_router_error(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_virtual_chat_connect_error_returns_502_and_closes_client(monkeypatch):
+async def test_virtual_chat_connect_error_returns_502_without_closing_shared_client(
+    monkeypatch,
+):
     resolution = {
         "matched": True,
         "available": True,
@@ -387,7 +389,61 @@ async def test_virtual_chat_connect_error_returns_502_and_closes_client(monkeypa
     assert response.status_code == 502
     assert response.headers["retry-after"] == "1"
     assert response.json()["error"]["type"] == "router_unavailable"
-    assert upstream_client.is_closed
+    assert upstream_client.is_closed is False
+    await api._close_token_router_client()
+    assert upstream_client.is_closed is True
+
+
+@pytest.mark.asyncio
+async def test_virtual_chat_reuses_shared_proxy_client(monkeypatch):
+    resolution = {
+        "matched": True,
+        "available": True,
+        "virtual_model_uid": "virtual-model",
+        "router_uid": "router-a",
+        "instance_id": "instance-a",
+        "endpoint": "http://router:10081",
+    }
+    api = make_rest_api(FakeSupervisor(resolution))
+    app = make_chat_app(api)
+    real_async_client = httpx.AsyncClient
+    created_clients = []
+
+    class UpstreamStream(httpx.AsyncByteStream):
+        async def __aiter__(self):
+            yield b'{"id":"chatcmpl-router"}'
+
+    def upstream_handler(_request):
+        return httpx.Response(
+            200,
+            headers={"content-type": "application/json"},
+            stream=UpstreamStream(),
+        )
+
+    upstream_client = real_async_client(transport=httpx.MockTransport(upstream_handler))
+
+    def make_upstream_client(**_kwargs):
+        created_clients.append(upstream_client)
+        return upstream_client
+
+    monkeypatch.setattr(restful_api_module.httpx, "AsyncClient", make_upstream_client)
+    transport = httpx.ASGITransport(app=app)
+    async with real_async_client(transport=transport, base_url="http://test") as client:
+        for _ in range(2):
+            response = await client.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "virtual-model",
+                    "messages": [{"role": "user", "content": "hello"}],
+                    "stream": False,
+                },
+            )
+            assert response.status_code == 200
+
+    assert created_clients == [upstream_client]
+    assert upstream_client.is_closed is False
+    await api._close_token_router_client()
+    assert upstream_client.is_closed is True
 
 
 @pytest.mark.asyncio

--- a/xinference/api/tests/test_token_router_dispatch.py
+++ b/xinference/api/tests/test_token_router_dispatch.py
@@ -19,6 +19,20 @@ from xinference.core.router_registry import RouterRuntimeRegistry
 from xinference.core.supervisor import SupervisorActor
 
 
+@pytest.mark.asyncio
+async def test_restful_api_lifespan_closes_token_router_client():
+    api = RESTfulAPI.__new__(RESTfulAPI)
+    client = httpx.AsyncClient()
+    api._token_router_client = client
+    app = FastAPI(lifespan=api._lifespan)
+
+    async with app.router.lifespan_context(app):
+        assert client.is_closed is False
+
+    assert client.is_closed is True
+    assert api._token_router_client is None
+
+
 def make_supervisor(tmp_path):
     supervisor = SupervisorActor.__new__(SupervisorActor)
     supervisor._token_router_store = RouterConfigStore(str(tmp_path / "routers.db"))

--- a/xinference/api/tests/test_token_router_dispatch.py
+++ b/xinference/api/tests/test_token_router_dispatch.py
@@ -1,0 +1,502 @@
+import json
+from types import MethodType
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from xinference.api import restful_api as restful_api_module
+
+
+@pytest.fixture(autouse=True)
+def enable_token_router(monkeypatch):
+    monkeypatch.setattr(restful_api_module, "XINFERENCE_TOKEN_ROUTER_ENABLED", True)
+
+
+from xinference.api.restful_api import RESTfulAPI
+from xinference.core.router_config_store import RouterConfigStore
+from xinference.core.router_registry import RouterRuntimeRegistry
+from xinference.core.supervisor import SupervisorActor
+
+
+def make_supervisor(tmp_path):
+    supervisor = SupervisorActor.__new__(SupervisorActor)
+    supervisor._token_router_store = RouterConfigStore(str(tmp_path / "routers.db"))
+    supervisor._token_router_registry = RouterRuntimeRegistry()
+    supervisor._token_router_runtime_cursors = {}
+    return supervisor
+
+
+def create_enabled_router(supervisor):
+    config = supervisor._token_router_store.create(
+        "router-a",
+        {
+            "virtual_model_uid": "virtual-model",
+            "model_type": "LLM",
+        },
+    )
+    assert config["revision"] == 1
+    return supervisor._token_router_store.set_enabled("router-a", True)
+
+
+def register_ready_runtime(supervisor, instance_id, endpoint, revision):
+    return supervisor._token_router_registry.register(
+        "router-a",
+        instance_id,
+        {
+            "endpoint": endpoint,
+            "status": "ready",
+            "acked_revision": revision,
+            "config_error": "",
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_resolve_virtual_model_runtime_and_round_robin(tmp_path):
+    supervisor = make_supervisor(tmp_path)
+    assert await supervisor.resolve_token_router_runtime("physical-model") is None
+
+    disabled = supervisor._token_router_store.create(
+        "router-a", {"virtual_model_uid": "virtual-model"}
+    )
+    resolution = await supervisor.resolve_token_router_runtime("virtual-model")
+    assert resolution["matched"] is True
+    assert resolution["available"] is False
+    assert resolution["status"] == "disabled"
+
+    config = supervisor._token_router_store.set_enabled("router-a", True)
+    register_ready_runtime(
+        supervisor, "instance-a", "http://router-a:10081/", config["revision"]
+    )
+    register_ready_runtime(
+        supervisor, "instance-b", "http://router-b:10081", config["revision"]
+    )
+
+    first = await supervisor.resolve_token_router_runtime("virtual-model")
+    second = await supervisor.resolve_token_router_runtime("virtual-model")
+    third = await supervisor.resolve_token_router_runtime("virtual-model")
+    assert [first["instance_id"], second["instance_id"], third["instance_id"]] == [
+        "instance-a",
+        "instance-b",
+        "instance-a",
+    ]
+    assert first["endpoint"] == "http://router-a:10081"
+    assert disabled["revision"] < first["revision"]
+
+
+@pytest.mark.asyncio
+async def test_resolve_rejects_stale_error_and_invalid_runtime(tmp_path):
+    supervisor = make_supervisor(tmp_path)
+    config = create_enabled_router(supervisor)
+    revision = config["revision"]
+    supervisor._token_router_registry.register(
+        "router-a",
+        "stale",
+        {
+            "endpoint": "http://stale:10081",
+            "status": "ready",
+            "acked_revision": revision - 1,
+        },
+    )
+    supervisor._token_router_registry.register(
+        "router-a",
+        "error",
+        {
+            "endpoint": "http://error:10081",
+            "status": "ready",
+            "acked_revision": revision,
+            "config_error": "bad config",
+        },
+    )
+    supervisor._token_router_registry.register(
+        "router-a",
+        "invalid-endpoint",
+        {
+            "endpoint": "router:10081",
+            "status": "ready",
+            "acked_revision": revision,
+        },
+    )
+
+    resolution = await supervisor.resolve_token_router_runtime("virtual-model")
+    assert resolution["matched"] is True
+    assert resolution["available"] is False
+
+
+@pytest.mark.asyncio
+async def test_resolve_rejects_offline_and_non_ready_runtime(tmp_path, monkeypatch):
+    now = [100.0]
+    monkeypatch.setattr("xinference.core.router_registry.time.time", lambda: now[0])
+    supervisor = make_supervisor(tmp_path)
+    supervisor._token_router_registry = RouterRuntimeRegistry(
+        heartbeat_timeout_seconds=10
+    )
+    config = create_enabled_router(supervisor)
+    supervisor._token_router_registry.register(
+        "router-a",
+        "starting",
+        {
+            "endpoint": "http://starting:10081",
+            "status": "starting",
+            "acked_revision": config["revision"],
+        },
+    )
+    resolution = await supervisor.resolve_token_router_runtime("virtual-model")
+    assert resolution["available"] is False
+
+    supervisor._token_router_registry.heartbeat("starting", {"status": "ready"})
+    now[0] = 111.0
+    resolution = await supervisor.resolve_token_router_runtime("virtual-model")
+    assert resolution["available"] is False
+    assert resolution["status"] == "offline"
+
+
+@pytest.mark.asyncio
+async def test_list_virtual_models_only_exposes_enabled_sanitized_models(tmp_path):
+    supervisor = make_supervisor(tmp_path)
+    supervisor._token_router_store.create(
+        "disabled-router", {"virtual_model_uid": "disabled-model"}
+    )
+    config = create_enabled_router(supervisor)
+    register_ready_runtime(
+        supervisor, "instance-a", "http://secret-router:10081", config["revision"]
+    )
+
+    models = await supervisor.list_virtual_models()
+    assert list(models) == ["virtual-model"]
+    assert models["virtual-model"] == {
+        "model_name": "virtual-model",
+        "model_type": "LLM",
+        "model_engine": "token_router",
+        "router_uid": "router-a",
+        "router_status": "ready",
+    }
+    assert "endpoint" not in json.dumps(models)
+
+
+class FakeSupervisor:
+    def __init__(self, resolution, *, physical_models=None, virtual_models=None):
+        self.resolution = resolution
+        self.physical_models = physical_models or {}
+        self.virtual_models = virtual_models or {}
+        self.resolved_model_uids = []
+
+    async def resolve_token_router_runtime(self, model_uid):
+        self.resolved_model_uids.append(model_uid)
+        return self.resolution
+
+    async def list_models(self):
+        return dict(self.physical_models)
+
+    async def list_virtual_models(self):
+        return dict(self.virtual_models)
+
+
+class FakeAuthService:
+    def __init__(self):
+        self.checked = []
+
+    def validate_model_access(self, token, model_uid, model_type):
+        self.checked.append((token, model_uid, model_type))
+        return True
+
+
+def make_rest_api(supervisor, auth_service=None):
+    api = RESTfulAPI.__new__(RESTfulAPI)
+    api._advanced_auth_service = auth_service
+    api._uid_to_model_name = {}
+
+    async def get_supervisor_ref(_self):
+        return supervisor
+
+    api._get_supervisor_ref = MethodType(get_supervisor_ref, api)
+    return api
+
+
+def make_chat_app(api):
+    app = FastAPI()
+    app.add_api_route(
+        "/v1/chat/completions", api.create_chat_completion, methods=["POST"]
+    )
+    return app
+
+
+@pytest.mark.asyncio
+async def test_virtual_chat_stream_is_proxied_with_auth_headers_and_done(monkeypatch):
+    resolution = {
+        "matched": True,
+        "available": True,
+        "virtual_model_uid": "virtual-model",
+        "router_uid": "router-a",
+        "instance_id": "instance-a",
+        "endpoint": "http://router:10081",
+    }
+    supervisor = FakeSupervisor(resolution)
+    auth_service = FakeAuthService()
+    api = make_rest_api(supervisor, auth_service)
+    app = make_chat_app(api)
+    real_async_client = httpx.AsyncClient
+    captured = {}
+
+    class UpstreamStream(httpx.AsyncByteStream):
+        async def __aiter__(self):
+            yield b'data: {"choices": []}\n\n'
+            yield b"data: [DONE]\n\n"
+
+        async def aclose(self):
+            captured["stream_closed"] = True
+
+    def upstream_handler(request):
+        captured["url"] = str(request.url)
+        captured["authorization"] = request.headers.get("authorization")
+        captured["traceparent"] = request.headers.get("traceparent")
+        captured["payload"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            headers={
+                "content-type": "text/event-stream",
+                "x-router-pool": "short",
+                "transfer-encoding": "chunked",
+            },
+            stream=UpstreamStream(),
+        )
+
+    upstream_client = real_async_client(transport=httpx.MockTransport(upstream_handler))
+    monkeypatch.setattr(
+        restful_api_module.httpx, "AsyncClient", lambda **_: upstream_client
+    )
+
+    transport = httpx.ASGITransport(app=app)
+    async with real_async_client(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/v1/chat/completions",
+            headers={
+                "Authorization": "Bearer virtual-key",
+                "traceparent": "00-test-trace",
+                "x-request-id": "request-a",
+            },
+            json={
+                "model": "virtual-model",
+                "messages": [{"role": "user", "content": "hello"}],
+                "stream": True,
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.headers["x-router-pool"] == "short"
+    assert response.headers["x-accel-buffering"] == "no"
+    assert "transfer-encoding" not in response.headers
+    assert response.content.endswith(b"data: [DONE]\n\n")
+    assert captured == {
+        "url": "http://router:10081/v1/chat/completions",
+        "authorization": "Bearer virtual-key",
+        "traceparent": "00-test-trace",
+        "payload": {
+            "model": "virtual-model",
+            "messages": [{"role": "user", "content": "hello"}],
+            "stream": True,
+        },
+        "stream_closed": True,
+    }
+    assert auth_service.checked == [("virtual-key", "virtual-model", "LLM")]
+
+
+@pytest.mark.asyncio
+async def test_virtual_chat_non_stream_preserves_router_error(monkeypatch):
+    resolution = {
+        "matched": True,
+        "available": True,
+        "virtual_model_uid": "virtual-model",
+        "router_uid": "router-a",
+        "instance_id": "instance-a",
+        "endpoint": "http://router:10081",
+    }
+    api = make_rest_api(FakeSupervisor(resolution))
+    app = make_chat_app(api)
+    real_async_client = httpx.AsyncClient
+
+    class ErrorStream(httpx.AsyncByteStream):
+        async def __aiter__(self):
+            yield b'{"error":{"type":"rate_limit_error"}}'
+
+    def upstream_handler(request):
+        return httpx.Response(
+            429,
+            headers={
+                "content-type": "application/json",
+                "retry-after": "5",
+                "connection": "close",
+            },
+            stream=ErrorStream(),
+        )
+
+    upstream_client = real_async_client(transport=httpx.MockTransport(upstream_handler))
+    monkeypatch.setattr(
+        restful_api_module.httpx, "AsyncClient", lambda **_: upstream_client
+    )
+    transport = httpx.ASGITransport(app=app)
+    async with real_async_client(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "virtual-model",
+                "messages": [{"role": "user", "content": "hello"}],
+                "stream": False,
+            },
+        )
+
+    assert response.status_code == 429
+    assert response.headers["retry-after"] == "5"
+    assert "connection" not in response.headers
+    assert response.json()["error"]["type"] == "rate_limit_error"
+
+
+@pytest.mark.asyncio
+async def test_virtual_chat_connect_error_returns_502_and_closes_client(monkeypatch):
+    resolution = {
+        "matched": True,
+        "available": True,
+        "virtual_model_uid": "virtual-model",
+        "router_uid": "router-a",
+        "instance_id": "instance-a",
+        "endpoint": "http://router:10081",
+    }
+    api = make_rest_api(FakeSupervisor(resolution))
+    app = make_chat_app(api)
+    real_async_client = httpx.AsyncClient
+
+    def upstream_handler(request):
+        raise httpx.ConnectError("router unavailable", request=request)
+
+    upstream_client = real_async_client(transport=httpx.MockTransport(upstream_handler))
+    monkeypatch.setattr(
+        restful_api_module.httpx, "AsyncClient", lambda **_: upstream_client
+    )
+    transport = httpx.ASGITransport(app=app)
+    async with real_async_client(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "virtual-model",
+                "messages": [{"role": "user", "content": "hello"}],
+                "stream": True,
+            },
+        )
+
+    assert response.status_code == 502
+    assert response.headers["retry-after"] == "1"
+    assert response.json()["error"]["type"] == "router_unavailable"
+    assert upstream_client.is_closed
+
+
+@pytest.mark.asyncio
+async def test_virtual_chat_unavailable_returns_503_without_proxy(monkeypatch):
+    supervisor = FakeSupervisor(
+        {
+            "matched": True,
+            "available": False,
+            "virtual_model_uid": "virtual-model",
+            "router_uid": "router-a",
+            "status": "offline",
+        }
+    )
+    api = make_rest_api(supervisor)
+    app = make_chat_app(api)
+
+    def fail_client(**kwargs):
+        raise AssertionError("proxy client must not be created")
+
+    real_async_client = httpx.AsyncClient
+    monkeypatch.setattr(restful_api_module.httpx, "AsyncClient", fail_client)
+    transport = httpx.ASGITransport(app=app)
+    async with real_async_client(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "virtual-model",
+                "messages": [{"role": "user", "content": "hello"}],
+                "stream": False,
+            },
+        )
+
+    assert response.status_code == 503
+    assert response.headers["retry-after"] == "1"
+    assert response.json()["error"]["type"] == "router_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_physical_chat_keeps_existing_path(monkeypatch):
+    supervisor = FakeSupervisor(None)
+    api = make_rest_api(supervisor)
+    app = make_chat_app(api)
+
+    class FakeModel:
+        uid = "physical-model"
+
+        async def chat(self, messages, kwargs, raw_params=None):
+            return json.dumps(
+                {
+                    "id": "chatcmpl-physical",
+                    "object": "chat.completion",
+                    "choices": [],
+                }
+            )
+
+        async def is_vllm_backend(self):
+            return False
+
+    async def fake_require_model(*args, **kwargs):
+        return FakeModel()
+
+    async def describe_model(model_uid):
+        return {"model_family": "test-family"}
+
+    supervisor.describe_model = describe_model
+    monkeypatch.setattr(restful_api_module, "require_model", fake_require_model)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "physical-model",
+                "messages": [{"role": "user", "content": "hello"}],
+                "stream": False,
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.json()["id"] == "chatcmpl-physical"
+    assert supervisor.resolved_model_uids == ["physical-model"]
+
+
+@pytest.mark.asyncio
+async def test_list_models_merges_sanitized_virtual_model(monkeypatch):
+    supervisor = FakeSupervisor(
+        None,
+        physical_models={
+            "physical-model": {"model_name": "physical", "model_type": "LLM"}
+        },
+        virtual_models={
+            "virtual-model": {
+                "model_name": "virtual-model",
+                "model_type": "LLM",
+                "model_engine": "token_router",
+                "router_uid": "router-a",
+                "router_status": "ready",
+            }
+        },
+    )
+    api = make_rest_api(supervisor)
+    monkeypatch.setattr(
+        "xinference.api.oauth2.advanced.audit.update_model_cache",
+        lambda *args, **kwargs: None,
+    )
+
+    response = await api.list_models()
+    payload = json.loads(response.body)
+    by_id = {item["id"]: item for item in payload["data"]}
+    assert set(by_id) == {"physical-model", "virtual-model"}
+    assert by_id["virtual-model"]["model_engine"] == "token_router"
+    assert by_id["virtual-model"]["router_status"] == "ready"
+    assert "endpoint" not in by_id["virtual-model"]

--- a/xinference/api/tests/test_token_router_dispatch.py
+++ b/xinference/api/tests/test_token_router_dispatch.py
@@ -3,7 +3,7 @@ from types import MethodType
 
 import httpx
 import pytest
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 
 from xinference.api import restful_api as restful_api_module
 
@@ -303,6 +303,134 @@ async def test_virtual_chat_stream_is_proxied_with_auth_headers_and_done(monkeyp
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "thinking_fields",
+    [
+        {"enable_thinking": True, "extra_body": {"enable_thinking": False}},
+        {"extra_body": {"enable_thinking": True}},
+    ],
+)
+async def test_virtual_chat_normalizes_router_estimation_fields(
+    monkeypatch, thinking_fields
+):
+    resolution = {
+        "matched": True,
+        "available": True,
+        "virtual_model_uid": "virtual-model",
+        "router_uid": "router-a",
+        "instance_id": "instance-a",
+        "endpoint": "http://router:10081",
+    }
+    api = make_rest_api(FakeSupervisor(resolution))
+    app = make_chat_app(api)
+    real_async_client = httpx.AsyncClient
+    captured = {}
+
+    class UpstreamStream(httpx.AsyncByteStream):
+        async def __aiter__(self):
+            yield b'{"id":"chatcmpl-router"}'
+
+    def upstream_handler(request):
+        captured["payload"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            headers={"content-type": "application/json"},
+            stream=UpstreamStream(),
+        )
+
+    upstream_client = real_async_client(transport=httpx.MockTransport(upstream_handler))
+    monkeypatch.setattr(
+        restful_api_module.httpx, "AsyncClient", lambda **_: upstream_client
+    )
+    transport = httpx.ASGITransport(app=app)
+    try:
+        async with real_async_client(
+            transport=transport, base_url="http://test"
+        ) as client:
+            response = await client.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "virtual-model",
+                    "messages": [{"role": "user", "content": "hello"}],
+                    "stream": False,
+                    "max_tokens": 8,
+                    "max_completion_tokens": 16,
+                    **thinking_fields,
+                },
+            )
+    finally:
+        await api._close_token_router_client()
+
+    assert response.status_code == 200
+    assert captured["payload"]["chat_template_kwargs"] == {
+        "enable_thinking": True,
+        "thinking": True,
+    }
+    assert captured["payload"]["max_tokens"] == 16
+
+
+@pytest.mark.asyncio
+async def test_stream_proxy_background_closes_uniterated_response_once():
+    api = make_rest_api(FakeSupervisor(None))
+    close_calls = 0
+
+    class UpstreamStream(httpx.AsyncByteStream):
+        async def __aiter__(self):
+            yield b"data: [DONE]\n\n"
+
+        async def aclose(self):
+            nonlocal close_calls
+            close_calls += 1
+
+    upstream_request = httpx.Request("POST", "http://router:10081/v1/chat/completions")
+    upstream_response = httpx.Response(
+        200,
+        headers={"content-type": "text/event-stream"},
+        stream=UpstreamStream(),
+        request=upstream_request,
+    )
+
+    class FakeClient:
+        def build_request(self, *args, **kwargs):
+            return upstream_request
+
+        async def send(self, request, *, stream):
+            assert stream is True
+            return upstream_response
+
+    api._get_token_router_client = lambda: FakeClient()
+    request = Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/v1/chat/completions",
+            "headers": [],
+            "query_string": b"",
+            "scheme": "http",
+            "server": ("test", 80),
+            "client": ("127.0.0.1", 1234),
+        }
+    )
+
+    response = await api._proxy_token_router_chat_completion(
+        request,
+        {"stream": True},
+        {
+            "endpoint": "http://router:10081",
+            "virtual_model_uid": "virtual-model",
+            "router_uid": "router-a",
+            "instance_id": "instance-a",
+        },
+    )
+
+    assert close_calls == 0
+    assert response.background is not None
+    await response.background()
+    await response.background()
+    assert close_calls == 1
+
+
+@pytest.mark.asyncio
 async def test_virtual_chat_non_stream_preserves_router_error(monkeypatch):
     resolution = {
         "matched": True,
@@ -556,3 +684,40 @@ async def test_list_models_merges_sanitized_virtual_model(monkeypatch):
     assert by_id["virtual-model"]["model_engine"] == "token_router"
     assert by_id["virtual-model"]["router_status"] == "ready"
     assert "endpoint" not in by_id["virtual-model"]
+
+
+@pytest.mark.asyncio
+async def test_list_models_hides_persisted_virtual_models_when_router_disabled(
+    monkeypatch,
+):
+    monkeypatch.setattr(restful_api_module, "XINFERENCE_TOKEN_ROUTER_ENABLED", False)
+    supervisor = FakeSupervisor(
+        None,
+        physical_models={
+            "physical-model": {"model_name": "physical", "model_type": "LLM"}
+        },
+        virtual_models={
+            "virtual-model": {
+                "model_name": "virtual-model",
+                "model_type": "LLM",
+                "model_engine": "token_router",
+            }
+        },
+    )
+
+    async def fail_list_virtual_models():
+        raise AssertionError(
+            "virtual models must not be loaded when Router is disabled"
+        )
+
+    supervisor.list_virtual_models = fail_list_virtual_models
+    api = make_rest_api(supervisor)
+    monkeypatch.setattr(
+        "xinference.api.oauth2.advanced.audit.update_model_cache",
+        lambda *args, **kwargs: None,
+    )
+
+    response = await api.list_models()
+    payload = json.loads(response.body)
+
+    assert [item["id"] for item in payload["data"]] == ["physical-model"]

--- a/xinference/constants.py
+++ b/xinference/constants.py
@@ -227,6 +227,18 @@ XINFERENCE_MONITOR_CONFIG_DB_PATH = os.environ.get(
     os.path.join(XINFERENCE_HOME, "monitor_config.db"),
 )
 
+XINFERENCE_TOKEN_ROUTER_ENABLED = os.environ.get(
+    "XINFERENCE_TOKEN_ROUTER_ENABLED", "false"
+).lower() in {"1", "true", "yes", "on"}
+
+XINFERENCE_TOKEN_ROUTER_DB_PATH = os.environ.get(
+    "XINFERENCE_TOKEN_ROUTER_DB_PATH",
+    os.path.join(XINFERENCE_HOME, "token_routers.db"),
+)
+XINFERENCE_TOKEN_ROUTER_HEARTBEAT_TIMEOUT_SECONDS = float(
+    os.environ.get("XINFERENCE_TOKEN_ROUTER_HEARTBEAT_TIMEOUT_SECONDS", "90")
+)
+
 # Whether to allow models to run their own bundled code (transformers /
 # sentence-transformers / FlagEmbedding / engine `trust_remote_code`). Off by
 # default; set XINFERENCE_TRUST_REMOTE_CODE=1 to allow it.

--- a/xinference/core/router_config_store.py
+++ b/xinference/core/router_config_store.py
@@ -1,0 +1,225 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+"""Persistent Token Router configuration store."""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import threading
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+
+class RouterConfigStore:
+    """SQLite-backed store with monotonic per-router configuration revisions."""
+
+    def __init__(self, db_path: str) -> None:
+        self._db_path = db_path
+        self._lock = threading.RLock()
+        parent = os.path.dirname(db_path)
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        self._init_db()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self._db_path, timeout=30)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def _init_db(self) -> None:
+        with self._connect() as conn:
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute(
+                """CREATE TABLE IF NOT EXISTS token_router_configs (
+                    router_uid TEXT PRIMARY KEY,
+                    config_json TEXT NOT NULL,
+                    enabled INTEGER NOT NULL DEFAULT 0,
+                    revision INTEGER NOT NULL DEFAULT 1,
+                    created_by TEXT NOT NULL DEFAULT '',
+                    updated_by TEXT NOT NULL DEFAULT '',
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL
+                )"""
+            )
+
+    @staticmethod
+    def _now() -> str:
+        return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+    @staticmethod
+    def _row_to_dict(row: sqlite3.Row) -> Dict[str, Any]:
+        config = json.loads(row["config_json"])
+        config.update(
+            {
+                "router_uid": row["router_uid"],
+                "enabled": bool(row["enabled"]),
+                "revision": row["revision"],
+                "created_by": row["created_by"],
+                "updated_by": row["updated_by"],
+                "created_at": row["created_at"],
+                "updated_at": row["updated_at"],
+            }
+        )
+        return config
+
+    def list(self) -> List[Dict[str, Any]]:
+        with self._connect() as conn:
+            rows = conn.execute(
+                "SELECT * FROM token_router_configs ORDER BY updated_at DESC"
+            ).fetchall()
+        return [self._row_to_dict(row) for row in rows]
+
+    def get(self, router_uid: str) -> Optional[Dict[str, Any]]:
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT * FROM token_router_configs WHERE router_uid = ?",
+                (router_uid,),
+            ).fetchone()
+        return self._row_to_dict(row) if row is not None else None
+
+    def get_by_virtual_model_uid(
+        self, virtual_model_uid: str
+    ) -> Optional[Dict[str, Any]]:
+        """Return the Router config that owns an exact Virtual Model UID."""
+        for config in self.list():
+            if config.get("virtual_model_uid") == virtual_model_uid:
+                return config
+        return None
+
+    def create(
+        self, router_uid: str, config: Dict[str, Any], username: str = ""
+    ) -> Dict[str, Any]:
+        payload = self._sanitize(config)
+        existing = self.get(router_uid)
+        if existing is not None:
+            existing_payload = self._sanitize(existing)
+            if existing_payload == payload:
+                return existing
+            raise ValueError(f"Token Router already exists: {router_uid}")
+        now = self._now()
+        with self._lock:
+            try:
+                with self._connect() as conn:
+                    conn.execute(
+                        """INSERT INTO token_router_configs
+                           (router_uid, config_json, enabled, revision,
+                            created_by, updated_by, created_at, updated_at)
+                           VALUES (?, ?, 0, 1, ?, ?, ?, ?)""",
+                        (
+                            router_uid,
+                            json.dumps(payload, ensure_ascii=False),
+                            username,
+                            username,
+                            now,
+                            now,
+                        ),
+                    )
+            except sqlite3.IntegrityError as exc:
+                raise ValueError(f"Token Router already exists: {router_uid}") from exc
+        result = self.get(router_uid)
+        assert result is not None
+        return result
+
+    @staticmethod
+    def _sanitize(config: Dict[str, Any]) -> Dict[str, Any]:
+        payload = dict(config)
+        for key in (
+            "router_uid",
+            "enabled",
+            "revision",
+            "created_by",
+            "updated_by",
+            "created_at",
+            "updated_at",
+            "status",
+            "runtime_instances",
+            "online_instances",
+        ):
+            payload.pop(key, None)
+        return payload
+
+    def update(
+        self,
+        router_uid: str,
+        config: Dict[str, Any],
+        username: str = "",
+        expected_revision: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        current = self.get(router_uid)
+        if current is None:
+            raise KeyError(router_uid)
+        if expected_revision is not None and current["revision"] != expected_revision:
+            raise RuntimeError(
+                f"Token Router revision conflict: expected {expected_revision}, "
+                f"current {current['revision']}"
+            )
+        payload = self._sanitize(config)
+        now = self._now()
+        with self._lock, self._connect() as conn:
+            if expected_revision is None:
+                cursor = conn.execute(
+                    """UPDATE token_router_configs
+                       SET config_json = ?, revision = revision + 1,
+                           updated_by = ?, updated_at = ?
+                       WHERE router_uid = ?""",
+                    (
+                        json.dumps(payload, ensure_ascii=False),
+                        username,
+                        now,
+                        router_uid,
+                    ),
+                )
+            else:
+                cursor = conn.execute(
+                    """UPDATE token_router_configs
+                       SET config_json = ?, revision = revision + 1,
+                           updated_by = ?, updated_at = ?
+                       WHERE router_uid = ? AND revision = ?""",
+                    (
+                        json.dumps(payload, ensure_ascii=False),
+                        username,
+                        now,
+                        router_uid,
+                        expected_revision,
+                    ),
+                )
+            if cursor.rowcount == 0:
+                raise RuntimeError("Token Router revision conflict")
+        result = self.get(router_uid)
+        assert result is not None
+        return result
+
+    def set_enabled(
+        self, router_uid: str, enabled: bool, username: str = ""
+    ) -> Dict[str, Any]:
+        current = self.get(router_uid)
+        if current is None:
+            raise KeyError(router_uid)
+        if current["enabled"] == enabled:
+            return current
+        now = self._now()
+        with self._lock, self._connect() as conn:
+            conn.execute(
+                """UPDATE token_router_configs
+                   SET enabled = ?, revision = revision + 1,
+                       updated_by = ?, updated_at = ?
+                   WHERE router_uid = ?""",
+                (1 if enabled else 0, username, now, router_uid),
+            )
+        result = self.get(router_uid)
+        assert result is not None
+        return result
+
+    def delete(self, router_uid: str) -> bool:
+        with self._lock, self._connect() as conn:
+            cursor = conn.execute(
+                "DELETE FROM token_router_configs WHERE router_uid = ?", (router_uid,)
+            )
+            return cursor.rowcount > 0

--- a/xinference/core/router_registry.py
+++ b/xinference/core/router_registry.py
@@ -1,0 +1,94 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+"""In-memory registry for independent Token Router runtime instances."""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, Iterable, List, Optional
+
+
+class RouterRuntimeRegistry:
+    def __init__(self, heartbeat_timeout_seconds: float = 90.0) -> None:
+        self._heartbeat_timeout_seconds = heartbeat_timeout_seconds
+        self._instances: Dict[str, Dict[str, Any]] = {}
+
+    def register(
+        self, router_uid: str, instance_id: str, data: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        existing = self._instances.get(instance_id)
+        if existing is not None and existing["router_uid"] != router_uid:
+            raise ValueError(
+                f"Router instance {instance_id} is already registered to "
+                f"{existing['router_uid']}"
+            )
+        now = time.time()
+        instance = {
+            **data,
+            "router_uid": router_uid,
+            "instance_id": instance_id,
+            "registered_at": now,
+            "last_heartbeat": now,
+            "acked_revision": int(data.get("acked_revision", 0)),
+        }
+        self._instances[instance_id] = instance
+        return self._render(instance, now)
+
+    def heartbeat(self, instance_id: str, data: Dict[str, Any]) -> Dict[str, Any]:
+        instance = self._instances.get(instance_id)
+        if instance is None:
+            raise KeyError(instance_id)
+        now = time.time()
+        immutable = {"router_uid", "instance_id", "registered_at"}
+        instance.update({k: v for k, v in data.items() if k not in immutable})
+        instance["last_heartbeat"] = now
+        return self._render(instance, now)
+
+    def ack(self, instance_id: str, revision: int, error: str = "") -> Dict[str, Any]:
+        instance = self._instances.get(instance_id)
+        if instance is None:
+            raise KeyError(instance_id)
+        current_revision = int(instance.get("acked_revision", 0))
+        if revision < current_revision:
+            raise ValueError(
+                f"Stale Token Router ACK: revision {revision} is older than "
+                f"acked revision {current_revision}"
+            )
+        instance["acked_revision"] = revision
+        instance["config_error"] = error
+        instance["last_heartbeat"] = time.time()
+        return self._render(instance)
+
+    def unregister(self, instance_id: str) -> bool:
+        return self._instances.pop(instance_id, None) is not None
+
+    def get(self, instance_id: str) -> Optional[Dict[str, Any]]:
+        instance = self._instances.get(instance_id)
+        return self._render(instance) if instance is not None else None
+
+    def list(self, router_uid: Optional[str] = None) -> List[Dict[str, Any]]:
+        now = time.time()
+        values: Iterable[Dict[str, Any]] = self._instances.values()
+        if router_uid is not None:
+            values = (v for v in values if v["router_uid"] == router_uid)
+        return sorted(
+            (self._render(v, now) for v in values),
+            key=lambda item: item["instance_id"],
+        )
+
+    def remove_router(self, router_uid: str) -> None:
+        for instance_id in [
+            key
+            for key, value in self._instances.items()
+            if value["router_uid"] == router_uid
+        ]:
+            self._instances.pop(instance_id, None)
+
+    def _render(
+        self, instance: Dict[str, Any], now: Optional[float] = None
+    ) -> Dict[str, Any]:
+        now = time.time() if now is None else now
+        result = dict(instance)
+        age = max(0.0, now - float(instance["last_heartbeat"]))
+        result["heartbeat_age_seconds"] = age
+        result["online"] = age <= self._heartbeat_timeout_seconds
+        return result

--- a/xinference/core/supervisor.py
+++ b/xinference/core/supervisor.py
@@ -51,6 +51,8 @@ from ..constants import (
     XINFERENCE_LAUNCH_STRATEGY,
     XINFERENCE_LIST_MODELS_DEBOUNCE_SECONDS,
     XINFERENCE_LIST_MODELS_PER_WORKER_TIMEOUT,
+    XINFERENCE_TOKEN_ROUTER_DB_PATH,
+    XINFERENCE_TOKEN_ROUTER_HEARTBEAT_TIMEOUT_SECONDS,
 )
 from ..core.model import ModelActor
 from ..core.status_guard import InstanceInfo, LaunchStatus
@@ -262,6 +264,15 @@ class SupervisorActor(xo.StatelessActor):
         self._launch_history_store = LaunchHistoryStore(
             XINFERENCE_LAUNCH_HISTORY_DB_PATH
         )
+
+        from .router_config_store import RouterConfigStore
+        from .router_registry import RouterRuntimeRegistry
+
+        self._token_router_store = RouterConfigStore(XINFERENCE_TOKEN_ROUTER_DB_PATH)
+        self._token_router_registry = RouterRuntimeRegistry(
+            XINFERENCE_TOKEN_ROUTER_HEARTBEAT_TIMEOUT_SECONDS
+        )
+        self._token_router_runtime_cursors: Dict[str, int] = {}
 
     @classmethod
     def default_uid(cls) -> str:
@@ -4778,6 +4789,411 @@ class SupervisorActor(xo.StatelessActor):
                 ret = False
 
         return ret
+
+    async def list_token_routers(self) -> List[Dict[str, Any]]:
+        return [
+            self._with_token_router_status(item)
+            for item in self._token_router_store.list()
+        ]
+
+    async def get_token_router(self, router_uid: str) -> Optional[Dict[str, Any]]:
+        item = self._token_router_store.get(router_uid)
+        return self._with_token_router_status(item) if item is not None else None
+
+    async def list_virtual_models(self) -> Dict[str, Dict[str, Any]]:
+        """List enabled Token Routers as OpenAI-compatible virtual models."""
+        result: Dict[str, Dict[str, Any]] = {}
+        for config in self._token_router_store.list():
+            if not config.get("enabled"):
+                continue
+            virtual_model_uid = config.get("virtual_model_uid")
+            if not isinstance(virtual_model_uid, str) or not virtual_model_uid:
+                continue
+            item = self._with_token_router_status(config)
+            result[virtual_model_uid] = {
+                "model_name": virtual_model_uid,
+                "model_type": config.get("model_type", "LLM"),
+                "model_engine": "token_router",
+                "router_uid": config["router_uid"],
+                "router_status": item["status"],
+            }
+        return result
+
+    async def resolve_token_router_runtime(
+        self, virtual_model_uid: str
+    ) -> Optional[Dict[str, Any]]:
+        """Resolve a Virtual Model UID to a ready Token Router runtime.
+
+        ``None`` means the UID is not owned by a Token Router. A matched but
+        unavailable Router returns ``available=False`` so the REST layer can
+        fail closed instead of falling through to physical-model lookup.
+        """
+        config = self._token_router_store.get_by_virtual_model_uid(virtual_model_uid)
+        if config is None:
+            return None
+
+        status = self._with_token_router_status(config)["status"]
+        ready_instances = [
+            instance
+            for instance in self._token_router_registry.list(config["router_uid"])
+            if instance.get("online")
+            and instance.get("status") == "ready"
+            and not instance.get("config_error")
+            and int(instance.get("acked_revision", 0)) >= int(config["revision"])
+            and isinstance(instance.get("endpoint"), str)
+            and instance["endpoint"].startswith(("http://", "https://"))
+        ]
+        base = {
+            "matched": True,
+            "available": False,
+            "router_uid": config["router_uid"],
+            "virtual_model_uid": virtual_model_uid,
+            "status": status,
+            "revision": config["revision"],
+        }
+        if not config.get("enabled") or not ready_instances:
+            return base
+
+        cursors = getattr(self, "_token_router_runtime_cursors", None)
+        if cursors is None:
+            cursors = self._token_router_runtime_cursors = {}
+        cursor = cursors.get(config["router_uid"], 0)
+        instance = ready_instances[cursor % len(ready_instances)]
+        cursors[config["router_uid"]] = (cursor + 1) % len(ready_instances)
+        return {
+            **base,
+            "available": True,
+            "status": "ready",
+            "endpoint": instance["endpoint"].rstrip("/"),
+            "instance_id": instance["instance_id"],
+            "acked_revision": instance.get("acked_revision", 0),
+        }
+
+    def _validate_token_router_uniqueness(
+        self, router_uid: str, config: Dict[str, Any]
+    ) -> None:
+        virtual_model_uid = config.get("virtual_model_uid")
+        for current in self._token_router_store.list():
+            if current["router_uid"] == router_uid:
+                continue
+            if current.get("virtual_model_uid") == virtual_model_uid:
+                raise ValueError(
+                    f"Virtual model UID is already used by Token Router "
+                    f"{current['router_uid']}: {virtual_model_uid}"
+                )
+
+    async def create_token_router(
+        self, router_uid: str, config: Dict[str, Any], username: str = ""
+    ) -> Dict[str, Any]:
+        self._validate_token_router_uniqueness(router_uid, config)
+        return self._with_token_router_status(
+            self._token_router_store.create(router_uid, config, username)
+        )
+
+    async def update_token_router(
+        self, router_uid: str, config: Dict[str, Any], username: str = ""
+    ) -> Dict[str, Any]:
+        payload = dict(config)
+        self._validate_token_router_uniqueness(router_uid, payload)
+        expected_revision = payload.pop("revision", None)
+        return self._with_token_router_status(
+            self._token_router_store.update(
+                router_uid,
+                payload,
+                username,
+                expected_revision=expected_revision,
+            )
+        )
+
+    async def delete_token_router(self, router_uid: str) -> bool:
+        current = self._token_router_store.get(router_uid)
+        if current is not None and current["enabled"]:
+            raise ValueError("Disable the Token Router before deleting it")
+        deleted = self._token_router_store.delete(router_uid)
+        if deleted:
+            self._token_router_registry.remove_router(router_uid)
+        return deleted
+
+    async def set_token_router_enabled(
+        self, router_uid: str, enabled: bool, username: str = ""
+    ) -> Dict[str, Any]:
+        return self._with_token_router_status(
+            self._token_router_store.set_enabled(router_uid, enabled, username)
+        )
+
+    @staticmethod
+    def _token_router_backend_entries(
+        config: Dict[str, Any],
+    ) -> List[tuple[str, Dict[str, Any]]]:
+        backends = config.get("backends", {})
+        if int(config.get("config_version", 1)) == 2:
+            if not isinstance(backends, list):
+                return []
+            return [
+                (str(backend.get("id") or ""), backend)
+                for backend in backends
+                if isinstance(backend, dict)
+            ]
+        if not isinstance(backends, dict):
+            return []
+        return [
+            (name, backend)
+            for name in ("short", "long")
+            if isinstance((backend := backends.get(name)), dict)
+        ]
+
+    @staticmethod
+    def _token_router_engine_compatibility(
+        model_info: Dict[str, Any],
+    ) -> Dict[str, str]:
+        engine = str(model_info.get("model_engine") or "").strip()
+        normalized = engine.casefold()
+        if normalized == "token_router":
+            return {
+                "status": "Unsupported",
+                "reason": "Token Router virtual models cannot be nested",
+            }
+        if "sglang" in normalized:
+            return {
+                "status": "Unsupported",
+                "reason": "SGLang is not validated for this Token Router profile",
+            }
+        if "vllm" in normalized:
+            return {
+                "status": "Verified",
+                "reason": "vLLM is the verified production engine",
+            }
+        if not normalized:
+            return {
+                "status": "Unknown",
+                "reason": "The running model does not report model_engine",
+            }
+        return {
+            "status": "Unknown",
+            "reason": f"Engine {engine} has not been validated for this Router",
+        }
+
+    async def list_token_router_backend_candidates(self) -> Dict[str, Any]:
+        running_models = await self.list_models()
+        items: List[Dict[str, Any]] = []
+        for model_uid, model_info in running_models.items():
+            if not isinstance(model_info, dict):
+                continue
+            reasons: List[str] = []
+            abilities = {
+                str(value).casefold()
+                for value in model_info.get("model_ability", []) or []
+            }
+            compatibility = self._token_router_engine_compatibility(model_info)
+            if model_info.get("model_type") != "LLM":
+                reasons.append("model_type must be LLM")
+            if "chat" not in abilities:
+                reasons.append("model_ability must include chat")
+            if compatibility["status"] in {"Unsupported", "Unknown"}:
+                reasons.append(compatibility["reason"])
+            items.append(
+                {
+                    "model_uid": model_uid,
+                    "model_name": model_info.get("model_name", ""),
+                    "model_type": model_info.get("model_type"),
+                    "model_engine": model_info.get("model_engine", ""),
+                    "model_format": model_info.get("model_format", ""),
+                    "model_ability": model_info.get("model_ability", []),
+                    "context_length": model_info.get("context_length"),
+                    "compatibility_status": compatibility["status"],
+                    "compatibility_reason": compatibility["reason"],
+                    "eligible": not reasons,
+                    "ineligible_reasons": reasons,
+                }
+            )
+        items.sort(key=lambda item: (not item["eligible"], item["model_uid"]))
+        return {"items": items, "errors": []}
+
+    async def validate_token_router(self, router_uid: str) -> Optional[Dict[str, Any]]:
+        config = self._token_router_store.get(router_uid)
+        if config is None:
+            return None
+        errors: List[str] = []
+        warnings: List[str] = []
+        running_models = await self.list_models()
+        backend_models: Dict[str, Dict[str, Any]] = {}
+        for backend_id, backend in self._token_router_backend_entries(config):
+            model_uid = str(backend.get("model_uid") or "")
+            model_info = running_models.get(model_uid)
+            if model_info is None:
+                errors.append(f"{backend_id} backend model is not running: {model_uid}")
+                continue
+            backend_models[backend_id] = model_info
+            if model_info.get("model_type") != "LLM":
+                errors.append(f"{backend_id} backend model must be an LLM: {model_uid}")
+            abilities = {
+                str(value).casefold()
+                for value in model_info.get("model_ability", []) or []
+            }
+            if "chat" not in abilities:
+                errors.append(
+                    f"{backend_id} backend model must support chat: {model_uid}"
+                )
+            compatibility = self._token_router_engine_compatibility(model_info)
+            if compatibility["status"] in {"Unsupported", "Unknown"}:
+                errors.append(
+                    f"{backend_id} backend engine is {compatibility['status']}: {compatibility['reason']}"
+                )
+            configured_context = backend.get("max_context_tokens")
+            actual_context = model_info.get("context_length")
+            if (
+                isinstance(configured_context, int)
+                and isinstance(actual_context, int)
+                and configured_context > actual_context
+            ):
+                errors.append(
+                    f"{backend_id} max_context_tokens {configured_context} exceeds backend context_length {actual_context}: {model_uid}"
+                )
+        if int(config.get("config_version", 1)) == 2:
+            routing = config.get("routing", {})
+            for rule in routing.get("rules", []) if isinstance(routing, dict) else []:
+                action = rule.get("action", {})
+                if action.get("type") != "route":
+                    continue
+                backend_id = str(action.get("backend_id") or "")
+                model_info = backend_models.get(backend_id)
+                if model_info is None:
+                    continue
+                abilities = {
+                    str(value).casefold()
+                    for value in model_info.get("model_ability", []) or []
+                }
+                match = rule.get("match", {})
+                if match.get("tools_present") is True and "tools" not in abilities:
+                    errors.append(
+                        f"Rule {rule.get('id')} requires tools but backend {backend_id} does not report tools capability"
+                    )
+                if match.get("thinking") is True and not (
+                    {"reasoning", "hybrid"} & abilities
+                ):
+                    errors.append(
+                        f"Rule {rule.get('id')} requires thinking but backend {backend_id} does not report reasoning or hybrid capability"
+                    )
+        return {
+            "router_uid": router_uid,
+            "valid": not errors,
+            "errors": errors,
+            "warnings": warnings,
+            "revision": config["revision"],
+        }
+
+    def _with_token_router_status(self, config: Dict[str, Any]) -> Dict[str, Any]:
+        item = dict(config)
+        instances = self._token_router_registry.list(config["router_uid"])
+        online = [instance for instance in instances if instance["online"]]
+        if not config["enabled"]:
+            status = "disabled"
+        elif not online:
+            status = "offline"
+        elif any(instance.get("config_error") for instance in online):
+            status = "error"
+        elif any(
+            instance.get("acked_revision", 0) < config["revision"]
+            for instance in online
+        ):
+            status = "syncing"
+        elif any(instance.get("status") not in (None, "ready") for instance in online):
+            status = "degraded"
+        else:
+            status = "ready"
+        item["status"] = status
+        item["runtime_instances"] = len(instances)
+        item["online_instances"] = len(online)
+        return item
+
+    async def get_token_router_status(
+        self, router_uid: str
+    ) -> Optional[Dict[str, Any]]:
+        config = self._token_router_store.get(router_uid)
+        if config is None:
+            return None
+        item = self._with_token_router_status(config)
+        return {
+            "router_uid": router_uid,
+            "enabled": item["enabled"],
+            "status": item["status"],
+            "revision": item["revision"],
+            "runtime_instances": item["runtime_instances"],
+            "online_instances": item["online_instances"],
+        }
+
+    async def list_token_router_instances(
+        self, router_uid: str
+    ) -> List[Dict[str, Any]]:
+        return self._token_router_registry.list(router_uid)
+
+    async def get_token_router_metrics(
+        self, router_uid: str
+    ) -> Optional[Dict[str, Any]]:
+        if self._token_router_store.get(router_uid) is None:
+            return None
+        instances = self._token_router_registry.list(router_uid)
+        return {
+            "router_uid": router_uid,
+            "instances": [
+                {
+                    "instance_id": item["instance_id"],
+                    "online": item["online"],
+                    "metrics": item.get("metrics", {}),
+                    "backend_health": item.get("backend_health", {}),
+                    "process": item.get("process", {}),
+                }
+                for item in instances
+            ],
+        }
+
+    async def register_token_router_instance(
+        self, router_uid: str, instance_id: str, data: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        config = self._token_router_store.get(router_uid)
+        if config is None:
+            raise KeyError(router_uid)
+        acked_revision = int(data.get("acked_revision", 0))
+        if acked_revision > config["revision"]:
+            raise ValueError(
+                f"Router instance ACK revision {acked_revision} exceeds current "
+                f"configuration revision {config['revision']}"
+            )
+        return self._token_router_registry.register(router_uid, instance_id, data)
+
+    async def heartbeat_token_router_instance(
+        self, instance_id: str, data: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        return self._token_router_registry.heartbeat(instance_id, data)
+
+    async def unregister_token_router_instance(self, instance_id: str) -> bool:
+        return self._token_router_registry.unregister(instance_id)
+
+    async def get_token_router_config_after(
+        self, router_uid: str, after_revision: int
+    ) -> Optional[Dict[str, Any]]:
+        config = self._token_router_store.get(router_uid)
+        if config is None:
+            raise KeyError(router_uid)
+        return config if config["revision"] > after_revision else None
+
+    async def ack_token_router_config(
+        self, instance_id: str, router_uid: str, revision: int, error: str = ""
+    ) -> Dict[str, Any]:
+        instance = self._token_router_registry.get(instance_id)
+        if instance is None:
+            raise KeyError(instance_id)
+        if instance["router_uid"] != router_uid:
+            raise ValueError("Router instance does not belong to router_uid")
+        config = self._token_router_store.get(router_uid)
+        if config is None:
+            raise KeyError(router_uid)
+        if revision > config["revision"]:
+            raise ValueError(
+                f"Router ACK revision {revision} exceeds current configuration "
+                f"revision {config['revision']}"
+            )
+        return self._token_router_registry.ack(instance_id, revision, error)
 
     async def get_workers_info(self) -> List[Dict[str, Any]]:
         ret = []

--- a/xinference/core/tests/test_router_config_store.py
+++ b/xinference/core/tests/test_router_config_store.py
@@ -1,0 +1,39 @@
+from xinference.core.router_config_store import RouterConfigStore
+
+
+def test_router_config_crud_and_revision(tmp_path):
+    store = RouterConfigStore(str(tmp_path / "routers.db"))
+    created = store.create("router-a", {"virtual_model_uid": "model-a"}, "admin")
+    assert created["revision"] == 1
+    assert created["enabled"] is False
+
+    updated = store.update(
+        "router-a", {"virtual_model_uid": "model-a", "strategy": "token_budget"}
+    )
+    assert updated["revision"] == 2
+    enabled = store.set_enabled("router-a", True)
+    assert enabled["revision"] == 3
+    assert enabled["enabled"] is True
+    assert store.list()[0]["router_uid"] == "router-a"
+    assert store.delete("router-a") is True
+    assert store.get("router-a") is None
+
+
+def test_router_config_rejects_duplicate(tmp_path):
+    store = RouterConfigStore(str(tmp_path / "routers.db"))
+    store.create("router-a", {"virtual_model_uid": "model-a"})
+    try:
+        store.create("router-a", {"virtual_model_uid": "model-b"})
+    except ValueError as exc:
+        assert "already exists" in str(exc)
+    else:
+        raise AssertionError("duplicate router was accepted")
+
+
+def test_router_config_lookup_by_exact_virtual_model_uid(tmp_path):
+    store = RouterConfigStore(str(tmp_path / "routers.db"))
+    store.create("router-a", {"virtual_model_uid": "virtual-model"})
+
+    assert store.get_by_virtual_model_uid("virtual-model")["router_uid"] == "router-a"
+    assert store.get_by_virtual_model_uid("virtual") is None
+    assert store.get_by_virtual_model_uid("virtual-model-suffix") is None

--- a/xinference/core/tests/test_router_registry.py
+++ b/xinference/core/tests/test_router_registry.py
@@ -1,0 +1,40 @@
+from xinference.core.router_registry import RouterRuntimeRegistry
+
+
+def test_runtime_registry_lifecycle(monkeypatch):
+    now = [100.0]
+    monkeypatch.setattr("xinference.core.router_registry.time.time", lambda: now[0])
+    registry = RouterRuntimeRegistry(heartbeat_timeout_seconds=10)
+    registered = registry.register("router-a", "instance-a", {"endpoint": "x"})
+    assert registered["online"] is True
+    now[0] = 111.0
+    assert registry.get("instance-a")["online"] is False
+    heartbeat = registry.heartbeat("instance-a", {"status": "ready"})
+    assert heartbeat["online"] is True
+    acked = registry.ack("instance-a", 3)
+    assert acked["acked_revision"] == 3
+    assert registry.unregister("instance-a") is True
+
+
+def test_runtime_registry_rejects_cross_router_instance_reuse():
+    registry = RouterRuntimeRegistry()
+    registry.register("router-a", "instance-a", {"acked_revision": 2})
+
+    try:
+        registry.register("router-b", "instance-a", {"acked_revision": 0})
+    except ValueError as exc:
+        assert "already registered" in str(exc)
+    else:
+        raise AssertionError("cross-router instance reuse was accepted")
+
+
+def test_runtime_registry_rejects_stale_ack():
+    registry = RouterRuntimeRegistry()
+    registry.register("router-a", "instance-a", {"acked_revision": 2})
+
+    try:
+        registry.ack("instance-a", 1)
+    except ValueError as exc:
+        assert "Stale Token Router ACK" in str(exc)
+    else:
+        raise AssertionError("stale ACK was accepted")

--- a/xinference/deploy/router.py
+++ b/xinference/deploy/router.py
@@ -1,0 +1,8 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+"""Entry point for the independent Xinference Token Router process."""
+
+from __future__ import annotations
+
+from ..router.service import main
+
+__all__ = ["main"]

--- a/xinference/router/__init__.py
+++ b/xinference/router/__init__.py
@@ -1,0 +1,3 @@
+"""Independent token-aware router for DeepSeek-V4 on Xinference."""
+
+__version__ = "0.1.0"

--- a/xinference/router/admission.py
+++ b/xinference/router/admission.py
@@ -55,7 +55,7 @@ class CapacityGate:
                     timeout=self.queue_timeout_seconds,
                 )
                 self._active += 1
-            except TimeoutError as exc:
+            except asyncio.TimeoutError as exc:
                 raise AdmissionRejected(
                     self.pool, "queue_timeout", self.retry_after_seconds
                 ) from exc

--- a/xinference/router/admission.py
+++ b/xinference/router/admission.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+
+
+class AdmissionRejected(RuntimeError):
+    def __init__(self, pool: str, reason: str, retry_after_seconds: int) -> None:
+        super().__init__(f"{pool} pool rejected request: {reason}")
+        self.pool = pool
+        self.reason = reason
+        self.retry_after_seconds = retry_after_seconds
+
+
+@dataclass(frozen=True)
+class GateSnapshot:
+    active: int
+    waiting: int
+    max_active: int
+    max_queue: int
+
+
+class CapacityGate:
+    def __init__(
+        self,
+        pool: str,
+        *,
+        max_active: int,
+        max_queue: int,
+        queue_timeout_seconds: float,
+        retry_after_seconds: int,
+    ) -> None:
+        self.pool = pool
+        self.max_active = max_active
+        self.max_queue = max_queue
+        self.queue_timeout_seconds = queue_timeout_seconds
+        self.retry_after_seconds = retry_after_seconds
+        self._active = 0
+        self._waiting = 0
+        self._condition = asyncio.Condition()
+
+    async def acquire(self) -> None:
+        async with self._condition:
+            if self._active < self.max_active:
+                self._active += 1
+                return
+            if self._waiting >= self.max_queue:
+                raise AdmissionRejected(
+                    self.pool, "queue_full", self.retry_after_seconds
+                )
+            self._waiting += 1
+            try:
+                await asyncio.wait_for(
+                    self._condition.wait_for(lambda: self._active < self.max_active),
+                    timeout=self.queue_timeout_seconds,
+                )
+                self._active += 1
+            except TimeoutError as exc:
+                raise AdmissionRejected(
+                    self.pool, "queue_timeout", self.retry_after_seconds
+                ) from exc
+            finally:
+                self._waiting -= 1
+
+    async def release(self) -> None:
+        async with self._condition:
+            if self._active <= 0:
+                raise RuntimeError(f"CapacityGate {self.pool} released without acquire")
+            self._active -= 1
+            self._condition.notify(1)
+
+    async def snapshot(self) -> GateSnapshot:
+        async with self._condition:
+            return GateSnapshot(
+                active=self._active,
+                waiting=self._waiting,
+                max_active=self.max_active,
+                max_queue=self.max_queue,
+            )

--- a/xinference/router/app.py
+++ b/xinference/router/app.py
@@ -1,0 +1,439 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+"""OpenAI-compatible data plane for the Xinference Token-aware Router."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hmac
+import logging
+import time
+import uuid
+from contextlib import asynccontextmanager
+from typing import AsyncIterator
+
+import httpx
+import uvicorn
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse, Response, StreamingResponse
+
+from .admission import AdmissionRejected
+from .backend import request_headers, response_headers
+from .classifier import (
+    ContextLimitExceeded,
+    RouteDecision,
+    RouteRejected,
+    ThinkingRejected,
+)
+from .config import RouterConfig, load_config
+from .metrics import RouterMetrics
+from .runtime import RouterDisabled, RouterRuntime, RuntimeSnapshot
+from .tokenization import TokenizationWorkerUnavailable
+from .tokenizer import TokenizationError
+
+logger = logging.getLogger("xinference.router")
+
+
+def _error(
+    status: int,
+    message: str,
+    error_type: str,
+    *,
+    headers: dict[str, str] | None = None,
+) -> JSONResponse:
+    return JSONResponse(
+        status_code=status,
+        headers=headers,
+        content={"error": {"message": message, "type": error_type, "code": status}},
+    )
+
+
+def _authorized(request: Request, config: RouterConfig) -> bool:
+    if not config.require_auth:
+        return True
+    value = request.headers.get("authorization", "")
+    prefix = "Bearer "
+    if not value.startswith(prefix):
+        return False
+    return hmac.compare_digest(value[len(prefix) :], config.backend_api_key)
+
+
+def _router_headers(decision: RouteDecision, request_id: str) -> dict[str, str]:
+    return {
+        "x-request-id": request_id,
+        "x-xinference-router-pool": decision.backend_id,
+        "x-xinference-router-backend": decision.backend_id,
+        "x-xinference-router-rule": decision.rule_id,
+        "x-xinference-router-reason": decision.reason,
+        "x-xinference-router-prompt-tokens": str(decision.budget.prompt_tokens),
+        "x-xinference-router-total-budget": str(decision.budget.total_tokens),
+    }
+
+
+def create_app(config: RouterConfig) -> FastAPI:
+    metrics = RouterMetrics()
+    runtime = RouterRuntime(config, metrics)
+
+    @asynccontextmanager
+    async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+        control_plane = getattr(app.state, "control_plane", None)
+        control_stop = asyncio.Event()
+        control_task = None
+        try:
+            await runtime.start()
+            if control_plane is not None:
+                # ACK only after the initial runtime snapshot is fully usable.
+                await control_plane.ack(runtime.current.config.revision)
+                control_task = asyncio.create_task(
+                    control_plane.run(runtime, control_stop),
+                    name="token-router-control-plane",
+                )
+            current = runtime.current.config
+            logger.info(
+                "Router started: router_uid=%s logical_model=%s backend=%s "
+                "route_profile=%s backends=%s revision=%d enabled=%s",
+                current.router_uid,
+                current.logical_model,
+                current.backend_url,
+                current.route_profile,
+                ",".join(backend.id for backend in current.backends),
+                current.revision,
+                current.enabled,
+            )
+            yield
+        finally:
+            control_stop.set()
+            try:
+                if control_task is not None:
+                    await control_task
+            finally:
+                try:
+                    if control_plane is not None:
+                        await control_plane.unregister()
+                finally:
+                    await runtime.aclose()
+
+    app = FastAPI(
+        title="Xinference Token-aware Router",
+        version="0.4.0",
+        lifespan=lifespan,
+    )
+
+    def sync_state(snapshot: RuntimeSnapshot) -> None:
+        # Keep these aliases for diagnostics and compatibility with the
+        # standalone prototype tests. Request handling always uses runtime.
+        app.state.config = snapshot.config
+        app.state.tokenization = snapshot.tokenization
+        app.state.policy = snapshot.policy
+        app.state.gates = snapshot.gates
+        app.state.client = snapshot.client
+
+    runtime.set_on_swap(sync_state)
+    app.state.runtime = runtime
+    app.state.metrics = metrics
+
+    @app.get("/healthz")
+    async def healthz() -> JSONResponse:
+        snapshot = runtime.current
+        summary = await runtime.summary()
+        status = "ok" if snapshot.config.enabled else "disabled"
+        return JSONResponse(
+            {
+                "status": status,
+                "router_uid": snapshot.config.router_uid,
+                "logical_model": snapshot.config.logical_model,
+                "backend_url": snapshot.config.backend_url,
+                **summary,
+            },
+            status_code=200,
+        )
+
+    @app.get("/readyz")
+    async def readyz() -> JSONResponse:
+        snapshot = runtime.current
+        if not snapshot.config.enabled:
+            return JSONResponse({"status": "disabled"}, status_code=503)
+        return JSONResponse(
+            {
+                "status": "ready",
+                "revision": snapshot.config.revision,
+                "router_uid": snapshot.config.router_uid,
+            }
+        )
+
+    @app.get("/metrics")
+    async def prometheus_metrics() -> Response:
+        return Response(await metrics.render(), media_type="text/plain; version=0.0.4")
+
+    @app.get("/v1/models")
+    async def models(request: Request) -> JSONResponse:
+        current = runtime.current.config
+        if not _authorized(request, current):
+            return _error(
+                401, "Invalid authentication credentials", "authentication_error"
+            )
+        return JSONResponse(
+            {
+                "object": "list",
+                "data": [
+                    {
+                        "id": current.logical_model,
+                        "object": "model",
+                        "owned_by": "xinference-token-router",
+                    }
+                ],
+            }
+        )
+
+    @app.post("/v1/chat/completions")
+    async def chat_completions(request: Request) -> Response:
+        started = time.monotonic()
+        request_id = request.headers.get("x-request-id") or f"router-{uuid.uuid4()}"
+        try:
+            snapshot = await runtime.acquire()
+        except RouterDisabled:
+            await metrics.increment("router_disabled", "none")
+            return _error(
+                503,
+                "Token Router is disabled and is not accepting new requests",
+                "router_disabled",
+                headers={"retry-after": "1", "x-request-id": request_id},
+            )
+
+        runtime_release_owned = True
+        config = snapshot.config
+
+        try:
+            if not _authorized(request, config):
+                await metrics.increment("auth_rejected", "none")
+                return _error(
+                    401, "Invalid authentication credentials", "authentication_error"
+                )
+
+            try:
+                body = await request.body()
+                payload = await request.json()
+            except Exception:
+                await metrics.increment("invalid_json", "none")
+                return _error(
+                    400, "Request body must be valid JSON", "invalid_request_error"
+                )
+            if not isinstance(payload, dict):
+                return _error(
+                    400, "Request body must be a JSON object", "invalid_request_error"
+                )
+
+            accepted_models = {config.logical_model, *config.model_aliases}
+            if payload.get("model") not in accepted_models:
+                await metrics.increment("unknown_model", "none")
+                return _error(404, "Unknown logical model", "model_not_found")
+            try:
+                budget = await snapshot.tokenization.estimate(
+                    payload, input_bytes=len(body)
+                )
+                decision = snapshot.policy.classify(
+                    budget,
+                    tools_present=bool(payload.get("tools")),
+                    stream=bool(payload.get("stream", False)),
+                )
+            except AdmissionRejected as exc:
+                await metrics.increment(f"tokenization_admission_{exc.reason}", "none")
+                return _error(
+                    429,
+                    "Router tokenization capacity is busy; retry later",
+                    "rate_limit_error",
+                    headers={
+                        "retry-after": str(exc.retry_after_seconds),
+                        "x-request-id": request_id,
+                    },
+                )
+            except TokenizationWorkerUnavailable:
+                await metrics.increment("tokenization_worker_unavailable", "none")
+                logger.exception(
+                    "request_id=%s tokenization worker unavailable", request_id
+                )
+                return _error(
+                    503,
+                    "Tokenization worker is unavailable; retry later",
+                    "tokenization_worker_unavailable",
+                    headers={"retry-after": "1", "x-request-id": request_id},
+                )
+            except ThinkingRejected as exc:
+                await metrics.increment("thinking_rejected", "none")
+                return _error(400, str(exc), "thinking_not_allowed")
+            except ContextLimitExceeded as exc:
+                await metrics.increment("context_limit_exceeded", "none")
+                return _error(400, str(exc), "context_length_exceeded")
+            except RouteRejected as exc:
+                await metrics.increment(exc.reason, "none")
+                return _error(400, str(exc), exc.reason)
+            except TokenizationError as exc:
+                await metrics.increment("tokenization_failed", "none")
+                return _error(400, str(exc), "invalid_request_error")
+
+            gate = snapshot.gates[decision.pool]
+            try:
+                await gate.acquire()
+            except AdmissionRejected as exc:
+                await metrics.increment(f"admission_{exc.reason}", decision.pool)
+                return _error(
+                    429,
+                    f"{decision.backend_id} backend is busy; retry later",
+                    "rate_limit_error",
+                    headers={
+                        "retry-after": str(exc.retry_after_seconds),
+                        **_router_headers(decision, request_id),
+                    },
+                )
+
+            gate_release_owned = True
+            backend_payload = dict(payload)
+            backend_payload["model"] = config.backend(decision.backend_id).model_uid
+            backend_url = f"{config.backend_url}/v1/chat/completions"
+            headers = request_headers(
+                request.headers.raw,
+                backend_api_key=config.backend_api_key,
+                request_id=request_id,
+            )
+            router_headers = _router_headers(decision, request_id)
+            stream = bool(payload.get("stream", False))
+            try:
+                if stream:
+                    backend_request = snapshot.client.build_request(
+                        "POST", backend_url, headers=headers, json=backend_payload
+                    )
+                    backend_response = await snapshot.client.send(
+                        backend_request, stream=True
+                    )
+                    if backend_response.status_code >= 400:
+                        try:
+                            response_body = await backend_response.aread()
+                        finally:
+                            await backend_response.aclose()
+                        await metrics.increment("backend_http_error", decision.pool)
+                        return Response(
+                            response_body,
+                            status_code=backend_response.status_code,
+                            headers={
+                                **response_headers(backend_response),
+                                **router_headers,
+                            },
+                        )
+
+                    async def body_stream() -> AsyncIterator[bytes]:
+                        disconnected = False
+                        try:
+                            async for chunk in backend_response.aiter_raw():
+                                if await request.is_disconnected():
+                                    disconnected = True
+                                    await metrics.increment(
+                                        "client_disconnected", decision.pool
+                                    )
+                                    break
+                                yield chunk
+                            if not disconnected:
+                                await metrics.increment("completed", decision.pool)
+                        except asyncio.CancelledError:
+                            await metrics.increment("cancelled", decision.pool)
+                            raise
+                        except Exception:
+                            await metrics.increment("stream_error", decision.pool)
+                            logger.exception(
+                                "request_id=%s backend stream failed", request_id
+                            )
+                            raise
+                        finally:
+                            await backend_response.aclose()
+                            await gate.release()
+                            await runtime.release(snapshot)
+                            logger.info(
+                                "request_id=%s backend_id=%s elapsed_seconds=%.3f released=true",
+                                request_id,
+                                decision.pool,
+                                time.monotonic() - started,
+                            )
+
+                    response = StreamingResponse(
+                        body_stream(),
+                        status_code=backend_response.status_code,
+                        media_type=backend_response.headers.get(
+                            "content-type", "text/event-stream"
+                        ),
+                        headers={
+                            **response_headers(backend_response),
+                            **router_headers,
+                        },
+                    )
+                    gate_release_owned = False
+                    runtime_release_owned = False
+                    return response
+
+                backend_response = await snapshot.client.post(
+                    backend_url, headers=headers, json=backend_payload
+                )
+                await metrics.increment(
+                    (
+                        "completed"
+                        if backend_response.status_code < 400
+                        else "backend_http_error"
+                    ),
+                    decision.pool,
+                )
+                return Response(
+                    backend_response.content,
+                    status_code=backend_response.status_code,
+                    headers={**response_headers(backend_response), **router_headers},
+                )
+            except httpx.TimeoutException:
+                await metrics.increment("backend_timeout", decision.pool)
+                return _error(
+                    504,
+                    f"{decision.pool} backend timed out",
+                    "backend_timeout",
+                    headers=router_headers,
+                )
+            except httpx.HTTPError:
+                await metrics.increment("backend_unavailable", decision.pool)
+                logger.exception("request_id=%s backend unavailable", request_id)
+                return _error(
+                    503,
+                    f"{decision.pool} backend unavailable",
+                    "backend_unavailable",
+                    headers=router_headers,
+                )
+            finally:
+                if gate_release_owned:
+                    await gate.release()
+                    logger.info(
+                        "request_id=%s backend_id=%s elapsed_seconds=%.3f released=true",
+                        request_id,
+                        decision.pool,
+                        time.monotonic() - started,
+                    )
+        finally:
+            if runtime_release_owned:
+                await runtime.release(snapshot)
+
+    return app
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Xinference Token-aware Router")
+    parser.add_argument("--config", default=None)
+    args = parser.parse_args()
+    config = load_config(args.config)
+    logging.basicConfig(
+        level=getattr(logging, config.log_level.upper(), logging.INFO),
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    uvicorn.run(
+        create_app(config),
+        host=config.listen_host,
+        port=config.listen_port,
+        log_level=config.log_level.lower(),
+        proxy_headers=True,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/xinference/router/app.py
+++ b/xinference/router/app.py
@@ -16,6 +16,7 @@ import httpx
 import uvicorn
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse, Response, StreamingResponse
+from starlette.background import BackgroundTask
 
 from .admission import AdmissionRejected
 from .backend import request_headers, response_headers
@@ -320,6 +321,31 @@ def create_app(config: RouterConfig) -> FastAPI:
                             },
                         )
 
+                    cleanup_task: asyncio.Task[None] | None = None
+
+                    async def release_resources() -> None:
+                        nonlocal cleanup_task
+
+                        async def _release() -> None:
+                            try:
+                                await backend_response.aclose()
+                            finally:
+                                try:
+                                    await gate.release()
+                                finally:
+                                    await runtime.release(snapshot)
+                                    logger.info(
+                                        "request_id=%s backend_id=%s "
+                                        "elapsed_seconds=%.3f released=true",
+                                        request_id,
+                                        decision.pool,
+                                        time.monotonic() - started,
+                                    )
+
+                        if cleanup_task is None:
+                            cleanup_task = asyncio.create_task(_release())
+                        await asyncio.shield(cleanup_task)
+
                     async def body_stream() -> AsyncIterator[bytes]:
                         disconnected = False
                         try:
@@ -343,15 +369,7 @@ def create_app(config: RouterConfig) -> FastAPI:
                             )
                             raise
                         finally:
-                            await backend_response.aclose()
-                            await gate.release()
-                            await runtime.release(snapshot)
-                            logger.info(
-                                "request_id=%s backend_id=%s elapsed_seconds=%.3f released=true",
-                                request_id,
-                                decision.pool,
-                                time.monotonic() - started,
-                            )
+                            await release_resources()
 
                     response = StreamingResponse(
                         body_stream(),
@@ -363,6 +381,7 @@ def create_app(config: RouterConfig) -> FastAPI:
                             **response_headers(backend_response),
                             **router_headers,
                         },
+                        background=BackgroundTask(release_resources),
                     )
                     gate_release_owned = False
                     runtime_release_owned = False

--- a/xinference/router/backend.py
+++ b/xinference/router/backend.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from typing import Iterable
+
+import httpx
+
+FORWARDED_REQUEST_HEADERS = {
+    "accept",
+    "content-type",
+    "user-agent",
+    "x-request-id",
+    "authorization",
+}
+FORWARDED_RESPONSE_HEADERS = {
+    "cache-control",
+    "content-type",
+    "x-request-id",
+}
+
+
+def request_headers(
+    incoming: Iterable[tuple[bytes, bytes]], *, backend_api_key: str, request_id: str
+) -> dict[str, str]:
+    headers: dict[str, str] = {}
+    for key_bytes, value_bytes in incoming:
+        key = key_bytes.decode("latin-1").lower()
+        if key in FORWARDED_REQUEST_HEADERS:
+            headers[key] = value_bytes.decode("latin-1")
+    if backend_api_key:
+        headers["authorization"] = f"Bearer {backend_api_key}"
+    headers["content-type"] = "application/json"
+    headers["x-request-id"] = request_id
+    return headers
+
+
+def response_headers(response: httpx.Response) -> dict[str, str]:
+    headers = {
+        key: value
+        for key, value in response.headers.items()
+        if key.lower() in FORWARDED_RESPONSE_HEADERS
+    }
+    headers.pop("content-length", None)
+    return headers

--- a/xinference/router/classifier.py
+++ b/xinference/router/classifier.py
@@ -133,6 +133,8 @@ class RoutingPolicy:
         long_max_model_len: int | None = None,
         thinking_pool: str | None = None,
     ) -> None:
+        backend_values: tuple[BackendConfig, ...]
+        rule_values: tuple[RoutingRule, ...]
         if backends is None:
             if None in (
                 short_threshold_tokens,
@@ -143,9 +145,13 @@ class RoutingPolicy:
                 raise TypeError(
                     "backends/rules or all legacy routing arguments are required"
                 )
+            assert short_threshold_tokens is not None
+            assert short_max_model_len is not None
+            assert long_max_model_len is not None
+            assert thinking_pool is not None
             backend_values = (
-                BackendConfig("short", "short", int(short_max_model_len), 1, 0, 0, 1),
-                BackendConfig("long", "long", int(long_max_model_len), 1, 0, 0, 1),
+                BackendConfig("short", "short", short_max_model_len, 1, 0, 0, 1),
+                BackendConfig("long", "long", long_max_model_len, 1, 0, 0, 1),
             )
             thinking_action = (
                 RouteAction(type="reject", reason="thinking_not_allowed")
@@ -159,13 +165,13 @@ class RoutingPolicy:
                 RoutingRule(
                     "short-threshold",
                     50,
-                    RuleMatch(total_tokens_lte=int(short_threshold_tokens)),
+                    RuleMatch(total_tokens_lte=short_threshold_tokens),
                     RouteAction(type="route", backend_id="short"),
                 ),
                 RoutingRule(
                     "long-threshold",
                     40,
-                    RuleMatch(total_tokens_gte=int(short_threshold_tokens) + 1),
+                    RuleMatch(total_tokens_gte=short_threshold_tokens + 1),
                     RouteAction(type="route", backend_id="long"),
                 ),
             )

--- a/xinference/router/classifier.py
+++ b/xinference/router/classifier.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Mapping
+
+from .config import BackendConfig, RouteAction, RoutingRule, RuleMatch
+from .tokenizer import TokenBudget
+
+
+class RouteRejected(ValueError):
+    def __init__(self, reason: str, message: str | None = None) -> None:
+        super().__init__(message or reason.replace("_", " "))
+        self.reason = reason
+
+
+class ThinkingRejected(RouteRejected):
+    """Raised when a Router policy rejects thinking-mode requests."""
+
+    def __init__(
+        self, message: str = "Thinking-mode requests are disabled by Router policy"
+    ) -> None:
+        super().__init__("thinking_not_allowed", message)
+
+
+class ContextLimitExceeded(RouteRejected):
+    def __init__(
+        self, total_tokens: int, max_model_len: int, backend_id: str = ""
+    ) -> None:
+        target = f" for backend {backend_id}" if backend_id else ""
+        super().__init__(
+            "context_length_exceeded",
+            f"Request token budget {total_tokens} exceeds context limit "
+            f"{max_model_len}{target}",
+        )
+        self.total_tokens = total_tokens
+        self.max_model_len = max_model_len
+        self.backend_id = backend_id
+
+
+@dataclass(frozen=True)
+class RequestProfile:
+    budget: TokenBudget
+    thinking: bool
+    tools_present: bool
+    stream: bool
+
+    @property
+    def prompt_tokens(self) -> int:
+        return self.budget.prompt_tokens
+
+    @property
+    def output_tokens(self) -> int:
+        return self.budget.output_tokens
+
+    @property
+    def reserve_tokens(self) -> int:
+        return self.budget.reserve_tokens
+
+    @property
+    def total_tokens(self) -> int:
+        return self.budget.total_tokens
+
+    @classmethod
+    def from_budget(
+        cls,
+        budget: TokenBudget,
+        *,
+        tools_present: bool = False,
+        stream: bool = False,
+    ) -> "RequestProfile":
+        return cls(
+            budget=budget,
+            thinking=budget.enable_thinking,
+            tools_present=tools_present,
+            stream=stream,
+        )
+
+
+@dataclass(frozen=True)
+class RouteDecision:
+    backend_id: str
+    rule_id: str
+    reason: str
+    profile: RequestProfile
+
+    @property
+    def pool(self) -> str:  # Compatibility header/metrics alias.
+        return self.backend_id
+
+    @property
+    def budget(self) -> TokenBudget:
+        return self.profile.budget
+
+
+def _matches(match: RuleMatch, profile: RequestProfile) -> bool:
+    if (
+        match.total_tokens_gte is not None
+        and profile.total_tokens < match.total_tokens_gte
+    ):
+        return False
+    if (
+        match.total_tokens_lte is not None
+        and profile.total_tokens > match.total_tokens_lte
+    ):
+        return False
+    if match.thinking is not None and profile.thinking is not match.thinking:
+        return False
+    if (
+        match.tools_present is not None
+        and profile.tools_present is not match.tools_present
+    ):
+        return False
+    if match.stream is not None and profile.stream is not match.stream:
+        return False
+    return True
+
+
+class RoutingPolicy:
+    """Deterministic first-match typed routing policy.
+
+    The legacy constructor arguments are retained for direct callers and tests; they
+    are normalized into the same ordered-rule representation used by V2 configs.
+    """
+
+    def __init__(
+        self,
+        *,
+        backends: Iterable[BackendConfig] | None = None,
+        rules: Iterable[RoutingRule] | None = None,
+        default_action: RouteAction | None = None,
+        short_threshold_tokens: int | None = None,
+        short_max_model_len: int | None = None,
+        long_max_model_len: int | None = None,
+        thinking_pool: str | None = None,
+    ) -> None:
+        if backends is None:
+            if None in (
+                short_threshold_tokens,
+                short_max_model_len,
+                long_max_model_len,
+                thinking_pool,
+            ):
+                raise TypeError(
+                    "backends/rules or all legacy routing arguments are required"
+                )
+            backend_values = (
+                BackendConfig("short", "short", int(short_max_model_len), 1, 0, 0, 1),
+                BackendConfig("long", "long", int(long_max_model_len), 1, 0, 0, 1),
+            )
+            thinking_action = (
+                RouteAction(type="reject", reason="thinking_not_allowed")
+                if thinking_pool == "reject"
+                else RouteAction(type="route", backend_id=str(thinking_pool))
+            )
+            rule_values = (
+                RoutingRule(
+                    "thinking-policy", 100, RuleMatch(thinking=True), thinking_action
+                ),
+                RoutingRule(
+                    "short-threshold",
+                    50,
+                    RuleMatch(total_tokens_lte=int(short_threshold_tokens)),
+                    RouteAction(type="route", backend_id="short"),
+                ),
+                RoutingRule(
+                    "long-threshold",
+                    40,
+                    RuleMatch(total_tokens_gte=int(short_threshold_tokens) + 1),
+                    RouteAction(type="route", backend_id="long"),
+                ),
+            )
+            default = RouteAction(type="reject", reason="context_length_exceeded")
+        else:
+            backend_values = tuple(backends)
+            rule_values = tuple(rules or ())
+            default = default_action or RouteAction(
+                type="reject", reason="no_matching_route"
+            )
+        self.backends: Mapping[str, BackendConfig] = {
+            backend.id: backend for backend in backend_values
+        }
+        self.rules = tuple(
+            sorted(rule_values, key=lambda item: item.priority, reverse=True)
+        )
+        self.default_action = default
+
+    def _execute(
+        self, action: RouteAction, profile: RequestProfile, rule_id: str, reason: str
+    ) -> RouteDecision:
+        if action.type == "reject":
+            if action.reason == "thinking_not_allowed":
+                raise ThinkingRejected()
+            if action.reason == "context_length_exceeded":
+                max_context = max(
+                    (backend.max_context_tokens for backend in self.backends.values()),
+                    default=0,
+                )
+                raise ContextLimitExceeded(profile.total_tokens, max_context)
+            raise RouteRejected(action.reason or "route_rejected")
+        backend = self.backends[action.backend_id]
+        if profile.total_tokens > backend.max_context_tokens:
+            raise ContextLimitExceeded(
+                profile.total_tokens, backend.max_context_tokens, backend.id
+            )
+        return RouteDecision(
+            backend_id=backend.id,
+            rule_id=rule_id,
+            reason=reason,
+            profile=profile,
+        )
+
+    def classify(
+        self,
+        value: TokenBudget | RequestProfile,
+        *,
+        tools_present: bool = False,
+        stream: bool = False,
+    ) -> RouteDecision:
+        profile = (
+            value
+            if isinstance(value, RequestProfile)
+            else RequestProfile.from_budget(
+                value, tools_present=tools_present, stream=stream
+            )
+        )
+        for rule in self.rules:
+            if _matches(rule.match, profile):
+                reason = (
+                    "thinking_policy"
+                    if rule.id == "thinking-policy"
+                    else (
+                        "within_short_threshold"
+                        if rule.id == "short-threshold"
+                        else (
+                            "exceeds_short_threshold"
+                            if rule.id == "long-threshold"
+                            else "rule_matched"
+                        )
+                    )
+                )
+                return self._execute(rule.action, profile, rule.id, reason)
+        return self._execute(self.default_action, profile, "default", "default_action")

--- a/xinference/router/config.py
+++ b/xinference/router/config.py
@@ -1,0 +1,539 @@
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+import yaml
+
+_ID_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$")
+
+
+class ConfigError(ValueError):
+    """Raised when Router configuration is invalid."""
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    normalized = value.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    raise ConfigError(f"{name} must be a boolean, got {value!r}")
+
+
+def _env_int(name: str, default: int) -> int:
+    value = os.getenv(name)
+    return default if value is None else int(value)
+
+
+def _env_float(name: str, default: float) -> float:
+    value = os.getenv(name)
+    return default if value is None else float(value)
+
+
+@dataclass(frozen=True)
+class BackendConfig:
+    id: str
+    model_uid: str
+    max_context_tokens: int
+    max_active: int
+    max_queue: int
+    queue_timeout_seconds: float
+    retry_after_seconds: int
+
+    @property
+    def name(self) -> str:  # V1 compatibility for metrics/tests.
+        return self.id
+
+
+PoolConfig = BackendConfig
+
+
+@dataclass(frozen=True)
+class RuleMatch:
+    total_tokens_gte: int | None = None
+    total_tokens_lte: int | None = None
+    thinking: bool | None = None
+    tools_present: bool | None = None
+    stream: bool | None = None
+
+
+@dataclass(frozen=True)
+class RouteAction:
+    type: str
+    backend_id: str = ""
+    reason: str = ""
+
+
+@dataclass(frozen=True)
+class RoutingRule:
+    id: str
+    priority: int
+    match: RuleMatch
+    action: RouteAction
+
+
+@dataclass(frozen=True)
+class TokenizationConfig:
+    max_workers: int
+    max_active: int
+    max_queue: int
+    queue_timeout_seconds: float
+    retry_after_seconds: int
+
+
+@dataclass(frozen=True)
+class RouterConfig:
+    listen_host: str
+    listen_port: int
+    backend_url: str
+    backend_api_key: str
+    require_auth: bool
+    logical_model: str
+    model_aliases: tuple[str, ...]
+    tokenizer_path: Path
+    context_reserve_tokens: int
+    default_output_tokens: int
+    request_timeout_seconds: float
+    connect_timeout_seconds: float
+    tokenization: TokenizationConfig
+    backends: tuple[BackendConfig, ...]
+    rules: tuple[RoutingRule, ...]
+    default_action: RouteAction
+    log_level: str
+    config_version: int = 2
+    route_profile: str = "llm_chat"
+    strategy: str = "typed_rules"
+    enabled: bool = True
+    revision: int = 0
+    router_uid: str = ""
+    tokenizer_asset_id: str = ""
+    tokenizer_asset_origin: str = ""
+    tokenizer_asset_revision: str = ""
+    tokenizer_asset_fingerprint: str = ""
+    legacy_short_threshold_tokens: int | None = None
+    legacy_thinking_pool: str = ""
+
+    def backend(self, backend_id: str) -> BackendConfig:
+        for backend in self.backends:
+            if backend.id == backend_id:
+                return backend
+        raise ConfigError(f"Unknown backend: {backend_id}")
+
+    def pool(self, name: str) -> BackendConfig:
+        return self.backend(name)
+
+    @property
+    def short_pool(self) -> BackendConfig:
+        return self.backend("short")
+
+    @property
+    def long_pool(self) -> BackendConfig:
+        return self.backend("long")
+
+    @property
+    def short_threshold_tokens(self) -> int:
+        if self.legacy_short_threshold_tokens is None:
+            raise ConfigError("short threshold is unavailable for V2 typed rules")
+        return self.legacy_short_threshold_tokens
+
+    @property
+    def short_max_model_len(self) -> int:
+        return self.short_pool.max_context_tokens
+
+    @property
+    def long_max_model_len(self) -> int:
+        return self.long_pool.max_context_tokens
+
+    @property
+    def thinking_pool(self) -> str:
+        return self.legacy_thinking_pool
+
+
+def _validate_action(action: RouteAction, backend_ids: set[str], where: str) -> None:
+    if action.type == "route":
+        if action.backend_id not in backend_ids:
+            raise ConfigError(
+                f"{where} references unknown backend {action.backend_id!r}"
+            )
+    elif action.type == "reject":
+        if not action.reason:
+            raise ConfigError(f"{where} reject action requires a reason")
+    else:
+        raise ConfigError(f"{where} action type must be route or reject")
+
+
+def _validate_config(cfg: RouterConfig) -> RouterConfig:
+    if not cfg.backend_url or not cfg.backend_url.startswith(("http://", "https://")):
+        raise ConfigError("backend URL must start with http:// or https://")
+    if not cfg.logical_model:
+        raise ConfigError("logical model UID is required")
+    if cfg.route_profile != "llm_chat":
+        raise ConfigError("route_profile must be llm_chat")
+    if not cfg.tokenizer_path.is_dir():
+        raise ConfigError(f"Tokenizer path does not exist: {cfg.tokenizer_path}")
+    if not 1 <= len(cfg.backends) <= 16:
+        raise ConfigError("Router requires 1 to 16 backends")
+    backend_ids = [backend.id for backend in cfg.backends]
+    if len(backend_ids) != len(set(backend_ids)):
+        raise ConfigError("backend ids must be unique")
+    for backend in cfg.backends:
+        if not _ID_RE.fullmatch(backend.id):
+            raise ConfigError(f"Invalid backend id: {backend.id!r}")
+        if not backend.model_uid:
+            raise ConfigError(f"backends.{backend.id}.model_uid is required")
+        if backend.max_context_tokens < 1:
+            raise ConfigError(f"Invalid context limit for backend {backend.id}")
+        if backend.max_active < 1 or backend.max_queue < 0:
+            raise ConfigError(f"Invalid capacity for backend {backend.id}")
+        if backend.queue_timeout_seconds < 0 or backend.retry_after_seconds < 0:
+            raise ConfigError(f"Invalid timeout for backend {backend.id}")
+    if not 1 <= len(cfg.rules) <= 64:
+        raise ConfigError("Router requires 1 to 64 routing rules")
+    rule_ids = [rule.id for rule in cfg.rules]
+    priorities = [rule.priority for rule in cfg.rules]
+    if len(rule_ids) != len(set(rule_ids)):
+        raise ConfigError("routing rule ids must be unique")
+    if len(priorities) != len(set(priorities)):
+        raise ConfigError("routing rule priorities must be unique")
+    backend_id_set = set(backend_ids)
+    for rule in cfg.rules:
+        if not _ID_RE.fullmatch(rule.id) or not 1 <= rule.priority <= 10000:
+            raise ConfigError(f"Invalid routing rule {rule.id!r}")
+        match = rule.match
+        if all(
+            value is None
+            for value in (
+                match.total_tokens_gte,
+                match.total_tokens_lte,
+                match.thinking,
+                match.tools_present,
+                match.stream,
+            )
+        ):
+            raise ConfigError(f"routing rule {rule.id!r} match cannot be empty")
+        if (
+            match.total_tokens_gte is not None
+            and match.total_tokens_lte is not None
+            and match.total_tokens_gte > match.total_tokens_lte
+        ):
+            raise ConfigError(f"Invalid token range in routing rule {rule.id!r}")
+        _validate_action(rule.action, backend_id_set, f"routing rule {rule.id!r}")
+    _validate_action(cfg.default_action, backend_id_set, "default action")
+    if cfg.context_reserve_tokens < 0 or cfg.default_output_tokens < 1:
+        raise ConfigError("Invalid token budget defaults")
+    if cfg.request_timeout_seconds <= 0 or cfg.connect_timeout_seconds <= 0:
+        raise ConfigError("backend timeouts must be greater than zero")
+    tokenization = cfg.tokenization
+    if (
+        tokenization.max_workers < 1
+        or tokenization.max_active < tokenization.max_workers
+    ):
+        raise ConfigError(
+            "tokenization.max_active must be greater than or equal to max_workers"
+        )
+    if tokenization.max_queue < 0 or tokenization.queue_timeout_seconds < 0:
+        raise ConfigError("Invalid tokenization capacity or timeout")
+    return cfg
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        raise ConfigError(f"Router config does not exist: {path}")
+    data = yaml.safe_load(path.read_text()) or {}
+    if not isinstance(data, dict):
+        raise ConfigError("Router config must be a YAML object")
+    return data
+
+
+def _legacy_pool(data: dict[str, Any], name: str, max_context: int) -> BackendConfig:
+    pool = data.get("pools", {}).get(name, {})
+    if not isinstance(pool, dict):
+        raise ConfigError(f"pools.{name} must be an object")
+    prefix = f"ROUTER_{name.upper()}"
+    model_uid = os.getenv(f"{prefix}_MODEL_UID", str(pool.get("model_uid", "")))
+    return BackendConfig(
+        id=name,
+        model_uid=model_uid,
+        max_context_tokens=max_context,
+        max_active=_env_int(f"{prefix}_MAX_ACTIVE", int(pool.get("max_active", 1))),
+        max_queue=_env_int(f"{prefix}_MAX_QUEUE", int(pool.get("max_queue", 0))),
+        queue_timeout_seconds=_env_float(
+            f"{prefix}_QUEUE_TIMEOUT_SECONDS",
+            float(pool.get("queue_timeout_seconds", 0)),
+        ),
+        retry_after_seconds=_env_int(
+            f"{prefix}_RETRY_AFTER_SECONDS", int(pool.get("retry_after_seconds", 1))
+        ),
+    )
+
+
+def _legacy_rules(threshold: int, thinking_pool: str) -> tuple[RoutingRule, ...]:
+    rules: list[RoutingRule] = []
+    if thinking_pool == "reject":
+        thinking_action = RouteAction(type="reject", reason="thinking_not_allowed")
+    else:
+        thinking_action = RouteAction(type="route", backend_id=thinking_pool)
+    rules.append(
+        RoutingRule("thinking-policy", 100, RuleMatch(thinking=True), thinking_action)
+    )
+    rules.append(
+        RoutingRule(
+            "short-threshold",
+            50,
+            RuleMatch(total_tokens_lte=threshold),
+            RouteAction(type="route", backend_id="short"),
+        )
+    )
+    rules.append(
+        RoutingRule(
+            "long-threshold",
+            40,
+            RuleMatch(total_tokens_gte=threshold + 1),
+            RouteAction(type="route", backend_id="long"),
+        )
+    )
+    return tuple(rules)
+
+
+def _tokenization(value: Mapping[str, Any]) -> TokenizationConfig:
+    return TokenizationConfig(
+        max_workers=int(value.get("max_workers", 2)),
+        max_active=int(value.get("max_active", 2)),
+        max_queue=int(value.get("max_queue", 8)),
+        queue_timeout_seconds=float(value.get("queue_timeout_seconds", 5)),
+        retry_after_seconds=int(value.get("retry_after_seconds", 1)),
+    )
+
+
+def load_config(path: str | Path | None = None) -> RouterConfig:
+    """Load the legacy standalone YAML format and normalize it to V2 internally."""
+    data = _load_yaml(
+        Path(path or os.getenv("ROUTER_CONFIG", "config.yaml")).expanduser()
+    )
+    listen, limits, auth = (
+        data.get("listen", {}),
+        data.get("limits", {}),
+        data.get("auth", {}),
+    )
+    backend, model = data.get("backend", {}), data.get("model", {})
+    tokenization_data = data.get("tokenization", {})
+    backend_api_key = os.getenv("XINFERENCE_API_KEY", "")
+    require_auth = _env_bool(
+        "ROUTER_REQUIRE_AUTH", bool(auth.get("require_auth", True))
+    )
+    if require_auth and not backend_api_key:
+        raise ConfigError("XINFERENCE_API_KEY is required when Router auth is enabled")
+    aliases = model.get("aliases", [])
+    if not isinstance(aliases, list):
+        raise ConfigError("model.aliases must be a list")
+    short_max = _env_int(
+        "ROUTER_SHORT_MAX_MODEL_LEN", int(limits.get("short_max_model_len", 131072))
+    )
+    long_max = _env_int(
+        "ROUTER_LONG_MAX_MODEL_LEN", int(limits.get("long_max_model_len", 1048576))
+    )
+    threshold = _env_int(
+        "ROUTER_SHORT_THRESHOLD_TOKENS",
+        int(limits.get("short_threshold_tokens", 32768)),
+    )
+    thinking_pool = os.getenv(
+        "ROUTER_THINKING_POOL", str(model.get("thinking_pool", "long"))
+    )
+    cfg = RouterConfig(
+        listen_host=os.getenv(
+            "ROUTER_LISTEN_HOST", str(listen.get("host", "127.0.0.1"))
+        ),
+        listen_port=_env_int("ROUTER_LISTEN_PORT", int(listen.get("port", 10080))),
+        backend_url=os.getenv("ROUTER_BACKEND_URL", str(backend.get("url", ""))).rstrip(
+            "/"
+        ),
+        backend_api_key=backend_api_key,
+        require_auth=require_auth,
+        logical_model=os.getenv(
+            "ROUTER_LOGICAL_MODEL", str(model.get("logical_model", ""))
+        ),
+        model_aliases=tuple(str(alias) for alias in aliases),
+        tokenizer_path=Path(
+            os.getenv("ROUTER_TOKENIZER_PATH", str(model.get("tokenizer_path", "")))
+        ).expanduser(),
+        context_reserve_tokens=_env_int(
+            "ROUTER_CONTEXT_RESERVE_TOKENS",
+            int(limits.get("context_reserve_tokens", 64)),
+        ),
+        default_output_tokens=_env_int(
+            "ROUTER_DEFAULT_OUTPUT_TOKENS",
+            int(limits.get("default_output_tokens", 512)),
+        ),
+        request_timeout_seconds=_env_float(
+            "ROUTER_REQUEST_TIMEOUT_SECONDS",
+            float(backend.get("request_timeout_seconds", 7200)),
+        ),
+        connect_timeout_seconds=_env_float(
+            "ROUTER_CONNECT_TIMEOUT_SECONDS",
+            float(backend.get("connect_timeout_seconds", 10)),
+        ),
+        tokenization=TokenizationConfig(
+            max_workers=_env_int(
+                "ROUTER_TOKENIZATION_MAX_WORKERS",
+                int(tokenization_data.get("max_workers", 2)),
+            ),
+            max_active=_env_int(
+                "ROUTER_TOKENIZATION_MAX_ACTIVE",
+                int(tokenization_data.get("max_active", 2)),
+            ),
+            max_queue=_env_int(
+                "ROUTER_TOKENIZATION_MAX_QUEUE",
+                int(tokenization_data.get("max_queue", 8)),
+            ),
+            queue_timeout_seconds=_env_float(
+                "ROUTER_TOKENIZATION_QUEUE_TIMEOUT_SECONDS",
+                float(tokenization_data.get("queue_timeout_seconds", 5)),
+            ),
+            retry_after_seconds=_env_int(
+                "ROUTER_TOKENIZATION_RETRY_AFTER_SECONDS",
+                int(tokenization_data.get("retry_after_seconds", 1)),
+            ),
+        ),
+        backends=(
+            _legacy_pool(data, "short", short_max),
+            _legacy_pool(data, "long", long_max),
+        ),
+        rules=_legacy_rules(threshold, thinking_pool),
+        default_action=RouteAction(type="reject", reason="context_length_exceeded"),
+        log_level=os.getenv("ROUTER_LOG_LEVEL", str(data.get("log_level", "INFO"))),
+        config_version=1,
+        strategy="token_budget",
+        legacy_short_threshold_tokens=threshold,
+        legacy_thinking_pool=thinking_pool,
+        tokenizer_asset_id=str(model.get("tokenizer_asset_id", "")),
+        tokenizer_asset_origin=str(model.get("tokenizer_asset_origin", "")),
+        tokenizer_asset_revision=str(model.get("tokenizer_asset_revision", "")),
+        tokenizer_asset_fingerprint=str(model.get("tokenizer_asset_fingerprint", "")),
+    )
+    return _validate_config(cfg)
+
+
+def _backend(value: Mapping[str, Any], backend_id: str | None = None) -> BackendConfig:
+    admission = value.get("admission", {})
+    return BackendConfig(
+        id=str(backend_id if backend_id is not None else value["id"]),
+        model_uid=str(value["model_uid"]),
+        max_context_tokens=int(value["max_context_tokens"]),
+        max_active=int(admission.get("max_active", 1)),
+        max_queue=int(admission.get("max_queue", 0)),
+        queue_timeout_seconds=float(admission.get("queue_timeout_seconds", 5)),
+        retry_after_seconds=int(admission.get("retry_after_seconds", 1)),
+    )
+
+
+def _action(value: Mapping[str, Any]) -> RouteAction:
+    return RouteAction(
+        type=str(value.get("type", "")),
+        backend_id=str(value.get("backend_id", "")),
+        reason=str(value.get("reason", "")),
+    )
+
+
+def _typed_rule(value: Mapping[str, Any]) -> RoutingRule:
+    match = value.get("match", {})
+    return RoutingRule(
+        id=str(value["id"]),
+        priority=int(value["priority"]),
+        match=RuleMatch(
+            total_tokens_gte=match.get("total_tokens_gte"),
+            total_tokens_lte=match.get("total_tokens_lte"),
+            thinking=match.get("thinking"),
+            tools_present=match.get("tools_present"),
+            stream=match.get("stream"),
+        ),
+        action=_action(value["action"]),
+    )
+
+
+def _resolve_tokenizer(data: Mapping[str, Any]) -> tuple[str, str, Path]:
+    tokenizer_path = str(data.get("tokenizer_path") or "").strip()
+    if not tokenizer_path:
+        raise ConfigError("tokenizer_path is required")
+    return "", "", Path(tokenizer_path).expanduser()
+
+
+def config_from_control_plane(
+    data: dict[str, Any],
+    *,
+    listen_host: str = "127.0.0.1",
+    listen_port: int = 10080,
+    log_level: str = "INFO",
+) -> RouterConfig:
+    """Convert V1 or V2 Supervisor data to one immutable V2 runtime config."""
+    try:
+        version = int(data.get("config_version", 1))
+        routing = data["routing"]
+        tokenization = data["tokenization"]
+        raw_backends = data["backends"]
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ConfigError(f"Invalid control-plane Router config: {exc}") from exc
+    asset_id, asset_origin, tokenizer_path = _resolve_tokenizer(data)
+    legacy_threshold: int | None = None
+    legacy_thinking = ""
+    if version == 1:
+        try:
+            threshold = int(routing["short_threshold_tokens"])
+            legacy_thinking = str(routing.get("thinking_policy", "long"))
+            backends = (
+                _backend(raw_backends["short"], "short"),
+                _backend(raw_backends["long"], "long"),
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            raise ConfigError(f"Invalid V1 Router config: {exc}") from exc
+        rules = _legacy_rules(threshold, legacy_thinking)
+        default_action = RouteAction(type="reject", reason="context_length_exceeded")
+        legacy_threshold = threshold
+        strategy = "token_budget"
+    elif version == 2:
+        if not isinstance(raw_backends, list):
+            raise ConfigError("V2 backends must be a list")
+        backends = tuple(_backend(value) for value in raw_backends)
+        rules = tuple(_typed_rule(value) for value in routing.get("rules", []))
+        default_action = _action(routing.get("default_action", {}))
+        strategy = str(data.get("strategy", "typed_rules"))
+    else:
+        raise ConfigError(f"Unsupported config_version: {version}")
+    cfg = RouterConfig(
+        listen_host=listen_host,
+        listen_port=listen_port,
+        backend_url=str(data["backend_url"]).rstrip("/"),
+        backend_api_key="",
+        require_auth=False,
+        logical_model=str(data["virtual_model_uid"]),
+        model_aliases=tuple(str(v) for v in data.get("model_aliases", [])),
+        tokenizer_path=tokenizer_path,
+        context_reserve_tokens=int(routing.get("context_reserve_tokens", 64)),
+        default_output_tokens=int(routing.get("default_output_tokens", 512)),
+        request_timeout_seconds=float(data.get("request_timeout_seconds", 10800)),
+        connect_timeout_seconds=float(data.get("connect_timeout_seconds", 10)),
+        tokenization=_tokenization(tokenization),
+        backends=backends,
+        rules=tuple(sorted(rules, key=lambda item: item.priority, reverse=True)),
+        default_action=default_action,
+        log_level=log_level,
+        config_version=version,
+        route_profile=str(data.get("route_profile", "llm_chat")),
+        strategy=strategy,
+        enabled=bool(data.get("enabled", False)),
+        revision=int(data.get("revision", 0)),
+        router_uid=str(data.get("router_uid", "")),
+        tokenizer_asset_id=asset_id,
+        tokenizer_asset_origin=asset_origin,
+        tokenizer_asset_revision=str(data.get("tokenizer_asset_revision", "")),
+        tokenizer_asset_fingerprint=str(data.get("tokenizer_asset_fingerprint", "")),
+        legacy_short_threshold_tokens=legacy_threshold,
+        legacy_thinking_pool=legacy_thinking,
+    )
+    return _validate_config(cfg)

--- a/xinference/router/config.py
+++ b/xinference/router/config.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Mapping
 
-import yaml
+import yaml  # type: ignore[import-untyped]
 
 _ID_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$")
 
@@ -314,9 +314,10 @@ def _tokenization(value: Mapping[str, Any]) -> TokenizationConfig:
 
 def load_config(path: str | Path | None = None) -> RouterConfig:
     """Load the legacy standalone YAML format and normalize it to V2 internally."""
-    data = _load_yaml(
-        Path(path or os.getenv("ROUTER_CONFIG", "config.yaml")).expanduser()
+    config_path = (
+        path if path is not None else os.getenv("ROUTER_CONFIG", "config.yaml")
     )
+    data = _load_yaml(Path(config_path).expanduser())
     listen, limits, auth = (
         data.get("listen", {}),
         data.get("limits", {}),
@@ -482,6 +483,7 @@ def config_from_control_plane(
     asset_id, asset_origin, tokenizer_path = _resolve_tokenizer(data)
     legacy_threshold: int | None = None
     legacy_thinking = ""
+    backends: tuple[BackendConfig, ...]
     if version == 1:
         try:
             threshold = int(routing["short_threshold_tokens"])

--- a/xinference/router/control_plane.py
+++ b/xinference/router/control_plane.py
@@ -249,5 +249,5 @@ class RouterControlPlaneClient:
 
             try:
                 await asyncio.wait_for(stop.wait(), timeout=poll_interval_seconds)
-            except TimeoutError:
+            except asyncio.TimeoutError:
                 pass

--- a/xinference/router/control_plane.py
+++ b/xinference/router/control_plane.py
@@ -1,0 +1,253 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+"""Supervisor control-plane client for independent Router runtimes."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import socket
+import uuid
+from typing import TYPE_CHECKING, Any, Dict, Optional
+
+import httpx
+
+from .config import config_from_control_plane
+
+if TYPE_CHECKING:
+    from .runtime import RouterRuntime
+
+logger = logging.getLogger(__name__)
+
+
+class RouterInstanceNotFound(RuntimeError):
+    """The Supervisor no longer has this Router runtime registration."""
+
+
+class RouterControlPlaneClient:
+    def __init__(
+        self,
+        supervisor_url: str,
+        router_uid: str,
+        *,
+        internal_token: str,
+        endpoint: str,
+        instance_id: Optional[str] = None,
+        timeout_seconds: float = 10.0,
+        listen_host: str = "127.0.0.1",
+        listen_port: int = 10080,
+        log_level: str = "INFO",
+    ) -> None:
+        if not internal_token:
+            raise ValueError("Token Router internal token is required")
+        self.supervisor_url = supervisor_url.rstrip("/")
+        self.router_uid = router_uid
+        self.internal_token = internal_token
+        self.endpoint = endpoint
+        self.instance_id = instance_id or f"{socket.gethostname()}-{uuid.uuid4()}"
+        self.revision = 0
+        self.listen_host = listen_host
+        self.listen_port = listen_port
+        self.log_level = log_level
+        self._client = httpx.AsyncClient(timeout=timeout_seconds)
+
+    @property
+    def _headers(self) -> Dict[str, str]:
+        return {"Authorization": f"Bearer {self.internal_token}"}
+
+    async def get_config(self, after_revision: int = 0) -> Optional[Dict[str, Any]]:
+        response = await self._client.get(
+            f"{self.supervisor_url}/v1/internal/token-router/configs/{self.router_uid}",
+            params={"after_revision": after_revision},
+            headers=self._headers,
+        )
+        if response.status_code == 204:
+            return None
+        response.raise_for_status()
+        data = response.json()
+        return data
+
+    async def register(self) -> Dict[str, Any]:
+        response = await self._client.post(
+            f"{self.supervisor_url}/v1/internal/token-router/instances/register",
+            headers=self._headers,
+            json={
+                "router_uid": self.router_uid,
+                "instance_id": self.instance_id,
+                "endpoint": self.endpoint,
+                "version": "1",
+                "acked_revision": self.revision,
+            },
+        )
+        response.raise_for_status()
+        return response.json()
+
+    async def heartbeat(
+        self,
+        *,
+        status: str,
+        metrics: Optional[Dict[str, Any]] = None,
+        backend_health: Optional[Dict[str, Any]] = None,
+        process: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        response = await self._client.post(
+            f"{self.supervisor_url}/v1/internal/token-router/instances/"
+            f"{self.instance_id}/heartbeat",
+            headers=self._headers,
+            json={
+                "status": status,
+                "metrics": metrics or {},
+                "backend_health": backend_health or {},
+                "process": process or {"pid": os.getpid()},
+            },
+        )
+        if response.status_code == 404:
+            raise RouterInstanceNotFound(
+                f"Token Router instance {self.instance_id} is not registered"
+            )
+        response.raise_for_status()
+        return response.json()
+
+    async def ack(self, revision: int, error: str = "") -> Dict[str, Any]:
+        response = await self._client.post(
+            f"{self.supervisor_url}/v1/internal/token-router/instances/"
+            f"{self.instance_id}/config-ack",
+            headers=self._headers,
+            json={
+                "router_uid": self.router_uid,
+                "revision": revision,
+                "error": error,
+            },
+        )
+        if response.status_code == 404:
+            raise RouterInstanceNotFound(
+                f"Token Router instance {self.instance_id} is not registered"
+            )
+        response.raise_for_status()
+        if not error:
+            self.revision = revision
+        return response.json()
+
+    async def aclose(self) -> None:
+        await self._client.aclose()
+
+    async def unregister(self) -> None:
+        try:
+            response = await self._client.post(
+                f"{self.supervisor_url}/v1/internal/token-router/instances/"
+                f"{self.instance_id}/unregister",
+                headers=self._headers,
+            )
+            if response.status_code not in (200, 404):
+                response.raise_for_status()
+        finally:
+            await self.aclose()
+
+    async def _publish_runtime_state(
+        self,
+        runtime: "RouterRuntime",
+        summary: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        summary = summary or await runtime.summary()
+        status = "ready" if summary["enabled"] else "disabled"
+        await self.heartbeat(
+            status=status,
+            metrics=await runtime.metrics.summary(),
+            process={
+                "pid": os.getpid(),
+                "revision": summary["revision"],
+                "active_requests": summary["active_requests"],
+                "tokenization": summary["tokenization"],
+                "pools": summary["pools"],
+            },
+        )
+        return summary
+
+    async def _reregister(self, runtime: "RouterRuntime") -> None:
+        summary = await runtime.summary()
+        runtime_revision = int(summary["revision"])
+        if runtime_revision < self.revision:
+            raise RuntimeError(
+                "Token Router runtime revision is older than the last ACKed "
+                f"revision: runtime={runtime_revision}, acked={self.revision}"
+            )
+
+        await self.register()
+        if runtime_revision > self.revision:
+            await self.ack(runtime_revision)
+        await self._publish_runtime_state(runtime, summary)
+        logger.info(
+            "Token Router instance re-registered: instance_id=%s revision=%s",
+            self.instance_id,
+            runtime_revision,
+        )
+
+    async def run(
+        self,
+        runtime: "RouterRuntime",
+        stop: asyncio.Event,
+        *,
+        poll_interval_seconds: float = 5.0,
+        heartbeat_interval_seconds: float = 30.0,
+    ) -> None:
+        """Poll revisions, atomically apply them, and publish runtime state."""
+        next_heartbeat = 0.0
+        registration_lost = False
+        loop = asyncio.get_running_loop()
+        while not stop.is_set():
+            if registration_lost:
+                try:
+                    await self._reregister(runtime)
+                except Exception:
+                    logger.exception("Token Router instance re-registration failed")
+                else:
+                    registration_lost = False
+                    next_heartbeat = loop.time() + heartbeat_interval_seconds
+            else:
+                try:
+                    data = await self.get_config(after_revision=self.revision)
+                    if data is not None:
+                        revision = int(data["revision"])
+                        if revision <= self.revision:
+                            logger.debug(
+                                "Ignoring already applied Token Router revision %s",
+                                revision,
+                            )
+                        else:
+                            try:
+                                config = config_from_control_plane(
+                                    data,
+                                    listen_host=self.listen_host,
+                                    listen_port=self.listen_port,
+                                    log_level=self.log_level,
+                                )
+                                await runtime.apply(config)
+                            except Exception as exc:
+                                logger.exception(
+                                    "Failed to apply Token Router revision %s",
+                                    revision,
+                                )
+                                await self.ack(revision, str(exc))
+                            else:
+                                await self.ack(revision)
+
+                    now = loop.time()
+                    if now >= next_heartbeat:
+                        await self._publish_runtime_state(runtime)
+                        next_heartbeat = now + heartbeat_interval_seconds
+                except RouterInstanceNotFound:
+                    registration_lost = True
+                    logger.warning(
+                        "Token Router instance registration was lost; "
+                        "re-registering: instance_id=%s",
+                        self.instance_id,
+                    )
+                except Exception:
+                    logger.exception(
+                        "Token Router control-plane synchronization failed"
+                    )
+
+            try:
+                await asyncio.wait_for(stop.wait(), timeout=poll_interval_seconds)
+            except TimeoutError:
+                pass

--- a/xinference/router/metrics.py
+++ b/xinference/router/metrics.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import asyncio
+from collections import Counter
+
+
+class RouterMetrics:
+    def __init__(self) -> None:
+        self._counters: Counter[tuple[str, ...]] = Counter()
+        self._tokenization_outcomes: Counter[str] = Counter()
+        self._tokenization_rejected: Counter[str] = Counter()
+        self._tokenization_duration_count = 0
+        self._tokenization_duration_sum = 0.0
+        self._tokenization_duration_max = 0.0
+        self._tokenization_input_bytes_count = 0
+        self._tokenization_input_bytes_sum = 0
+        self._tokenization_input_bytes_max = 0
+        self._tokenization_active = 0
+        self._tokenization_waiting = 0
+        self._lock = asyncio.Lock()
+
+    async def increment(self, *labels: str) -> None:
+        async with self._lock:
+            self._counters[tuple(labels)] += 1
+
+    async def increment_tokenization_rejected(self, reason: str) -> None:
+        async with self._lock:
+            self._tokenization_rejected[reason] += 1
+
+    async def observe_tokenization(
+        self, *, duration_seconds: float, input_bytes: int, outcome: str
+    ) -> None:
+        async with self._lock:
+            self._tokenization_outcomes[outcome] += 1
+            self._tokenization_duration_count += 1
+            self._tokenization_duration_sum += duration_seconds
+            self._tokenization_duration_max = max(
+                self._tokenization_duration_max, duration_seconds
+            )
+            self._tokenization_input_bytes_count += 1
+            self._tokenization_input_bytes_sum += input_bytes
+            self._tokenization_input_bytes_max = max(
+                self._tokenization_input_bytes_max, input_bytes
+            )
+
+    async def set_tokenization_capacity(self, *, active: int, waiting: int) -> None:
+        async with self._lock:
+            self._tokenization_active = active
+            self._tokenization_waiting = waiting
+
+    async def summary(self) -> dict[str, object]:
+        async with self._lock:
+            return {
+                "requests": {
+                    "/".join(labels): value for labels, value in self._counters.items()
+                },
+                "tokenization_outcomes": dict(self._tokenization_outcomes),
+                "tokenization_rejected": dict(self._tokenization_rejected),
+                "tokenization_duration": {
+                    "count": self._tokenization_duration_count,
+                    "sum_seconds": self._tokenization_duration_sum,
+                    "max_seconds": self._tokenization_duration_max,
+                },
+                "tokenization_input_bytes": {
+                    "count": self._tokenization_input_bytes_count,
+                    "sum": self._tokenization_input_bytes_sum,
+                    "max": self._tokenization_input_bytes_max,
+                },
+                "tokenization_active": self._tokenization_active,
+                "tokenization_waiting": self._tokenization_waiting,
+            }
+
+    async def render(self) -> str:
+        async with self._lock:
+            counters = dict(self._counters)
+            outcomes = dict(self._tokenization_outcomes)
+            rejected = dict(self._tokenization_rejected)
+            duration_count = self._tokenization_duration_count
+            duration_sum = self._tokenization_duration_sum
+            duration_max = self._tokenization_duration_max
+            input_bytes_count = self._tokenization_input_bytes_count
+            input_bytes_sum = self._tokenization_input_bytes_sum
+            input_bytes_max = self._tokenization_input_bytes_max
+            active = self._tokenization_active
+            waiting = self._tokenization_waiting
+
+        lines = [
+            "# HELP xinference_token_router_requests_total Router request outcomes.",
+            "# TYPE xinference_token_router_requests_total counter",
+        ]
+        for labels, value in sorted(counters.items()):
+            event = labels[0] if labels else "unknown"
+            pool = labels[1] if len(labels) > 1 else "none"
+            lines.append(
+                "xinference_token_router_requests_total"
+                f'{{event="{event}",pool="{pool}"}} {value}'
+            )
+
+        lines.extend(
+            [
+                "# HELP xinference_token_router_tokenization_active "
+                "Tokenization tasks currently admitted.",
+                "# TYPE xinference_token_router_tokenization_active gauge",
+                f"xinference_token_router_tokenization_active {active}",
+                "# HELP xinference_token_router_tokenization_waiting "
+                "Tokenization tasks waiting for admission.",
+                "# TYPE xinference_token_router_tokenization_waiting gauge",
+                f"xinference_token_router_tokenization_waiting {waiting}",
+                "# HELP xinference_token_router_tokenization_duration_seconds "
+                "Tokenization execution duration.",
+                "# TYPE xinference_token_router_tokenization_duration_seconds summary",
+                "xinference_token_router_tokenization_duration_seconds_count "
+                f"{duration_count}",
+                "xinference_token_router_tokenization_duration_seconds_sum "
+                f"{duration_sum:.9f}",
+                "# HELP xinference_token_router_tokenization_duration_seconds_max "
+                "Maximum observed tokenization duration.",
+                "# TYPE xinference_token_router_tokenization_duration_seconds_max gauge",
+                "xinference_token_router_tokenization_duration_seconds_max "
+                f"{duration_max:.9f}",
+                "# HELP xinference_token_router_tokenization_input_bytes "
+                "Request body bytes processed by tokenization.",
+                "# TYPE xinference_token_router_tokenization_input_bytes summary",
+                f"xinference_token_router_tokenization_input_bytes_count {input_bytes_count}",
+                f"xinference_token_router_tokenization_input_bytes_sum {input_bytes_sum}",
+                "# HELP xinference_token_router_tokenization_input_bytes_max "
+                "Maximum observed tokenization request body size.",
+                "# TYPE xinference_token_router_tokenization_input_bytes_max gauge",
+                f"xinference_token_router_tokenization_input_bytes_max {input_bytes_max}",
+                "# HELP xinference_token_router_tokenization_outcomes_total "
+                "Tokenization task outcomes.",
+                "# TYPE xinference_token_router_tokenization_outcomes_total counter",
+            ]
+        )
+        for outcome, value in sorted(outcomes.items()):
+            lines.append(
+                "xinference_token_router_tokenization_outcomes_total"
+                f'{{outcome="{outcome}"}} {value}'
+            )
+        lines.extend(
+            [
+                "# HELP xinference_token_router_tokenization_rejected_total "
+                "Tokenization admission rejections.",
+                "# TYPE xinference_token_router_tokenization_rejected_total counter",
+            ]
+        )
+        for reason, value in sorted(rejected.items()):
+            lines.append(
+                "xinference_token_router_tokenization_rejected_total"
+                f'{{reason="{reason}"}} {value}'
+            )
+        return "\n".join(lines) + "\n"

--- a/xinference/router/runtime.py
+++ b/xinference/router/runtime.py
@@ -1,0 +1,184 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+"""Hot-reloadable runtime state for the independent Token Router process."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import asdict, dataclass
+from typing import Any, Callable, Dict, Optional
+
+import httpx
+
+from .admission import CapacityGate
+from .classifier import RoutingPolicy
+from .config import RouterConfig
+from .metrics import RouterMetrics
+from .tokenization import TokenizationService
+
+
+class RouterDisabled(RuntimeError):
+    """Raised when a disabled Router refuses a new request."""
+
+
+@dataclass
+class RuntimeSnapshot:
+    config: RouterConfig
+    tokenization: TokenizationService
+    policy: RoutingPolicy
+    gates: Dict[str, CapacityGate]
+    client: httpx.AsyncClient
+    active_requests: int = 0
+    draining: bool = False
+    closed: bool = False
+
+    async def close(self) -> None:
+        if self.closed:
+            return
+        self.closed = True
+        await self.client.aclose()
+        await self.tokenization.aclose()
+
+
+class RouterRuntime:
+    """Own the active immutable config snapshot and drain replaced snapshots."""
+
+    def __init__(
+        self,
+        config: RouterConfig,
+        metrics: Optional[RouterMetrics] = None,
+        on_swap: Optional[Callable[[RuntimeSnapshot], None]] = None,
+    ) -> None:
+        self.metrics = metrics or RouterMetrics()
+        self._current = self._build_snapshot(config)
+        self._lock = asyncio.Lock()
+        self._started = False
+        self._on_swap = on_swap
+        self._drain_tasks: set[asyncio.Task[None]] = set()
+
+    def _build_snapshot(self, config: RouterConfig) -> RuntimeSnapshot:
+        tokenization = TokenizationService(
+            config.tokenizer_path,
+            self.metrics,
+            reserve_tokens=config.context_reserve_tokens,
+            default_output_tokens=config.default_output_tokens,
+            max_workers=config.tokenization.max_workers,
+            max_active=config.tokenization.max_active,
+            max_queue=config.tokenization.max_queue,
+            queue_timeout_seconds=config.tokenization.queue_timeout_seconds,
+            retry_after_seconds=config.tokenization.retry_after_seconds,
+        )
+        policy = RoutingPolicy(
+            backends=config.backends,
+            rules=config.rules,
+            default_action=config.default_action,
+        )
+        gates = {
+            backend.id: CapacityGate(
+                backend.id,
+                max_active=backend.max_active,
+                max_queue=backend.max_queue,
+                queue_timeout_seconds=backend.queue_timeout_seconds,
+                retry_after_seconds=backend.retry_after_seconds,
+            )
+            for backend in config.backends
+        }
+        timeout = httpx.Timeout(
+            connect=config.connect_timeout_seconds,
+            read=config.request_timeout_seconds,
+            write=config.request_timeout_seconds,
+            pool=config.connect_timeout_seconds,
+        )
+        return RuntimeSnapshot(
+            config=config,
+            tokenization=tokenization,
+            policy=policy,
+            gates=gates,
+            client=httpx.AsyncClient(timeout=timeout, http2=False),
+        )
+
+    def set_on_swap(self, callback: Callable[[RuntimeSnapshot], None]) -> None:
+        self._on_swap = callback
+        callback(self._current)
+
+    @property
+    def current(self) -> RuntimeSnapshot:
+        return self._current
+
+    async def start(self) -> None:
+        if self._started:
+            return
+        await self._current.tokenization.start()
+        self._started = True
+        self._notify_swap(self._current)
+
+    async def acquire(self) -> RuntimeSnapshot:
+        async with self._lock:
+            snapshot = self._current
+            if not snapshot.config.enabled:
+                raise RouterDisabled("Token Router is disabled")
+            snapshot.active_requests += 1
+            return snapshot
+
+    async def release(self, snapshot: RuntimeSnapshot) -> None:
+        close = False
+        async with self._lock:
+            snapshot.active_requests = max(0, snapshot.active_requests - 1)
+            close = snapshot.draining and snapshot.active_requests == 0
+        if close:
+            await snapshot.close()
+
+    async def apply(self, config: RouterConfig) -> None:
+        replacement = self._build_snapshot(config)
+        try:
+            await replacement.tokenization.start()
+        except Exception:
+            await replacement.close()
+            raise
+
+        old: RuntimeSnapshot
+        async with self._lock:
+            old = self._current
+            old.draining = True
+            self._current = replacement
+        self._notify_swap(replacement)
+        if old.active_requests == 0:
+            await old.close()
+        else:
+            task = asyncio.create_task(self._drain(old))
+            self._drain_tasks.add(task)
+            task.add_done_callback(self._drain_tasks.discard)
+
+    async def _drain(self, snapshot: RuntimeSnapshot) -> None:
+        while snapshot.active_requests:
+            await asyncio.sleep(0.1)
+        await snapshot.close()
+
+    def _notify_swap(self, snapshot: RuntimeSnapshot) -> None:
+        if self._on_swap is not None:
+            self._on_swap(snapshot)
+
+    async def summary(self) -> Dict[str, Any]:
+        snapshot = self._current
+        pools = {
+            name: asdict(await gate.snapshot()) for name, gate in snapshot.gates.items()
+        }
+        tokenization = asdict(await snapshot.tokenization.snapshot())
+        tokenization["worker_pids"] = snapshot.tokenization.worker_pids
+        return {
+            "enabled": snapshot.config.enabled,
+            "revision": snapshot.config.revision,
+            "active_requests": snapshot.active_requests,
+            "pools": pools,
+            "tokenization": tokenization,
+        }
+
+    async def aclose(self) -> None:
+        async with self._lock:
+            current = self._current
+            current.draining = True
+        if current.active_requests == 0:
+            await current.close()
+        else:
+            await self._drain(current)
+        if self._drain_tasks:
+            await asyncio.gather(*self._drain_tasks, return_exceptions=True)

--- a/xinference/router/schemas.py
+++ b/xinference/router/schemas.py
@@ -1,0 +1,26 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+"""Data-plane response schemas and constants."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from .._compat import BaseModel
+
+
+class RouterError(BaseModel):
+    message: str
+    type: str
+    code: int
+
+
+class RouterErrorResponse(BaseModel):
+    error: RouterError
+
+
+class RouterHealth(BaseModel):
+    status: str
+    logical_model: str
+    backend_url: str
+    pools: Dict[str, Any]
+    tokenization: Dict[str, Any]

--- a/xinference/router/service.py
+++ b/xinference/router/service.py
@@ -1,0 +1,104 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+"""Token Router service bootstrap."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+from typing import Optional
+
+import uvicorn
+
+from .app import create_app
+from .config import config_from_control_plane, load_config
+from .control_plane import RouterControlPlaneClient
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Xinference Token-aware Router")
+    parser.add_argument("--config", default=None, help="Standalone YAML config")
+    parser.add_argument("--supervisor-url", default=None)
+    parser.add_argument("--router-uid", default=None)
+    parser.add_argument("--internal-token", default=None)
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=10080)
+    parser.add_argument("--public-endpoint", default=None)
+    parser.add_argument("--log-level", default="INFO")
+    return parser
+
+
+async def _load_control_plane_config(args: argparse.Namespace):
+    token = args.internal_token or os.getenv(
+        "XINFERENCE_TOKEN_ROUTER_INTERNAL_TOKEN", ""
+    )
+    endpoint = args.public_endpoint or f"http://{args.host}:{args.port}"
+    client = RouterControlPlaneClient(
+        args.supervisor_url,
+        args.router_uid,
+        internal_token=token,
+        endpoint=endpoint,
+        listen_host=args.host,
+        listen_port=args.port,
+        log_level=args.log_level,
+    )
+    try:
+        data = await client.get_config()
+        if data is None:
+            raise RuntimeError("Supervisor returned no Token Router configuration")
+        config = config_from_control_plane(
+            data,
+            listen_host=args.host,
+            listen_port=args.port,
+            log_level=args.log_level,
+        )
+        # Register as not yet ready. The application lifespan ACKs the initial
+        # revision only after RouterRuntime.start() has completed successfully.
+        await client.register()
+        return config, client
+    except Exception:
+        await client.aclose()
+        raise
+
+
+async def _serve(args: argparse.Namespace) -> None:
+    control_plane = None
+    if args.supervisor_url or args.router_uid:
+        if not (args.supervisor_url and args.router_uid):
+            raise SystemExit("--supervisor-url and --router-uid must be used together")
+        config, control_plane = await _load_control_plane_config(args)
+    else:
+        config = load_config(args.config)
+
+    try:
+        app = create_app(config)
+        app.state.control_plane = control_plane
+        uvicorn_config = uvicorn.Config(
+            app,
+            host=config.listen_host,
+            port=config.listen_port,
+            log_level=config.log_level.lower(),
+            proxy_headers=True,
+        )
+        server = uvicorn.Server(uvicorn_config)
+    except BaseException:
+        # The application lifespan owns unregistering once Server.serve() has
+        # started. If bootstrapping fails before then, close the async client
+        # here so it is not leaked on the current event loop.
+        if control_plane is not None:
+            await control_plane.aclose()
+        raise
+
+    # Keep control-plane configuration loading, registration, lifespan ACK,
+    # heartbeat, hot reload, and shutdown on the same asyncio event loop.
+    await server.serve()
+
+
+def main(argv: Optional[list[str]] = None) -> None:
+    args = build_parser().parse_args(argv)
+    logging.basicConfig(
+        level=getattr(logging, args.log_level.upper(), logging.INFO),
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    asyncio.run(_serve(args))

--- a/xinference/router/sse.py
+++ b/xinference/router/sse.py
@@ -1,0 +1,14 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+"""SSE helpers shared by the Token Router data plane."""
+
+from __future__ import annotations
+
+from typing import AsyncIterator
+
+import httpx
+
+
+async def relay_sse(response: httpx.Response) -> AsyncIterator[bytes]:
+    """Relay raw SSE bytes without parsing or re-encoding event payloads."""
+    async for chunk in response.aiter_raw():
+        yield chunk

--- a/xinference/router/tests/test_admission.py
+++ b/xinference/router/tests/test_admission.py
@@ -1,0 +1,47 @@
+import asyncio
+
+import pytest
+
+from xinference.router.admission import AdmissionRejected, CapacityGate
+
+
+@pytest.mark.asyncio
+async def test_queue_full_rejected_and_release_wakes_waiter() -> None:
+    gate = CapacityGate(
+        "long",
+        max_active=1,
+        max_queue=1,
+        queue_timeout_seconds=1,
+        retry_after_seconds=10,
+    )
+    await gate.acquire()
+    waiter = asyncio.create_task(gate.acquire())
+    await asyncio.sleep(0)
+    with pytest.raises(AdmissionRejected) as exc_info:
+        await gate.acquire()
+    assert exc_info.value.reason == "queue_full"
+    await gate.release()
+    await waiter
+    snapshot = await gate.snapshot()
+    assert snapshot.active == 1
+    assert snapshot.waiting == 0
+    await gate.release()
+
+
+@pytest.mark.asyncio
+async def test_queue_timeout_does_not_leak_capacity() -> None:
+    gate = CapacityGate(
+        "short",
+        max_active=1,
+        max_queue=1,
+        queue_timeout_seconds=0.01,
+        retry_after_seconds=1,
+    )
+    await gate.acquire()
+    with pytest.raises(AdmissionRejected) as exc_info:
+        await gate.acquire()
+    assert exc_info.value.reason == "queue_timeout"
+    snapshot = await gate.snapshot()
+    assert snapshot.active == 1
+    assert snapshot.waiting == 0
+    await gate.release()

--- a/xinference/router/tests/test_app.py
+++ b/xinference/router/tests/test_app.py
@@ -1,0 +1,428 @@
+import asyncio
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+from fastapi import Request
+from tokenizers import Tokenizer, models, pre_tokenizers
+
+from xinference.router.admission import GateSnapshot
+from xinference.router.app import create_app
+from xinference.router.config import (
+    BackendConfig,
+    RouteAction,
+    RouterConfig,
+    RoutingRule,
+    RuleMatch,
+    TokenizationConfig,
+)
+from xinference.router.tokenizer import TokenBudget
+
+
+class FakeTokenizationService:
+    def __init__(
+        self,
+        _tokenizer_path,
+        _metrics,
+        *,
+        reserve_tokens: int,
+        default_output_tokens: int,
+        max_workers: int,
+        max_active: int,
+        max_queue: int,
+        queue_timeout_seconds: float,
+        retry_after_seconds: int,
+    ) -> None:
+        self._reserve_tokens = reserve_tokens
+        self._default_output_tokens = default_output_tokens
+        self._snapshot = GateSnapshot(
+            active=0,
+            waiting=0,
+            max_active=max_active,
+            max_queue=max_queue,
+        )
+        self.worker_pids = tuple(range(1000, 1000 + max_workers))
+
+    async def start(self) -> None:
+        return None
+
+    async def estimate(self, payload, *, input_bytes: int) -> TokenBudget:
+        return TokenBudget(
+            prompt_tokens=1,
+            output_tokens=int(payload.get("max_tokens", self._default_output_tokens)),
+            reserve_tokens=self._reserve_tokens,
+            total_tokens=1
+            + int(payload.get("max_tokens", self._default_output_tokens))
+            + self._reserve_tokens,
+            enable_thinking=False,
+        )
+
+    async def snapshot(self) -> GateSnapshot:
+        return self._snapshot
+
+    async def aclose(self) -> None:
+        self.worker_pids = ()
+
+
+@pytest.fixture(autouse=True)
+def fake_tokenization_service(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "xinference.router.runtime.TokenizationService", FakeTokenizationService
+    )
+
+
+class ChunkStream(httpx.AsyncByteStream):
+    def __init__(self, *chunks: bytes) -> None:
+        self._chunks = chunks
+
+    async def __aiter__(self):
+        for chunk in self._chunks:
+            yield chunk
+
+
+def make_assets(tmp_path: Path) -> Path:
+    tokenizer = Tokenizer(models.WordLevel({"[UNK]": 0, "hello": 1}, unk_token="[UNK]"))
+    tokenizer.pre_tokenizer = pre_tokenizers.Whitespace()
+    tokenizer.save(str(tmp_path / "tokenizer.json"))
+    encoding = tmp_path / "encoding"
+    encoding.mkdir()
+    (encoding / "encoding_dsv4.py").write_text(
+        "def encode_messages(messages, thinking_mode, reasoning_effort=None):\n"
+        "    return ' '.join(str(m.get('content', '')) for m in messages)\n"
+    )
+    return tmp_path
+
+
+def make_config(tmp_path: Path) -> RouterConfig:
+    backends = (
+        BackendConfig("short", "short-model", 200, 1, 0, 0, 1),
+        BackendConfig("long", "long-model", 1000, 1, 0, 0, 1),
+    )
+    rules = (
+        RoutingRule(
+            "thinking-policy",
+            100,
+            RuleMatch(thinking=True),
+            RouteAction(type="route", backend_id="long"),
+        ),
+        RoutingRule(
+            "short-threshold",
+            50,
+            RuleMatch(total_tokens_lte=100),
+            RouteAction(type="route", backend_id="short"),
+        ),
+        RoutingRule(
+            "long-threshold",
+            40,
+            RuleMatch(total_tokens_gte=101),
+            RouteAction(type="route", backend_id="long"),
+        ),
+    )
+    return RouterConfig(
+        listen_host="127.0.0.1",
+        listen_port=10080,
+        backend_url="http://backend",
+        backend_api_key="secret",
+        require_auth=True,
+        logical_model="router-model",
+        model_aliases=("router-alias",),
+        tokenizer_path=make_assets(tmp_path),
+        context_reserve_tokens=0,
+        default_output_tokens=8,
+        request_timeout_seconds=10,
+        connect_timeout_seconds=1,
+        tokenization=TokenizationConfig(2, 2, 2, 1, 1),
+        backends=backends,
+        rules=rules,
+        default_action=RouteAction(type="reject", reason="context_length_exceeded"),
+        log_level="INFO",
+        config_version=1,
+        strategy="token_budget",
+        legacy_short_threshold_tokens=100,
+        legacy_thinking_pool="long",
+        tokenizer_asset_id="deepseek-v4-flash-0731",
+        tokenizer_asset_revision="0731",
+        tokenizer_asset_fingerprint="sha256:test-fingerprint",
+    )
+
+
+async def call_router(
+    config: RouterConfig,
+    backend_handler,
+) -> tuple[httpx.Response, int, str]:
+    app = create_app(config)
+    async with app.router.lifespan_context(app):
+        snapshot = app.state.runtime.current
+        await snapshot.client.aclose()
+        snapshot.client = httpx.AsyncClient(
+            transport=httpx.MockTransport(backend_handler),
+            timeout=10,
+        )
+        app.state.client = snapshot.client
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://router",
+        ) as client:
+            response = await client.post(
+                "/v1/chat/completions",
+                headers={"authorization": "Bearer secret"},
+                json={
+                    "model": "router-model",
+                    "messages": [{"role": "user", "content": "hello"}],
+                    "max_tokens": 8,
+                    "stream": True,
+                },
+            )
+        active = (await app.state.gates["short"].snapshot()).active
+        metrics = await app.state.metrics.render()
+    return response, active, metrics
+
+
+@pytest.mark.asyncio
+async def test_stream_connect_error_releases_gate(tmp_path: Path) -> None:
+    async def backend_handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("backend unavailable", request=request)
+
+    response, active, metrics = await call_router(
+        make_config(tmp_path), backend_handler
+    )
+
+    assert response.status_code == 503
+    assert active == 0
+    assert 'event="backend_unavailable",pool="short"} 1' in metrics
+
+
+@pytest.mark.asyncio
+async def test_stream_backend_http_error_releases_gate(tmp_path: Path) -> None:
+    async def backend_handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, json={"error": "failed"})
+
+    response, active, metrics = await call_router(
+        make_config(tmp_path), backend_handler
+    )
+
+    assert response.status_code == 500
+    assert active == 0
+    assert 'event="backend_http_error",pool="short"} 1' in metrics
+
+
+@pytest.mark.asyncio
+async def test_completed_stream_releases_gate(tmp_path: Path) -> None:
+    async def backend_handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            stream=ChunkStream(
+                b'data: {"choices":[]}\n\n',
+                b"data: [DONE]\n\n",
+            ),
+        )
+
+    response, active, metrics = await call_router(
+        make_config(tmp_path), backend_handler
+    )
+
+    assert response.status_code == 200
+    assert response.content.endswith(b"data: [DONE]\n\n")
+    assert active == 0
+    assert 'event="completed",pool="short"} 1' in metrics
+
+
+@pytest.mark.asyncio
+async def test_client_disconnect_releases_gate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    async def disconnected(_request: Request) -> bool:
+        return True
+
+    monkeypatch.setattr(Request, "is_disconnected", disconnected)
+
+    async def backend_handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            stream=ChunkStream(
+                b'data: {"choices":[]}\n\n',
+                b"data: [DONE]\n\n",
+            ),
+        )
+
+    response, active, metrics = await call_router(
+        make_config(tmp_path), backend_handler
+    )
+
+    assert response.status_code == 200
+    assert response.content == b""
+    assert active == 0
+    assert 'event="client_disconnected",pool="short"} 1' in metrics
+    assert 'event="completed",pool="short"}' not in metrics
+
+
+@pytest.mark.asyncio
+async def test_health_exposes_process_tokenization_workers(tmp_path: Path) -> None:
+    app = create_app(make_config(tmp_path))
+    async with app.router.lifespan_context(app):
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://router",
+        ) as client:
+            response = await client.get("/healthz")
+            ready_response = await client.get("/readyz")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert set(body["pools"]) == {"short", "long"}
+        assert body["tokenization"]["active"] == 0
+        assert body["tokenization"]["waiting"] == 0
+        assert body["tokenization"]["max_active"] == 2
+        assert len(body["tokenization"]["worker_pids"]) == 2
+        assert ready_response.status_code == 200
+
+
+class FakeControlPlane:
+    def __init__(self, events: list[str]) -> None:
+        self.events = events
+
+    async def ack(self, revision: int) -> None:
+        self.events.append(f"ack:{revision}")
+
+    async def run(self, runtime, stop: asyncio.Event) -> None:
+        self.events.append("run")
+        await stop.wait()
+
+    async def unregister(self) -> None:
+        self.events.append("unregister")
+
+
+@pytest.mark.asyncio
+async def test_lifespan_acks_only_after_runtime_start(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    app = create_app(make_config(tmp_path))
+    runtime = app.state.runtime
+    events: list[str] = []
+    control_plane = FakeControlPlane(events)
+    app.state.control_plane = control_plane
+
+    async def start() -> None:
+        events.append("start")
+
+    monkeypatch.setattr(runtime, "start", start)
+
+    async with app.router.lifespan_context(app):
+        assert events[:2] == ["start", "ack:0"]
+
+    assert events[-1] == "unregister"
+    assert runtime.current.closed is True
+
+
+@pytest.mark.asyncio
+async def test_lifespan_start_failure_does_not_ack_and_still_cleans_up(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    app = create_app(make_config(tmp_path))
+    runtime = app.state.runtime
+    events: list[str] = []
+    app.state.control_plane = FakeControlPlane(events)
+
+    async def fail_start() -> None:
+        events.append("start")
+        raise RuntimeError("tokenization startup failed")
+
+    monkeypatch.setattr(runtime, "start", fail_start)
+
+    with pytest.raises(RuntimeError, match="tokenization startup failed"):
+        async with app.router.lifespan_context(app):
+            pytest.fail("lifespan must not yield after startup failure")
+
+    assert events == ["start", "unregister"]
+    assert runtime.current.closed is True
+
+
+@pytest.mark.asyncio
+async def test_auth_rejection_releases_runtime_snapshot(tmp_path: Path) -> None:
+    app = create_app(make_config(tmp_path))
+    async with app.router.lifespan_context(app):
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://router",
+        ) as client:
+            for _ in range(3):
+                response = await client.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "router-model",
+                        "messages": [{"role": "user", "content": "hello"}],
+                        "max_tokens": 8,
+                        "stream": True,
+                    },
+                )
+                assert response.status_code == 401
+                assert app.state.runtime.current.active_requests == 0
+
+        metrics = await app.state.metrics.render()
+        assert 'event="auth_rejected",pool="none"} 3' in metrics
+
+
+@pytest.mark.asyncio
+async def test_v2_tools_rule_routes_to_dynamic_backend_and_sets_headers(
+    tmp_path: Path,
+) -> None:
+    from dataclasses import replace
+
+    config = make_config(tmp_path)
+    tools_backend = BackendConfig("tools", "tools-model", 400, 2, 1, 1, 1)
+    config = replace(
+        config,
+        config_version=2,
+        strategy="typed_rules",
+        backends=(*config.backends, tools_backend),
+        rules=(
+            RoutingRule(
+                "tools-route",
+                200,
+                RuleMatch(tools_present=True),
+                RouteAction(type="route", backend_id="tools"),
+            ),
+            *config.rules,
+        ),
+    )
+    received_payload = {}
+
+    async def backend_handler(request: httpx.Request) -> httpx.Response:
+        received_payload.update(json.loads(request.content))
+        return httpx.Response(
+            200,
+            json={"id": "chatcmpl-test", "choices": []},
+            headers={"content-type": "application/json"},
+        )
+
+    app = create_app(config)
+    async with app.router.lifespan_context(app):
+        snapshot = app.state.runtime.current
+        await snapshot.client.aclose()
+        snapshot.client = httpx.AsyncClient(
+            transport=httpx.MockTransport(backend_handler), timeout=10
+        )
+        app.state.client = snapshot.client
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://router"
+        ) as client:
+            response = await client.post(
+                "/v1/chat/completions",
+                headers={"authorization": "Bearer secret"},
+                json={
+                    "model": "router-model",
+                    "messages": [{"role": "user", "content": "hello"}],
+                    "tools": [{"type": "function", "function": {"name": "lookup"}}],
+                    "max_tokens": 8,
+                    "stream": False,
+                },
+            )
+
+    assert response.status_code == 200
+    assert received_payload["model"] == "tools-model"
+    assert response.headers["x-xinference-router-backend"] == "tools"
+    assert response.headers["x-xinference-router-rule"] == "tools-route"
+    assert response.headers["x-xinference-router-pool"] == "tools"

--- a/xinference/router/tests/test_app.py
+++ b/xinference/router/tests/test_app.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 from pathlib import Path
+from unittest.mock import AsyncMock
 
 import httpx
 import pytest
@@ -257,6 +258,95 @@ async def test_client_disconnect_releases_gate(
     assert active == 0
     assert 'event="client_disconnected",pool="short"} 1' in metrics
     assert 'event="completed",pool="short"}' not in metrics
+
+
+@pytest.mark.asyncio
+async def test_disconnect_before_stream_starts_releases_resources(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    app = create_app(make_config(tmp_path))
+    stream_started = False
+    stream_closed = False
+
+    class TrackingStream(httpx.AsyncByteStream):
+        async def __aiter__(self):
+            nonlocal stream_started
+            stream_started = True
+            yield b"data: [DONE]\n\n"
+
+        async def aclose(self) -> None:
+            nonlocal stream_closed
+            stream_closed = True
+
+    async def backend_handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            stream=TrackingStream(),
+        )
+
+    async with app.router.lifespan_context(app):
+        snapshot = app.state.runtime.current
+        await snapshot.client.aclose()
+        snapshot.client = httpx.AsyncClient(
+            transport=httpx.MockTransport(backend_handler), timeout=10
+        )
+        gate = snapshot.gates["short"]
+        gate_release = AsyncMock(wraps=gate.release)
+        runtime_release = AsyncMock(wraps=app.state.runtime.release)
+        monkeypatch.setattr(gate, "release", gate_release)
+        monkeypatch.setattr(app.state.runtime, "release", runtime_release)
+
+        request_body = json.dumps(
+            {
+                "model": "router-model",
+                "messages": [{"role": "user", "content": "hello"}],
+                "max_tokens": 8,
+                "stream": True,
+            }
+        ).encode()
+        receive_calls = 0
+
+        async def receive():
+            nonlocal receive_calls
+            receive_calls += 1
+            if receive_calls == 1:
+                return {
+                    "type": "http.request",
+                    "body": request_body,
+                    "more_body": False,
+                }
+            return {"type": "http.disconnect"}
+
+        async def send(message):
+            if message["type"] == "http.response.start":
+                await asyncio.sleep(3600)
+
+        scope = {
+            "type": "http",
+            "asgi": {"version": "3.0", "spec_version": "2.3"},
+            "http_version": "1.1",
+            "method": "POST",
+            "scheme": "http",
+            "path": "/v1/chat/completions",
+            "raw_path": b"/v1/chat/completions",
+            "query_string": b"",
+            "root_path": "",
+            "headers": [
+                (b"content-type", b"application/json"),
+                (b"authorization", b"Bearer secret"),
+            ],
+            "client": ("test", 1234),
+            "server": ("router", 10080),
+        }
+        await app(scope, receive, send)
+
+        assert stream_started is False
+        assert stream_closed is True
+        assert gate_release.await_count == 1
+        assert runtime_release.await_count == 1
+        assert (await gate.snapshot()).active == 0
+        assert snapshot.active_requests == 0
 
 
 @pytest.mark.asyncio

--- a/xinference/router/tests/test_classifier.py
+++ b/xinference/router/tests/test_classifier.py
@@ -1,0 +1,149 @@
+import pytest
+
+from xinference.router.classifier import (
+    ContextLimitExceeded,
+    RoutingPolicy,
+    ThinkingRejected,
+)
+from xinference.router.tokenizer import TokenBudget
+
+
+def budget(total: int, *, thinking: bool = False) -> TokenBudget:
+    return TokenBudget(
+        prompt_tokens=total - 65,
+        output_tokens=1,
+        reserve_tokens=64,
+        total_tokens=total,
+        enable_thinking=thinking,
+    )
+
+
+def policy() -> RoutingPolicy:
+    return RoutingPolicy(
+        short_threshold_tokens=32768,
+        short_max_model_len=131072,
+        long_max_model_len=1048576,
+        thinking_pool="long",
+    )
+
+
+def test_routes_short_boundary_to_short() -> None:
+    decision = policy().classify(budget(32768))
+    assert decision.pool == "short"
+    assert decision.reason == "within_short_threshold"
+
+
+def test_routes_above_short_boundary_to_long() -> None:
+    decision = policy().classify(budget(32769))
+    assert decision.pool == "long"
+    assert decision.reason == "exceeds_short_threshold"
+
+
+def test_routes_thinking_to_long() -> None:
+    decision = policy().classify(budget(1024, thinking=True))
+    assert decision.pool == "long"
+    assert decision.reason == "thinking_policy"
+
+
+def test_rejects_above_long_context_limit() -> None:
+    with pytest.raises(ContextLimitExceeded):
+        policy().classify(budget(1048577))
+
+
+def test_rejects_thinking_when_policy_is_reject() -> None:
+    policy = RoutingPolicy(
+        short_threshold_tokens=100,
+        short_max_model_len=200,
+        long_max_model_len=1000,
+        thinking_pool="reject",
+    )
+
+    with pytest.raises(ThinkingRejected, match="disabled"):
+        policy.classify(budget(50, thinking=True))
+
+
+def typed_policy() -> RoutingPolicy:
+    from xinference.router.config import (
+        BackendConfig,
+        RouteAction,
+        RoutingRule,
+        RuleMatch,
+    )
+
+    backends = (
+        BackendConfig("fast", "fast-model", 100, 1, 0, 0, 1),
+        BackendConfig("tools", "tools-model", 200, 1, 0, 0, 1),
+        BackendConfig("reasoning", "reasoning-model", 300, 1, 0, 0, 1),
+        BackendConfig("stream", "stream-model", 400, 1, 0, 0, 1),
+    )
+    rules = (
+        RoutingRule(
+            "tools-thinking",
+            500,
+            RuleMatch(tools_present=True, thinking=True),
+            RouteAction(type="route", backend_id="reasoning"),
+        ),
+        RoutingRule(
+            "tools",
+            400,
+            RuleMatch(tools_present=True),
+            RouteAction(type="route", backend_id="tools"),
+        ),
+        RoutingRule(
+            "thinking",
+            300,
+            RuleMatch(thinking=True),
+            RouteAction(type="route", backend_id="reasoning"),
+        ),
+        RoutingRule(
+            "stream",
+            200,
+            RuleMatch(stream=True),
+            RouteAction(type="route", backend_id="stream"),
+        ),
+        RoutingRule(
+            "fast",
+            100,
+            RuleMatch(total_tokens_lte=100),
+            RouteAction(type="route", backend_id="fast"),
+        ),
+    )
+    return RoutingPolicy(
+        backends=backends,
+        rules=rules,
+        default_action=RouteAction(type="reject", reason="no_matching_route"),
+    )
+
+
+def test_typed_rules_use_first_match_across_four_backends() -> None:
+    decision = typed_policy().classify(
+        budget(50, thinking=True), tools_present=True, stream=True
+    )
+
+    assert decision.backend_id == "reasoning"
+    assert decision.rule_id == "tools-thinking"
+    assert decision.reason == "rule_matched"
+
+
+def test_typed_rule_conditions_are_combined_with_and() -> None:
+    decision = typed_policy().classify(budget(50), tools_present=True)
+
+    assert decision.backend_id == "tools"
+    assert decision.rule_id == "tools"
+
+
+def test_typed_rules_match_stream_and_default_reject() -> None:
+    from xinference.router.classifier import RouteRejected
+
+    stream_decision = typed_policy().classify(budget(150), stream=True)
+    assert stream_decision.backend_id == "stream"
+    assert stream_decision.rule_id == "stream"
+
+    with pytest.raises(RouteRejected, match="no matching route") as exc_info:
+        typed_policy().classify(budget(150))
+    assert exc_info.value.reason == "no_matching_route"
+
+
+def test_typed_route_enforces_target_backend_context() -> None:
+    with pytest.raises(ContextLimitExceeded, match="backend tools"):
+        typed_policy().classify(budget(201), tools_present=True)

--- a/xinference/router/tests/test_config.py
+++ b/xinference/router/tests/test_config.py
@@ -1,0 +1,256 @@
+from pathlib import Path
+
+import pytest
+
+from xinference.router.config import load_config
+
+
+def test_loads_config_with_environment_secret(tmp_path: Path, monkeypatch) -> None:
+    assets = tmp_path / "assets"
+    assets.mkdir()
+    config = tmp_path / "config.yaml"
+    config.write_text(f"""
+backend:
+  url: http://127.0.0.1:9997
+model:
+  logical_model: router-model
+  tokenizer_path: {assets}
+  tokenizer_asset_id: deepseek-v4-flash-0731
+  tokenizer_asset_revision: "0731"
+  tokenizer_asset_fingerprint: sha256:test-fingerprint
+limits:
+  short_threshold_tokens: 100
+  short_max_model_len: 200
+  long_max_model_len: 1000
+pools:
+  short:
+    model_uid: short-model
+    max_active: 2
+  long:
+    model_uid: long-model
+    max_active: 1
+""")
+    monkeypatch.setenv("XINFERENCE_API_KEY", "secret")
+    loaded = load_config(config)
+    assert loaded.logical_model == "router-model"
+    assert loaded.short_pool.model_uid == "short-model"
+    assert loaded.long_pool.model_uid == "long-model"
+    assert loaded.backend_api_key == "secret"
+    assert loaded.tokenization.max_workers == 2
+    assert loaded.tokenization.max_active == 2
+    assert loaded.tokenization.max_queue == 8
+    assert loaded.tokenizer_asset_revision == "0731"
+    assert loaded.tokenizer_asset_fingerprint == "sha256:test-fingerprint"
+
+
+def control_plane_config(assets: Path) -> dict:
+    return {
+        "router_uid": "router-1",
+        "revision": 3,
+        "enabled": True,
+        "virtual_model_uid": "router-model",
+        "tokenizer_path": str(assets),
+        "tokenizer_asset_id": "deepseek-v4-flash-0731",
+        "tokenizer_asset_revision": "0731",
+        "tokenizer_asset_fingerprint": "sha256:test-fingerprint",
+        "backend_url": "http://supervisor:9997",
+        "backends": {
+            "short": {
+                "model_uid": "short-model",
+                "max_context_tokens": 200,
+                "admission": {"max_active": 2},
+            },
+            "long": {
+                "model_uid": "long-model",
+                "max_context_tokens": 1000,
+                "admission": {"max_active": 1},
+            },
+        },
+        "routing": {
+            "short_threshold_tokens": 100,
+            "context_reserve_tokens": 0,
+            "default_output_tokens": 8,
+            "thinking_policy": "reject",
+        },
+        "tokenization": {
+            "max_workers": 2,
+            "max_active": 2,
+            "max_queue": 8,
+        },
+    }
+
+
+def test_control_plane_config_uses_authorization_passthrough(
+    tmp_path: Path, monkeypatch
+) -> None:
+    from xinference.router.config import config_from_control_plane
+
+    assets = tmp_path / "assets"
+    assets.mkdir()
+    monkeypatch.setenv("XINFERENCE_API_KEY", "must-not-be-used")
+
+    loaded = config_from_control_plane(control_plane_config(assets))
+
+    assert loaded.backend_api_key == ""
+    assert loaded.require_auth is False
+    assert loaded.thinking_pool == "reject"
+    assert loaded.tokenizer_asset_revision == "0731"
+    assert loaded.tokenizer_asset_fingerprint == "sha256:test-fingerprint"
+
+
+def test_control_plane_config_is_fully_validated(tmp_path: Path) -> None:
+    from xinference.router.config import ConfigError, config_from_control_plane
+
+    assets = tmp_path / "assets"
+    assets.mkdir()
+    payload = control_plane_config(assets)
+    payload["tokenization"]["max_active"] = 1
+
+    with pytest.raises(ConfigError, match="greater than or equal"):
+        config_from_control_plane(payload)
+
+
+def typed_control_plane_config(assets: Path) -> dict:
+    return {
+        "config_version": 2,
+        "route_profile": "llm_chat",
+        "strategy": "typed_rules",
+        "router_uid": "router-v2",
+        "revision": 7,
+        "enabled": True,
+        "virtual_model_uid": "router-model-v2",
+        "tokenizer_path": str(assets),
+        "tokenizer_asset_id": "deepseek-v4-flash-0731",
+        "tokenizer_asset_revision": "0731",
+        "tokenizer_asset_fingerprint": "sha256:test-fingerprint",
+        "backend_url": "http://supervisor:9997",
+        "backends": [
+            {
+                "id": backend_id,
+                "model_uid": f"{backend_id}-model",
+                "max_context_tokens": context,
+                "admission": {"max_active": 1, "max_queue": 2},
+            }
+            for backend_id, context in (
+                ("fast", 32768),
+                ("tools", 65536),
+                ("reasoning", 131072),
+                ("long", 1048576),
+            )
+        ],
+        "routing": {
+            "evaluation_mode": "first_match",
+            "context_reserve_tokens": 64,
+            "default_output_tokens": 512,
+            "rules": [
+                {
+                    "id": "tools-route",
+                    "priority": 400,
+                    "match": {"tools_present": True},
+                    "action": {"type": "route", "backend_id": "tools"},
+                },
+                {
+                    "id": "thinking-route",
+                    "priority": 300,
+                    "match": {"thinking": True},
+                    "action": {"type": "route", "backend_id": "reasoning"},
+                },
+                {
+                    "id": "short-route",
+                    "priority": 200,
+                    "match": {"total_tokens_lte": 32768},
+                    "action": {"type": "route", "backend_id": "fast"},
+                },
+                {
+                    "id": "long-route",
+                    "priority": 100,
+                    "match": {"total_tokens_gte": 32769},
+                    "action": {"type": "route", "backend_id": "long"},
+                },
+            ],
+            "default_action": {"type": "reject", "reason": "no_matching_route"},
+        },
+        "tokenization": {
+            "max_workers": 2,
+            "max_active": 2,
+            "max_queue": 8,
+        },
+    }
+
+
+def test_control_plane_v2_loads_four_dynamic_backends(tmp_path: Path) -> None:
+    from xinference.router.config import config_from_control_plane
+
+    assets = tmp_path / "assets"
+    assets.mkdir()
+    loaded = config_from_control_plane(typed_control_plane_config(assets))
+
+    assert loaded.config_version == 2
+    assert loaded.route_profile == "llm_chat"
+    assert loaded.strategy == "typed_rules"
+    assert [backend.id for backend in loaded.backends] == [
+        "fast",
+        "tools",
+        "reasoning",
+        "long",
+    ]
+    assert [rule.id for rule in loaded.rules] == [
+        "tools-route",
+        "thinking-route",
+        "short-route",
+        "long-route",
+    ]
+    assert loaded.default_action.reason == "no_matching_route"
+
+
+@pytest.mark.parametrize(
+    ("mutate", "message"),
+    [
+        (
+            lambda payload: payload["backends"][1].update(id="fast"),
+            "backend ids must be unique",
+        ),
+        (
+            lambda payload: payload["routing"]["rules"][1].update(id="tools-route"),
+            "routing rule ids must be unique",
+        ),
+        (
+            lambda payload: payload["routing"]["rules"][1].update(priority=400),
+            "routing rule priorities must be unique",
+        ),
+        (
+            lambda payload: payload["routing"]["rules"][0]["action"].update(
+                backend_id="missing"
+            ),
+            "references unknown backend",
+        ),
+        (
+            lambda payload: payload["routing"]["rules"][0].update(match={}),
+            "match cannot be empty",
+        ),
+        (
+            lambda payload: payload["routing"]["rules"][0].update(
+                match={"total_tokens_gte": 10, "total_tokens_lte": 9}
+            ),
+            "Invalid token range",
+        ),
+        (
+            lambda payload: payload.update(config_version=3),
+            "Unsupported config_version",
+        ),
+    ],
+)
+def test_control_plane_v2_rejects_invalid_dynamic_config(
+    tmp_path: Path, mutate, message: str
+) -> None:
+    from copy import deepcopy
+
+    from xinference.router.config import ConfigError, config_from_control_plane
+
+    assets = tmp_path / "assets"
+    assets.mkdir()
+    payload = deepcopy(typed_control_plane_config(assets))
+    mutate(payload)
+
+    with pytest.raises(ConfigError, match=message):
+        config_from_control_plane(payload)

--- a/xinference/router/tests/test_config.py
+++ b/xinference/router/tests/test_config.py
@@ -9,7 +9,8 @@ def test_loads_config_with_environment_secret(tmp_path: Path, monkeypatch) -> No
     assets = tmp_path / "assets"
     assets.mkdir()
     config = tmp_path / "config.yaml"
-    config.write_text(f"""
+    config.write_text(
+        f"""
 backend:
   url: http://127.0.0.1:9997
 model:
@@ -29,7 +30,8 @@ pools:
   long:
     model_uid: long-model
     max_active: 1
-""")
+"""
+    )
     monkeypatch.setenv("XINFERENCE_API_KEY", "secret")
     loaded = load_config(config)
     assert loaded.logical_model == "router-model"

--- a/xinference/router/tests/test_control_plane.py
+++ b/xinference/router/tests/test_control_plane.py
@@ -1,0 +1,503 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+
+import httpx
+import pytest
+
+from xinference.router import control_plane as control_plane_module
+from xinference.router.control_plane import (
+    RouterControlPlaneClient,
+    RouterInstanceNotFound,
+)
+
+
+class FakeMetrics:
+    async def summary(self) -> dict[str, int]:
+        return {"requests": 3}
+
+
+class FakeRuntime:
+    def __init__(
+        self, *, apply_error: Exception | None = None, revision: int = 2
+    ) -> None:
+        self.metrics = FakeMetrics()
+        self.apply_error = apply_error
+        self.revision = revision
+        self.applied: list[Any] = []
+
+    async def apply(self, config: Any) -> None:
+        self.applied.append(config)
+        if self.apply_error is not None:
+            raise self.apply_error
+        self.revision = config.revision
+
+    async def summary(self) -> dict[str, Any]:
+        return {
+            "enabled": True,
+            "revision": self.revision,
+            "active_requests": 4,
+            "tokenization": {"active": 1, "waiting": 2},
+            "pools": {"short": {"active": 3}, "long": {"active": 1}},
+        }
+
+
+def make_client(*, revision: int = 1) -> RouterControlPlaneClient:
+    client = RouterControlPlaneClient(
+        "http://supervisor",
+        "router-1",
+        internal_token="internal-secret",
+        endpoint="http://router:10080",
+        instance_id="instance-1",
+    )
+    client.revision = revision
+    return client
+
+
+@pytest.mark.asyncio
+async def test_ack_advances_revision_only_after_success() -> None:
+    payloads: list[dict[str, Any]] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        payloads.append(__import__("json").loads(request.content))
+        return httpx.Response(200, json={"ok": True})
+
+    client = make_client()
+    await client._client.aclose()
+    client._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    try:
+        await client.ack(2, "invalid config")
+        assert client.revision == 1
+        await client.ack(2)
+        assert client.revision == 2
+    finally:
+        await client._client.aclose()
+
+    assert payloads == [
+        {"router_uid": "router-1", "revision": 2, "error": "invalid config"},
+        {"router_uid": "router-1", "revision": 2, "error": ""},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_instance_scoped_404_reports_lost_registration() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(404, json={"detail": "not found"})
+
+    client = make_client()
+    await client.aclose()
+    client._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    try:
+        with pytest.raises(RouterInstanceNotFound):
+            await client.heartbeat(status="ready")
+        with pytest.raises(RouterInstanceNotFound):
+            await client.ack(2)
+    finally:
+        await client.aclose()
+
+    assert client.revision == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status_code", [401, 403, 409, 422, 500])
+async def test_heartbeat_non_404_preserves_http_error(status_code: int) -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(status_code, json={"detail": "failed"})
+
+    client = make_client()
+    await client.aclose()
+    client._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    try:
+        with pytest.raises(httpx.HTTPStatusError) as exc_info:
+            await client.heartbeat(status="ready")
+    finally:
+        await client.aclose()
+
+    assert exc_info.value.response.status_code == status_code
+
+
+@pytest.mark.asyncio
+async def test_register_404_preserves_http_error() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(404, json={"detail": "router not found"})
+
+    client = make_client()
+    await client.aclose()
+    client._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    try:
+        with pytest.raises(httpx.HTTPStatusError):
+            await client.register()
+    finally:
+        await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_run_applies_revision_then_acks_and_heartbeats(monkeypatch) -> None:
+    client = make_client()
+    runtime = FakeRuntime()
+    stop = asyncio.Event()
+    config = SimpleNamespace(revision=2)
+    acked: list[tuple[int, str]] = []
+    heartbeats: list[dict[str, Any]] = []
+
+    async def get_config(after_revision: int = 0) -> dict[str, Any]:
+        assert after_revision == 1
+        return {"revision": 2}
+
+    async def ack(revision: int, error: str = "") -> dict[str, Any]:
+        acked.append((revision, error))
+        if not error:
+            client.revision = revision
+        return {"ok": True}
+
+    async def heartbeat(**kwargs: Any) -> dict[str, Any]:
+        heartbeats.append(kwargs)
+        stop.set()
+        return {"ok": True}
+
+    monkeypatch.setattr(client, "get_config", get_config)
+    monkeypatch.setattr(client, "ack", ack)
+    monkeypatch.setattr(client, "heartbeat", heartbeat)
+    monkeypatch.setattr(
+        control_plane_module,
+        "config_from_control_plane",
+        lambda data, **kwargs: config,
+    )
+    try:
+        await client.run(
+            runtime,
+            stop,
+            poll_interval_seconds=0.01,
+            heartbeat_interval_seconds=30,
+        )
+    finally:
+        await client._client.aclose()
+
+    assert runtime.applied == [config]
+    assert acked == [(2, "")]
+    assert client.revision == 2
+    assert heartbeats == [
+        {
+            "status": "ready",
+            "metrics": {"requests": 3},
+            "process": {
+                "pid": __import__("os").getpid(),
+                "revision": 2,
+                "active_requests": 4,
+                "tokenization": {"active": 1, "waiting": 2},
+                "pools": {
+                    "short": {"active": 3},
+                    "long": {"active": 1},
+                },
+            },
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_run_reports_apply_error_without_advancing_revision(monkeypatch) -> None:
+    client = make_client()
+    runtime = FakeRuntime(apply_error=RuntimeError("worker start failed"))
+    stop = asyncio.Event()
+    acked: list[tuple[int, str]] = []
+
+    async def get_config(after_revision: int = 0) -> dict[str, Any]:
+        assert after_revision == 1
+        return {"revision": 2}
+
+    async def ack(revision: int, error: str = "") -> dict[str, Any]:
+        acked.append((revision, error))
+        return {"ok": True}
+
+    async def heartbeat(**kwargs: Any) -> dict[str, Any]:
+        stop.set()
+        return {"ok": True}
+
+    monkeypatch.setattr(client, "get_config", get_config)
+    monkeypatch.setattr(client, "ack", ack)
+    monkeypatch.setattr(client, "heartbeat", heartbeat)
+    monkeypatch.setattr(
+        control_plane_module,
+        "config_from_control_plane",
+        lambda data, **kwargs: SimpleNamespace(revision=2),
+    )
+    try:
+        await client.run(runtime, stop, poll_interval_seconds=0.01)
+    finally:
+        await client._client.aclose()
+
+    assert len(runtime.applied) == 1
+    assert acked == [(2, "worker start failed")]
+    assert client.revision == 1
+
+
+@pytest.mark.asyncio
+async def test_run_ignores_already_acked_revision(monkeypatch) -> None:
+    client = make_client(revision=2)
+    runtime = FakeRuntime()
+    stop = asyncio.Event()
+    acked: list[tuple[int, str]] = []
+
+    async def get_config(after_revision: int = 0) -> dict[str, Any]:
+        assert after_revision == 2
+        return {"revision": 2}
+
+    async def ack(revision: int, error: str = "") -> dict[str, Any]:
+        acked.append((revision, error))
+        return {"ok": True}
+
+    async def heartbeat(**kwargs: Any) -> dict[str, Any]:
+        stop.set()
+        return {"ok": True}
+
+    monkeypatch.setattr(client, "get_config", get_config)
+    monkeypatch.setattr(client, "ack", ack)
+    monkeypatch.setattr(client, "heartbeat", heartbeat)
+    monkeypatch.setattr(
+        control_plane_module,
+        "config_from_control_plane",
+        lambda data, **kwargs: pytest.fail("config must not be rebuilt"),
+    )
+    try:
+        await client.run(runtime, stop, poll_interval_seconds=0.01)
+    finally:
+        await client._client.aclose()
+
+    assert runtime.applied == []
+    assert acked == []
+
+
+@pytest.mark.asyncio
+async def test_run_reregisters_after_heartbeat_404(monkeypatch) -> None:
+    client = make_client(revision=2)
+    runtime = FakeRuntime(revision=2)
+    stop = asyncio.Event()
+    registered_revisions: list[int] = []
+    heartbeat_attempts: list[dict[str, Any]] = []
+
+    async def get_config(after_revision: int = 0) -> None:
+        assert after_revision == 2
+        return None
+
+    async def register() -> dict[str, Any]:
+        registered_revisions.append(client.revision)
+        return {"ok": True}
+
+    async def heartbeat(**kwargs: Any) -> dict[str, Any]:
+        heartbeat_attempts.append(kwargs)
+        if len(heartbeat_attempts) == 1:
+            raise RouterInstanceNotFound("instance lost")
+        stop.set()
+        return {"ok": True}
+
+    monkeypatch.setattr(client, "get_config", get_config)
+    monkeypatch.setattr(client, "register", register)
+    monkeypatch.setattr(client, "heartbeat", heartbeat)
+    try:
+        await client.run(runtime, stop, poll_interval_seconds=0.01)
+    finally:
+        await client.aclose()
+
+    assert registered_revisions == [2]
+    assert len(heartbeat_attempts) == 2
+    assert heartbeat_attempts[1]["process"]["revision"] == 2
+    assert runtime.applied == []
+
+
+@pytest.mark.asyncio
+async def test_run_reregisters_and_reacks_after_ack_404(monkeypatch) -> None:
+    client = make_client(revision=1)
+    runtime = FakeRuntime(revision=1)
+    stop = asyncio.Event()
+    config = SimpleNamespace(revision=2)
+    get_config_calls = 0
+    registered_revisions: list[int] = []
+    acked: list[tuple[int, str]] = []
+
+    async def get_config(after_revision: int = 0) -> dict[str, Any]:
+        nonlocal get_config_calls
+        get_config_calls += 1
+        assert after_revision == 1
+        return {"revision": 2}
+
+    async def register() -> dict[str, Any]:
+        registered_revisions.append(client.revision)
+        return {"ok": True}
+
+    async def ack(revision: int, error: str = "") -> dict[str, Any]:
+        acked.append((revision, error))
+        if len(acked) == 1:
+            raise RouterInstanceNotFound("instance lost")
+        client.revision = revision
+        return {"ok": True}
+
+    async def heartbeat(**kwargs: Any) -> dict[str, Any]:
+        stop.set()
+        return {"ok": True}
+
+    monkeypatch.setattr(client, "get_config", get_config)
+    monkeypatch.setattr(client, "register", register)
+    monkeypatch.setattr(client, "ack", ack)
+    monkeypatch.setattr(client, "heartbeat", heartbeat)
+    monkeypatch.setattr(
+        control_plane_module,
+        "config_from_control_plane",
+        lambda data, **kwargs: config,
+    )
+    try:
+        await client.run(runtime, stop, poll_interval_seconds=0.01)
+    finally:
+        await client.aclose()
+
+    assert get_config_calls == 1
+    assert runtime.applied == [config]
+    assert registered_revisions == [1]
+    assert acked == [(2, ""), (2, "")]
+    assert client.revision == 2
+
+
+@pytest.mark.asyncio
+async def test_run_reregisters_old_revision_after_error_ack_404(monkeypatch) -> None:
+    client = make_client(revision=1)
+    runtime = FakeRuntime(apply_error=RuntimeError("worker start failed"), revision=1)
+    stop = asyncio.Event()
+    registered_revisions: list[int] = []
+    acked: list[tuple[int, str]] = []
+
+    async def get_config(after_revision: int = 0) -> dict[str, Any]:
+        assert after_revision == 1
+        return {"revision": 2}
+
+    async def register() -> dict[str, Any]:
+        registered_revisions.append(client.revision)
+        return {"ok": True}
+
+    async def ack(revision: int, error: str = "") -> dict[str, Any]:
+        acked.append((revision, error))
+        if len(acked) == 1:
+            raise RouterInstanceNotFound("instance lost")
+        stop.set()
+        return {"ok": True}
+
+    async def heartbeat(**kwargs: Any) -> dict[str, Any]:
+        return {"ok": True}
+
+    monkeypatch.setattr(client, "get_config", get_config)
+    monkeypatch.setattr(client, "register", register)
+    monkeypatch.setattr(client, "ack", ack)
+    monkeypatch.setattr(client, "heartbeat", heartbeat)
+    monkeypatch.setattr(
+        control_plane_module,
+        "config_from_control_plane",
+        lambda data, **kwargs: SimpleNamespace(revision=2),
+    )
+    try:
+        await client.run(runtime, stop, poll_interval_seconds=0.01)
+    finally:
+        await client.aclose()
+
+    assert len(runtime.applied) == 2
+    assert registered_revisions == [1]
+    assert acked == [
+        (2, "worker start failed"),
+        (2, "worker start failed"),
+    ]
+    assert client.revision == 1
+
+
+@pytest.mark.asyncio
+async def test_run_retries_failed_reregistration(monkeypatch) -> None:
+    client = make_client(revision=2)
+    runtime = FakeRuntime(revision=2)
+    stop = asyncio.Event()
+    register_attempts = 0
+    heartbeat_attempts = 0
+
+    async def get_config(after_revision: int = 0) -> None:
+        return None
+
+    async def register() -> dict[str, Any]:
+        nonlocal register_attempts
+        register_attempts += 1
+        if register_attempts == 1:
+            raise RuntimeError("supervisor unavailable")
+        return {"ok": True}
+
+    async def heartbeat(**kwargs: Any) -> dict[str, Any]:
+        nonlocal heartbeat_attempts
+        heartbeat_attempts += 1
+        if heartbeat_attempts == 1:
+            raise RouterInstanceNotFound("instance lost")
+        stop.set()
+        return {"ok": True}
+
+    monkeypatch.setattr(client, "get_config", get_config)
+    monkeypatch.setattr(client, "register", register)
+    monkeypatch.setattr(client, "heartbeat", heartbeat)
+    try:
+        await client.run(runtime, stop, poll_interval_seconds=0.01)
+    finally:
+        await client.aclose()
+
+    assert register_attempts == 2
+    assert heartbeat_attempts == 2
+
+
+@pytest.mark.asyncio
+async def test_run_stops_before_polling(monkeypatch) -> None:
+    client = make_client()
+    runtime = FakeRuntime()
+    stop = asyncio.Event()
+    stop.set()
+
+    async def unexpected_get_config(after_revision: int = 0) -> None:
+        pytest.fail("stopped control plane must not poll")
+
+    monkeypatch.setattr(client, "get_config", unexpected_get_config)
+    try:
+        await client.run(runtime, stop, poll_interval_seconds=0.01)
+    finally:
+        await client._client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_unregister_404_is_idempotent() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(404, json={"detail": "not found"})
+
+    client = make_client()
+    await client.aclose()
+    client._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+    await client.unregister()
+
+    assert client._client.is_closed
+
+
+@pytest.mark.asyncio
+async def test_register_reports_initial_revision_zero() -> None:
+    payloads: list[dict[str, Any]] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        payloads.append(__import__("json").loads(request.content))
+        return httpx.Response(200, json={"ok": True})
+
+    client = make_client(revision=0)
+    await client.aclose()
+    client._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    try:
+        await client.register()
+    finally:
+        await client.aclose()
+
+    assert payloads == [
+        {
+            "router_uid": "router-1",
+            "instance_id": "instance-1",
+            "endpoint": "http://router:10080",
+            "version": "1",
+            "acked_revision": 0,
+        }
+    ]

--- a/xinference/router/tests/test_control_plane.py
+++ b/xinference/router/tests/test_control_plane.py
@@ -136,7 +136,7 @@ async def test_register_404_preserves_http_error() -> None:
 @pytest.mark.asyncio
 async def test_run_applies_revision_then_acks_and_heartbeats(monkeypatch) -> None:
     client = make_client()
-    runtime = FakeRuntime()
+    runtime: Any = FakeRuntime()
     stop = asyncio.Event()
     config = SimpleNamespace(revision=2)
     acked: list[tuple[int, str]] = []
@@ -199,7 +199,7 @@ async def test_run_applies_revision_then_acks_and_heartbeats(monkeypatch) -> Non
 @pytest.mark.asyncio
 async def test_run_reports_apply_error_without_advancing_revision(monkeypatch) -> None:
     client = make_client()
-    runtime = FakeRuntime(apply_error=RuntimeError("worker start failed"))
+    runtime: Any = FakeRuntime(apply_error=RuntimeError("worker start failed"))
     stop = asyncio.Event()
     acked: list[tuple[int, str]] = []
 
@@ -236,7 +236,7 @@ async def test_run_reports_apply_error_without_advancing_revision(monkeypatch) -
 @pytest.mark.asyncio
 async def test_run_ignores_already_acked_revision(monkeypatch) -> None:
     client = make_client(revision=2)
-    runtime = FakeRuntime()
+    runtime: Any = FakeRuntime()
     stop = asyncio.Event()
     acked: list[tuple[int, str]] = []
 
@@ -272,7 +272,7 @@ async def test_run_ignores_already_acked_revision(monkeypatch) -> None:
 @pytest.mark.asyncio
 async def test_run_reregisters_after_heartbeat_404(monkeypatch) -> None:
     client = make_client(revision=2)
-    runtime = FakeRuntime(revision=2)
+    runtime: Any = FakeRuntime(revision=2)
     stop = asyncio.Event()
     registered_revisions: list[int] = []
     heartbeat_attempts: list[dict[str, Any]] = []
@@ -309,7 +309,7 @@ async def test_run_reregisters_after_heartbeat_404(monkeypatch) -> None:
 @pytest.mark.asyncio
 async def test_run_reregisters_and_reacks_after_ack_404(monkeypatch) -> None:
     client = make_client(revision=1)
-    runtime = FakeRuntime(revision=1)
+    runtime: Any = FakeRuntime(revision=1)
     stop = asyncio.Event()
     config = SimpleNamespace(revision=2)
     get_config_calls = 0
@@ -361,7 +361,9 @@ async def test_run_reregisters_and_reacks_after_ack_404(monkeypatch) -> None:
 @pytest.mark.asyncio
 async def test_run_reregisters_old_revision_after_error_ack_404(monkeypatch) -> None:
     client = make_client(revision=1)
-    runtime = FakeRuntime(apply_error=RuntimeError("worker start failed"), revision=1)
+    runtime: Any = FakeRuntime(
+        apply_error=RuntimeError("worker start failed"), revision=1
+    )
     stop = asyncio.Event()
     registered_revisions: list[int] = []
     acked: list[tuple[int, str]] = []
@@ -410,7 +412,7 @@ async def test_run_reregisters_old_revision_after_error_ack_404(monkeypatch) -> 
 @pytest.mark.asyncio
 async def test_run_retries_failed_reregistration(monkeypatch) -> None:
     client = make_client(revision=2)
-    runtime = FakeRuntime(revision=2)
+    runtime: Any = FakeRuntime(revision=2)
     stop = asyncio.Event()
     register_attempts = 0
     heartbeat_attempts = 0
@@ -448,7 +450,7 @@ async def test_run_retries_failed_reregistration(monkeypatch) -> None:
 @pytest.mark.asyncio
 async def test_run_stops_before_polling(monkeypatch) -> None:
     client = make_client()
-    runtime = FakeRuntime()
+    runtime: Any = FakeRuntime()
     stop = asyncio.Event()
     stop.set()
 

--- a/xinference/router/tests/test_runtime.py
+++ b/xinference/router/tests/test_runtime.py
@@ -1,4 +1,5 @@
 from types import SimpleNamespace
+from typing import Any, cast
 
 import pytest
 
@@ -50,8 +51,8 @@ def config(revision: int, *, enabled: bool = True):
 def snapshot(cfg, *, fail_start: bool = False) -> RuntimeSnapshot:
     return RuntimeSnapshot(
         config=cfg,
-        tokenization=FakeTokenization(fail_start=fail_start),
-        policy=SimpleNamespace(),
+        tokenization=cast(Any, FakeTokenization(fail_start=fail_start)),
+        policy=cast(Any, SimpleNamespace()),
         gates={},
         client=FakeClient(),
     )
@@ -77,7 +78,7 @@ async def test_apply_drains_old_snapshot_after_inflight_request(monkeypatch) -> 
     assert runtime.current is snapshots[2]
     assert held.draining is True
     assert held.closed is False
-    assert snapshots[2].tokenization.started is True
+    assert cast(FakeTokenization, snapshots[2].tokenization).started is True
 
     await runtime.release(held)
 
@@ -129,5 +130,3 @@ async def test_failed_apply_keeps_previous_snapshot(monkeypatch) -> None:
     assert first_snapshot.closed is False
     assert failed_snapshot.closed is True
     await runtime.aclose()
-
-

--- a/xinference/router/tests/test_runtime.py
+++ b/xinference/router/tests/test_runtime.py
@@ -1,0 +1,133 @@
+from types import SimpleNamespace
+
+import pytest
+
+from xinference.router.admission import GateSnapshot
+from xinference.router.runtime import RouterDisabled, RouterRuntime, RuntimeSnapshot
+
+
+class FakeTokenization:
+    def __init__(self, *, fail_start: bool = False) -> None:
+        self.fail_start = fail_start
+        self.started = False
+        self.closed = False
+
+    async def start(self) -> None:
+        if self.fail_start:
+            raise RuntimeError("start failed")
+        self.started = True
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+    async def snapshot(self):
+        return GateSnapshot(active=0, waiting=0, max_active=2, max_queue=8)
+
+    @property
+    def worker_pids(self) -> list[int]:
+        return [101, 102]
+
+
+class FakeClient:
+    def __init__(self) -> None:
+        self.closed = False
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+def config(revision: int, *, enabled: bool = True):
+    return SimpleNamespace(
+        revision=revision,
+        enabled=enabled,
+        tokenizer_asset_id="deepseek-v4-flash-0731",
+        tokenizer_asset_origin="external",
+        tokenizer_asset_revision="0731",
+        tokenizer_asset_fingerprint="sha256:test-fingerprint",
+    )
+
+
+def snapshot(cfg, *, fail_start: bool = False) -> RuntimeSnapshot:
+    return RuntimeSnapshot(
+        config=cfg,
+        tokenization=FakeTokenization(fail_start=fail_start),
+        policy=SimpleNamespace(),
+        gates={},
+        client=FakeClient(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_apply_drains_old_snapshot_after_inflight_request(monkeypatch) -> None:
+    first = config(1)
+    second = config(2)
+    snapshots = {1: snapshot(first), 2: snapshot(second)}
+    monkeypatch.setattr(
+        RouterRuntime,
+        "_build_snapshot",
+        lambda self, cfg: snapshots[cfg.revision],
+    )
+
+    runtime = RouterRuntime(first)
+    await runtime.start()
+    held = await runtime.acquire()
+
+    await runtime.apply(second)
+
+    assert runtime.current is snapshots[2]
+    assert held.draining is True
+    assert held.closed is False
+    assert snapshots[2].tokenization.started is True
+
+    await runtime.release(held)
+
+    assert held.closed is True
+    assert held.client.closed is True
+    assert held.tokenization.closed is True
+    await runtime.aclose()
+
+
+@pytest.mark.asyncio
+async def test_disabled_snapshot_rejects_new_requests(monkeypatch) -> None:
+    disabled = config(2, enabled=False)
+    disabled_snapshot = snapshot(disabled)
+    monkeypatch.setattr(
+        RouterRuntime,
+        "_build_snapshot",
+        lambda self, cfg: disabled_snapshot,
+    )
+
+    runtime = RouterRuntime(disabled)
+    await runtime.start()
+
+    with pytest.raises(RouterDisabled):
+        await runtime.acquire()
+
+    await runtime.aclose()
+
+
+@pytest.mark.asyncio
+async def test_failed_apply_keeps_previous_snapshot(monkeypatch) -> None:
+    first = config(1)
+    second = config(2)
+    first_snapshot = snapshot(first)
+    failed_snapshot = snapshot(second, fail_start=True)
+    snapshots = {1: first_snapshot, 2: failed_snapshot}
+    monkeypatch.setattr(
+        RouterRuntime,
+        "_build_snapshot",
+        lambda self, cfg: snapshots[cfg.revision],
+    )
+
+    runtime = RouterRuntime(first)
+    await runtime.start()
+
+    with pytest.raises(RuntimeError, match="start failed"):
+        await runtime.apply(second)
+
+    assert runtime.current is first_snapshot
+    assert first_snapshot.closed is False
+    assert failed_snapshot.closed is True
+    await runtime.aclose()
+
+

--- a/xinference/router/tests/test_service.py
+++ b/xinference/router/tests/test_service.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import asyncio
+from argparse import Namespace
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from xinference.router import service as service_module
+
+
+class FakeControlPlaneClient:
+    instances: list["FakeControlPlaneClient"] = []
+    config_data: dict[str, Any] | None = {"revision": 7}
+    get_error: Exception | None = None
+    register_error: Exception | None = None
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        self.revision = 0
+        self.registered_revision: int | None = None
+        self.get_loop: asyncio.AbstractEventLoop | None = None
+        self.register_loop: asyncio.AbstractEventLoop | None = None
+        self.closed = False
+        self.__class__.instances.append(self)
+
+    async def get_config(self) -> dict[str, Any] | None:
+        self.get_loop = asyncio.get_running_loop()
+        if self.__class__.get_error is not None:
+            raise self.__class__.get_error
+        return self.__class__.config_data
+
+    async def register(self) -> dict[str, bool]:
+        self.register_loop = asyncio.get_running_loop()
+        self.registered_revision = self.revision
+        if self.__class__.register_error is not None:
+            raise self.__class__.register_error
+        return {"ok": True}
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+@pytest.fixture(autouse=True)
+def reset_fake_client() -> None:
+    FakeControlPlaneClient.instances = []
+    FakeControlPlaneClient.config_data = {"revision": 7}
+    FakeControlPlaneClient.get_error = None
+    FakeControlPlaneClient.register_error = None
+
+
+def make_args() -> Namespace:
+    return Namespace(
+        internal_token="internal-secret",
+        public_endpoint="http://router:10080",
+        host="127.0.0.1",
+        port=10080,
+        supervisor_url="http://supervisor",
+        router_uid="router-1",
+        log_level="INFO",
+    )
+
+
+@pytest.mark.asyncio
+async def test_load_control_plane_config_registers_unacked_instance(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = object()
+    monkeypatch.setattr(
+        service_module, "RouterControlPlaneClient", FakeControlPlaneClient
+    )
+    monkeypatch.setattr(
+        service_module,
+        "config_from_control_plane",
+        lambda data, **kwargs: config,
+    )
+
+    loaded, client = await service_module._load_control_plane_config(make_args())
+
+    assert loaded is config
+    assert client.revision == 0
+    assert client.registered_revision == 0
+    assert client.closed is False
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure_stage", ["get", "config", "register", "missing"])
+async def test_load_control_plane_config_closes_client_on_failure(
+    failure_stage: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        service_module, "RouterControlPlaneClient", FakeControlPlaneClient
+    )
+
+    if failure_stage == "get":
+        FakeControlPlaneClient.get_error = RuntimeError("get failed")
+    elif failure_stage == "missing":
+        FakeControlPlaneClient.config_data = None
+    elif failure_stage == "register":
+        FakeControlPlaneClient.register_error = RuntimeError("register failed")
+
+    def build_config(data: dict[str, Any], **kwargs: Any) -> object:
+        if failure_stage == "config":
+            raise ValueError("invalid config")
+        return object()
+
+    monkeypatch.setattr(service_module, "config_from_control_plane", build_config)
+
+    with pytest.raises((RuntimeError, ValueError)):
+        await service_module._load_control_plane_config(make_args())
+
+    assert len(FakeControlPlaneClient.instances) == 1
+    assert FakeControlPlaneClient.instances[0].closed is True
+
+
+@pytest.mark.asyncio
+async def test_serve_uses_one_event_loop_for_control_plane_and_uvicorn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = SimpleNamespace(
+        listen_host="127.0.0.1", listen_port=10081, log_level="INFO"
+    )
+    app = SimpleNamespace(state=SimpleNamespace())
+    server_loops: list[asyncio.AbstractEventLoop] = []
+
+    class FakeUvicornConfig:
+        def __init__(self, configured_app: Any, **kwargs: Any) -> None:
+            assert configured_app is app
+            assert kwargs == {
+                "host": "127.0.0.1",
+                "port": 10081,
+                "log_level": "info",
+                "proxy_headers": True,
+            }
+
+    class FakeUvicornServer:
+        def __init__(self, configured: FakeUvicornConfig) -> None:
+            assert isinstance(configured, FakeUvicornConfig)
+
+        async def serve(self) -> None:
+            server_loops.append(asyncio.get_running_loop())
+
+    monkeypatch.setattr(
+        service_module, "RouterControlPlaneClient", FakeControlPlaneClient
+    )
+    monkeypatch.setattr(
+        service_module, "config_from_control_plane", lambda data, **kwargs: config
+    )
+    monkeypatch.setattr(service_module, "create_app", lambda loaded: app)
+    monkeypatch.setattr(service_module.uvicorn, "Config", FakeUvicornConfig)
+    monkeypatch.setattr(service_module.uvicorn, "Server", FakeUvicornServer)
+
+    await service_module._serve(make_args())
+
+    client = FakeControlPlaneClient.instances[0]
+    assert app.state.control_plane is client
+    assert client.get_loop is server_loops[0]
+    assert client.register_loop is server_loops[0]
+    await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_serve_closes_control_plane_if_app_bootstrap_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = SimpleNamespace(
+        listen_host="127.0.0.1", listen_port=10081, log_level="INFO"
+    )
+    monkeypatch.setattr(
+        service_module, "RouterControlPlaneClient", FakeControlPlaneClient
+    )
+    monkeypatch.setattr(
+        service_module, "config_from_control_plane", lambda data, **kwargs: config
+    )
+
+    def fail_create_app(loaded: Any) -> None:
+        assert loaded is config
+        raise RuntimeError("app bootstrap failed")
+
+    monkeypatch.setattr(service_module, "create_app", fail_create_app)
+
+    with pytest.raises(RuntimeError, match="app bootstrap failed"):
+        await service_module._serve(make_args())
+
+    assert len(FakeControlPlaneClient.instances) == 1
+    assert FakeControlPlaneClient.instances[0].closed is True

--- a/xinference/router/tests/test_tokenization.py
+++ b/xinference/router/tests/test_tokenization.py
@@ -1,0 +1,193 @@
+import asyncio
+import os
+import time
+from pathlib import Path
+
+import pytest
+from tokenizers import Tokenizer, models, pre_tokenizers
+
+from xinference.router.admission import AdmissionRejected
+from xinference.router.metrics import RouterMetrics
+from xinference.router.tokenization import TokenizationService
+from xinference.router.tokenizer import TokenizationError
+
+
+def make_assets(tmp_path: Path) -> Path:
+    tokenizer = Tokenizer(models.WordLevel({"[UNK]": 0, "hello": 1}, unk_token="[UNK]"))
+    tokenizer.pre_tokenizer = pre_tokenizers.Whitespace()
+    tokenizer.save(str(tmp_path / "tokenizer.json"))
+    encoding = tmp_path / "encoding"
+    encoding.mkdir()
+    (encoding / "encoding_dsv4.py").write_text(
+        "import time\n"
+        "\n"
+        "def encode_messages(messages, thinking_mode, reasoning_effort=None):\n"
+        "    content = ' '.join(str(m.get('content', '')) for m in messages)\n"
+        "    if content.startswith('__cpu__:'):\n"
+        "        duration = float(content.split(':', 1)[1])\n"
+        "        deadline = time.perf_counter() + duration\n"
+        "        while time.perf_counter() < deadline:\n"
+        "            pass\n"
+        "        return 'hello'\n"
+        "    if content == '__error__':\n"
+        "        raise RuntimeError('synthetic rendering failure')\n"
+        "    return content\n"
+    )
+    return tmp_path
+
+
+def payload(content: str = "hello") -> dict:
+    return {
+        "messages": [{"role": "user", "content": content}],
+        "max_tokens": 1,
+        "chat_template_kwargs": {"enable_thinking": False},
+    }
+
+
+def make_service(
+    tmp_path: Path,
+    *,
+    max_workers: int = 1,
+    max_active: int = 1,
+    max_queue: int = 1,
+    queue_timeout_seconds: float = 1,
+    retry_after_seconds: int = 1,
+) -> tuple[TokenizationService, RouterMetrics]:
+    metrics = RouterMetrics()
+    service = TokenizationService(
+        make_assets(tmp_path),
+        metrics,
+        reserve_tokens=0,
+        default_output_tokens=1,
+        max_workers=max_workers,
+        max_active=max_active,
+        max_queue=max_queue,
+        queue_timeout_seconds=queue_timeout_seconds,
+        retry_after_seconds=retry_after_seconds,
+    )
+    return service, metrics
+
+
+async def wait_for_active(service: TokenizationService, expected: int = 1) -> None:
+    deadline = time.monotonic() + 2
+    while time.monotonic() < deadline:
+        if (await service.snapshot()).active == expected:
+            return
+        await asyncio.sleep(0.005)
+    raise AssertionError(f"tokenization active count did not become {expected}")
+
+
+@pytest.mark.asyncio
+async def test_spawn_workers_are_prestarted_and_remove_api_key(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("XINFERENCE_API_KEY", "parent-secret")
+    service, _ = make_service(
+        tmp_path,
+        max_workers=2,
+        max_active=2,
+    )
+    try:
+        await service.start()
+        assert len(service.worker_pids) == 2
+        assert os.getpid() not in service.worker_pids
+        assert os.environ["XINFERENCE_API_KEY"] == "parent-secret"
+    finally:
+        await service.aclose()
+
+
+@pytest.mark.asyncio
+async def test_process_tokenization_does_not_block_event_loop(tmp_path: Path) -> None:
+    service, _ = make_service(tmp_path)
+    try:
+        await service.start()
+        task = asyncio.create_task(
+            service.estimate(payload("__cpu__:0.3"), input_bytes=123)
+        )
+        await wait_for_active(service)
+
+        ticks = 0
+        deadline = time.monotonic() + 0.15
+        while time.monotonic() < deadline:
+            await asyncio.sleep(0.01)
+            ticks += 1
+
+        assert ticks >= 8
+        assert not task.done()
+        result = await task
+        assert result.prompt_tokens == 1
+        assert (await service.snapshot()).active == 0
+    finally:
+        await service.aclose()
+
+
+@pytest.mark.asyncio
+async def test_tokenization_queue_full_is_rejected_and_observed(
+    tmp_path: Path,
+) -> None:
+    service, metrics = make_service(
+        tmp_path,
+        max_queue=0,
+        queue_timeout_seconds=0,
+        retry_after_seconds=3,
+    )
+    try:
+        await service.start()
+        first = asyncio.create_task(
+            service.estimate(payload("__cpu__:0.2"), input_bytes=10)
+        )
+        await wait_for_active(service)
+        with pytest.raises(AdmissionRejected) as exc_info:
+            await service.estimate(payload(), input_bytes=20)
+        assert exc_info.value.reason == "queue_full"
+        assert exc_info.value.retry_after_seconds == 3
+        await first
+        rendered = await metrics.render()
+        assert 'reason="queue_full"} 1' in rendered
+        assert "xinference_token_router_tokenization_input_bytes_sum 10" in rendered
+        assert "xinference_token_router_tokenization_active 0" in rendered
+    finally:
+        await service.aclose()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_caller_keeps_slot_until_worker_finishes(
+    tmp_path: Path,
+) -> None:
+    service, metrics = make_service(
+        tmp_path,
+        max_queue=0,
+        queue_timeout_seconds=0,
+    )
+    try:
+        await service.start()
+        task = asyncio.create_task(
+            service.estimate(payload("__cpu__:0.25"), input_bytes=10)
+        )
+        await wait_for_active(service)
+        task.cancel()
+        await asyncio.sleep(0.03)
+        assert (await service.snapshot()).active == 1
+        with pytest.raises(AdmissionRejected):
+            await service.estimate(payload(), input_bytes=20)
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert (await service.snapshot()).active == 0
+        rendered = await metrics.render()
+        assert 'outcome="cancelled"} 1' in rendered
+    finally:
+        await service.aclose()
+
+
+@pytest.mark.asyncio
+async def test_tokenization_error_crosses_process_boundary(tmp_path: Path) -> None:
+    service, metrics = make_service(tmp_path)
+    try:
+        await service.start()
+        with pytest.raises(TokenizationError, match="synthetic rendering failure"):
+            await service.estimate(payload("__error__"), input_bytes=11)
+        assert (await service.snapshot()).active == 0
+        rendered = await metrics.render()
+        assert 'outcome="failed"} 1' in rendered
+    finally:
+        await service.aclose()

--- a/xinference/router/tests/test_tokenization.py
+++ b/xinference/router/tests/test_tokenization.py
@@ -78,10 +78,11 @@ async def wait_for_active(service: TokenizationService, expected: int = 1) -> No
 
 
 @pytest.mark.asyncio
-async def test_spawn_workers_are_prestarted_and_remove_api_key(
+async def test_spawn_workers_are_prestarted_and_remove_router_credentials(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setenv("XINFERENCE_API_KEY", "parent-secret")
+    monkeypatch.setenv("XINFERENCE_TOKEN_ROUTER_INTERNAL_TOKEN", "internal-secret")
     service, _ = make_service(
         tmp_path,
         max_workers=2,
@@ -92,6 +93,7 @@ async def test_spawn_workers_are_prestarted_and_remove_api_key(
         assert len(service.worker_pids) == 2
         assert os.getpid() not in service.worker_pids
         assert os.environ["XINFERENCE_API_KEY"] == "parent-secret"
+        assert os.environ["XINFERENCE_TOKEN_ROUTER_INTERNAL_TOKEN"] == "internal-secret"
     finally:
         await service.aclose()
 

--- a/xinference/router/tests/test_tokenizer.py
+++ b/xinference/router/tests/test_tokenizer.py
@@ -125,3 +125,56 @@ def test_rejects_multimodal_content(tmp_path: Path) -> None:
                 ]
             }
         )
+
+
+def test_top_level_thinking_overrides_extra_body_and_template_kwargs(
+    tmp_path: Path,
+) -> None:
+    estimator = DeepSeekV4TokenEstimator(
+        make_assets(tmp_path), reserve_tokens=0, default_output_tokens=1
+    )
+
+    result = estimator.estimate(
+        {
+            "messages": [{"role": "user", "content": "hello"}],
+            "enable_thinking": False,
+            "extra_body": {"enable_thinking": True},
+            "chat_template_kwargs": {"enable_thinking": True},
+        }
+    )
+
+    assert result.enable_thinking is False
+    assert result.prompt_tokens == 1
+
+
+def test_extra_body_thinking_is_normalized(tmp_path: Path) -> None:
+    estimator = DeepSeekV4TokenEstimator(
+        make_assets(tmp_path), reserve_tokens=0, default_output_tokens=1
+    )
+
+    result = estimator.estimate(
+        {
+            "messages": [{"role": "user", "content": "hello"}],
+            "extra_body": {"enable_thinking": True},
+        }
+    )
+
+    assert result.enable_thinking is True
+    assert result.prompt_tokens == 4
+
+
+def test_max_completion_tokens_overrides_max_tokens(tmp_path: Path) -> None:
+    estimator = DeepSeekV4TokenEstimator(
+        make_assets(tmp_path), reserve_tokens=0, default_output_tokens=1
+    )
+
+    result = estimator.estimate(
+        {
+            "messages": [{"role": "user", "content": "hello"}],
+            "max_tokens": 8,
+            "max_completion_tokens": 16,
+        }
+    )
+
+    assert result.output_tokens == 16
+    assert result.total_tokens == result.prompt_tokens + 16

--- a/xinference/router/tests/test_tokenizer.py
+++ b/xinference/router/tests/test_tokenizer.py
@@ -1,0 +1,71 @@
+from pathlib import Path
+
+import pytest
+from tokenizers import Tokenizer, models, pre_tokenizers
+
+from xinference.router.tokenizer import DeepSeekV4TokenEstimator, TokenizationError
+
+
+def make_assets(tmp_path: Path) -> Path:
+    tokenizer = Tokenizer(models.WordLevel({"[UNK]": 0, "hello": 1}, unk_token="[UNK]"))
+    tokenizer.pre_tokenizer = pre_tokenizers.Whitespace()
+    tokenizer.save(str(tmp_path / "tokenizer.json"))
+    encoding = tmp_path / "encoding"
+    encoding.mkdir()
+    (encoding / "encoding_dsv4.py").write_text(
+        "def encode_messages(messages, thinking_mode, reasoning_effort=None):\n"
+        "    prefix = '<think> ' if thinking_mode == 'thinking' else ''\n"
+        "    return prefix + ' '.join(str(m.get('content', '')) for m in messages)\n"
+    )
+    return tmp_path
+
+
+def test_estimates_final_budget(tmp_path: Path) -> None:
+    estimator = DeepSeekV4TokenEstimator(
+        make_assets(tmp_path), reserve_tokens=64, default_output_tokens=512
+    )
+    result = estimator.estimate(
+        {
+            "messages": [{"role": "user", "content": "hello hello"}],
+            "max_tokens": 8,
+            "chat_template_kwargs": {"enable_thinking": False},
+        }
+    )
+    assert result.prompt_tokens == 2
+    assert result.output_tokens == 8
+    assert result.total_tokens == 74
+    assert result.enable_thinking is False
+
+
+def test_thinking_and_text_content_list(tmp_path: Path) -> None:
+    estimator = DeepSeekV4TokenEstimator(
+        make_assets(tmp_path), reserve_tokens=0, default_output_tokens=1
+    )
+    result = estimator.estimate(
+        {
+            "messages": [
+                {"role": "user", "content": [{"type": "text", "text": "hello"}]}
+            ],
+            "chat_template_kwargs": {"enable_thinking": True},
+        }
+    )
+    assert result.enable_thinking is True
+    assert result.prompt_tokens == 4
+    assert result.total_tokens == 5
+
+
+def test_rejects_multimodal_content(tmp_path: Path) -> None:
+    estimator = DeepSeekV4TokenEstimator(
+        make_assets(tmp_path), reserve_tokens=0, default_output_tokens=1
+    )
+    with pytest.raises(TokenizationError):
+        estimator.estimate(
+            {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [{"type": "image_url", "image_url": {"url": "x"}}],
+                    }
+                ]
+            }
+        )

--- a/xinference/router/tests/test_tokenizer.py
+++ b/xinference/router/tests/test_tokenizer.py
@@ -54,6 +54,26 @@ def test_thinking_and_text_content_list(tmp_path: Path) -> None:
     assert result.total_tokens == 5
 
 
+def test_chat_template_kwargs_cannot_override_messages(tmp_path: Path) -> None:
+    estimator = DeepSeekV4TokenEstimator(
+        make_assets(tmp_path), reserve_tokens=0, default_output_tokens=1
+    )
+
+    result = estimator.estimate(
+        {
+            "messages": [{"role": "user", "content": "hello hello"}],
+            "chat_template_kwargs": {
+                "messages": [],
+                "enable_thinking": True,
+                "reasoning_effort": "high",
+            },
+        }
+    )
+
+    assert result.prompt_tokens == 5
+    assert result.enable_thinking is True
+
+
 def test_normalization_does_not_mutate_input_messages(tmp_path: Path) -> None:
     estimator = DeepSeekV4TokenEstimator(
         make_assets(tmp_path), reserve_tokens=0, default_output_tokens=1

--- a/xinference/router/tests/test_tokenizer.py
+++ b/xinference/router/tests/test_tokenizer.py
@@ -54,6 +54,19 @@ def test_thinking_and_text_content_list(tmp_path: Path) -> None:
     assert result.total_tokens == 5
 
 
+def test_null_text_content_part_is_treated_as_empty(tmp_path: Path) -> None:
+    estimator = DeepSeekV4TokenEstimator(
+        make_assets(tmp_path), reserve_tokens=0, default_output_tokens=1
+    )
+
+    result = estimator.estimate(
+        {"messages": [{"role": "user", "content": [{"type": "text", "text": None}]}]}
+    )
+
+    assert result.prompt_tokens == 0
+    assert result.total_tokens == 1
+
+
 def test_chat_template_kwargs_cannot_override_messages(tmp_path: Path) -> None:
     estimator = DeepSeekV4TokenEstimator(
         make_assets(tmp_path), reserve_tokens=0, default_output_tokens=1

--- a/xinference/router/tests/test_tokenizer.py
+++ b/xinference/router/tests/test_tokenizer.py
@@ -54,6 +54,29 @@ def test_thinking_and_text_content_list(tmp_path: Path) -> None:
     assert result.total_tokens == 5
 
 
+def test_normalization_does_not_mutate_input_messages(tmp_path: Path) -> None:
+    estimator = DeepSeekV4TokenEstimator(
+        make_assets(tmp_path), reserve_tokens=0, default_output_tokens=1
+    )
+    messages = [
+        {
+            "role": "user",
+            "content": [{"type": "text", "text": "hello"}],
+            "tool_calls": [{"id": "call-1"}],
+        }
+    ]
+
+    estimator.estimate({"messages": messages})
+
+    assert messages == [
+        {
+            "role": "user",
+            "content": [{"type": "text", "text": "hello"}],
+            "tool_calls": [{"id": "call-1"}],
+        }
+    ]
+
+
 def test_rejects_multimodal_content(tmp_path: Path) -> None:
     estimator = DeepSeekV4TokenEstimator(
         make_assets(tmp_path), reserve_tokens=0, default_output_tokens=1

--- a/xinference/router/tokenization.py
+++ b/xinference/router/tokenization.py
@@ -76,7 +76,7 @@ class TokenizationService:
             raise TokenizationWorkerUnavailable("Tokenization service is closed")
         executor = self._executor
         loop = asyncio.get_running_loop()
-        results: list[tuple[int, bool]] = []
+        results: list[tuple[int, bool, bool]] = []
 
         # ProcessPoolExecutor starts processes lazily. Multiple bounded waves
         # ensure every configured spawn worker completes its initializer even
@@ -92,11 +92,14 @@ class TokenizationService:
                 raise TokenizationWorkerUnavailable(
                     f"Unable to start tokenization workers: {exc}"
                 ) from exc
-            if any(api_key_present for _, api_key_present in results):
+            if any(
+                api_key_present or internal_token_present
+                for _, api_key_present, internal_token_present in results
+            ):
                 raise TokenizationWorkerUnavailable(
-                    "Tokenization worker retained XINFERENCE_API_KEY"
+                    "Tokenization worker retained a Router credential"
                 )
-            worker_pids = {pid for pid, _ in results}
+            worker_pids = {pid for pid, _, _ in results}
             if len(worker_pids) >= self._max_workers:
                 self._worker_pids = tuple(sorted(worker_pids))
                 logger.info("Tokenization workers started: pids=%s", self._worker_pids)

--- a/xinference/router/tokenization.py
+++ b/xinference/router/tokenization.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import multiprocessing
+import time
+from concurrent.futures import ProcessPoolExecutor
+from concurrent.futures.process import BrokenProcessPool
+from pathlib import Path
+from typing import Any
+
+from .admission import AdmissionRejected, CapacityGate, GateSnapshot
+from .metrics import RouterMetrics
+from .tokenization_worker import (
+    estimate_in_worker,
+    initialize_tokenization_worker,
+    ping_worker,
+)
+from .tokenizer import TokenBudget
+
+logger = logging.getLogger("deepseek_v4_token_router.tokenization")
+
+
+class TokenizationWorkerUnavailable(RuntimeError):
+    """Raised when the isolated tokenization process pool is unavailable."""
+
+
+class TokenizationService:
+    """Run prompt rendering/tokenization in a bounded spawn process pool."""
+
+    def __init__(
+        self,
+        tokenizer_path: Path,
+        metrics: RouterMetrics,
+        *,
+        reserve_tokens: int,
+        default_output_tokens: int,
+        max_workers: int,
+        max_active: int,
+        max_queue: int,
+        queue_timeout_seconds: float,
+        retry_after_seconds: int,
+    ) -> None:
+        self._tokenizer_path = tokenizer_path
+        self._reserve_tokens = reserve_tokens
+        self._default_output_tokens = default_output_tokens
+        self._max_workers = max_workers
+        self._metrics = metrics
+        self._gate = CapacityGate(
+            "tokenization",
+            max_active=max_active,
+            max_queue=max_queue,
+            queue_timeout_seconds=queue_timeout_seconds,
+            retry_after_seconds=retry_after_seconds,
+        )
+        self._executor = self._create_executor()
+        self._replace_lock = asyncio.Lock()
+        self._closed = False
+        self._worker_pids: tuple[int, ...] = ()
+
+    def _create_executor(self) -> ProcessPoolExecutor:
+        return ProcessPoolExecutor(
+            max_workers=self._max_workers,
+            mp_context=multiprocessing.get_context("spawn"),
+            initializer=initialize_tokenization_worker,
+            initargs=(
+                str(self._tokenizer_path),
+                self._reserve_tokens,
+                self._default_output_tokens,
+            ),
+        )
+
+    async def start(self) -> None:
+        """Prestart all workers and verify backend credentials were removed."""
+        if self._closed:
+            raise TokenizationWorkerUnavailable("Tokenization service is closed")
+        executor = self._executor
+        loop = asyncio.get_running_loop()
+        results: list[tuple[int, bool]] = []
+
+        # ProcessPoolExecutor starts processes lazily. Multiple bounded waves
+        # ensure every configured spawn worker completes its initializer even
+        # when loading the tokenizer takes different amounts of time.
+        for _ in range(3):
+            probes = [
+                loop.run_in_executor(executor, ping_worker, 0.2)
+                for _ in range(self._max_workers * 2)
+            ]
+            try:
+                results.extend(await asyncio.gather(*probes))
+            except Exception as exc:
+                raise TokenizationWorkerUnavailable(
+                    f"Unable to start tokenization workers: {exc}"
+                ) from exc
+            if any(api_key_present for _, api_key_present in results):
+                raise TokenizationWorkerUnavailable(
+                    "Tokenization worker retained XINFERENCE_API_KEY"
+                )
+            worker_pids = {pid for pid, _ in results}
+            if len(worker_pids) >= self._max_workers:
+                self._worker_pids = tuple(sorted(worker_pids))
+                logger.info("Tokenization workers started: pids=%s", self._worker_pids)
+                return
+
+        raise TokenizationWorkerUnavailable(
+            "Tokenization process pool did not start all configured workers"
+        )
+
+    async def estimate(
+        self, payload: dict[str, Any], *, input_bytes: int
+    ) -> TokenBudget:
+        try:
+            await self._gate.acquire()
+        except AdmissionRejected as exc:
+            await self._metrics.increment_tokenization_rejected(exc.reason)
+            await self._publish_gate_snapshot()
+            raise
+
+        await self._publish_gate_snapshot()
+        started = time.monotonic()
+        outcome = "completed"
+        future: asyncio.Future[TokenBudget] | None = None
+        executor = self._executor
+        try:
+            loop = asyncio.get_running_loop()
+            future = loop.run_in_executor(
+                executor,
+                estimate_in_worker,
+                payload,
+            )
+            # Shield the process future so request cancellation does not make
+            # the slot available while CPU tokenization is still running.
+            return await asyncio.shield(future)
+        except asyncio.CancelledError:
+            outcome = "cancelled"
+            if future is not None:
+                try:
+                    await asyncio.shield(future)
+                except Exception:
+                    pass
+            raise
+        except BrokenProcessPool as exc:
+            outcome = "worker_unavailable"
+            await self._replace_broken_executor(executor)
+            raise TokenizationWorkerUnavailable(
+                "Tokenization worker process failed"
+            ) from exc
+        except Exception:
+            outcome = "failed"
+            raise
+        finally:
+            await self._metrics.observe_tokenization(
+                duration_seconds=time.monotonic() - started,
+                input_bytes=input_bytes,
+                outcome=outcome,
+            )
+            await self._gate.release()
+            await self._publish_gate_snapshot()
+
+    async def snapshot(self) -> GateSnapshot:
+        return await self._gate.snapshot()
+
+    @property
+    def worker_pids(self) -> tuple[int, ...]:
+        return self._worker_pids
+
+    async def _publish_gate_snapshot(self) -> None:
+        snapshot = await self._gate.snapshot()
+        await self._metrics.set_tokenization_capacity(
+            active=snapshot.active,
+            waiting=snapshot.waiting,
+        )
+
+    async def _replace_broken_executor(
+        self, failed_executor: ProcessPoolExecutor
+    ) -> None:
+        async with self._replace_lock:
+            if self._closed or self._executor is not failed_executor:
+                return
+            replacement = self._create_executor()
+            self._executor = replacement
+            self._worker_pids = ()
+            failed_executor.shutdown(wait=False, cancel_futures=True)
+            try:
+                await self.start()
+            except Exception:
+                # Keep the replacement assigned so subsequent submissions
+                # receive BrokenProcessPool and can trigger another guarded
+                # recovery attempt instead of using the failed executor.
+                logger.exception("Failed to restart tokenization process pool")
+
+    async def aclose(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        executor = self._executor
+        self._worker_pids = ()
+        await asyncio.to_thread(
+            executor.shutdown,
+            wait=True,
+            cancel_futures=True,
+        )

--- a/xinference/router/tokenization_worker.py
+++ b/xinference/router/tokenization_worker.py
@@ -18,6 +18,7 @@ def initialize_tokenization_worker(
     """Initialize one process-local estimator and remove backend credentials."""
     global _ESTIMATOR
     os.environ.pop("XINFERENCE_API_KEY", None)
+    os.environ.pop("XINFERENCE_TOKEN_ROUTER_INTERNAL_TOKEN", None)
     _ESTIMATOR = DeepSeekV4TokenEstimator(
         Path(tokenizer_path),
         reserve_tokens=reserve_tokens,
@@ -31,9 +32,13 @@ def estimate_in_worker(payload: dict[str, Any]) -> TokenBudget:
     return _ESTIMATOR.estimate(payload)
 
 
-def ping_worker(delay_seconds: float = 0.05) -> tuple[int, bool]:
+def ping_worker(delay_seconds: float = 0.05) -> tuple[int, bool, bool]:
     """Return worker identity without exposing any credential value."""
     if _ESTIMATOR is None:
         raise RuntimeError("Tokenization worker is not initialized")
     time.sleep(delay_seconds)
-    return os.getpid(), "XINFERENCE_API_KEY" in os.environ
+    return (
+        os.getpid(),
+        "XINFERENCE_API_KEY" in os.environ,
+        "XINFERENCE_TOKEN_ROUTER_INTERNAL_TOKEN" in os.environ,
+    )

--- a/xinference/router/tokenization_worker.py
+++ b/xinference/router/tokenization_worker.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+from .tokenizer import DeepSeekV4TokenEstimator, TokenBudget
+
+_ESTIMATOR: DeepSeekV4TokenEstimator | None = None
+
+
+def initialize_tokenization_worker(
+    tokenizer_path: str,
+    reserve_tokens: int,
+    default_output_tokens: int,
+) -> None:
+    """Initialize one process-local estimator and remove backend credentials."""
+    global _ESTIMATOR
+    os.environ.pop("XINFERENCE_API_KEY", None)
+    _ESTIMATOR = DeepSeekV4TokenEstimator(
+        Path(tokenizer_path),
+        reserve_tokens=reserve_tokens,
+        default_output_tokens=default_output_tokens,
+    )
+
+
+def estimate_in_worker(payload: dict[str, Any]) -> TokenBudget:
+    if _ESTIMATOR is None:
+        raise RuntimeError("Tokenization worker is not initialized")
+    return _ESTIMATOR.estimate(payload)
+
+
+def ping_worker(delay_seconds: float = 0.05) -> tuple[int, bool]:
+    """Return worker identity without exposing any credential value."""
+    if _ESTIMATOR is None:
+        raise RuntimeError("Tokenization worker is not initialized")
+    time.sleep(delay_seconds)
+    return os.getpid(), "XINFERENCE_API_KEY" in os.environ

--- a/xinference/router/tokenizer.py
+++ b/xinference/router/tokenizer.py
@@ -82,7 +82,17 @@ def _chat_template_kwargs(payload: dict[str, Any]) -> dict[str, Any]:
             raise TokenizationError("chat_template_kwargs must be valid JSON") from exc
     if not isinstance(raw, dict):
         raise TokenizationError("chat_template_kwargs must be an object")
-    return dict(raw)
+
+    normalized = dict(raw)
+    enable_thinking = payload.get("enable_thinking")
+    if enable_thinking is None:
+        extra_body = payload.get("extra_body")
+        if isinstance(extra_body, dict):
+            enable_thinking = extra_body.get("enable_thinking")
+    if isinstance(enable_thinking, bool):
+        normalized["enable_thinking"] = enable_thinking
+        normalized["thinking"] = enable_thinking
+    return normalized
 
 
 class DeepSeekV4TokenEstimator:
@@ -137,9 +147,9 @@ class DeepSeekV4TokenEstimator:
             raise TokenizationError("DeepSeek-V4 renderer did not return text")
 
         prompt_tokens = len(self._tokenizer.encode(prompt, add_special_tokens=True).ids)
-        output_value = payload.get("max_tokens")
+        output_value = payload.get("max_completion_tokens")
         if output_value is None:
-            output_value = payload.get("max_completion_tokens")
+            output_value = payload.get("max_tokens")
         if output_value is None:
             output_value = self._default_output_tokens
         if isinstance(output_value, bool) or not isinstance(output_value, int):

--- a/xinference/router/tokenizer.py
+++ b/xinference/router/tokenizer.py
@@ -53,7 +53,7 @@ def _normalize_content(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
                     raise TokenizationError(
                         "The phase-1 Router only supports text chat content"
                     )
-                text_parts.append(str(part.get("text", "")))
+                text_parts.append(str(part.get("text") or ""))
             message["content"] = "\n".join(text_parts)
         elif not isinstance(content, str):
             raise TokenizationError("Message content must be a string or text list")

--- a/xinference/router/tokenizer.py
+++ b/xinference/router/tokenizer.py
@@ -125,7 +125,7 @@ class DeepSeekV4TokenEstimator:
         }
         signature = inspect.signature(encode_messages)
         for name in signature.parameters:
-            if name in template_kwargs:
+            if name != "messages" and name in template_kwargs:
                 kwargs[name] = template_kwargs[name]
         try:
             prompt = encode_messages(messages, **kwargs)

--- a/xinference/router/tokenizer.py
+++ b/xinference/router/tokenizer.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import copy
+import importlib.util
+import inspect
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+from tokenizers import Tokenizer
+
+
+class TokenizationError(ValueError):
+    """Raised when a request cannot be rendered or tokenized safely."""
+
+
+@dataclass(frozen=True)
+class TokenBudget:
+    prompt_tokens: int
+    output_tokens: int
+    reserve_tokens: int
+    total_tokens: int
+    enable_thinking: bool
+
+
+def _load_encoding_module(path: Path) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        f"deepseek_v4_router_encoding_{abs(hash(path))}", path
+    )
+    if spec is None or spec.loader is None:
+        raise TokenizationError(f"Unable to load DeepSeek-V4 encoding module: {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    if not callable(getattr(module, "encode_messages", None)):
+        raise TokenizationError(f"Encoding module has no encode_messages(): {path}")
+    return module
+
+
+def _normalize_content(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    normalized: list[dict[str, Any]] = []
+    for original in messages:
+        if not isinstance(original, dict):
+            raise TokenizationError("Each chat message must be an object")
+        message = copy.deepcopy(original)
+        content = message.get("content")
+        if content is None:
+            message["content"] = ""
+        elif isinstance(content, list):
+            text_parts: list[str] = []
+            for part in content:
+                if not isinstance(part, dict) or part.get("type") != "text":
+                    raise TokenizationError(
+                        "The phase-1 Router only supports text chat content"
+                    )
+                text_parts.append(str(part.get("text", "")))
+            message["content"] = "\n".join(text_parts)
+        elif not isinstance(content, str):
+            raise TokenizationError("Message content must be a string or text list")
+        normalized.append(message)
+    return normalized
+
+
+def _attach_tools(
+    messages: list[dict[str, Any]], tools: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    prepared = [dict(message) for message in messages]
+    for message in prepared:
+        if message.get("role") in {"system", "developer"}:
+            existing_tools = message.get("tools") or []
+            message["tools"] = [*existing_tools, *tools]
+            return prepared
+    return [{"role": "system", "content": "", "tools": tools}, *prepared]
+
+
+def _chat_template_kwargs(payload: dict[str, Any]) -> dict[str, Any]:
+    raw = payload.get("chat_template_kwargs") or {}
+    if isinstance(raw, str):
+        try:
+            raw = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise TokenizationError("chat_template_kwargs must be valid JSON") from exc
+    if not isinstance(raw, dict):
+        raise TokenizationError("chat_template_kwargs must be an object")
+    return dict(raw)
+
+
+class DeepSeekV4TokenEstimator:
+    """Mirror Xinference's DeepSeek-V4 chat rendering before routing."""
+
+    def __init__(
+        self,
+        tokenizer_path: Path,
+        *,
+        reserve_tokens: int,
+        default_output_tokens: int,
+    ) -> None:
+        tokenizer_json = tokenizer_path / "tokenizer.json"
+        encoding_path = tokenizer_path / "encoding" / "encoding_dsv4.py"
+        if not tokenizer_json.is_file():
+            raise TokenizationError(f"Missing tokenizer.json: {tokenizer_json}")
+        if not encoding_path.is_file():
+            raise TokenizationError(f"Missing encoding module: {encoding_path}")
+        self._tokenizer = Tokenizer.from_file(str(tokenizer_json))
+        self._encoding = _load_encoding_module(encoding_path)
+        self._reserve_tokens = reserve_tokens
+        self._default_output_tokens = default_output_tokens
+
+    def estimate(self, payload: dict[str, Any]) -> TokenBudget:
+        raw_messages = payload.get("messages")
+        if not isinstance(raw_messages, list) or not raw_messages:
+            raise TokenizationError("messages must be a non-empty list")
+        messages = _normalize_content(raw_messages)
+        tools = payload.get("tools") or []
+        if tools:
+            if not isinstance(tools, list):
+                raise TokenizationError("tools must be a list")
+            messages = _attach_tools(messages, tools)
+
+        template_kwargs = _chat_template_kwargs(payload)
+        enable_thinking = bool(template_kwargs.get("enable_thinking", False))
+        encode_messages = self._encoding.encode_messages
+        kwargs: dict[str, Any] = {
+            "thinking_mode": "thinking" if enable_thinking else "chat"
+        }
+        signature = inspect.signature(encode_messages)
+        for name in signature.parameters:
+            if name in template_kwargs:
+                kwargs[name] = template_kwargs[name]
+        try:
+            prompt = encode_messages(messages, **kwargs)
+        except Exception as exc:
+            raise TokenizationError(
+                f"DeepSeek-V4 chat rendering failed: {exc}"
+            ) from exc
+        if not isinstance(prompt, str):
+            raise TokenizationError("DeepSeek-V4 renderer did not return text")
+
+        prompt_tokens = len(self._tokenizer.encode(prompt, add_special_tokens=True).ids)
+        output_value = payload.get("max_tokens")
+        if output_value is None:
+            output_value = payload.get("max_completion_tokens")
+        if output_value is None:
+            output_value = self._default_output_tokens
+        if isinstance(output_value, bool) or not isinstance(output_value, int):
+            raise TokenizationError("max_tokens must be an integer")
+        if output_value < 1:
+            raise TokenizationError("max_tokens must be at least 1")
+
+        total_tokens = prompt_tokens + output_value + self._reserve_tokens
+        return TokenBudget(
+            prompt_tokens=prompt_tokens,
+            output_tokens=output_value,
+            reserve_tokens=self._reserve_tokens,
+            total_tokens=total_tokens,
+            enable_thinking=enable_thinking,
+        )

--- a/xinference/router/tokenizer.py
+++ b/xinference/router/tokenizer.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import copy
 import importlib.util
 import inspect
 import json
@@ -43,7 +42,7 @@ def _normalize_content(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
     for original in messages:
         if not isinstance(original, dict):
             raise TokenizationError("Each chat message must be an object")
-        message = copy.deepcopy(original)
+        message = dict(original)
         content = message.get("content")
         if content is None:
             message["content"] = ""


### PR DESCRIPTION
## Summary
- add a native `xinference-router` data-plane process with process-isolated tokenization, admission control, typed first-match routing rules, and HTTP/SSE proxying
- add V1 short/long compatibility plus V2 dynamic 1-16 backend configuration for the `llm_chat` route profile
- add Supervisor-backed Router configuration/runtime registries, virtual model discovery, OpenAI chat dispatch, internal runtime registration, heartbeat, config polling, and acknowledgement APIs
- protect existing deployments with the opt-in `XINFERENCE_TOKEN_ROUTER_ENABLED` feature gate (disabled by default)
- add Router management scopes, audit coverage, API/runtime/configuration tests, and CLI packaging

## Validation
- focused Router suite: 98 passed
- `pre-commit run --files <modified files>`

## Follow-ups
Tokenizer asset management, bundled assets, Web UI, Agent orchestration, and monitoring are intentionally split into dependent PRs.
