### PR TITLE
feat(router): add tokenizer asset registry

### DIFF
--- a/xinference/api/routers/token_routers.py
+++ b/xinference/api/routers/token_routers.py
@@ -67,6 +67,30 @@ async def list_backend_candidates(api: "RESTfulAPI") -> JSONResponse:
     )
 
 
+async def list_tokenizer_assets(api: "RESTfulAPI") -> JSONResponse:
+    return JSONResponse(content=await (await _supervisor(api)).list_tokenizer_assets())
+
+
+async def get_tokenizer_asset(asset_id: str, api: "RESTfulAPI") -> JSONResponse:
+    try:
+        result = await (await _supervisor(api)).get_tokenizer_asset(asset_id)
+    except KeyError as exc:
+        raise HTTPException(
+            status_code=404, detail="Tokenizer asset not found"
+        ) from exc
+    return JSONResponse(content=result)
+
+
+async def validate_tokenizer_asset(asset_id: str, api: "RESTfulAPI") -> JSONResponse:
+    try:
+        result = await (await _supervisor(api)).validate_tokenizer_asset(asset_id)
+    except KeyError as exc:
+        raise HTTPException(
+            status_code=404, detail="Tokenizer asset not found"
+        ) from exc
+    return JSONResponse(content=result)
+
+
 async def create_router(
     payload: TokenRouterCreate, api: "RESTfulAPI", user: Optional[dict]
 ) -> JSONResponse:
@@ -76,6 +100,12 @@ async def create_router(
         result = await (await _supervisor(api)).create_token_router(
             router_uid, data, _username(user)
         )
+    except KeyError as exc:
+        raise HTTPException(
+            status_code=404, detail="Tokenizer asset not found"
+        ) from exc
+    except PermissionError as exc:
+        raise HTTPException(status_code=403, detail=str(exc)) from exc
     except ValueError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
     return JSONResponse(status_code=201, content=result)
@@ -99,7 +129,14 @@ async def update_router(
             router_uid, payload.dict(), _username(user)
         )
     except KeyError as exc:
-        raise HTTPException(status_code=404, detail="Token Router not found") from exc
+        detail = (
+            "Token Router not found"
+            if str(exc).strip("'") == router_uid
+            else "Tokenizer asset not found"
+        )
+        raise HTTPException(status_code=404, detail=detail) from exc
+    except PermissionError as exc:
+        raise HTTPException(status_code=403, detail=str(exc)) from exc
     except (RuntimeError, ValueError) as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
     return JSONResponse(content=result)
@@ -278,6 +315,20 @@ def register_routes(api: "RESTfulAPI") -> None:
 
             handler = anonymous
         router.add_api_route(path, handler, methods=methods)
+
+    route("/v1/tokenizer_assets", list_tokenizer_assets, ["GET"], "routers:list")
+    route(
+        "/v1/tokenizer_assets/{asset_id}",
+        get_tokenizer_asset,
+        ["GET"],
+        "routers:read",
+    )
+    route(
+        "/v1/tokenizer_assets/{asset_id}/validate",
+        validate_tokenizer_asset,
+        ["POST"],
+        "routers:operate",
+    )
 
     route("/v1/token_routers", list_routers, ["GET"], "routers:list")
     route(

--- a/xinference/api/schemas/router.py
+++ b/xinference/api/schemas/router.py
@@ -128,7 +128,8 @@ class TokenRouterConfigBase(BaseModel):
     model_type: Literal["LLM"] = "LLM"
     route_profile: Literal["llm_chat"] = "llm_chat"
     strategy: Literal["token_budget", "typed_rules"] = "token_budget"
-    tokenizer_path: str = Field(min_length=1)
+    tokenizer_asset_id: Optional[str] = Field(default=None, min_length=1)
+    tokenizer_path: Optional[str] = Field(default=None, min_length=1)
     backend_url: str = Field(min_length=1)
     model_aliases: list[str] = Field(default_factory=list)
     request_timeout_seconds: float = Field(default=10800.0, gt=0)
@@ -136,6 +137,21 @@ class TokenRouterConfigBase(BaseModel):
     backends: Union[RouterBackendsConfig, list[DynamicRouterBackendConfig]]
     routing: Union[TypedRoutingConfig, RoutingConfig]
     tokenization: TokenizationConfig = Field(default_factory=TokenizationConfig)
+
+    @validator("tokenizer_asset_id", "tokenizer_path", pre=True)
+    def normalize_tokenizer_source(cls, value: Any):
+        if isinstance(value, str):
+            value = value.strip()
+            return value or None
+        return value
+
+    @validator("tokenizer_path", always=True)
+    def validate_tokenizer_source(
+        cls, value: Optional[str], values: Dict[str, Any]
+    ) -> Optional[str]:
+        if not values.get("tokenizer_asset_id") and not value:
+            raise ValueError("tokenizer_asset_id or tokenizer_path must be provided")
+        return value
 
     @validator("config_version")
     def validate_config_version(cls, value: int) -> int:

--- a/xinference/api/tests/test_token_router_api.py
+++ b/xinference/api/tests/test_token_router_api.py
@@ -251,6 +251,43 @@ async def test_management_crud_revision_and_validation(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("process", [None, {"tokenizer_asset": None}])
+async def test_validation_tolerates_missing_process_tokenizer_metadata(
+    tmp_path, process
+) -> None:
+    class TokenizerAssetRegistry:
+        def reload(self) -> None:
+            pass
+
+        def validate_asset(self, asset_id: str) -> dict:
+            assert asset_id == "test-asset"
+            return {"valid": True, "errors": []}
+
+    supervisor = make_supervisor(tmp_path)
+    supervisor._tokenizer_asset_registry = TokenizerAssetRegistry()
+    payload = router_payload()
+    payload["tokenizer_asset_id"] = "test-asset"
+    supervisor._token_router_store.create("router-a", payload)
+    supervisor._token_router_registry.register(
+        "router-a",
+        "instance-a",
+        {"endpoint": "http://router.internal", "acked_revision": 1},
+    )
+    supervisor._token_router_registry.heartbeat(
+        "instance-a", {"status": "ready", "process": process}
+    )
+
+    result = await supervisor.validate_token_router("router-a")
+
+    assert result is not None
+    assert result["valid"] is False
+    assert any(
+        "loaded Tokenizer asset <unknown>, expected test-asset" in error
+        for error in result["errors"]
+    )
+
+
+@pytest.mark.asyncio
 async def test_validation_checks_running_backend_type_and_context(tmp_path) -> None:
     supervisor = make_supervisor(tmp_path)
 

--- a/xinference/api/tests/test_token_router_api.py
+++ b/xinference/api/tests/test_token_router_api.py
@@ -1,3 +1,6 @@
+import asyncio
+import threading
+import time
 from copy import deepcopy
 from types import MethodType
 
@@ -248,6 +251,138 @@ async def test_management_crud_revision_and_validation(tmp_path) -> None:
         assert disabled.json()["enabled"] is False
         assert (await client.delete("/v1/token_routers/router-a")).status_code == 200
         assert (await client.get("/v1/token_routers/router-a")).status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_tokenizer_asset_registry_operations_run_off_event_loop(tmp_path) -> None:
+    event_loop_thread = threading.current_thread()
+    calls = []
+
+    class TokenizerAssetRegistry:
+        allow_custom_path = False
+
+        @staticmethod
+        def _record(name: str) -> None:
+            calls.append((name, threading.current_thread()))
+
+        def reload(self) -> None:
+            self._record("reload")
+
+        def resolve(self, asset_id: str, tokenizer_path=None) -> dict:
+            self._record("resolve")
+            assert asset_id == "test-asset"
+            assert tokenizer_path is None
+            return {
+                "tokenizer_asset_id": asset_id,
+                "tokenizer_path": "/models/tokenizer",
+                "tokenizer_asset_revision": "1",
+                "tokenizer_asset_fingerprint": "sha256:test",
+            }
+
+        def validate_asset(self, asset_id: str) -> dict:
+            self._record("validate_asset")
+            assert asset_id == "test-asset"
+            return {
+                "valid": True,
+                "errors": [],
+                "revision": "1",
+                "fingerprint": "sha256:test",
+            }
+
+        def validate_path(self, tokenizer_path: str, *, smoke_test: bool) -> dict:
+            self._record("validate_path")
+            assert tokenizer_path == "/models/tokenizer"
+            assert smoke_test is True
+            return {"valid": True, "errors": []}
+
+    supervisor = make_supervisor(tmp_path)
+    supervisor._tokenizer_asset_registry = TokenizerAssetRegistry()
+    payload = router_payload()
+    payload.pop("tokenizer_path")
+    payload["tokenizer_asset_id"] = "test-asset"
+
+    await supervisor.validate_tokenizer_asset("test-asset")
+    created = await supervisor.create_token_router("router-a", payload)
+    update_payload = deepcopy(payload)
+    update_payload["revision"] = created["revision"]
+    await supervisor.update_token_router("router-a", update_payload)
+    assert await supervisor.validate_token_router("router-a") is not None
+
+    custom_path_payload = router_payload()
+    custom_path_payload["virtual_model_uid"] = "virtual-model-path"
+    supervisor._token_router_store.create("router-path", custom_path_payload)
+    assert await supervisor.validate_token_router("router-path") is not None
+
+    assert [name for name, _ in calls].count("resolve") == 2
+    assert [name for name, _ in calls].count("validate_asset") == 2
+    assert [name for name, _ in calls].count("validate_path") == 1
+    assert all(thread is not event_loop_thread for _, thread in calls)
+
+
+@pytest.mark.asyncio
+async def test_tokenizer_asset_registry_operations_are_serialized(tmp_path) -> None:
+    state_lock = threading.Lock()
+    active = 0
+    max_active = 0
+
+    class TokenizerAssetRegistry:
+        def reload(self) -> None:
+            pass
+
+        def validate_asset(self, asset_id: str) -> dict:
+            nonlocal active, max_active
+            with state_lock:
+                active += 1
+                max_active = max(max_active, active)
+            time.sleep(0.05)
+            with state_lock:
+                active -= 1
+            return {"asset_id": asset_id, "valid": True, "errors": []}
+
+    supervisor = make_supervisor(tmp_path)
+    supervisor._tokenizer_asset_registry = TokenizerAssetRegistry()
+
+    await asyncio.gather(
+        supervisor.validate_tokenizer_asset("asset-a"),
+        supervisor.validate_tokenizer_asset("asset-b"),
+    )
+
+    assert max_active == 1
+
+
+@pytest.mark.asyncio
+async def test_tokenizer_asset_validation_keeps_event_loop_responsive(
+    tmp_path,
+) -> None:
+    started = threading.Event()
+    release = threading.Event()
+
+    class TokenizerAssetRegistry:
+        def reload(self) -> None:
+            pass
+
+        def validate_asset(self, asset_id: str) -> dict:
+            assert asset_id == "test-asset"
+            started.set()
+            release.wait(timeout=1)
+            return {"valid": True, "errors": []}
+
+    supervisor = make_supervisor(tmp_path)
+    supervisor._tokenizer_asset_registry = TokenizerAssetRegistry()
+    safety_timer = threading.Timer(0.5, release.set)
+    safety_timer.start()
+    loop = asyncio.get_running_loop()
+    started_at = loop.time()
+    task = asyncio.create_task(supervisor.validate_tokenizer_asset("test-asset"))
+    try:
+        await asyncio.sleep(0.02)
+        elapsed = loop.time() - started_at
+        assert started.is_set()
+        assert elapsed < 0.25
+    finally:
+        release.set()
+        safety_timer.cancel()
+        await task
 
 
 @pytest.mark.asyncio

--- a/xinference/api/tests/test_token_router_api.py
+++ b/xinference/api/tests/test_token_router_api.py
@@ -758,3 +758,109 @@ async def test_v2_validation_checks_tools_and_thinking_capabilities(tmp_path) ->
     assert result["valid"] is False
     assert any("requires tools" in error for error in result["errors"])
     assert any("requires thinking" in error for error in result["errors"])
+
+
+@pytest.mark.asyncio
+async def test_validation_detects_loaded_fingerprint_mismatch(tmp_path) -> None:
+    class TokenizerAssetRegistry:
+        def reload(self) -> None:
+            pass
+
+        def resolve(self, asset_id: str, tokenizer_path=None) -> dict:
+            return {
+                "tokenizer_asset_id": asset_id,
+                "tokenizer_path": "/models/tokenizer",
+                "tokenizer_asset_revision": "0731",
+                "tokenizer_asset_fingerprint": "sha256:expected",
+            }
+
+        def validate_asset(self, asset_id: str) -> dict:
+            assert asset_id == "test-asset"
+            return {
+                "valid": True,
+                "errors": [],
+                "revision": "0731",
+                "fingerprint": "sha256:expected",
+                "capabilities": {"chat": True, "tools": True, "thinking": True},
+            }
+
+        def validate_path(self, tokenizer_path: str, *, smoke_test: bool) -> dict:
+            return {"valid": True, "errors": []}
+
+    supervisor = make_supervisor(tmp_path)
+    supervisor._tokenizer_asset_registry = TokenizerAssetRegistry()
+    payload = router_payload()
+    payload.pop("tokenizer_path")
+    payload["tokenizer_asset_id"] = "test-asset"
+    payload["tokenizer_asset_revision"] = "0731"
+    payload["tokenizer_asset_fingerprint"] = "sha256:expected"
+    supervisor._token_router_store.create("router-a", payload)
+    supervisor._token_router_registry.register(
+        "router-a",
+        "instance-a",
+        {"endpoint": "http://router.internal", "acked_revision": 1},
+    )
+    supervisor._token_router_registry.heartbeat(
+        "instance-a",
+        {
+            "status": "ready",
+            "process": {
+                "tokenizer_asset": {
+                    "asset_id": "test-asset",
+                    "revision": "0731",
+                    "fingerprint": "sha256:swapped",
+                }
+            },
+        },
+    )
+
+    result = await supervisor.validate_token_router("router-a")
+
+    assert result is not None
+    assert result["valid"] is False
+    assert any(
+        "loaded Tokenizer asset fingerprint differs from the Router configuration"
+        in error
+        for error in result["errors"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_v2_validation_rejects_rules_asset_cannot_support(tmp_path) -> None:
+    class TokenizerAssetRegistry:
+        def reload(self) -> None:
+            pass
+
+        def validate_asset(self, asset_id: str) -> dict:
+            return {
+                "valid": True,
+                "errors": [],
+                "revision": "0731",
+                "fingerprint": "sha256:expected",
+                "capabilities": {"chat": True, "tools": False, "thinking": False},
+            }
+
+        def validate_path(self, tokenizer_path: str, *, smoke_test: bool) -> dict:
+            return {"valid": True, "errors": []}
+
+    supervisor = make_supervisor(tmp_path)
+    supervisor._tokenizer_asset_registry = TokenizerAssetRegistry()
+    payload = typed_router_payload()
+    payload.pop("tokenizer_path")
+    payload["tokenizer_asset_id"] = "test-asset"
+    payload["tokenizer_asset_revision"] = "0731"
+    payload["tokenizer_asset_fingerprint"] = "sha256:expected"
+    supervisor._token_router_store.create("router-a", payload)
+
+    result = await supervisor.validate_token_router("router-a")
+
+    assert result is not None
+    assert result["valid"] is False
+    assert any(
+        "requires tools but Tokenizer asset does not support tools" in error
+        for error in result["errors"]
+    )
+    assert any(
+        "requires thinking but Tokenizer asset does not support thinking" in error
+        for error in result["errors"]
+    )

--- a/xinference/api/tests/test_token_router_api.py
+++ b/xinference/api/tests/test_token_router_api.py
@@ -133,10 +133,24 @@ def typed_router_payload() -> dict:
     return payload
 
 
+class FakeTokenizerAssetRegistry:
+    allow_custom_path = True
+
+    def reload(self) -> None:
+        pass
+
+    def match_path(self, tokenizer_path: str):
+        return None
+
+    def validate_path(self, tokenizer_path: str, *, smoke_test: bool) -> dict:
+        return {"valid": True, "errors": []}
+
+
 def make_supervisor(tmp_path):
     supervisor = SupervisorActor.__new__(SupervisorActor)
     supervisor._token_router_store = RouterConfigStore(str(tmp_path / "routers.db"))
     supervisor._token_router_registry = RouterRuntimeRegistry()
+    supervisor._tokenizer_asset_registry = FakeTokenizerAssetRegistry()
 
     async def list_models(_self):
         return {
@@ -446,7 +460,9 @@ async def test_validation_checks_running_backend_type_and_context(tmp_path) -> N
     assert response.status_code == 200
     result = response.json()
     assert result["valid"] is False
-    assert "short backend model must be an LLM" in result["errors"][0]
+    assert any(
+        "short backend model must be an LLM" in error for error in result["errors"]
+    )
     assert any("short max_context_tokens" in error for error in result["errors"])
     assert any(
         "long backend model is not running" in error for error in result["errors"]

--- a/xinference/constants.py
+++ b/xinference/constants.py
@@ -231,12 +231,19 @@ XINFERENCE_TOKEN_ROUTER_ENABLED = os.environ.get(
     "XINFERENCE_TOKEN_ROUTER_ENABLED", "false"
 ).lower() in {"1", "true", "yes", "on"}
 
+XINFERENCE_TOKENIZER_ASSET_CONFIG = os.environ.get(
+    "XINFERENCE_TOKENIZER_ASSET_CONFIG", ""
+)
+
 XINFERENCE_TOKEN_ROUTER_DB_PATH = os.environ.get(
     "XINFERENCE_TOKEN_ROUTER_DB_PATH",
     os.path.join(XINFERENCE_HOME, "token_routers.db"),
 )
 XINFERENCE_TOKEN_ROUTER_HEARTBEAT_TIMEOUT_SECONDS = float(
     os.environ.get("XINFERENCE_TOKEN_ROUTER_HEARTBEAT_TIMEOUT_SECONDS", "90")
+)
+XINFERENCE_TOKENIZER_ASSET_CONFIG = os.environ.get(
+    "XINFERENCE_TOKENIZER_ASSET_CONFIG", ""
 )
 
 # Whether to allow models to run their own bundled code (transformers /

--- a/xinference/core/supervisor.py
+++ b/xinference/core/supervisor.py
@@ -5226,7 +5226,8 @@ class SupervisorActor(xo.StatelessActor):
                     continue
                 if int(instance.get("acked_revision", 0)) < int(config["revision"]):
                     continue
-                loaded = instance.get("process", {}).get("tokenizer_asset", {})
+                process_info = instance.get("process") or {}
+                loaded = process_info.get("tokenizer_asset") or {}
                 loaded_id = str(loaded.get("asset_id") or "")
                 loaded_revision = str(loaded.get("revision") or "")
                 loaded_fingerprint = str(loaded.get("fingerprint") or "")

--- a/xinference/core/supervisor.py
+++ b/xinference/core/supervisor.py
@@ -271,6 +271,7 @@ class SupervisorActor(xo.StatelessActor):
 
         self._token_router_store = RouterConfigStore(XINFERENCE_TOKEN_ROUTER_DB_PATH)
         self._tokenizer_asset_registry = TokenizerAssetRegistry()
+        self._tokenizer_asset_registry_lock = asyncio.Lock()
         self._token_router_registry = RouterRuntimeRegistry(
             XINFERENCE_TOKEN_ROUTER_HEARTBEAT_TIMEOUT_SECONDS
         )
@@ -4879,7 +4880,28 @@ class SupervisorActor(xo.StatelessActor):
             registry = self._tokenizer_asset_registry = TokenizerAssetRegistry()
         return registry
 
-    def _normalize_token_router_tokenizer(
+    def _get_tokenizer_asset_registry_lock(self) -> asyncio.Lock:
+        lock = getattr(self, "_tokenizer_asset_registry_lock", None)
+        if lock is None:
+            lock = self._tokenizer_asset_registry_lock = asyncio.Lock()
+        return lock
+
+    def _call_tokenizer_asset_registry(
+        self, method_name: str, *args: Any, **kwargs: Any
+    ) -> Any:
+        registry = self._get_tokenizer_asset_registry()
+        registry.reload()
+        return getattr(registry, method_name)(*args, **kwargs)
+
+    async def _call_tokenizer_asset_registry_async(
+        self, method_name: str, *args: Any, **kwargs: Any
+    ) -> Any:
+        async with self._get_tokenizer_asset_registry_lock():
+            return await asyncio.to_thread(
+                self._call_tokenizer_asset_registry, method_name, *args, **kwargs
+            )
+
+    def _normalize_token_router_tokenizer_sync(
         self,
         config: Dict[str, Any],
         current: Optional[Dict[str, Any]] = None,
@@ -4934,20 +4956,26 @@ class SupervisorActor(xo.StatelessActor):
         payload.pop("tokenizer_asset_fingerprint", None)
         return payload
 
+    async def _normalize_token_router_tokenizer(
+        self,
+        config: Dict[str, Any],
+        current: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        async with self._get_tokenizer_asset_registry_lock():
+            return await asyncio.to_thread(
+                self._normalize_token_router_tokenizer_sync, config, current
+            )
+
     async def list_tokenizer_assets(self) -> Dict[str, Any]:
-        registry = self._get_tokenizer_asset_registry()
-        registry.reload()
-        return registry.list_assets()
+        return await self._call_tokenizer_asset_registry_async("list_assets")
 
     async def get_tokenizer_asset(self, asset_id: str) -> Dict[str, Any]:
-        registry = self._get_tokenizer_asset_registry()
-        registry.reload()
-        return registry.get_asset(asset_id)
+        return await self._call_tokenizer_asset_registry_async("get_asset", asset_id)
 
     async def validate_tokenizer_asset(self, asset_id: str) -> Dict[str, Any]:
-        registry = self._get_tokenizer_asset_registry()
-        registry.reload()
-        return registry.validate_asset(asset_id)
+        return await self._call_tokenizer_asset_registry_async(
+            "validate_asset", asset_id
+        )
 
     def _validate_token_router_uniqueness(
         self, router_uid: str, config: Dict[str, Any]
@@ -4965,7 +4993,7 @@ class SupervisorActor(xo.StatelessActor):
     async def create_token_router(
         self, router_uid: str, config: Dict[str, Any], username: str = ""
     ) -> Dict[str, Any]:
-        payload = self._normalize_token_router_tokenizer(config)
+        payload = await self._normalize_token_router_tokenizer(config)
         self._validate_token_router_uniqueness(router_uid, payload)
         return self._with_token_router_status(
             self._token_router_store.create(router_uid, payload, username)
@@ -4977,7 +5005,7 @@ class SupervisorActor(xo.StatelessActor):
         current = self._token_router_store.get(router_uid)
         if current is None:
             raise KeyError(router_uid)
-        payload = self._normalize_token_router_tokenizer(config, current)
+        payload = await self._normalize_token_router_tokenizer(config, current)
         self._validate_token_router_uniqueness(router_uid, payload)
         expected_revision = payload.pop("revision", None)
         return self._with_token_router_status(
@@ -5101,11 +5129,11 @@ class SupervisorActor(xo.StatelessActor):
         warnings: List[str] = []
         asset_validation: Dict[str, Any]
         asset_id = str(config.get("tokenizer_asset_id") or "").strip()
-        registry = self._get_tokenizer_asset_registry()
-        registry.reload()
         try:
             if asset_id:
-                asset_validation = registry.validate_asset(asset_id)
+                asset_validation = await self._call_tokenizer_asset_registry_async(
+                    "validate_asset", asset_id
+                )
                 configured_revision = str(config.get("tokenizer_asset_revision") or "")
                 configured_fingerprint = str(
                     config.get("tokenizer_asset_fingerprint") or ""
@@ -5125,8 +5153,10 @@ class SupervisorActor(xo.StatelessActor):
                         "configuration"
                     )
             else:
-                asset_validation = registry.validate_path(
-                    str(config.get("tokenizer_path") or ""), smoke_test=True
+                asset_validation = await self._call_tokenizer_asset_registry_async(
+                    "validate_path",
+                    str(config.get("tokenizer_path") or ""),
+                    smoke_test=True,
                 )
         except KeyError:
             asset_validation = {

--- a/xinference/core/supervisor.py
+++ b/xinference/core/supervisor.py
@@ -267,8 +267,10 @@ class SupervisorActor(xo.StatelessActor):
 
         from .router_config_store import RouterConfigStore
         from .router_registry import RouterRuntimeRegistry
+        from .tokenizer_asset_registry import TokenizerAssetRegistry
 
         self._token_router_store = RouterConfigStore(XINFERENCE_TOKEN_ROUTER_DB_PATH)
+        self._tokenizer_asset_registry = TokenizerAssetRegistry()
         self._token_router_registry = RouterRuntimeRegistry(
             XINFERENCE_TOKEN_ROUTER_HEARTBEAT_TIMEOUT_SECONDS
         )
@@ -4869,6 +4871,84 @@ class SupervisorActor(xo.StatelessActor):
             "acked_revision": instance.get("acked_revision", 0),
         }
 
+    def _get_tokenizer_asset_registry(self):
+        registry = getattr(self, "_tokenizer_asset_registry", None)
+        if registry is None:
+            from .tokenizer_asset_registry import TokenizerAssetRegistry
+
+            registry = self._tokenizer_asset_registry = TokenizerAssetRegistry()
+        return registry
+
+    def _normalize_token_router_tokenizer(
+        self,
+        config: Dict[str, Any],
+        current: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        from pathlib import Path
+
+        from .tokenizer_asset_registry import TokenizerAssetError
+
+        payload = dict(config)
+        asset_id = str(payload.get("tokenizer_asset_id") or "").strip()
+        tokenizer_path = str(payload.get("tokenizer_path") or "").strip()
+        registry = self._get_tokenizer_asset_registry()
+        registry.reload()
+
+        if asset_id:
+            payload.update(registry.resolve(asset_id, tokenizer_path or None))
+            return payload
+
+        if not tokenizer_path:
+            raise ValueError("tokenizer_asset_id or tokenizer_path must be provided")
+
+        resolved_path = str(Path(tokenizer_path).expanduser().resolve())
+        matched = registry.match_path(resolved_path)
+        if matched is not None:
+            if matched.get("status") != "available":
+                detail = "; ".join(matched.get("errors", [])) or matched.get(
+                    "status", "invalid"
+                )
+                raise TokenizerAssetError(
+                    f"Tokenizer asset is not available: "
+                    f"{matched['asset_id']}: {detail}"
+                )
+            payload.update(registry.resolve(str(matched["asset_id"]), resolved_path))
+            return payload
+
+        same_historical_path = False
+        if current is not None and not current.get("tokenizer_asset_id"):
+            current_path = str(current.get("tokenizer_path") or "").strip()
+            if current_path:
+                same_historical_path = (
+                    str(Path(current_path).expanduser().resolve()) == resolved_path
+                )
+        if not registry.allow_custom_path and not same_historical_path:
+            raise PermissionError(
+                "Custom tokenizer_path is disabled; select a registered "
+                "tokenizer_asset_id"
+            )
+
+        payload["tokenizer_path"] = resolved_path
+        payload.pop("tokenizer_asset_id", None)
+        payload.pop("tokenizer_asset_revision", None)
+        payload.pop("tokenizer_asset_fingerprint", None)
+        return payload
+
+    async def list_tokenizer_assets(self) -> Dict[str, Any]:
+        registry = self._get_tokenizer_asset_registry()
+        registry.reload()
+        return registry.list_assets()
+
+    async def get_tokenizer_asset(self, asset_id: str) -> Dict[str, Any]:
+        registry = self._get_tokenizer_asset_registry()
+        registry.reload()
+        return registry.get_asset(asset_id)
+
+    async def validate_tokenizer_asset(self, asset_id: str) -> Dict[str, Any]:
+        registry = self._get_tokenizer_asset_registry()
+        registry.reload()
+        return registry.validate_asset(asset_id)
+
     def _validate_token_router_uniqueness(
         self, router_uid: str, config: Dict[str, Any]
     ) -> None:
@@ -4885,15 +4965,19 @@ class SupervisorActor(xo.StatelessActor):
     async def create_token_router(
         self, router_uid: str, config: Dict[str, Any], username: str = ""
     ) -> Dict[str, Any]:
-        self._validate_token_router_uniqueness(router_uid, config)
+        payload = self._normalize_token_router_tokenizer(config)
+        self._validate_token_router_uniqueness(router_uid, payload)
         return self._with_token_router_status(
-            self._token_router_store.create(router_uid, config, username)
+            self._token_router_store.create(router_uid, payload, username)
         )
 
     async def update_token_router(
         self, router_uid: str, config: Dict[str, Any], username: str = ""
     ) -> Dict[str, Any]:
-        payload = dict(config)
+        current = self._token_router_store.get(router_uid)
+        if current is None:
+            raise KeyError(router_uid)
+        payload = self._normalize_token_router_tokenizer(config, current)
         self._validate_token_router_uniqueness(router_uid, payload)
         expected_revision = payload.pop("revision", None)
         return self._with_token_router_status(
@@ -5015,7 +5099,55 @@ class SupervisorActor(xo.StatelessActor):
             return None
         errors: List[str] = []
         warnings: List[str] = []
+        asset_validation: Dict[str, Any]
+        asset_id = str(config.get("tokenizer_asset_id") or "").strip()
+        registry = self._get_tokenizer_asset_registry()
+        registry.reload()
+        try:
+            if asset_id:
+                asset_validation = registry.validate_asset(asset_id)
+                configured_revision = str(config.get("tokenizer_asset_revision") or "")
+                configured_fingerprint = str(
+                    config.get("tokenizer_asset_fingerprint") or ""
+                )
+                if configured_revision and configured_revision != str(
+                    asset_validation.get("revision") or ""
+                ):
+                    errors.append(
+                        "Tokenizer asset revision differs from the stored Router "
+                        "configuration"
+                    )
+                if configured_fingerprint and configured_fingerprint != str(
+                    asset_validation.get("fingerprint") or ""
+                ):
+                    errors.append(
+                        "Tokenizer asset fingerprint differs from the stored Router "
+                        "configuration"
+                    )
+            else:
+                asset_validation = registry.validate_path(
+                    str(config.get("tokenizer_path") or ""), smoke_test=True
+                )
+        except KeyError:
+            asset_validation = {
+                "valid": False,
+                "status": "missing",
+                "errors": [f"Tokenizer asset is not registered: {asset_id}"],
+            }
+        except Exception as exc:
+            asset_validation = {
+                "valid": False,
+                "status": "invalid",
+                "errors": [str(exc)],
+            }
+        errors.extend(str(error) for error in asset_validation.get("errors", []))
+
         running_models = await self.list_models()
+        compatible_models = {
+            str(name).strip().casefold()
+            for name in asset_validation.get("compatible_models", [])
+            if str(name).strip()
+        }
         backend_models: Dict[str, Dict[str, Any]] = {}
         for backend_id, backend in self._token_router_backend_entries(config):
             model_uid = str(backend.get("model_uid") or "")
@@ -5026,6 +5158,18 @@ class SupervisorActor(xo.StatelessActor):
             backend_models[backend_id] = model_info
             if model_info.get("model_type") != "LLM":
                 errors.append(f"{backend_id} backend model must be an LLM: {model_uid}")
+            if asset_id and compatible_models:
+                model_name = str(model_info.get("model_name") or "").strip()
+                if not model_name:
+                    errors.append(
+                        f"{backend_id} backend does not report model_name for Tokenizer "
+                        f"asset compatibility validation: {model_uid}"
+                    )
+                elif model_name.casefold() not in compatible_models:
+                    errors.append(
+                        f"{backend_id} backend model is not compatible with Tokenizer "
+                        f"asset {asset_id}: {model_name}"
+                    )
             abilities = {
                 str(value).casefold()
                 for value in model_info.get("model_ability", []) or []
@@ -5074,12 +5218,40 @@ class SupervisorActor(xo.StatelessActor):
                     errors.append(
                         f"Rule {rule.get('id')} requires thinking but backend {backend_id} does not report reasoning or hybrid capability"
                     )
+        if asset_id and asset_validation.get("valid"):
+            expected_revision = str(config.get("tokenizer_asset_revision") or "")
+            expected_fingerprint = str(config.get("tokenizer_asset_fingerprint") or "")
+            for instance in self._token_router_registry.list(router_uid):
+                if not instance.get("online"):
+                    continue
+                if int(instance.get("acked_revision", 0)) < int(config["revision"]):
+                    continue
+                loaded = instance.get("process", {}).get("tokenizer_asset", {})
+                loaded_id = str(loaded.get("asset_id") or "")
+                loaded_revision = str(loaded.get("revision") or "")
+                loaded_fingerprint = str(loaded.get("fingerprint") or "")
+                if loaded_id != asset_id:
+                    errors.append(
+                        f"Router instance {instance['instance_id']} loaded Tokenizer "
+                        f"asset {loaded_id or '<unknown>'}, expected {asset_id}"
+                    )
+                if expected_revision and loaded_revision != expected_revision:
+                    errors.append(
+                        f"Router instance {instance['instance_id']} loaded Tokenizer "
+                        "asset revision differs from the Router configuration"
+                    )
+                if expected_fingerprint and loaded_fingerprint != expected_fingerprint:
+                    errors.append(
+                        f"Router instance {instance['instance_id']} loaded Tokenizer "
+                        "asset fingerprint differs from the Router configuration"
+                    )
         return {
             "router_uid": router_uid,
             "valid": not errors,
             "errors": errors,
             "warnings": warnings,
             "revision": config["revision"],
+            "tokenizer_asset": asset_validation,
         }
 
     def _with_token_router_status(self, config: Dict[str, Any]) -> Dict[str, Any]:

--- a/xinference/core/supervisor.py
+++ b/xinference/core/supervisor.py
@@ -4954,6 +4954,16 @@ class SupervisorActor(xo.StatelessActor):
         payload.pop("tokenizer_asset_id", None)
         payload.pop("tokenizer_asset_revision", None)
         payload.pop("tokenizer_asset_fingerprint", None)
+        # Custom paths have no declared capability metadata; preserve phase-1
+        # behavior where every request shape is accepted.
+        from ..router.tokenizer_asset import DEFAULT_TOKENIZER_ASSET_FILES
+
+        payload["tokenizer_asset_capabilities"] = {
+            "chat": True,
+            "tools": True,
+            "thinking": True,
+        }
+        payload["tokenizer_asset_files"] = list(DEFAULT_TOKENIZER_ASSET_FILES)
         return payload
 
     async def _normalize_token_router_tokenizer(
@@ -5172,6 +5182,18 @@ class SupervisorActor(xo.StatelessActor):
             }
         errors.extend(str(error) for error in asset_validation.get("errors", []))
 
+        declared_asset_capabilities = asset_validation.get("capabilities")
+        asset_capabilities = None
+        if (
+            isinstance(declared_asset_capabilities, dict)
+            and declared_asset_capabilities
+        ):
+            asset_capabilities = {
+                str(name)
+                for name, enabled in declared_asset_capabilities.items()
+                if enabled
+            }
+
         running_models = await self.list_models()
         compatible_models = {
             str(name).strip().casefold()
@@ -5247,6 +5269,22 @@ class SupervisorActor(xo.StatelessActor):
                 ):
                     errors.append(
                         f"Rule {rule.get('id')} requires thinking but backend {backend_id} does not report reasoning or hybrid capability"
+                    )
+                if (
+                    asset_capabilities is not None
+                    and match.get("tools_present") is True
+                    and "tools" not in asset_capabilities
+                ):
+                    errors.append(
+                        f"Rule {rule.get('id')} requires tools but Tokenizer asset does not support tools"
+                    )
+                if (
+                    asset_capabilities is not None
+                    and match.get("thinking") is True
+                    and "thinking" not in asset_capabilities
+                ):
+                    errors.append(
+                        f"Rule {rule.get('id')} requires thinking but Tokenizer asset does not support thinking"
                     )
         if asset_id and asset_validation.get("valid"):
             expected_revision = str(config.get("tokenizer_asset_revision") or "")

--- a/xinference/core/tests/test_tokenizer_asset_registry.py
+++ b/xinference/core/tests/test_tokenizer_asset_registry.py
@@ -1,0 +1,292 @@
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+import yaml  # type: ignore[import-untyped]
+from tokenizers import Tokenizer, models, pre_tokenizers
+
+from xinference.core.tokenizer_asset_registry import (
+    TokenizerAssetError,
+    TokenizerAssetRegistry,
+)
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def make_asset(root: Path, asset_id: str = "deepseek-v4-flash-0731") -> Path:
+    path = root / asset_id
+    path.mkdir(parents=True)
+    tokenizer = Tokenizer(models.WordLevel({"[UNK]": 0, "hello": 1}, unk_token="[UNK]"))
+    tokenizer.pre_tokenizer = pre_tokenizers.Whitespace()
+    tokenizer.save(str(path / "tokenizer.json"))
+    encoding = path / "encoding"
+    encoding.mkdir()
+    (encoding / "encoding_dsv4.py").write_text(
+        "def encode_messages(messages, thinking_mode, reasoning_effort=None):\n"
+        "    prefix = '<think> ' if thinking_mode == 'thinking' else ''\n"
+        "    return prefix + ' '.join(str(m.get('content', '')) for m in messages)\n",
+        encoding="utf-8",
+    )
+    manifest = {
+        "schema_version": 1,
+        "asset_id": asset_id,
+        "display_name": "DeepSeek-V4-Flash-0731",
+        "model_family": "deepseek-v4",
+        "model_name": "DeepSeek-V4-Flash-0731",
+        "revision": "0731",
+        "encoding_type": "deepseek_v4",
+        "compatible_models": ["DeepSeek-V4-Flash-0731"],
+        "required_files": ["tokenizer.json", "encoding/encoding_dsv4.py"],
+        "checksums": {
+            "tokenizer.json": f"sha256:{_sha256(path / 'tokenizer.json')}",
+            "encoding/encoding_dsv4.py": f"sha256:{_sha256(encoding / 'encoding_dsv4.py')}",
+        },
+        "capabilities": {"chat": True, "tools": True, "thinking": True},
+    }
+    (path / "asset.json").write_text(json.dumps(manifest), encoding="utf-8")
+    return path
+
+
+def make_registry_config(
+    tmp_path: Path,
+    asset_root: Path,
+    *,
+    assets: list[dict] | None = None,
+    allow_custom_path: bool = False,
+) -> Path:
+    config = tmp_path / "tokenizer-assets.yaml"
+    config.write_text(
+        yaml.safe_dump(
+            {
+                "schema_version": 1,
+                "asset_roots": [str(asset_root)],
+                "allow_custom_path": allow_custom_path,
+                "assets": (
+                    assets
+                    if assets is not None
+                    else [
+                        {
+                            "asset_id": "deepseek-v4-flash-0731",
+                            "path": "deepseek-v4-flash-0731",
+                            "enabled": True,
+                        }
+                    ]
+                ),
+            }
+        ),
+        encoding="utf-8",
+    )
+    return config
+
+
+def test_registered_asset_list_resolve_and_validate(tmp_path: Path) -> None:
+    asset_root = tmp_path / "assets"
+    asset_path = make_asset(asset_root)
+    registry = TokenizerAssetRegistry(str(make_registry_config(tmp_path, asset_root)))
+
+    listed = registry.list_assets()
+    assert listed["allow_custom_path"] is False
+    assert listed["config_error"] == ""
+    assert listed["items"][0]["status"] == "available"
+    assert "path" not in listed["items"][0]
+
+    resolved = registry.resolve("deepseek-v4-flash-0731")
+    assert resolved["tokenizer_path"] == str(asset_path.resolve())
+    assert resolved["tokenizer_asset_revision"] == "0731"
+    assert resolved["tokenizer_asset_fingerprint"].startswith("sha256:")
+
+    validated = registry.validate_asset("deepseek-v4-flash-0731")
+    assert validated["valid"] is True
+    assert validated["validated_at"]
+    assert validated["checks"]["chat_smoke_test"] == "ok"
+    assert validated["checks"]["tools_smoke_test"] == "ok"
+    assert validated["checks"]["thinking_smoke_test"] == "ok"
+
+
+def test_explicit_missing_config_fails_closed(tmp_path: Path) -> None:
+    registry = TokenizerAssetRegistry(str(tmp_path / "missing.yaml"))
+    assert registry.allow_custom_path is False
+    assert "does not exist" in registry.config_error
+
+
+def test_no_registry_keeps_legacy_custom_path_compatibility() -> None:
+    registry = TokenizerAssetRegistry("")
+    assert registry.allow_custom_path is True
+    assert registry.list_assets()["items"] == []
+
+
+def test_checksum_mismatch_marks_only_that_asset_invalid(tmp_path: Path) -> None:
+    asset_root = tmp_path / "assets"
+    first = make_asset(asset_root)
+    make_asset(asset_root, "second")
+    (first / "tokenizer.json").write_text("changed", encoding="utf-8")
+    config = make_registry_config(
+        tmp_path,
+        asset_root,
+        assets=[
+            {"asset_id": "deepseek-v4-flash-0731", "path": first.name},
+            {"asset_id": "second", "path": "second"},
+        ],
+    )
+
+    items = {
+        item["asset_id"]: item
+        for item in TokenizerAssetRegistry(str(config)).list_assets()["items"]
+    }
+    assert items["deepseek-v4-flash-0731"]["status"] == "invalid"
+    assert "SHA-256 mismatch" in items["deepseek-v4-flash-0731"]["errors"][0]
+    assert items["second"]["status"] == "available"
+
+
+def test_duplicate_asset_id_invalidates_registry_config(tmp_path: Path) -> None:
+    asset_root = tmp_path / "assets"
+    make_asset(asset_root)
+    config = make_registry_config(
+        tmp_path,
+        asset_root,
+        assets=[
+            {"asset_id": "deepseek-v4-flash-0731", "path": "deepseek-v4-flash-0731"},
+            {"asset_id": "deepseek-v4-flash-0731", "path": "deepseek-v4-flash-0731"},
+        ],
+    )
+    registry = TokenizerAssetRegistry(str(config))
+    assert registry.allow_custom_path is False
+    assert registry.list_assets()["items"] == []
+    assert "Duplicate Tokenizer asset_id" in registry.config_error
+
+
+def test_symlink_escape_is_rejected(tmp_path: Path) -> None:
+    asset_root = tmp_path / "assets"
+    outside = tmp_path / "outside"
+    make_asset(outside)
+    asset_root.mkdir()
+    (asset_root / "escaped").symlink_to(
+        outside / "deepseek-v4-flash-0731", target_is_directory=True
+    )
+    config = make_registry_config(
+        tmp_path,
+        asset_root,
+        assets=[{"asset_id": "deepseek-v4-flash-0731", "path": "escaped"}],
+    )
+
+    item = TokenizerAssetRegistry(str(config)).list_assets()["items"][0]
+    assert item["status"] == "invalid"
+    assert "escapes configured asset_roots" in item["errors"][0]
+
+
+def test_disabled_asset_cannot_be_resolved(tmp_path: Path) -> None:
+    asset_root = tmp_path / "assets"
+    make_asset(asset_root)
+    config = make_registry_config(
+        tmp_path,
+        asset_root,
+        assets=[
+            {
+                "asset_id": "deepseek-v4-flash-0731",
+                "path": "deepseek-v4-flash-0731",
+                "enabled": False,
+            }
+        ],
+    )
+    registry = TokenizerAssetRegistry(str(config))
+    assert registry.get_asset("deepseek-v4-flash-0731")["status"] == "disabled"
+    with pytest.raises(TokenizerAssetError, match="not available"):
+        registry.resolve("deepseek-v4-flash-0731")
+
+
+def test_asset_id_and_path_must_resolve_to_same_directory(tmp_path: Path) -> None:
+    asset_root = tmp_path / "assets"
+    make_asset(asset_root)
+    registry = TokenizerAssetRegistry(str(make_registry_config(tmp_path, asset_root)))
+    with pytest.raises(TokenizerAssetError, match="different directories"):
+        registry.resolve("deepseek-v4-flash-0731", str(tmp_path / "other"))
+
+
+def test_registered_asset_requires_checksums_for_all_required_files(
+    tmp_path: Path,
+) -> None:
+    asset_root = tmp_path / "assets"
+    asset_path = make_asset(asset_root)
+    manifest_path = asset_path / "asset.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["checksums"].pop("encoding/encoding_dsv4.py")
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    item = TokenizerAssetRegistry(
+        str(make_registry_config(tmp_path, asset_root))
+    ).list_assets()["items"][0]
+
+    assert item["status"] == "invalid"
+    assert any("Missing SHA-256 checksum" in error for error in item["errors"])
+
+
+def test_manifest_metadata_is_validated(tmp_path: Path) -> None:
+    asset_root = tmp_path / "assets"
+    asset_path = make_asset(asset_root)
+    manifest_path = asset_path / "asset.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["compatible_models"] = []
+    manifest["capabilities"]["chat"] = False
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    item = TokenizerAssetRegistry(
+        str(make_registry_config(tmp_path, asset_root))
+    ).list_assets()["items"][0]
+
+    assert item["status"] == "invalid"
+    assert any("compatible_models" in error for error in item["errors"])
+    assert any("capability chat must be true" in error for error in item["errors"])
+
+
+def test_declared_capabilities_control_dynamic_smoke_tests(tmp_path: Path) -> None:
+    asset_root = tmp_path / "assets"
+    asset_path = make_asset(asset_root)
+    manifest_path = asset_path / "asset.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["capabilities"] = {"chat": True, "tools": False, "thinking": False}
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    registry = TokenizerAssetRegistry(str(make_registry_config(tmp_path, asset_root)))
+
+    validated = registry.validate_asset("deepseek-v4-flash-0731")
+
+    assert validated["valid"] is True
+    assert validated["checks"]["chat_smoke_test"] == "ok"
+    assert "tools_smoke_test" not in validated["checks"]
+    assert "thinking_smoke_test" not in validated["checks"]
+
+
+def test_reload_picks_up_registry_changes(tmp_path: Path) -> None:
+    asset_root = tmp_path / "assets"
+    make_asset(asset_root)
+    config = make_registry_config(tmp_path, asset_root)
+    registry = TokenizerAssetRegistry(str(config))
+    make_asset(asset_root, "second")
+    config.write_text(
+        yaml.safe_dump(
+            {
+                "schema_version": 1,
+                "asset_roots": [str(asset_root)],
+                "allow_custom_path": False,
+                "assets": [
+                    {
+                        "asset_id": "deepseek-v4-flash-0731",
+                        "path": "deepseek-v4-flash-0731",
+                    },
+                    {"asset_id": "second", "path": "second"},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert [item["asset_id"] for item in registry.list_assets()["items"]] == [
+        "deepseek-v4-flash-0731"
+    ]
+    registry.reload()
+    assert [item["asset_id"] for item in registry.list_assets()["items"]] == [
+        "deepseek-v4-flash-0731",
+        "second",
+    ]

--- a/xinference/core/tests/test_tokenizer_asset_registry.py
+++ b/xinference/core/tests/test_tokenizer_asset_registry.py
@@ -101,9 +101,18 @@ def test_registered_asset_list_resolve_and_validate(tmp_path: Path) -> None:
     validated = registry.validate_asset("deepseek-v4-flash-0731")
     assert validated["valid"] is True
     assert validated["validated_at"]
-    assert validated["checks"]["chat_smoke_test"] == "ok"
-    assert validated["checks"]["tools_smoke_test"] == "ok"
-    assert validated["checks"]["thinking_smoke_test"] == "ok"
+    assert validated["checks"]["required_files"] == "ok"
+    assert validated["checks"]["checksums"] == "ok"
+    assert validated["checks"]["manifest"] == "ok"
+    assert validated["capabilities"] == {
+        "chat": True,
+        "tools": True,
+        "thinking": True,
+    }
+    assert validated["required_files"] == [
+        "tokenizer.json",
+        "encoding/encoding_dsv4.py",
+    ]
 
 
 def test_explicit_missing_config_fails_closed(tmp_path: Path) -> None:
@@ -241,7 +250,7 @@ def test_manifest_metadata_is_validated(tmp_path: Path) -> None:
     assert any("capability chat must be true" in error for error in item["errors"])
 
 
-def test_declared_capabilities_control_dynamic_smoke_tests(tmp_path: Path) -> None:
+def test_declared_capabilities_are_reported(tmp_path: Path) -> None:
     asset_root = tmp_path / "assets"
     asset_path = make_asset(asset_root)
     manifest_path = asset_path / "asset.json"
@@ -253,9 +262,19 @@ def test_declared_capabilities_control_dynamic_smoke_tests(tmp_path: Path) -> No
     validated = registry.validate_asset("deepseek-v4-flash-0731")
 
     assert validated["valid"] is True
-    assert validated["checks"]["chat_smoke_test"] == "ok"
-    assert "tools_smoke_test" not in validated["checks"]
-    assert "thinking_smoke_test" not in validated["checks"]
+    assert validated["checks"]["required_files"] == "ok"
+    assert validated["capabilities"] == {
+        "chat": True,
+        "tools": False,
+        "thinking": False,
+    }
+
+    resolved = registry.resolve("deepseek-v4-flash-0731")
+    assert resolved["tokenizer_asset_capabilities"] == {
+        "chat": True,
+        "tools": False,
+        "thinking": False,
+    }
 
 
 def test_reload_picks_up_registry_changes(tmp_path: Path) -> None:

--- a/xinference/core/tokenizer_asset_registry.py
+++ b/xinference/core/tokenizer_asset_registry.py
@@ -1,0 +1,556 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+"""Registered Tokenizer assets for Token-aware Routers."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import multiprocessing
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import yaml  # type: ignore[import-untyped]
+
+from ..constants import XINFERENCE_TOKENIZER_ASSET_CONFIG
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_REQUIRED_FILES = (
+    "tokenizer.json",
+    "encoding/encoding_dsv4.py",
+)
+_MAX_MANIFEST_BYTES = 1024 * 1024
+_MAX_TOKENIZER_BYTES = 4 * 1024 * 1024 * 1024
+_MAX_ENCODING_BYTES = 16 * 1024 * 1024
+_SMOKE_TEST_TIMEOUT_SECONDS = 30
+
+
+def _execute_smoke_test(path: Path, capabilities: Dict[str, bool]) -> Dict[str, str]:
+    from ..router.tokenizer import DeepSeekV4TokenEstimator
+
+    checks: Dict[str, str] = {}
+    estimator = DeepSeekV4TokenEstimator(
+        path, reserve_tokens=64, default_output_tokens=512
+    )
+    payloads: Dict[str, Dict[str, Any]] = {
+        "chat_smoke_test": {
+            "messages": [{"role": "user", "content": "hello"}],
+            "max_tokens": 8,
+        }
+    }
+    if capabilities.get("tools", False):
+        payloads["tools_smoke_test"] = {
+            "messages": [{"role": "user", "content": "hello"}],
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "ping",
+                        "description": "ping",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                }
+            ],
+            "max_tokens": 8,
+        }
+    if capabilities.get("thinking", False):
+        payloads["thinking_smoke_test"] = {
+            "messages": [{"role": "user", "content": "hello"}],
+            "chat_template_kwargs": {"enable_thinking": True},
+            "max_tokens": 8,
+        }
+
+    for name, payload in payloads.items():
+        first = estimator.estimate(payload)
+        second = estimator.estimate(payload)
+        if first.total_tokens < 1:
+            raise TokenizerAssetError(f"{name} returned an invalid Token budget")
+        if first != second:
+            raise TokenizerAssetError(f"{name} returned an unstable Token budget")
+        checks[name] = "ok"
+    return checks
+
+
+def _smoke_test_worker(
+    path: str, capabilities: Dict[str, bool], connection: Any
+) -> None:
+    try:
+        connection.send(("ok", _execute_smoke_test(Path(path), capabilities)))
+    except BaseException as exc:  # noqa: BLE001 - isolate untrusted asset code.
+        connection.send(("error", f"{type(exc).__name__}: {exc}"))
+    finally:
+        connection.close()
+
+
+class TokenizerAssetError(ValueError):
+    """Raised when a registered Tokenizer asset cannot be used safely."""
+
+
+class TokenizerAssetRegistry:
+    """Load and validate the Supervisor-side Tokenizer asset whitelist."""
+
+    def __init__(self, config_path: Optional[str] = None) -> None:
+        configured_path = config_path
+        if configured_path is None:
+            configured_path = XINFERENCE_TOKENIZER_ASSET_CONFIG
+        self._config_path = (
+            Path(configured_path).expanduser() if configured_path else None
+        )
+        self._asset_roots: List[Path] = []
+        self._entries: Dict[str, Dict[str, Any]] = {}
+        # Preserve the pre-registry API when no production registry is configured.
+        self._allow_custom_path = True
+        self._config_error = ""
+        self._last_validated_at: Dict[str, str] = {}
+        self.reload()
+
+    @property
+    def allow_custom_path(self) -> bool:
+        return self._allow_custom_path
+
+    @property
+    def config_error(self) -> str:
+        return self._config_error
+
+    def reload(self) -> None:
+        self._asset_roots = []
+        self._entries = {}
+        self._allow_custom_path = True
+        self._config_error = ""
+        if self._config_path is None:
+            return
+        if not self._config_path.is_file():
+            self._allow_custom_path = False
+            self._config_error = "Tokenizer asset config does not exist"
+            logger.error("%s: %s", self._config_error, self._config_path)
+            return
+
+        try:
+            raw = yaml.safe_load(self._config_path.read_text(encoding="utf-8")) or {}
+            if not isinstance(raw, dict):
+                raise TokenizerAssetError("Tokenizer asset config must be an object")
+            if int(raw.get("schema_version", 1)) != 1:
+                raise TokenizerAssetError("Unsupported Tokenizer asset schema_version")
+
+            roots = raw.get("asset_roots", [])
+            if not isinstance(roots, list):
+                raise TokenizerAssetError("asset_roots must be a list")
+            self._asset_roots = [
+                Path(str(root)).expanduser().resolve() for root in roots
+            ]
+            self._allow_custom_path = bool(raw.get("allow_custom_path", False))
+
+            assets = raw.get("assets", [])
+            if not isinstance(assets, list):
+                raise TokenizerAssetError("assets must be a list")
+            for entry in assets:
+                if not isinstance(entry, dict):
+                    raise TokenizerAssetError("Each Tokenizer asset must be an object")
+                asset_id = str(entry.get("asset_id", "")).strip()
+                if not asset_id:
+                    raise TokenizerAssetError("Tokenizer asset_id is required")
+                if asset_id in self._entries:
+                    raise TokenizerAssetError(
+                        f"Duplicate Tokenizer asset_id: {asset_id}"
+                    )
+                self._entries[asset_id] = dict(entry)
+        except Exception as exc:
+            self._config_error = str(exc)
+            self._asset_roots = []
+            self._entries = {}
+            self._allow_custom_path = False
+            logger.error(
+                "Failed to load Tokenizer asset config %s: %s",
+                self._config_path,
+                exc,
+            )
+
+    def _entry_path(self, entry: Dict[str, Any]) -> Path:
+        raw_path = str(entry.get("path", "")).strip()
+        if not raw_path:
+            raise TokenizerAssetError("Tokenizer asset path is required")
+        path = Path(raw_path).expanduser()
+        if not path.is_absolute():
+            if not self._asset_roots:
+                raise TokenizerAssetError(
+                    "Relative Tokenizer asset path requires asset_roots"
+                )
+            path = self._asset_roots[0] / path
+        return path.resolve()
+
+    def _ensure_allowed_root(self, path: Path) -> None:
+        if not self._asset_roots:
+            return
+        if not any(
+            path == root or path.is_relative_to(root) for root in self._asset_roots
+        ):
+            raise TokenizerAssetError(
+                "Tokenizer asset path escapes configured asset_roots"
+            )
+
+    @staticmethod
+    def _read_manifest(path: Path) -> Dict[str, Any]:
+        manifest_path = path / "asset.json"
+        if not manifest_path.is_file():
+            raise TokenizerAssetError("Missing Tokenizer asset manifest")
+        resolved_manifest_path = manifest_path.resolve()
+        if (
+            resolved_manifest_path != path
+            and not resolved_manifest_path.is_relative_to(path)
+        ):
+            raise TokenizerAssetError(
+                "Tokenizer asset manifest escapes asset directory"
+            )
+        if resolved_manifest_path.stat().st_size > _MAX_MANIFEST_BYTES:
+            raise TokenizerAssetError("Tokenizer asset manifest is too large")
+        try:
+            manifest = json.loads(resolved_manifest_path.read_text(encoding="utf-8"))
+        except OSError as exc:
+            raise TokenizerAssetError(
+                f"Cannot read Tokenizer asset manifest: {exc.strerror or exc}"
+            ) from exc
+        except json.JSONDecodeError as exc:
+            raise TokenizerAssetError(
+                f"Invalid Tokenizer asset manifest JSON: {exc.msg}"
+            ) from exc
+        if not isinstance(manifest, dict):
+            raise TokenizerAssetError("Tokenizer asset manifest must be an object")
+        if int(manifest.get("schema_version", 1)) != 1:
+            raise TokenizerAssetError("Unsupported Tokenizer asset manifest version")
+        return manifest
+
+    @staticmethod
+    def _required_files(manifest: Optional[Dict[str, Any]]) -> List[str]:
+        if manifest is None:
+            return list(_DEFAULT_REQUIRED_FILES)
+        required = manifest.get("required_files", list(_DEFAULT_REQUIRED_FILES))
+        if not isinstance(required, list) or not required:
+            raise TokenizerAssetError("required_files must be a non-empty list")
+        result = [str(item).strip() for item in required]
+        if any(not item for item in result):
+            raise TokenizerAssetError("required_files cannot contain an empty path")
+        for required_file in _DEFAULT_REQUIRED_FILES:
+            if required_file not in result:
+                result.append(required_file)
+        return result
+
+    @staticmethod
+    def _validate_manifest_metadata(manifest: Dict[str, Any]) -> List[str]:
+        errors: List[str] = []
+        for key in ("model_family", "model_name", "revision", "encoding_type"):
+            if not isinstance(manifest.get(key), str) or not manifest[key].strip():
+                errors.append(f"Tokenizer asset manifest {key} is required")
+
+        compatible_models = manifest.get("compatible_models")
+        if (
+            not isinstance(compatible_models, list)
+            or not compatible_models
+            or any(
+                not isinstance(item, str) or not item.strip()
+                for item in compatible_models
+            )
+        ):
+            errors.append(
+                "Tokenizer asset manifest compatible_models must be a non-empty string list"
+            )
+
+        capabilities = manifest.get("capabilities")
+        if not isinstance(capabilities, dict):
+            errors.append("Tokenizer asset manifest capabilities must be an object")
+        else:
+            for name in ("chat", "tools", "thinking"):
+                if not isinstance(capabilities.get(name), bool):
+                    errors.append(
+                        f"Tokenizer asset manifest capability {name} must be boolean"
+                    )
+            if capabilities.get("chat") is not True:
+                errors.append("Tokenizer asset manifest capability chat must be true")
+        return errors
+
+    @staticmethod
+    def _file_sha256(path: Path) -> str:
+        digest = hashlib.sha256()
+        with path.open("rb") as file:
+            for chunk in iter(lambda: file.read(1024 * 1024), b""):
+                digest.update(chunk)
+        return digest.hexdigest()
+
+    def _validate_files(
+        self, path: Path, manifest: Optional[Dict[str, Any]]
+    ) -> tuple[List[str], str]:
+        errors: List[str] = []
+        if not path.is_dir():
+            return ["Tokenizer asset directory does not exist"], ""
+
+        try:
+            required_files = self._required_files(manifest)
+        except TokenizerAssetError as exc:
+            return [str(exc)], ""
+
+        checksums = manifest.get("checksums", {}) if manifest else {}
+        require_checksums = manifest is not None
+        if not isinstance(checksums, dict):
+            errors.append("checksums must be an object")
+            checksums = {}
+        elif require_checksums:
+            for relative_name in required_files:
+                expected = str(checksums.get(relative_name, "")).removeprefix("sha256:")
+                if not expected:
+                    errors.append(
+                        f"Missing SHA-256 checksum for Tokenizer file: {relative_name}"
+                    )
+                elif len(expected) != 64 or any(
+                    char not in "0123456789abcdefABCDEF" for char in expected
+                ):
+                    errors.append(
+                        f"Invalid SHA-256 checksum for Tokenizer file: {relative_name}"
+                    )
+
+        aggregate = hashlib.sha256()
+        for relative_name in sorted(required_files):
+            relative_path = Path(relative_name)
+            if relative_path.is_absolute() or ".." in relative_path.parts:
+                errors.append(f"Unsafe required file path: {relative_name}")
+                continue
+            file_path = (path / relative_path).resolve()
+            if file_path != path and not file_path.is_relative_to(path):
+                errors.append(f"Required file escapes asset directory: {relative_name}")
+                continue
+            if not file_path.is_file():
+                errors.append(f"Missing required Tokenizer file: {relative_name}")
+                continue
+            try:
+                file_size = file_path.stat().st_size
+            except OSError as exc:
+                errors.append(f"Cannot stat Tokenizer file {relative_name}: {exc}")
+                continue
+            max_size = (
+                _MAX_ENCODING_BYTES
+                if relative_name == "encoding/encoding_dsv4.py"
+                else _MAX_TOKENIZER_BYTES
+            )
+            if file_size <= 0:
+                errors.append(f"Tokenizer file is empty: {relative_name}")
+                continue
+            if file_size > max_size:
+                errors.append(f"Tokenizer file is too large: {relative_name}")
+                continue
+            try:
+                digest = self._file_sha256(file_path)
+            except OSError as exc:
+                errors.append(f"Cannot read Tokenizer file {relative_name}: {exc}")
+                continue
+            expected = str(checksums.get(relative_name, "")).removeprefix("sha256:")
+            if expected and digest.lower() != expected.lower():
+                errors.append(f"SHA-256 mismatch for Tokenizer file: {relative_name}")
+            aggregate.update(relative_name.encode("utf-8"))
+            aggregate.update(b"\0")
+            aggregate.update(digest.encode("ascii"))
+            aggregate.update(b"\0")
+        return errors, aggregate.hexdigest() if not errors else ""
+
+    @staticmethod
+    def _smoke_test(path: Path, capabilities: Dict[str, bool]) -> Dict[str, str]:
+        context = multiprocessing.get_context("spawn")
+        parent_connection, child_connection = context.Pipe(duplex=False)
+        process = context.Process(
+            target=_smoke_test_worker,
+            args=(str(path), capabilities, child_connection),
+            daemon=True,
+        )
+        try:
+            process.start()
+        except Exception as exc:
+            parent_connection.close()
+            child_connection.close()
+            raise TokenizerAssetError(
+                f"Cannot start Tokenizer asset smoke test process: {exc}"
+            ) from exc
+        child_connection.close()
+        try:
+            if not parent_connection.poll(_SMOKE_TEST_TIMEOUT_SECONDS):
+                process.terminate()
+                process.join(timeout=5)
+                raise TokenizerAssetError("Tokenizer asset smoke test timed out")
+            try:
+                status, payload = parent_connection.recv()
+            except EOFError as exc:
+                raise TokenizerAssetError(
+                    "Tokenizer asset smoke test process exited unexpectedly"
+                ) from exc
+        finally:
+            parent_connection.close()
+            process.join(timeout=5)
+            if process.is_alive():
+                process.kill()
+                process.join(timeout=5)
+
+        if status != "ok":
+            raise TokenizerAssetError(str(payload))
+        if not isinstance(payload, dict):
+            raise TokenizerAssetError(
+                "Tokenizer asset smoke test returned invalid data"
+            )
+        return {str(key): str(value) for key, value in payload.items()}
+
+    def _inspect_entry(self, asset_id: str, *, smoke_test: bool) -> Dict[str, Any]:
+        entry = self._entries.get(asset_id)
+        if entry is None:
+            raise KeyError(asset_id)
+
+        result: Dict[str, Any] = {
+            "asset_id": asset_id,
+            "display_name": asset_id,
+            "model_family": "",
+            "model_name": "",
+            "revision": "",
+            "encoding_type": "",
+            "compatible_models": [],
+            "capabilities": {},
+            "enabled": bool(entry.get("enabled", True)),
+            "status": "invalid",
+            "fingerprint": "",
+            "errors": [],
+            "checks": {},
+            "validated_at": self._last_validated_at.get(asset_id, ""),
+        }
+        try:
+            path = self._entry_path(entry)
+            self._ensure_allowed_root(path)
+            result["path"] = str(path)
+            manifest = self._read_manifest(path)
+            if str(manifest.get("asset_id", "")).strip() != asset_id:
+                raise TokenizerAssetError(
+                    "Tokenizer asset manifest asset_id does not match registry"
+                )
+            for key in (
+                "display_name",
+                "model_family",
+                "model_name",
+                "revision",
+                "encoding_type",
+                "compatible_models",
+                "capabilities",
+            ):
+                if key in manifest:
+                    result[key] = manifest[key]
+            metadata_errors = self._validate_manifest_metadata(manifest)
+            if not metadata_errors:
+                result["checks"]["manifest"] = "ok"
+            result["errors"].extend(metadata_errors)
+            errors, fingerprint = self._validate_files(path, manifest)
+            result["errors"].extend(errors)
+            if not errors:
+                result["fingerprint"] = f"sha256:{fingerprint}"
+                result["checks"]["required_files"] = "ok"
+                result["checks"]["checksums"] = "ok"
+            if result["enabled"] and not result["errors"] and smoke_test:
+                capabilities = {
+                    str(name): bool(enabled)
+                    for name, enabled in result["capabilities"].items()
+                }
+                result["checks"].update(self._smoke_test(path, capabilities))
+                result["checks"]["tokenizer_load"] = "ok"
+                result["checks"]["encoding_load"] = "ok"
+        except Exception as exc:
+            result["errors"].append(str(exc))
+
+        if not result["enabled"]:
+            result["status"] = "disabled"
+        elif result["errors"]:
+            path_value = result.get("path")
+            result["status"] = (
+                "missing" if path_value and not Path(path_value).is_dir() else "invalid"
+            )
+        else:
+            result["status"] = "available"
+        result["valid"] = result["status"] == "available"
+        return result
+
+    @staticmethod
+    def _public_asset(asset: Dict[str, Any]) -> Dict[str, Any]:
+        result = dict(asset)
+        result.pop("path", None)
+        return result
+
+    def list_assets(self) -> Dict[str, Any]:
+        return {
+            "items": [
+                self._public_asset(self._inspect_entry(asset_id, smoke_test=False))
+                for asset_id in sorted(self._entries)
+            ],
+            "allow_custom_path": self._allow_custom_path,
+            "config_error": self._config_error,
+        }
+
+    def get_asset(self, asset_id: str) -> Dict[str, Any]:
+        return self._public_asset(self._inspect_entry(asset_id, smoke_test=False))
+
+    def validate_asset(self, asset_id: str) -> Dict[str, Any]:
+        validated_at = datetime.now(timezone.utc).isoformat()
+        self._last_validated_at[asset_id] = validated_at
+        result = self._inspect_entry(asset_id, smoke_test=True)
+        result["validated_at"] = validated_at
+        return self._public_asset(result)
+
+    def match_path(self, tokenizer_path: str) -> Optional[Dict[str, Any]]:
+        try:
+            requested = Path(tokenizer_path).expanduser().resolve()
+        except (OSError, RuntimeError):
+            return None
+        for asset_id in self._entries:
+            asset = self._inspect_entry(asset_id, smoke_test=False)
+            if asset.get("path") == str(requested):
+                return asset
+        return None
+
+    def resolve(
+        self, asset_id: str, tokenizer_path: Optional[str] = None
+    ) -> Dict[str, Any]:
+        asset = self._inspect_entry(asset_id, smoke_test=True)
+        if asset["status"] != "available":
+            detail = "; ".join(asset["errors"]) or asset["status"]
+            raise TokenizerAssetError(
+                f"Tokenizer asset is not available: {asset_id}: {detail}"
+            )
+        resolved_path = str(asset["path"])
+        if tokenizer_path:
+            supplied = str(Path(tokenizer_path).expanduser().resolve())
+            if supplied != resolved_path:
+                raise TokenizerAssetError(
+                    "tokenizer_asset_id and tokenizer_path resolve to different directories"
+                )
+        return {
+            "tokenizer_asset_id": asset_id,
+            "tokenizer_path": resolved_path,
+            "tokenizer_asset_revision": str(asset.get("revision", "")),
+            "tokenizer_asset_fingerprint": str(asset.get("fingerprint", "")),
+        }
+
+    def validate_path(self, tokenizer_path: str, *, smoke_test: bool) -> Dict[str, Any]:
+        path = Path(tokenizer_path).expanduser().resolve()
+        errors, fingerprint = self._validate_files(path, None)
+        checks: Dict[str, str] = {}
+        if not errors:
+            checks["required_files"] = "ok"
+            if smoke_test:
+                try:
+                    checks.update(
+                        self._smoke_test(
+                            path,
+                            {"chat": True, "tools": True, "thinking": True},
+                        )
+                    )
+                    checks["tokenizer_load"] = "ok"
+                    checks["encoding_load"] = "ok"
+                except Exception as exc:
+                    errors.append(str(exc))
+        return {
+            "valid": not errors,
+            "status": "available" if not errors else "invalid",
+            "fingerprint": f"sha256:{fingerprint}" if fingerprint else "",
+            "checks": checks,
+            "errors": errors,
+        }

--- a/xinference/core/tokenizer_asset_registry.py
+++ b/xinference/core/tokenizer_asset_registry.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
-import multiprocessing
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -14,74 +13,17 @@ from typing import Any, Dict, List, Optional
 import yaml  # type: ignore[import-untyped]
 
 from ..constants import XINFERENCE_TOKENIZER_ASSET_CONFIG
+from ..router.tokenizer_asset import (
+    DEFAULT_TOKENIZER_ASSET_FILES,
+    aggregate_tokenizer_asset_fingerprint,
+)
 
 logger = logging.getLogger(__name__)
 
-_DEFAULT_REQUIRED_FILES = (
-    "tokenizer.json",
-    "encoding/encoding_dsv4.py",
-)
+_DEFAULT_REQUIRED_FILES = DEFAULT_TOKENIZER_ASSET_FILES
 _MAX_MANIFEST_BYTES = 1024 * 1024
 _MAX_TOKENIZER_BYTES = 4 * 1024 * 1024 * 1024
 _MAX_ENCODING_BYTES = 16 * 1024 * 1024
-_SMOKE_TEST_TIMEOUT_SECONDS = 30
-
-
-def _execute_smoke_test(path: Path, capabilities: Dict[str, bool]) -> Dict[str, str]:
-    from ..router.tokenizer import DeepSeekV4TokenEstimator
-
-    checks: Dict[str, str] = {}
-    estimator = DeepSeekV4TokenEstimator(
-        path, reserve_tokens=64, default_output_tokens=512
-    )
-    payloads: Dict[str, Dict[str, Any]] = {
-        "chat_smoke_test": {
-            "messages": [{"role": "user", "content": "hello"}],
-            "max_tokens": 8,
-        }
-    }
-    if capabilities.get("tools", False):
-        payloads["tools_smoke_test"] = {
-            "messages": [{"role": "user", "content": "hello"}],
-            "tools": [
-                {
-                    "type": "function",
-                    "function": {
-                        "name": "ping",
-                        "description": "ping",
-                        "parameters": {"type": "object", "properties": {}},
-                    },
-                }
-            ],
-            "max_tokens": 8,
-        }
-    if capabilities.get("thinking", False):
-        payloads["thinking_smoke_test"] = {
-            "messages": [{"role": "user", "content": "hello"}],
-            "chat_template_kwargs": {"enable_thinking": True},
-            "max_tokens": 8,
-        }
-
-    for name, payload in payloads.items():
-        first = estimator.estimate(payload)
-        second = estimator.estimate(payload)
-        if first.total_tokens < 1:
-            raise TokenizerAssetError(f"{name} returned an invalid Token budget")
-        if first != second:
-            raise TokenizerAssetError(f"{name} returned an unstable Token budget")
-        checks[name] = "ok"
-    return checks
-
-
-def _smoke_test_worker(
-    path: str, capabilities: Dict[str, bool], connection: Any
-) -> None:
-    try:
-        connection.send(("ok", _execute_smoke_test(Path(path), capabilities)))
-    except BaseException as exc:  # noqa: BLE001 - isolate untrusted asset code.
-        connection.send(("error", f"{type(exc).__name__}: {exc}"))
-    finally:
-        connection.close()
 
 
 class TokenizerAssetError(ValueError):
@@ -308,7 +250,7 @@ class TokenizerAssetRegistry:
                         f"Invalid SHA-256 checksum for Tokenizer file: {relative_name}"
                     )
 
-        aggregate = hashlib.sha256()
+        file_digests: Dict[str, str] = {}
         for relative_name in sorted(required_files):
             relative_path = Path(relative_name)
             if relative_path.is_absolute() or ".." in relative_path.parts:
@@ -345,55 +287,11 @@ class TokenizerAssetRegistry:
             expected = str(checksums.get(relative_name, "")).removeprefix("sha256:")
             if expected and digest.lower() != expected.lower():
                 errors.append(f"SHA-256 mismatch for Tokenizer file: {relative_name}")
-            aggregate.update(relative_name.encode("utf-8"))
-            aggregate.update(b"\0")
-            aggregate.update(digest.encode("ascii"))
-            aggregate.update(b"\0")
-        return errors, aggregate.hexdigest() if not errors else ""
-
-    @staticmethod
-    def _smoke_test(path: Path, capabilities: Dict[str, bool]) -> Dict[str, str]:
-        context = multiprocessing.get_context("spawn")
-        parent_connection, child_connection = context.Pipe(duplex=False)
-        process = context.Process(
-            target=_smoke_test_worker,
-            args=(str(path), capabilities, child_connection),
-            daemon=True,
+            file_digests[relative_name] = digest
+        return (
+            errors,
+            aggregate_tokenizer_asset_fingerprint(file_digests) if not errors else "",
         )
-        try:
-            process.start()
-        except Exception as exc:
-            parent_connection.close()
-            child_connection.close()
-            raise TokenizerAssetError(
-                f"Cannot start Tokenizer asset smoke test process: {exc}"
-            ) from exc
-        child_connection.close()
-        try:
-            if not parent_connection.poll(_SMOKE_TEST_TIMEOUT_SECONDS):
-                process.terminate()
-                process.join(timeout=5)
-                raise TokenizerAssetError("Tokenizer asset smoke test timed out")
-            try:
-                status, payload = parent_connection.recv()
-            except EOFError as exc:
-                raise TokenizerAssetError(
-                    "Tokenizer asset smoke test process exited unexpectedly"
-                ) from exc
-        finally:
-            parent_connection.close()
-            process.join(timeout=5)
-            if process.is_alive():
-                process.kill()
-                process.join(timeout=5)
-
-        if status != "ok":
-            raise TokenizerAssetError(str(payload))
-        if not isinstance(payload, dict):
-            raise TokenizerAssetError(
-                "Tokenizer asset smoke test returned invalid data"
-            )
-        return {str(key): str(value) for key, value in payload.items()}
 
     def _inspect_entry(self, asset_id: str, *, smoke_test: bool) -> Dict[str, Any]:
         entry = self._entries.get(asset_id)
@@ -440,20 +338,13 @@ class TokenizerAssetRegistry:
             if not metadata_errors:
                 result["checks"]["manifest"] = "ok"
             result["errors"].extend(metadata_errors)
+            result["required_files"] = self._required_files(manifest)
             errors, fingerprint = self._validate_files(path, manifest)
             result["errors"].extend(errors)
             if not errors:
                 result["fingerprint"] = f"sha256:{fingerprint}"
                 result["checks"]["required_files"] = "ok"
                 result["checks"]["checksums"] = "ok"
-            if result["enabled"] and not result["errors"] and smoke_test:
-                capabilities = {
-                    str(name): bool(enabled)
-                    for name, enabled in result["capabilities"].items()
-                }
-                result["checks"].update(self._smoke_test(path, capabilities))
-                result["checks"]["tokenizer_load"] = "ok"
-                result["checks"]["encoding_load"] = "ok"
         except Exception as exc:
             result["errors"].append(str(exc))
 
@@ -522,35 +413,34 @@ class TokenizerAssetRegistry:
                 raise TokenizerAssetError(
                     "tokenizer_asset_id and tokenizer_path resolve to different directories"
                 )
+        capabilities = asset.get("capabilities") or {}
         return {
             "tokenizer_asset_id": asset_id,
             "tokenizer_path": resolved_path,
             "tokenizer_asset_revision": str(asset.get("revision", "")),
             "tokenizer_asset_fingerprint": str(asset.get("fingerprint", "")),
+            "tokenizer_asset_files": list(
+                asset.get("required_files") or DEFAULT_TOKENIZER_ASSET_FILES
+            ),
+            "tokenizer_asset_capabilities": {
+                str(name): bool(enabled) for name, enabled in capabilities.items()
+            },
         }
 
     def validate_path(self, tokenizer_path: str, *, smoke_test: bool) -> Dict[str, Any]:
+        # ``smoke_test`` is retained for API compatibility. Executing asset
+        # Python in the Supervisor is intentionally not supported.
         path = Path(tokenizer_path).expanduser().resolve()
         errors, fingerprint = self._validate_files(path, None)
         checks: Dict[str, str] = {}
         if not errors:
             checks["required_files"] = "ok"
-            if smoke_test:
-                try:
-                    checks.update(
-                        self._smoke_test(
-                            path,
-                            {"chat": True, "tools": True, "thinking": True},
-                        )
-                    )
-                    checks["tokenizer_load"] = "ok"
-                    checks["encoding_load"] = "ok"
-                except Exception as exc:
-                    errors.append(str(exc))
         return {
             "valid": not errors,
             "status": "available" if not errors else "invalid",
             "fingerprint": f"sha256:{fingerprint}" if fingerprint else "",
+            "required_files": list(DEFAULT_TOKENIZER_ASSET_FILES),
+            "capabilities": {"chat": True, "tools": True, "thinking": True},
             "checks": checks,
             "errors": errors,
         }

--- a/xinference/deploy/test/test_cmdline.py
+++ b/xinference/deploy/test/test_cmdline.py
@@ -151,7 +151,7 @@ def test_cmdline(setup, stream, model_uid):
 
 def test_cmdline_model_path_error(setup):
     endpoint, _ = setup
-    runner = CliRunner(mix_stderr=False)
+    runner = CliRunner()
 
     # launch model
     result = runner.invoke(
@@ -244,7 +244,7 @@ def test_cmdline_of_custom_model(setup):
         ],
     )
     assert result.exit_code == 0
-    assert "custom_model" in result.stdout
+    assert "custom_model" in result.output
 
     # unregister custom model
     result = runner.invoke(
@@ -271,7 +271,7 @@ def test_cmdline_of_custom_model(setup):
         ],
     )
     assert result.exit_code == 0
-    assert "custom_model" not in result.stdout
+    assert "custom_model" not in result.output
 
 
 def test_worker_command_passes_endpoint_and_internal_address(monkeypatch):

--- a/xinference/router/app.py
+++ b/xinference/router/app.py
@@ -59,6 +59,24 @@ def _authorized(request: Request, config: RouterConfig) -> bool:
     return hmac.compare_digest(value[len(prefix) :], config.backend_api_key)
 
 
+def _payload_thinking(payload: dict) -> bool:
+    """Return whether the request asks for thinking mode.
+
+    Mirrors the tokenizer normalization so capability enforcement rejects the
+    request before expensive rendering when the asset does not support it.
+    """
+    value = payload.get("enable_thinking")
+    if value is None:
+        extra_body = payload.get("extra_body")
+        if isinstance(extra_body, dict):
+            value = extra_body.get("enable_thinking")
+    if value is None:
+        template_kwargs = payload.get("chat_template_kwargs")
+        if isinstance(template_kwargs, dict):
+            value = template_kwargs.get("enable_thinking")
+    return bool(value)
+
+
 def _router_headers(decision: RouteDecision, request_id: str) -> dict[str, str]:
     return {
         "x-request-id": request_id,
@@ -230,6 +248,15 @@ def create_app(config: RouterConfig) -> FastAPI:
             if payload.get("model") not in accepted_models:
                 await metrics.increment("unknown_model", "none")
                 return _error(404, "Unknown logical model", "model_not_found")
+            capabilities = config.tokenizer_asset_capabilities
+            if bool(payload.get("tools")) and "tools" not in capabilities:
+                await metrics.increment("tools_not_allowed", "none")
+                return _error(
+                    400,
+                    "Tool requests are not supported by this Tokenizer asset",
+                    "tools_not_allowed",
+                    headers={"x-request-id": request_id},
+                )
             try:
                 budget = await snapshot.tokenization.estimate(
                     payload, input_bytes=len(body)
@@ -239,6 +266,15 @@ def create_app(config: RouterConfig) -> FastAPI:
                     tools_present=bool(payload.get("tools")),
                     stream=bool(payload.get("stream", False)),
                 )
+                if budget.enable_thinking and "thinking" not in capabilities:
+                    await metrics.increment("thinking_not_allowed", "none")
+                    return _error(
+                        400,
+                        "Thinking-mode requests are not supported by this "
+                        "Tokenizer asset",
+                        "thinking_not_allowed",
+                        headers={"x-request-id": request_id},
+                    )
             except AdmissionRejected as exc:
                 await metrics.increment(f"tokenization_admission_{exc.reason}", "none")
                 return _error(

--- a/xinference/router/app.py
+++ b/xinference/router/app.py
@@ -159,6 +159,8 @@ def create_app(config: RouterConfig) -> FastAPI:
                 "status": "ready",
                 "revision": snapshot.config.revision,
                 "router_uid": snapshot.config.router_uid,
+                "tokenizer_asset_id": snapshot.config.tokenizer_asset_id,
+                "tokenizer_asset_revision": snapshot.config.tokenizer_asset_revision,
             }
         )
 

--- a/xinference/router/app.py
+++ b/xinference/router/app.py
@@ -124,7 +124,15 @@ def create_app(config: RouterConfig) -> FastAPI:
             control_stop.set()
             try:
                 if control_task is not None:
-                    await control_task
+                    # The control-plane task may be blocked in an HTTP call or
+                    # while applying a new runtime snapshot. Setting the stop
+                    # event alone cannot interrupt either operation, so cancel
+                    # the task explicitly before waiting for shutdown.
+                    control_task.cancel()
+                    try:
+                        await control_task
+                    except asyncio.CancelledError:
+                        pass
             finally:
                 try:
                     if control_plane is not None:

--- a/xinference/router/app.py
+++ b/xinference/router/app.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import hmac
+import json
 import logging
 import time
 import uuid
@@ -64,17 +65,27 @@ def _payload_thinking(payload: dict) -> bool:
 
     Mirrors the tokenizer normalization so capability enforcement rejects the
     request before expensive rendering when the asset does not support it.
+    Invalid ``chat_template_kwargs`` are left for the tokenizer to report as a
+    malformed request.
     """
+    template_kwargs = payload.get("chat_template_kwargs") or {}
+    if isinstance(template_kwargs, str):
+        try:
+            template_kwargs = json.loads(template_kwargs)
+        except json.JSONDecodeError:
+            return False
+    if not isinstance(template_kwargs, dict):
+        return False
+
+    normalized = dict(template_kwargs)
     value = payload.get("enable_thinking")
     if value is None:
         extra_body = payload.get("extra_body")
         if isinstance(extra_body, dict):
             value = extra_body.get("enable_thinking")
-    if value is None:
-        template_kwargs = payload.get("chat_template_kwargs")
-        if isinstance(template_kwargs, dict):
-            value = template_kwargs.get("enable_thinking")
-    return bool(value)
+    if isinstance(value, bool):
+        normalized["enable_thinking"] = value
+    return bool(normalized.get("enable_thinking", False))
 
 
 def _router_headers(decision: RouteDecision, request_id: str) -> dict[str, str]:
@@ -263,6 +274,15 @@ def create_app(config: RouterConfig) -> FastAPI:
                     400,
                     "Tool requests are not supported by this Tokenizer asset",
                     "tools_not_allowed",
+                    headers={"x-request-id": request_id},
+                )
+            if "thinking" not in capabilities and _payload_thinking(payload):
+                await metrics.increment("thinking_not_allowed", "none")
+                return _error(
+                    400,
+                    "Thinking-mode requests are not supported by this "
+                    "Tokenizer asset",
+                    "thinking_not_allowed",
                     headers={"x-request-id": request_id},
                 )
             try:

--- a/xinference/router/config.py
+++ b/xinference/router/config.py
@@ -314,7 +314,7 @@ def _tokenization(value: Mapping[str, Any]) -> TokenizationConfig:
 
 def load_config(path: str | Path | None = None) -> RouterConfig:
     """Load the legacy standalone YAML format and normalize it to V2 internally."""
-    config_path = (
+    config_path: str | Path = (
         path if path is not None else os.getenv("ROUTER_CONFIG", "config.yaml")
     )
     data = _load_yaml(Path(config_path).expanduser())
@@ -460,9 +460,11 @@ def _typed_rule(value: Mapping[str, Any]) -> RoutingRule:
 
 def _resolve_tokenizer(data: Mapping[str, Any]) -> tuple[str, str, Path]:
     tokenizer_path = str(data.get("tokenizer_path") or "").strip()
+    asset_id = str(data.get("tokenizer_asset_id") or "").strip()
     if not tokenizer_path:
         raise ConfigError("tokenizer_path is required")
-    return "", "", Path(tokenizer_path).expanduser()
+    asset_origin = "registered" if asset_id else "custom_path"
+    return asset_id, asset_origin, Path(tokenizer_path).expanduser()
 
 
 def config_from_control_plane(

--- a/xinference/router/config.py
+++ b/xinference/router/config.py
@@ -8,6 +8,8 @@ from typing import Any, Mapping
 
 import yaml  # type: ignore[import-untyped]
 
+from .tokenizer_asset import DEFAULT_TOKENIZER_ASSET_FILES
+
 _ID_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$")
 
 
@@ -117,6 +119,8 @@ class RouterConfig:
     tokenizer_asset_origin: str = ""
     tokenizer_asset_revision: str = ""
     tokenizer_asset_fingerprint: str = ""
+    tokenizer_asset_files: tuple[str, ...] = DEFAULT_TOKENIZER_ASSET_FILES
+    tokenizer_asset_capabilities: tuple[str, ...] = ("chat", "tools", "thinking")
     legacy_short_threshold_tokens: int | None = None
     legacy_thinking_pool: str = ""
 
@@ -225,6 +229,22 @@ def _validate_config(cfg: RouterConfig) -> RouterConfig:
         ):
             raise ConfigError(f"Invalid token range in routing rule {rule.id!r}")
         _validate_action(rule.action, backend_id_set, f"routing rule {rule.id!r}")
+        if (
+            match.tools_present is True
+            and "tools" not in cfg.tokenizer_asset_capabilities
+        ):
+            raise ConfigError(
+                f"routing rule {rule.id!r} requires tools but the Tokenizer "
+                "asset does not support tools"
+            )
+        if (
+            match.thinking is True
+            and "thinking" not in cfg.tokenizer_asset_capabilities
+        ):
+            raise ConfigError(
+                f"routing rule {rule.id!r} requires thinking but the Tokenizer "
+                "asset does not support thinking"
+            )
     _validate_action(cfg.default_action, backend_id_set, "default action")
     if cfg.context_reserve_tokens < 0 or cfg.default_output_tokens < 1:
         raise ConfigError("Invalid token budget defaults")
@@ -467,6 +487,15 @@ def _resolve_tokenizer(data: Mapping[str, Any]) -> tuple[str, str, Path]:
     return asset_id, asset_origin, Path(tokenizer_path).expanduser()
 
 
+def _control_plane_capabilities(data: Mapping[str, Any]) -> tuple[str, ...]:
+    raw = data.get("tokenizer_asset_capabilities")
+    if raw is None:
+        return ("chat", "tools", "thinking")
+    if isinstance(raw, Mapping):
+        return tuple(str(name) for name, enabled in raw.items() if enabled)
+    return tuple(str(item) for item in raw)
+
+
 def config_from_control_plane(
     data: dict[str, Any],
     *,
@@ -537,6 +566,13 @@ def config_from_control_plane(
         tokenizer_asset_origin=asset_origin,
         tokenizer_asset_revision=str(data.get("tokenizer_asset_revision", "")),
         tokenizer_asset_fingerprint=str(data.get("tokenizer_asset_fingerprint", "")),
+        tokenizer_asset_files=tuple(
+            str(item)
+            for item in (
+                data.get("tokenizer_asset_files") or DEFAULT_TOKENIZER_ASSET_FILES
+            )
+        ),
+        tokenizer_asset_capabilities=_control_plane_capabilities(data),
         legacy_short_threshold_tokens=legacy_threshold,
         legacy_thinking_pool=legacy_thinking,
     )

--- a/xinference/router/control_plane.py
+++ b/xinference/router/control_plane.py
@@ -159,6 +159,7 @@ class RouterControlPlaneClient:
                 "active_requests": summary["active_requests"],
                 "tokenization": summary["tokenization"],
                 "pools": summary["pools"],
+                "tokenizer_asset": summary["tokenizer_asset"],
             },
         )
         return summary

--- a/xinference/router/runtime.py
+++ b/xinference/router/runtime.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from dataclasses import asdict, dataclass
 from typing import Any, Callable, Dict, Optional
 
@@ -14,6 +15,8 @@ from .classifier import RoutingPolicy
 from .config import RouterConfig
 from .metrics import RouterMetrics
 from .tokenization import TokenizationService
+
+logger = logging.getLogger("xinference.router.runtime")
 
 
 class RouterDisabled(RuntimeError):
@@ -67,6 +70,8 @@ class RouterRuntime:
             queue_timeout_seconds=config.tokenization.queue_timeout_seconds,
             retry_after_seconds=config.tokenization.retry_after_seconds,
             tokenizer_asset_files=config.tokenizer_asset_files,
+            expected_asset_fingerprint=config.tokenizer_asset_fingerprint,
+            expected_asset_revision=config.tokenizer_asset_revision,
         )
         policy = RoutingPolicy(
             backends=config.backends,
@@ -132,8 +137,11 @@ class RouterRuntime:
         replacement = self._build_snapshot(config)
         try:
             await replacement.tokenization.start()
-        except Exception:
-            await replacement.close()
+        except BaseException:
+            try:
+                await replacement.close()
+            except BaseException:
+                logger.exception("Failed to clean up replacement runtime snapshot")
             raise
 
         old: RuntimeSnapshot

--- a/xinference/router/runtime.py
+++ b/xinference/router/runtime.py
@@ -66,6 +66,7 @@ class RouterRuntime:
             max_queue=config.tokenization.max_queue,
             queue_timeout_seconds=config.tokenization.queue_timeout_seconds,
             retry_after_seconds=config.tokenization.retry_after_seconds,
+            tokenizer_asset_files=config.tokenizer_asset_files,
         )
         policy = RoutingPolicy(
             backends=config.backends,
@@ -172,8 +173,8 @@ class RouterRuntime:
             "tokenization": tokenization,
             "tokenizer_asset": {
                 "asset_id": snapshot.config.tokenizer_asset_id,
-                "revision": snapshot.config.tokenizer_asset_revision,
-                "fingerprint": snapshot.config.tokenizer_asset_fingerprint,
+                "revision": snapshot.tokenization.asset_revision,
+                "fingerprint": snapshot.tokenization.asset_fingerprint,
             },
         }
 

--- a/xinference/router/runtime.py
+++ b/xinference/router/runtime.py
@@ -170,6 +170,11 @@ class RouterRuntime:
             "active_requests": snapshot.active_requests,
             "pools": pools,
             "tokenization": tokenization,
+            "tokenizer_asset": {
+                "asset_id": snapshot.config.tokenizer_asset_id,
+                "revision": snapshot.config.tokenizer_asset_revision,
+                "fingerprint": snapshot.config.tokenizer_asset_fingerprint,
+            },
         }
 
     async def aclose(self) -> None:

--- a/xinference/router/runtime.py
+++ b/xinference/router/runtime.py
@@ -135,20 +135,23 @@ class RouterRuntime:
 
     async def apply(self, config: RouterConfig) -> None:
         replacement = self._build_snapshot(config)
+        replacement_owned = True
+        old: RuntimeSnapshot
         try:
             await replacement.tokenization.start()
+            async with self._lock:
+                old = self._current
+                old.draining = True
+                self._current = replacement
+                replacement_owned = False
         except BaseException:
-            try:
-                await replacement.close()
-            except BaseException:
-                logger.exception("Failed to clean up replacement runtime snapshot")
+            if replacement_owned:
+                try:
+                    await replacement.close()
+                except BaseException:
+                    logger.exception("Failed to clean up replacement runtime snapshot")
             raise
 
-        old: RuntimeSnapshot
-        async with self._lock:
-            old = self._current
-            old.draining = True
-            self._current = replacement
         self._notify_swap(replacement)
         if old.active_requests == 0:
             await old.close()

--- a/xinference/router/runtime.py
+++ b/xinference/router/runtime.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from typing import Any, Callable, Dict, Optional
 
 import httpx
@@ -33,13 +33,29 @@ class RuntimeSnapshot:
     active_requests: int = 0
     draining: bool = False
     closed: bool = False
+    _close_task: Optional[asyncio.Task[None]] = field(
+        default=None, init=False, repr=False, compare=False
+    )
 
     async def close(self) -> None:
         if self.closed:
             return
+        task = self._close_task
+        if task is None:
+            task = asyncio.create_task(self._close_resources())
+            self._close_task = task
+        try:
+            await asyncio.shield(task)
+        finally:
+            if task.done() and not self.closed and self._close_task is task:
+                self._close_task = None
+
+    async def _close_resources(self) -> None:
+        try:
+            await self.client.aclose()
+        finally:
+            await self.tokenization.aclose()
         self.closed = True
-        await self.client.aclose()
-        await self.tokenization.aclose()
 
 
 class RouterRuntime:
@@ -153,12 +169,11 @@ class RouterRuntime:
             raise
 
         self._notify_swap(replacement)
+        task = asyncio.create_task(self._drain(old))
+        self._drain_tasks.add(task)
+        task.add_done_callback(self._drain_tasks.discard)
         if old.active_requests == 0:
-            await old.close()
-        else:
-            task = asyncio.create_task(self._drain(old))
-            self._drain_tasks.add(task)
-            task.add_done_callback(self._drain_tasks.discard)
+            await asyncio.shield(task)
 
     async def _drain(self, snapshot: RuntimeSnapshot) -> None:
         while snapshot.active_requests:
@@ -198,4 +213,6 @@ class RouterRuntime:
         else:
             await self._drain(current)
         if self._drain_tasks:
-            await asyncio.gather(*self._drain_tasks, return_exceptions=True)
+            drain_tasks = set(self._drain_tasks)
+            await asyncio.gather(*drain_tasks, return_exceptions=True)
+            self._drain_tasks.difference_update(drain_tasks)

--- a/xinference/router/tests/test_app.py
+++ b/xinference/router/tests/test_app.py
@@ -38,6 +38,8 @@ class FakeTokenizationService:
             "tokenizer.json",
             "encoding/encoding_dsv4.py",
         ),
+        expected_asset_fingerprint: str = "",
+        expected_asset_revision: str = "",
     ) -> None:
         self._reserve_tokens = reserve_tokens
         self._default_output_tokens = default_output_tokens
@@ -619,6 +621,41 @@ async def test_tools_request_rejected_when_asset_lacks_tools_capability(
 
     assert response.status_code == 400
     assert response.json()["error"]["type"] == "tools_not_allowed"
+
+
+@pytest.mark.asyncio
+async def test_thinking_request_is_rejected_before_tokenization(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from dataclasses import replace
+
+    config = replace(
+        make_config(tmp_path),
+        tokenizer_asset_capabilities=("chat", "tools"),
+    )
+    app = create_app(config)
+    tokenization = app.state.runtime.current.tokenization
+    estimate = AsyncMock(side_effect=AssertionError("tokenizer should not run"))
+    monkeypatch.setattr(tokenization, "estimate", estimate)
+
+    async with app.router.lifespan_context(app):
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://router"
+        ) as client:
+            response = await client.post(
+                "/v1/chat/completions",
+                headers={"authorization": "Bearer secret"},
+                json={
+                    "model": "router-model",
+                    "messages": [{"role": "user", "content": "hello"}],
+                    "chat_template_kwargs": json.dumps({"enable_thinking": True}),
+                    "max_tokens": 8,
+                },
+            )
+
+    assert response.status_code == 400
+    assert response.json()["error"]["type"] == "thinking_not_allowed"
+    estimate.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/xinference/router/tests/test_app.py
+++ b/xinference/router/tests/test_app.py
@@ -402,6 +402,24 @@ class FakeControlPlane:
         self.events.append("unregister")
 
 
+class BlockingControlPlane(FakeControlPlane):
+    def __init__(self, events: list[str]) -> None:
+        super().__init__(events)
+        self.started = asyncio.Event()
+        self.cancelled = False
+        self.run_task: asyncio.Task[None] | None = None
+
+    async def run(self, runtime, stop: asyncio.Event) -> None:
+        self.events.append("run")
+        self.run_task = asyncio.current_task()
+        self.started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            self.cancelled = True
+            raise
+
+
 @pytest.mark.asyncio
 async def test_lifespan_acks_only_after_runtime_start(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -422,6 +440,44 @@ async def test_lifespan_acks_only_after_runtime_start(
 
     assert events[-1] == "unregister"
     assert runtime.current.closed is True
+
+
+@pytest.mark.asyncio
+async def test_lifespan_cancels_control_plane_before_waiting_for_shutdown(
+    tmp_path: Path,
+) -> None:
+    app = create_app(make_config(tmp_path))
+    events: list[str] = []
+    control_plane = BlockingControlPlane(events)
+    app.state.control_plane = control_plane
+
+    async def serve_and_shutdown() -> None:
+        async with app.router.lifespan_context(app):
+            await asyncio.wait_for(control_plane.started.wait(), 1)
+
+    shutdown_task = asyncio.create_task(serve_and_shutdown())
+    await asyncio.wait_for(control_plane.started.wait(), 1)
+    await asyncio.sleep(0.05)
+
+    # If lifespan only sets the stop event, it remains stuck awaiting the
+    # deliberately blocked control-plane task. Cancel it as a bounded fallback
+    # so this test fails without hanging the test process.
+    forced_cancel = False
+    if not shutdown_task.done():
+        forced_cancel = True
+        assert control_plane.run_task is not None
+        control_plane.run_task.cancel()
+
+    try:
+        await shutdown_task
+    except asyncio.CancelledError:
+        # The forced fallback above cancels the old implementation's control
+        # task, which propagates through its lifespan cleanup.
+        pass
+
+    assert forced_cancel is False
+    assert control_plane.cancelled is True
+    assert app.state.runtime.current.closed is True
 
 
 @pytest.mark.asyncio

--- a/xinference/router/tests/test_app.py
+++ b/xinference/router/tests/test_app.py
@@ -34,9 +34,15 @@ class FakeTokenizationService:
         max_queue: int,
         queue_timeout_seconds: float,
         retry_after_seconds: int,
+        tokenizer_asset_files: tuple[str, ...] = (
+            "tokenizer.json",
+            "encoding/encoding_dsv4.py",
+        ),
     ) -> None:
         self._reserve_tokens = reserve_tokens
         self._default_output_tokens = default_output_tokens
+        self.asset_fingerprint = "sha256:test-fingerprint"
+        self.asset_revision = "0731"
         self._snapshot = GateSnapshot(
             active=0,
             waiting=0,
@@ -49,6 +55,17 @@ class FakeTokenizationService:
         return None
 
     async def estimate(self, payload, *, input_bytes: int) -> TokenBudget:
+        thinking = (
+            payload.get("enable_thinking")
+            or (
+                isinstance(payload.get("extra_body"), dict)
+                and payload["extra_body"].get("enable_thinking")
+            )
+            or (
+                isinstance(payload.get("chat_template_kwargs"), dict)
+                and payload["chat_template_kwargs"].get("enable_thinking")
+            )
+        )
         return TokenBudget(
             prompt_tokens=1,
             output_tokens=int(payload.get("max_tokens", self._default_output_tokens)),
@@ -56,7 +73,7 @@ class FakeTokenizationService:
             total_tokens=1
             + int(payload.get("max_tokens", self._default_output_tokens))
             + self._reserve_tokens,
-            enable_thinking=False,
+            enable_thinking=bool(thinking),
         )
 
     async def snapshot(self) -> GateSnapshot:
@@ -516,3 +533,63 @@ async def test_v2_tools_rule_routes_to_dynamic_backend_and_sets_headers(
     assert response.headers["x-xinference-router-backend"] == "tools"
     assert response.headers["x-xinference-router-rule"] == "tools-route"
     assert response.headers["x-xinference-router-pool"] == "tools"
+
+
+@pytest.mark.asyncio
+async def test_tools_request_rejected_when_asset_lacks_tools_capability(
+    tmp_path: Path,
+) -> None:
+    from dataclasses import replace
+
+    config = replace(
+        make_config(tmp_path),
+        tokenizer_asset_capabilities=("chat", "thinking"),
+    )
+    app = create_app(config)
+    async with app.router.lifespan_context(app):
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://router"
+        ) as client:
+            response = await client.post(
+                "/v1/chat/completions",
+                headers={"authorization": "Bearer secret"},
+                json={
+                    "model": "router-model",
+                    "messages": [{"role": "user", "content": "hello"}],
+                    "tools": [{"type": "function", "function": {"name": "lookup"}}],
+                    "max_tokens": 8,
+                },
+            )
+
+    assert response.status_code == 400
+    assert response.json()["error"]["type"] == "tools_not_allowed"
+
+
+@pytest.mark.asyncio
+async def test_thinking_request_rejected_when_asset_lacks_thinking_capability(
+    tmp_path: Path,
+) -> None:
+    from dataclasses import replace
+
+    config = replace(
+        make_config(tmp_path),
+        tokenizer_asset_capabilities=("chat", "tools"),
+    )
+    app = create_app(config)
+    async with app.router.lifespan_context(app):
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app), base_url="http://router"
+        ) as client:
+            response = await client.post(
+                "/v1/chat/completions",
+                headers={"authorization": "Bearer secret"},
+                json={
+                    "model": "router-model",
+                    "messages": [{"role": "user", "content": "hello"}],
+                    "chat_template_kwargs": {"enable_thinking": True},
+                    "max_tokens": 8,
+                },
+            )
+
+    assert response.status_code == 400
+    assert response.json()["error"]["type"] == "thinking_not_allowed"

--- a/xinference/router/tests/test_config.py
+++ b/xinference/router/tests/test_config.py
@@ -240,6 +240,26 @@ def test_control_plane_v2_loads_four_dynamic_backends(tmp_path: Path) -> None:
             lambda payload: payload.update(config_version=3),
             "Unsupported config_version",
         ),
+        (
+            lambda payload: payload.update(
+                tokenizer_asset_capabilities={
+                    "chat": True,
+                    "tools": False,
+                    "thinking": True,
+                }
+            ),
+            "requires tools but the Tokenizer asset",
+        ),
+        (
+            lambda payload: payload.update(
+                tokenizer_asset_capabilities={
+                    "chat": True,
+                    "tools": True,
+                    "thinking": False,
+                }
+            ),
+            "requires thinking but the Tokenizer asset",
+        ),
     ],
 )
 def test_control_plane_v2_rejects_invalid_dynamic_config(

--- a/xinference/router/tests/test_control_plane.py
+++ b/xinference/router/tests/test_control_plane.py
@@ -41,6 +41,11 @@ class FakeRuntime:
             "active_requests": 4,
             "tokenization": {"active": 1, "waiting": 2},
             "pools": {"short": {"active": 3}, "long": {"active": 1}},
+            "tokenizer_asset": {
+                "asset_id": "deepseek-v4-flash-0731",
+                "revision": "0731",
+                "fingerprint": "sha256:test-fingerprint",
+            },
         }
 
 
@@ -190,6 +195,11 @@ async def test_run_applies_revision_then_acks_and_heartbeats(monkeypatch) -> Non
                 "pools": {
                     "short": {"active": 3},
                     "long": {"active": 1},
+                },
+                "tokenizer_asset": {
+                    "asset_id": "deepseek-v4-flash-0731",
+                    "revision": "0731",
+                    "fingerprint": "sha256:test-fingerprint",
                 },
             },
         }

--- a/xinference/router/tests/test_runtime.py
+++ b/xinference/router/tests/test_runtime.py
@@ -159,7 +159,7 @@ async def test_cancelled_apply_while_closing_old_snapshot_finishes_cleanup(
 
     assert old_snapshot.closed is False
     assert old_client.closed is False
-    assert old_snapshot.tokenization.closed is False
+    assert cast(FakeTokenization, old_snapshot.tokenization).closed is False
     assert len(runtime._drain_tasks) == 1
 
     old_client.allow_close.set()
@@ -167,7 +167,7 @@ async def test_cancelled_apply_while_closing_old_snapshot_finishes_cleanup(
 
     assert old_snapshot.closed is True
     assert old_client.closed is True
-    assert old_snapshot.tokenization.closed is True
+    assert cast(FakeTokenization, old_snapshot.tokenization).closed is True
     assert not runtime._drain_tasks
 
 

--- a/xinference/router/tests/test_runtime.py
+++ b/xinference/router/tests/test_runtime.py
@@ -1,3 +1,4 @@
+import asyncio
 from types import SimpleNamespace
 from typing import Any, cast
 
@@ -31,6 +32,16 @@ class FakeTokenization:
         return [101, 102]
 
 
+class BlockingTokenization(FakeTokenization):
+    def __init__(self) -> None:
+        super().__init__()
+        self.started_event = asyncio.Event()
+
+    async def start(self) -> None:
+        self.started_event.set()
+        await asyncio.Event().wait()
+
+
 class FakeClient:
     def __init__(self) -> None:
         self.closed = False
@@ -50,10 +61,15 @@ def config(revision: int, *, enabled: bool = True):
     )
 
 
-def snapshot(cfg, *, fail_start: bool = False) -> RuntimeSnapshot:
+def snapshot(
+    cfg,
+    *,
+    fail_start: bool = False,
+    tokenization: Any | None = None,
+) -> RuntimeSnapshot:
     return RuntimeSnapshot(
         config=cfg,
-        tokenization=cast(Any, FakeTokenization(fail_start=fail_start)),
+        tokenization=cast(Any, tokenization or FakeTokenization(fail_start=fail_start)),
         policy=cast(Any, SimpleNamespace()),
         gates={},
         client=FakeClient(),
@@ -87,6 +103,36 @@ async def test_apply_drains_old_snapshot_after_inflight_request(monkeypatch) -> 
     assert held.closed is True
     assert held.client.closed is True
     assert held.tokenization.closed is True
+    await runtime.aclose()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_apply_closes_replacement_snapshot(monkeypatch) -> None:
+    first = config(1)
+    second = config(2)
+    replacement_tokenization = BlockingTokenization()
+    first_snapshot = snapshot(first)
+    replacement_snapshot = snapshot(second, tokenization=replacement_tokenization)
+    snapshots = {1: first_snapshot, 2: replacement_snapshot}
+    monkeypatch.setattr(
+        RouterRuntime,
+        "_build_snapshot",
+        lambda self, cfg: snapshots[cfg.revision],
+    )
+
+    runtime = RouterRuntime(first)
+    await runtime.start()
+    apply_task = asyncio.create_task(runtime.apply(second))
+    await replacement_tokenization.started_event.wait()
+
+    apply_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await apply_task
+
+    assert runtime.current is first_snapshot
+    assert replacement_snapshot.closed is True
+    assert replacement_snapshot.client.closed is True
+    assert replacement_tokenization.closed is True
     await runtime.aclose()
 
 

--- a/xinference/router/tests/test_runtime.py
+++ b/xinference/router/tests/test_runtime.py
@@ -12,6 +12,8 @@ class FakeTokenization:
         self.fail_start = fail_start
         self.started = False
         self.closed = False
+        self.asset_fingerprint = "sha256:measured-fingerprint"
+        self.asset_revision = "measured-revision"
 
     async def start(self) -> None:
         if self.fail_start:
@@ -129,4 +131,26 @@ async def test_failed_apply_keeps_previous_snapshot(monkeypatch) -> None:
     assert runtime.current is first_snapshot
     assert first_snapshot.closed is False
     assert failed_snapshot.closed is True
+    await runtime.aclose()
+
+
+@pytest.mark.asyncio
+async def test_summary_reports_measured_asset_fingerprint(monkeypatch) -> None:
+    runtime_config = config(1)
+    runtime_snapshot = snapshot(runtime_config)
+    monkeypatch.setattr(
+        RouterRuntime,
+        "_build_snapshot",
+        lambda self, cfg: runtime_snapshot,
+    )
+
+    runtime = RouterRuntime(runtime_config)
+    await runtime.start()
+
+    summary = await runtime.summary()
+
+    assert summary["tokenizer_asset"]["asset_id"] == "deepseek-v4-flash-0731"
+    assert summary["tokenizer_asset"]["revision"] == "measured-revision"
+    assert summary["tokenizer_asset"]["fingerprint"] == "sha256:measured-fingerprint"
+
     await runtime.aclose()

--- a/xinference/router/tests/test_runtime.py
+++ b/xinference/router/tests/test_runtime.py
@@ -42,6 +42,16 @@ class BlockingTokenization(FakeTokenization):
         await asyncio.Event().wait()
 
 
+class StartedTokenization(FakeTokenization):
+    def __init__(self) -> None:
+        super().__init__()
+        self.started_event = asyncio.Event()
+
+    async def start(self) -> None:
+        self.started = True
+        self.started_event.set()
+
+
 class FakeClient:
     def __init__(self) -> None:
         self.closed = False
@@ -128,6 +138,44 @@ async def test_cancelled_apply_closes_replacement_snapshot(monkeypatch) -> None:
     apply_task.cancel()
     with pytest.raises(asyncio.CancelledError):
         await apply_task
+
+    assert runtime.current is first_snapshot
+    assert replacement_snapshot.closed is True
+    assert replacement_snapshot.client.closed is True
+    assert replacement_tokenization.closed is True
+    await runtime.aclose()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_apply_while_waiting_for_lock_closes_replacement(
+    monkeypatch,
+) -> None:
+    first = config(1)
+    second = config(2)
+    replacement_tokenization = StartedTokenization()
+    first_snapshot = snapshot(first)
+    replacement_snapshot = snapshot(second, tokenization=replacement_tokenization)
+    snapshots = {1: first_snapshot, 2: replacement_snapshot}
+    monkeypatch.setattr(
+        RouterRuntime,
+        "_build_snapshot",
+        lambda self, cfg: snapshots[cfg.revision],
+    )
+
+    runtime = RouterRuntime(first)
+    await runtime.start()
+    await runtime._lock.acquire()
+    try:
+        apply_task = asyncio.create_task(runtime.apply(second))
+        await replacement_tokenization.started_event.wait()
+        await asyncio.sleep(0)
+        assert apply_task.done() is False
+
+        apply_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await apply_task
+    finally:
+        runtime._lock.release()
 
     assert runtime.current is first_snapshot
     assert replacement_snapshot.closed is True

--- a/xinference/router/tests/test_runtime.py
+++ b/xinference/router/tests/test_runtime.py
@@ -60,6 +60,18 @@ class FakeClient:
         self.closed = True
 
 
+class BlockingClient(FakeClient):
+    def __init__(self) -> None:
+        super().__init__()
+        self.close_started = asyncio.Event()
+        self.allow_close = asyncio.Event()
+
+    async def aclose(self) -> None:
+        self.close_started.set()
+        await self.allow_close.wait()
+        self.closed = True
+
+
 def config(revision: int, *, enabled: bool = True):
     return SimpleNamespace(
         revision=revision,
@@ -114,6 +126,49 @@ async def test_apply_drains_old_snapshot_after_inflight_request(monkeypatch) -> 
     assert held.client.closed is True
     assert held.tokenization.closed is True
     await runtime.aclose()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_apply_while_closing_old_snapshot_finishes_cleanup(
+    monkeypatch,
+) -> None:
+    first = config(1)
+    second = config(2)
+    old_snapshot = snapshot(first)
+    old_client = BlockingClient()
+    old_snapshot.client = cast(Any, old_client)
+    replacement_snapshot = snapshot(second)
+    snapshots = {1: old_snapshot, 2: replacement_snapshot}
+    monkeypatch.setattr(
+        RouterRuntime,
+        "_build_snapshot",
+        lambda self, cfg: snapshots[cfg.revision],
+    )
+
+    runtime = RouterRuntime(first)
+    await runtime.start()
+    apply_task = asyncio.create_task(runtime.apply(second))
+    await old_client.close_started.wait()
+
+    assert runtime.current is replacement_snapshot
+    assert len(runtime._drain_tasks) == 1
+
+    apply_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await apply_task
+
+    assert old_snapshot.closed is False
+    assert old_client.closed is False
+    assert old_snapshot.tokenization.closed is False
+    assert len(runtime._drain_tasks) == 1
+
+    old_client.allow_close.set()
+    await runtime.aclose()
+
+    assert old_snapshot.closed is True
+    assert old_client.closed is True
+    assert old_snapshot.tokenization.closed is True
+    assert not runtime._drain_tasks
 
 
 @pytest.mark.asyncio

--- a/xinference/router/tests/test_tokenization.py
+++ b/xinference/router/tests/test_tokenization.py
@@ -193,3 +193,15 @@ async def test_tokenization_error_crosses_process_boundary(tmp_path: Path) -> No
         assert 'outcome="failed"} 1' in rendered
     finally:
         await service.aclose()
+
+
+@pytest.mark.asyncio
+async def test_start_measures_tokenizer_asset_fingerprint(tmp_path: Path) -> None:
+    service, _ = make_service(tmp_path, max_workers=2, max_active=2)
+    try:
+        await service.start()
+        assert service.asset_fingerprint.startswith("sha256:")
+        assert len(service.asset_fingerprint) == len("sha256:") + 64
+        assert service.asset_revision == ""
+    finally:
+        await service.aclose()

--- a/xinference/router/tests/test_tokenization.py
+++ b/xinference/router/tests/test_tokenization.py
@@ -8,7 +8,10 @@ from tokenizers import Tokenizer, models, pre_tokenizers
 
 from xinference.router.admission import AdmissionRejected
 from xinference.router.metrics import RouterMetrics
-from xinference.router.tokenization import TokenizationService
+from xinference.router.tokenization import (
+    TokenizationService,
+    TokenizationWorkerUnavailable,
+)
 from xinference.router.tokenizer import TokenizationError
 
 
@@ -52,6 +55,8 @@ def make_service(
     max_queue: int = 1,
     queue_timeout_seconds: float = 1,
     retry_after_seconds: int = 1,
+    expected_asset_fingerprint: str = "",
+    expected_asset_revision: str = "",
 ) -> tuple[TokenizationService, RouterMetrics]:
     metrics = RouterMetrics()
     service = TokenizationService(
@@ -64,6 +69,8 @@ def make_service(
         max_queue=max_queue,
         queue_timeout_seconds=queue_timeout_seconds,
         retry_after_seconds=retry_after_seconds,
+        expected_asset_fingerprint=expected_asset_fingerprint,
+        expected_asset_revision=expected_asset_revision,
     )
     return service, metrics
 
@@ -191,6 +198,35 @@ async def test_tokenization_error_crosses_process_boundary(tmp_path: Path) -> No
         assert (await service.snapshot()).active == 0
         rendered = await metrics.render()
         assert 'outcome="failed"} 1' in rendered
+    finally:
+        await service.aclose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mismatch", ["fingerprint", "revision"])
+async def test_start_rejects_asset_metadata_mismatch(
+    tmp_path: Path, mismatch: str
+) -> None:
+    expected_fingerprint = ""
+    expected_revision = ""
+    if mismatch == "fingerprint":
+        expected_fingerprint = "sha256:configured-fingerprint"
+        expected_message = "fingerprint does not match configuration"
+    else:
+        (tmp_path / "asset.json").write_text(
+            '{"revision": "loaded-revision"}', encoding="utf-8"
+        )
+        expected_revision = "configured-revision"
+        expected_message = "revision does not match configuration"
+
+    service, _ = make_service(
+        tmp_path,
+        expected_asset_fingerprint=expected_fingerprint,
+        expected_asset_revision=expected_revision,
+    )
+    try:
+        with pytest.raises(TokenizationWorkerUnavailable, match=expected_message):
+            await service.start()
     finally:
         await service.aclose()
 

--- a/xinference/router/tokenization.py
+++ b/xinference/router/tokenization.py
@@ -42,12 +42,16 @@ class TokenizationService:
         queue_timeout_seconds: float,
         retry_after_seconds: int,
         tokenizer_asset_files: tuple[str, ...] = DEFAULT_TOKENIZER_ASSET_FILES,
+        expected_asset_fingerprint: str = "",
+        expected_asset_revision: str = "",
     ) -> None:
         self._tokenizer_path = tokenizer_path
         self._reserve_tokens = reserve_tokens
         self._default_output_tokens = default_output_tokens
         self._max_workers = max_workers
         self._tokenizer_asset_files = tokenizer_asset_files
+        self._expected_asset_fingerprint = expected_asset_fingerprint
+        self._expected_asset_revision = expected_asset_revision
         self._asset_fingerprint = ""
         self._asset_revision = ""
         self._metrics = metrics
@@ -115,10 +119,26 @@ class TokenizationService:
                 raise TokenizationWorkerUnavailable(
                     "Tokenization workers loaded different Tokenizer asset revisions"
                 )
+            fingerprint = next(iter(fingerprints))
+            revision = next(iter(revisions))
+            if (
+                self._expected_asset_fingerprint
+                and fingerprint != self._expected_asset_fingerprint
+            ):
+                raise TokenizationWorkerUnavailable(
+                    "Tokenizer asset fingerprint does not match configuration"
+                )
+            if (
+                self._expected_asset_revision
+                and revision != self._expected_asset_revision
+            ):
+                raise TokenizationWorkerUnavailable(
+                    "Tokenizer asset revision does not match configuration"
+                )
             worker_pids = {pid for pid, _, _, _, _ in results}
             if len(worker_pids) >= self._max_workers:
-                self._asset_fingerprint = fingerprints.pop()
-                self._asset_revision = revisions.pop()
+                self._asset_fingerprint = fingerprint
+                self._asset_revision = revision
                 self._worker_pids = tuple(sorted(worker_pids))
                 logger.info("Tokenization workers started: pids=%s", self._worker_pids)
                 return

--- a/xinference/router/tokenization.py
+++ b/xinference/router/tokenization.py
@@ -17,6 +17,7 @@ from .tokenization_worker import (
     ping_worker,
 )
 from .tokenizer import TokenBudget
+from .tokenizer_asset import DEFAULT_TOKENIZER_ASSET_FILES
 
 logger = logging.getLogger("deepseek_v4_token_router.tokenization")
 
@@ -40,11 +41,15 @@ class TokenizationService:
         max_queue: int,
         queue_timeout_seconds: float,
         retry_after_seconds: int,
+        tokenizer_asset_files: tuple[str, ...] = DEFAULT_TOKENIZER_ASSET_FILES,
     ) -> None:
         self._tokenizer_path = tokenizer_path
         self._reserve_tokens = reserve_tokens
         self._default_output_tokens = default_output_tokens
         self._max_workers = max_workers
+        self._tokenizer_asset_files = tokenizer_asset_files
+        self._asset_fingerprint = ""
+        self._asset_revision = ""
         self._metrics = metrics
         self._gate = CapacityGate(
             "tokenization",
@@ -67,6 +72,7 @@ class TokenizationService:
                 str(self._tokenizer_path),
                 self._reserve_tokens,
                 self._default_output_tokens,
+                self._tokenizer_asset_files,
             ),
         )
 
@@ -76,7 +82,7 @@ class TokenizationService:
             raise TokenizationWorkerUnavailable("Tokenization service is closed")
         executor = self._executor
         loop = asyncio.get_running_loop()
-        results: list[tuple[int, bool, bool]] = []
+        results: list[tuple[int, bool, bool, str, str]] = []
 
         # ProcessPoolExecutor starts processes lazily. Multiple bounded waves
         # ensure every configured spawn worker completes its initializer even
@@ -94,13 +100,25 @@ class TokenizationService:
                 ) from exc
             if any(
                 api_key_present or internal_token_present
-                for _, api_key_present, internal_token_present in results
+                for _, api_key_present, internal_token_present, _, _ in results
             ):
                 raise TokenizationWorkerUnavailable(
                     "Tokenization worker retained a Router credential"
                 )
-            worker_pids = {pid for pid, _, _ in results}
+            fingerprints = {fingerprint for _, _, _, fingerprint, _ in results}
+            revisions = {revision for _, _, _, _, revision in results}
+            if len(fingerprints) != 1 or "" in fingerprints:
+                raise TokenizationWorkerUnavailable(
+                    "Tokenization workers loaded different Tokenizer assets"
+                )
+            if len(revisions) != 1:
+                raise TokenizationWorkerUnavailable(
+                    "Tokenization workers loaded different Tokenizer asset revisions"
+                )
+            worker_pids = {pid for pid, _, _, _, _ in results}
             if len(worker_pids) >= self._max_workers:
+                self._asset_fingerprint = fingerprints.pop()
+                self._asset_revision = revisions.pop()
                 self._worker_pids = tuple(sorted(worker_pids))
                 logger.info("Tokenization workers started: pids=%s", self._worker_pids)
                 return
@@ -159,6 +177,14 @@ class TokenizationService:
             )
             await self._gate.release()
             await self._publish_gate_snapshot()
+
+    @property
+    def asset_fingerprint(self) -> str:
+        return self._asset_fingerprint
+
+    @property
+    def asset_revision(self) -> str:
+        return self._asset_revision
 
     async def snapshot(self) -> GateSnapshot:
         return await self._gate.snapshot()

--- a/xinference/router/tokenization.py
+++ b/xinference/router/tokenization.py
@@ -157,7 +157,10 @@ class TokenizationService:
             if future is not None:
                 try:
                     await asyncio.shield(future)
-                except Exception:
+                except (Exception, asyncio.CancelledError):
+                    # The worker future can itself be cancelled or propagate
+                    # CancelledError. Either way, keep the outer cancellation
+                    # and let the finally block release the admission slot.
                     pass
             raise
         except BrokenProcessPool as exc:

--- a/xinference/router/tokenization_worker.py
+++ b/xinference/router/tokenization_worker.py
@@ -6,24 +6,49 @@ from pathlib import Path
 from typing import Any
 
 from .tokenizer import DeepSeekV4TokenEstimator, TokenBudget
+from .tokenizer_asset import (
+    DEFAULT_TOKENIZER_ASSET_FILES,
+    compute_tokenizer_asset_fingerprint,
+    read_tokenizer_asset_revision,
+)
 
 _ESTIMATOR: DeepSeekV4TokenEstimator | None = None
+_ASSET_FINGERPRINT = ""
+_ASSET_REVISION = ""
+
+
+def _scrub_router_credentials() -> None:
+    for name in (
+        "XINFERENCE_API_KEY",
+        "XINFERENCE_TOKEN_ROUTER_INTERNAL_TOKEN",
+        "XINFERENCE_TOKEN_ROUTER_DATA_PLANE_TOKEN",
+    ):
+        os.environ.pop(name, None)
 
 
 def initialize_tokenization_worker(
     tokenizer_path: str,
     reserve_tokens: int,
     default_output_tokens: int,
+    required_files: tuple[str, ...] = DEFAULT_TOKENIZER_ASSET_FILES,
 ) -> None:
-    """Initialize one process-local estimator and remove backend credentials."""
-    global _ESTIMATOR
-    os.environ.pop("XINFERENCE_API_KEY", None)
-    os.environ.pop("XINFERENCE_TOKEN_ROUTER_INTERNAL_TOKEN", None)
+    """Initialize an estimator and measure the files it actually loaded."""
+    global _ESTIMATOR, _ASSET_FINGERPRINT, _ASSET_REVISION
+    _scrub_router_credentials()
+    path = Path(tokenizer_path)
+    before_fingerprint = compute_tokenizer_asset_fingerprint(path, required_files)
+    before_revision = read_tokenizer_asset_revision(path)
     _ESTIMATOR = DeepSeekV4TokenEstimator(
-        Path(tokenizer_path),
+        path,
         reserve_tokens=reserve_tokens,
         default_output_tokens=default_output_tokens,
     )
+    after_fingerprint = compute_tokenizer_asset_fingerprint(path, required_files)
+    after_revision = read_tokenizer_asset_revision(path)
+    if before_fingerprint != after_fingerprint or before_revision != after_revision:
+        raise RuntimeError("Tokenizer asset changed while it was being loaded")
+    _ASSET_FINGERPRINT = after_fingerprint
+    _ASSET_REVISION = after_revision
 
 
 def estimate_in_worker(payload: dict[str, Any]) -> TokenBudget:
@@ -32,8 +57,10 @@ def estimate_in_worker(payload: dict[str, Any]) -> TokenBudget:
     return _ESTIMATOR.estimate(payload)
 
 
-def ping_worker(delay_seconds: float = 0.05) -> tuple[int, bool, bool]:
-    """Return worker identity without exposing any credential value."""
+def ping_worker(
+    delay_seconds: float = 0.05,
+) -> tuple[int, bool, bool, str, str]:
+    """Return worker identity, credential state, and measured asset metadata."""
     if _ESTIMATOR is None:
         raise RuntimeError("Tokenization worker is not initialized")
     time.sleep(delay_seconds)
@@ -41,4 +68,6 @@ def ping_worker(delay_seconds: float = 0.05) -> tuple[int, bool, bool]:
         os.getpid(),
         "XINFERENCE_API_KEY" in os.environ,
         "XINFERENCE_TOKEN_ROUTER_INTERNAL_TOKEN" in os.environ,
+        _ASSET_FINGERPRINT,
+        _ASSET_REVISION,
     )

--- a/xinference/router/tokenizer_asset.py
+++ b/xinference/router/tokenizer_asset.py
@@ -1,0 +1,81 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Iterable, Mapping
+
+DEFAULT_TOKENIZER_ASSET_FILES = (
+    "tokenizer.json",
+    "encoding/encoding_dsv4.py",
+)
+
+
+def aggregate_tokenizer_asset_fingerprint(file_digests: Mapping[str, str]) -> str:
+    """Build the fingerprint used by both the registry and Router workers."""
+    aggregate = hashlib.sha256()
+    for relative_name in sorted(file_digests):
+        aggregate.update(relative_name.encode("utf-8"))
+        aggregate.update(b"\0")
+        aggregate.update(file_digests[relative_name].encode("ascii"))
+        aggregate.update(b"\0")
+    return aggregate.hexdigest()
+
+
+def compute_tokenizer_asset_fingerprint(
+    path: Path, required_files: Iterable[str] = DEFAULT_TOKENIZER_ASSET_FILES
+) -> str:
+    """Hash the files used by a Router tokenizer worker."""
+    path = path.expanduser().resolve()
+    file_digests: dict[str, str] = {}
+    for relative_name in sorted(set(required_files)):
+        relative_path = Path(relative_name)
+        if relative_path.is_absolute() or ".." in relative_path.parts:
+            raise ValueError(f"Unsafe required file path: {relative_name}")
+        file_path = (path / relative_path).resolve()
+        if file_path != path and not file_path.is_relative_to(path):
+            raise ValueError(f"Required file escapes asset directory: {relative_name}")
+        if not file_path.is_file():
+            raise ValueError(f"Missing required Tokenizer file: {relative_name}")
+        digest = hashlib.sha256()
+        with file_path.open("rb") as file:
+            for chunk in iter(lambda: file.read(1024 * 1024), b""):
+                digest.update(chunk)
+        file_digests[relative_name] = digest.hexdigest()
+    return f"sha256:{aggregate_tokenizer_asset_fingerprint(file_digests)}"
+
+
+def read_tokenizer_asset_revision(path: Path) -> str:
+    """Read the revision declared by the manifest at the loaded asset path.
+
+    The manifest is parsed statically (JSON only, no code execution), so this
+    is safe to run inside the Supervisor. Returns an empty string when the
+    path is not a registered asset (no ``asset.json``) or the manifest cannot
+    be parsed.
+    """
+    path = path.expanduser().resolve()
+    manifest_path = path / "asset.json"
+    if not manifest_path.is_file():
+        return ""
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return ""
+    if not isinstance(manifest, dict):
+        return ""
+    revision = manifest.get("revision")
+    return str(revision).strip() if isinstance(revision, str) else ""


### PR DESCRIPTION
## Summary
- add a managed Tokenizer asset registry for Token-aware Router deployments
- validate manifests, required files, checksums, path traversal and symlink safety
- support external asset roots through explicit configuration and isolated smoke tests
- add focused registry tests

Depends on #5375

## Validation
- `pytest -q xinference/core/tests/test_tokenizer_asset_registry.py`
- `pre-commit run --files xinference/constants.py xinference/core/tokenizer_asset_registry.py xinference/core/tests/test_tokenizer_asset_registry.py`


Please review now if convenient, but merge only after the dependency PRs have landed.
