### PR TITLE
feat(monitoring): add Token Router observability

### DIFF
--- a/frontend/src/constants/monitor.ts
+++ b/frontend/src/constants/monitor.ts
@@ -22,6 +22,7 @@ export const REFRESH = [
 export const MONITOR_DASHBOARD_TABS = [
   { key: 'overview', labelKey: 'monitorCenter.tab.overview' },
   { key: 'model_load', labelKey: 'monitorCenter.tab.modelLoad' },
+  { key: 'token_router', labelKey: 'monitorCenter.tab.tokenRouter' },
   { key: 'llm_slo', labelKey: 'monitorCenter.tab.llmSlo' },
   { key: 'gpu', labelKey: 'monitorCenter.tab.gpu' },
   { key: 'host', labelKey: 'monitorCenter.tab.host' },

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -594,6 +594,7 @@ const en = {
       'Monitoring not configured. Please set XINFERENCE_GRAFANA_URL environment variable.',
     tab: {
       overview: 'Overview',
+      tokenRouter: 'Token Router',
       modelLoad: 'Model Load',
       llmSlo: 'LLM SLO',
       gpu: 'GPU',

--- a/frontend/src/i18n/locales/ja.ts
+++ b/frontend/src/i18n/locales/ja.ts
@@ -583,6 +583,7 @@ const ja = {
       'モニタリングが設定されていません。XINFERENCE_GRAFANA_URL 環境変数を設定してください。',
     tab: {
       overview: '概要',
+      tokenRouter: 'Token Router',
       modelLoad: 'モデル負荷',
       llmSlo: 'LLM SLO',
       gpu: 'GPU',

--- a/frontend/src/i18n/locales/ko.ts
+++ b/frontend/src/i18n/locales/ko.ts
@@ -577,6 +577,7 @@ const ko = {
     notConfigured: '모니터링이 구성되지 않았습니다. XINFERENCE_GRAFANA_URL 환경 변수를 설정하세요.',
     tab: {
       overview: '개요',
+      tokenRouter: 'Token Router',
       modelLoad: '모델 부하',
       llmSlo: 'LLM SLO',
       gpu: 'GPU',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -574,6 +574,7 @@ const zh = {
     notConfigured: '监控未配置，请设置 XINFERENCE_GRAFANA_URL 环境变量。',
     tab: {
       overview: '概览',
+      tokenRouter: 'Token Router',
       modelLoad: '模型负载',
       llmSlo: 'LLM SLO',
       gpu: 'GPU',

--- a/monitor/alert/README.md
+++ b/monitor/alert/README.md
@@ -115,3 +115,37 @@ route:
         severity: warning
       receiver: warning-channel
 ```
+
+## Token Router Monitoring V2.1 alerts
+
+The `xinference-token-router-monitoring-v2` group adds layered alerts for Agent
+connectivity, Assignment readiness, Runtime availability/control/config revision,
+Tokenizer Asset Bindings, and logical Router health.
+
+The key availability semantics are intentional:
+
+- Agent suspected/offline is a **warning** and does not directly mean that the Router
+  data plane is unavailable.
+- An effective Runtime that is no longer controllable raises
+  `TokenRouterRuntimeUncontrollable`.
+- `TokenRouterUnavailable` is **critical** only when desired replicas are greater than
+  zero and effective ready replicas are zero.
+- Do not inhibit `TokenRouterUnavailable` merely because an Agent-offline warning is
+  active; Runtime availability is the higher-level service signal.
+
+### Alertmanager inhibition
+
+`alertmanager-inhibition.yml` is an integration fragment. Merge its
+`inhibit_rules` list into the production `alertmanager.yml` rather than loading it
+as a Prometheus rule file. The example applies two narrowly scoped rules:
+
+- `TokenRouterUnavailable` suppresses `TokenRouterRuntimeDown` and
+  `TokenRouterAssignmentNotReady` only for the same `router_uid`.
+- `TokenRouterAgentOffline` suppresses only lower-level Agent connectivity or
+  capacity symptoms for the same `node_id`.
+
+It deliberately does **not** suppress `TokenRouterUnavailable`, Runtime data-plane
+alerts, or other service-level symptoms when an Agent is offline. The existing
+aggregate `WorkerOffline` alert has no `worker_address` label, so a safe
+same-worker replica inhibition cannot be expressed until Worker offline alerts are
+emitted per worker.

--- a/monitor/alert/README_zh-CN.md
+++ b/monitor/alert/README_zh-CN.md
@@ -115,3 +115,32 @@ route:
         severity: warning
       receiver: warning-channel
 ```
+
+## Token Router Monitoring V2.1 告警
+
+`xinference-token-router-monitoring-v2` 规则组新增 Agent 连接、Assignment 就绪、
+Runtime 可用性/可控性/配置版本、Tokenizer 资产绑定和逻辑 Router 健康的分层告警。
+
+关键可用性语义如下：
+
+- Agent suspected/offline 是**警告**，不直接等于 Router 数据面不可用；
+- 有效 Runtime 失去控制链路时触发 `TokenRouterRuntimeUncontrollable`；
+- 仅当期望副本数大于 0 且有效 Ready Runtime 为 0 时，才触发严重级别的
+  `TokenRouterUnavailable`；
+- 不应因为 Agent Offline 警告而抑制 `TokenRouterUnavailable`，Runtime 有效性才是更高层的
+  服务可用性信号。
+
+### Alertmanager 告警抑制
+
+`alertmanager-inhibition.yml` 是集成片段，应将其中的 `inhibit_rules` 合并到生产
+`alertmanager.yml`，不能把它当作 Prometheus 告警规则文件加载。示例仅包含两条
+严格限定范围的抑制规则：
+
+- `TokenRouterUnavailable` 只抑制相同 `router_uid` 的
+  `TokenRouterRuntimeDown` 和 `TokenRouterAssignmentNotReady`；
+- `TokenRouterAgentOffline` 只抑制相同 `node_id` 的 Agent 低层连接性或容量派生告警。
+
+Agent 离线时不会抑制 `TokenRouterUnavailable`、Runtime 数据面告警或其他业务可用性
+告警。当前 `WorkerOffline` 是无 `worker_address` 标签的集群汇总告警，暂时无法安全
+表达“只抑制同一 Worker 的副本派生告警”；需要先将 Worker 离线告警调整为逐节点
+指标后再增加对应 inhibition。

--- a/monitor/alert/alertmanager-inhibition.yml
+++ b/monitor/alert/alertmanager-inhibition.yml
@@ -1,0 +1,21 @@
+# Merge these rules under the top-level `inhibit_rules` key in alertmanager.yml.
+# Agent connectivity warnings must never suppress TokenRouterUnavailable.
+inhibit_rules:
+  # Prefer the logical Router availability signal over per-runtime and
+  # per-assignment symptoms for the same Router.
+  - source_matchers:
+      - alertname="TokenRouterUnavailable"
+    target_matchers:
+      - alertname=~"TokenRouterRuntimeDown|TokenRouterAssignmentNotReady"
+    equal:
+      - router_uid
+
+  # When the Agent is already offline, suppress only lower-level connectivity
+  # or capacity symptoms emitted for the same node. Runtime and Router service
+  # availability alerts remain visible.
+  - source_matchers:
+      - alertname="TokenRouterAgentOffline"
+    target_matchers:
+      - alertname=~"TokenRouterAgentSuspected|TokenRouterAgentCapacityMismatch|TokenRouterAgentHeartbeatStale"
+    equal:
+      - node_id

--- a/monitor/alert/rules-ja.yml
+++ b/monitor/alert/rules-ja.yml
@@ -99,3 +99,105 @@ groups:
         annotations:
           summary: "BAN された IP 数が異常に多い"
           description: "現在 {{ $value }} 件の IP が BAN されています。ブルートフォース攻撃や不正利用の可能性があります。"
+
+  - name: xinference-token-router-monitoring-v2
+    rules:
+      - alert: TokenRouterAgentSuspected
+        expr: xinference:token_router_agent_connectivity_status{status="suspected"} == 1
+        for: 30s
+        labels:
+          severity: warning
+          component: token-router
+        annotations:
+          summary: "Token Router の監視異常を検出: TokenRouterAgentSuspected"
+          description: "ラベル対象の Router 制御面、Runtime、Binding、またはレプリカ状態を確認してください。"
+
+      - alert: TokenRouterAgentOffline
+        expr: xinference:token_router_agent_connectivity_status{status="offline"} == 1
+        for: 0m
+        labels:
+          severity: warning
+          component: token-router
+        annotations:
+          summary: "Token Router の監視異常を検出: TokenRouterAgentOffline"
+          description: "ラベル対象の Router 制御面、Runtime、Binding、またはレプリカ状態を確認してください。"
+
+      - alert: TokenRouterRuntimeUncontrollable
+        expr: xinference:token_router_runtime_effective_ready == 1 and on (router_uid, assignment_id, instance_id) xinference:token_router_runtime_controllable == 0
+        for: 1m
+        labels:
+          severity: warning
+          component: token-router
+        annotations:
+          summary: "Token Router の監視異常を検出: TokenRouterRuntimeUncontrollable"
+          description: "ラベル対象の Router 制御面、Runtime、Binding、またはレプリカ状態を確認してください。"
+
+      - alert: TokenRouterRuntimeDown
+        expr: xinference:token_router_runtime_up == 0
+        for: 1m
+        labels:
+          severity: warning
+          component: token-router
+        annotations:
+          summary: "Token Router の監視異常を検出: TokenRouterRuntimeDown"
+          description: "ラベル対象の Router 制御面、Runtime、Binding、またはレプリカ状態を確認してください。"
+
+      - alert: TokenRouterRuntimeConfigOutOfSync
+        expr: xinference:token_router_runtime_up == 1 and on (router_uid, assignment_id, instance_id) xinference:token_router_runtime_config_synced == 0
+        for: 1m
+        labels:
+          severity: warning
+          component: token-router
+        annotations:
+          summary: "Token Router の監視異常を検出: TokenRouterRuntimeConfigOutOfSync"
+          description: "ラベル対象の Router 制御面、Runtime、Binding、またはレプリカ状態を確認してください。"
+
+      - alert: TokenRouterAssignmentNotReady
+        expr: xinference:token_router_assignment_desired_state{state="running"} == 1 and on (router_uid, assignment_id, replica_index, node_id) xinference:token_router_assignment_runtime_ready == 0
+        for: 2m
+        labels:
+          severity: warning
+          component: token-router
+        annotations:
+          summary: "Token Router の監視異常を検出: TokenRouterAssignmentNotReady"
+          description: "ラベル対象の Router 制御面、Runtime、Binding、またはレプリカ状態を確認してください。"
+
+      - alert: TokenRouterTokenizerBindingFailed
+        expr: xinference:token_router_tokenizer_binding_state{observed_state="failed"} == 1
+        for: 1m
+        labels:
+          severity: warning
+          component: token-router
+        annotations:
+          summary: "Token Router の監視異常を検出: TokenRouterTokenizerBindingFailed"
+          description: "ラベル対象の Router 制御面、Runtime、Binding、またはレプリカ状態を確認してください。"
+
+      - alert: TokenRouterTokenizerBindingStale
+        expr: xinference:token_router_tokenizer_binding_state{observed_state="stale"} == 1
+        for: 2m
+        labels:
+          severity: warning
+          component: token-router
+        annotations:
+          summary: "Token Router の監視異常を検出: TokenRouterTokenizerBindingStale"
+          description: "ラベル対象の Router 制御面、Runtime、Binding、またはレプリカ状態を確認してください。"
+
+      - alert: TokenRouterDegraded
+        expr: xinference:token_router_status{status="degraded"} == 1
+        for: 2m
+        labels:
+          severity: warning
+          component: token-router
+        annotations:
+          summary: "Token Router の監視異常を検出: TokenRouterDegraded"
+          description: "ラベル対象の Router 制御面、Runtime、Binding、またはレプリカ状態を確認してください。"
+
+      - alert: TokenRouterUnavailable
+        expr: xinference:token_router_desired_replicas > 0 and on (router_uid) xinference:token_router_effective_ready_replicas == 0
+        for: 1m
+        labels:
+          severity: critical
+          component: token-router
+        annotations:
+          summary: "Token Router の監視異常を検出: TokenRouterUnavailable"
+          description: "ラベル対象の Router 制御面、Runtime、Binding、またはレプリカ状態を確認してください。"

--- a/monitor/alert/rules-ko.yml
+++ b/monitor/alert/rules-ko.yml
@@ -99,3 +99,105 @@ groups:
         annotations:
           summary: "차단 IP 수 이상 증가"
           description: "현재 {{ $value }}개의 IP가 차단되었습니다. 무차별 공격 또는 오용 가능성이 있습니다."
+
+  - name: xinference-token-router-monitoring-v2
+    rules:
+      - alert: TokenRouterAgentSuspected
+        expr: xinference:token_router_agent_connectivity_status{status="suspected"} == 1
+        for: 30s
+        labels:
+          severity: warning
+          component: token-router
+        annotations:
+          summary: "Token Router 모니터링 이상 감지: TokenRouterAgentSuspected"
+          description: "레이블 대상의 Router 제어 플레인, Runtime, Binding 또는 복제본 상태를 확인하십시오."
+
+      - alert: TokenRouterAgentOffline
+        expr: xinference:token_router_agent_connectivity_status{status="offline"} == 1
+        for: 0m
+        labels:
+          severity: warning
+          component: token-router
+        annotations:
+          summary: "Token Router 모니터링 이상 감지: TokenRouterAgentOffline"
+          description: "레이블 대상의 Router 제어 플레인, Runtime, Binding 또는 복제본 상태를 확인하십시오."
+
+      - alert: TokenRouterRuntimeUncontrollable
+        expr: xinference:token_router_runtime_effective_ready == 1 and on (router_uid, assignment_id, instance_id) xinference:token_router_runtime_controllable == 0
+        for: 1m
+        labels:
+          severity: warning
+          component: token-router
+        annotations:
+          summary: "Token Router 모니터링 이상 감지: TokenRouterRuntimeUncontrollable"
+          description: "레이블 대상의 Router 제어 플레인, Runtime, Binding 또는 복제본 상태를 확인하십시오."
+
+      - alert: TokenRouterRuntimeDown
+        expr: xinference:token_router_runtime_up == 0
+        for: 1m
+        labels:
+          severity: warning
+          component: token-router
+        annotations:
+          summary: "Token Router 모니터링 이상 감지: TokenRouterRuntimeDown"
+          description: "레이블 대상의 Router 제어 플레인, Runtime, Binding 또는 복제본 상태를 확인하십시오."
+
+      - alert: TokenRouterRuntimeConfigOutOfSync
+        expr: xinference:token_router_runtime_up == 1 and on (router_uid, assignment_id, instance_id) xinference:token_router_runtime_config_synced == 0
+        for: 1m
+        labels:
+          severity: warning
+          component: token-router
+        annotations:
+          summary: "Token Router 모니터링 이상 감지: TokenRouterRuntimeConfigOutOfSync"
+          description: "레이블 대상의 Router 제어 플레인, Runtime, Binding 또는 복제본 상태를 확인하십시오."
+
+      - alert: TokenRouterAssignmentNotReady
+        expr: xinference:token_router_assignment_desired_state{state="running"} == 1 and on (router_uid, assignment_id, replica_index, node_id) xinference:token_router_assignment_runtime_ready == 0
+        for: 2m
+        labels:
+          severity: warning
+          component: token-router
+        annotations:
+          summary: "Token Router 모니터링 이상 감지: TokenRouterAssignmentNotReady"
+          description: "레이블 대상의 Router 제어 플레인, Runtime, Binding 또는 복제본 상태를 확인하십시오."
+
+      - alert: TokenRouterTokenizerBindingFailed
+        expr: xinference:token_router_tokenizer_binding_state{observed_state="failed"} == 1
+        for: 1m
+        labels:
+          severity: warning
+          component: token-router
+        annotations:
+          summary: "Token Router 모니터링 이상 감지: TokenRouterTokenizerBindingFailed"
+          description: "레이블 대상의 Router 제어 플레인, Runtime, Binding 또는 복제본 상태를 확인하십시오."
+
+      - alert: TokenRouterTokenizerBindingStale
+        expr: xinference:token_router_tokenizer_binding_state{observed_state="stale"} == 1
+        for: 2m
+        labels:
+          severity: warning
+          component: token-router
+        annotations:
+          summary: "Token Router 모니터링 이상 감지: TokenRouterTokenizerBindingStale"
+          description: "레이블 대상의 Router 제어 플레인, Runtime, Binding 또는 복제본 상태를 확인하십시오."
+
+      - alert: TokenRouterDegraded
+        expr: xinference:token_router_status{status="degraded"} == 1
+        for: 2m
+        labels:
+          severity: warning
+          component: token-router
+        annotations:
+          summary: "Token Router 모니터링 이상 감지: TokenRouterDegraded"
+          description: "레이블 대상의 Router 제어 플레인, Runtime, Binding 또는 복제본 상태를 확인하십시오."
+
+      - alert: TokenRouterUnavailable
+        expr: xinference:token_router_desired_replicas > 0 and on (router_uid) xinference:token_router_effective_ready_replicas == 0
+        for: 1m
+        labels:
+          severity: critical
+          component: token-router
+        annotations:
+          summary: "Token Router 모니터링 이상 감지: TokenRouterUnavailable"
+          description: "레이블 대상의 Router 제어 플레인, Runtime, Binding 또는 복제본 상태를 확인하십시오."

--- a/monitor/alert/rules-zh-CN.yml
+++ b/monitor/alert/rules-zh-CN.yml
@@ -99,3 +99,105 @@ groups:
         annotations:
           summary: "封禁 IP 数量异常偏高"
           description: "当前封禁 IP 数 {{ $value }}，可能存在暴力攻击或滥用行为。"
+
+  - name: xinference-token-router-monitoring-v2
+    rules:
+      - alert: TokenRouterAgentSuspected
+        expr: xinference:token_router_agent_connectivity_status{status="suspected"} == 1
+        for: 30s
+        labels:
+          severity: warning
+          component: token-router
+        annotations:
+          summary: "检测到 Token Router 监控异常: TokenRouterAgentSuspected"
+          description: "请根据标签检查 Router 控制面、Runtime、资产绑定或模型副本状态。"
+
+      - alert: TokenRouterAgentOffline
+        expr: xinference:token_router_agent_connectivity_status{status="offline"} == 1
+        for: 0m
+        labels:
+          severity: warning
+          component: token-router
+        annotations:
+          summary: "检测到 Token Router 监控异常: TokenRouterAgentOffline"
+          description: "请根据标签检查 Router 控制面、Runtime、资产绑定或模型副本状态。"
+
+      - alert: TokenRouterRuntimeUncontrollable
+        expr: xinference:token_router_runtime_effective_ready == 1 and on (router_uid, assignment_id, instance_id) xinference:token_router_runtime_controllable == 0
+        for: 1m
+        labels:
+          severity: warning
+          component: token-router
+        annotations:
+          summary: "检测到 Token Router 监控异常: TokenRouterRuntimeUncontrollable"
+          description: "请根据标签检查 Router 控制面、Runtime、资产绑定或模型副本状态。"
+
+      - alert: TokenRouterRuntimeDown
+        expr: xinference:token_router_runtime_up == 0
+        for: 1m
+        labels:
+          severity: warning
+          component: token-router
+        annotations:
+          summary: "检测到 Token Router 监控异常: TokenRouterRuntimeDown"
+          description: "请根据标签检查 Router 控制面、Runtime、资产绑定或模型副本状态。"
+
+      - alert: TokenRouterRuntimeConfigOutOfSync
+        expr: xinference:token_router_runtime_up == 1 and on (router_uid, assignment_id, instance_id) xinference:token_router_runtime_config_synced == 0
+        for: 1m
+        labels:
+          severity: warning
+          component: token-router
+        annotations:
+          summary: "检测到 Token Router 监控异常: TokenRouterRuntimeConfigOutOfSync"
+          description: "请根据标签检查 Router 控制面、Runtime、资产绑定或模型副本状态。"
+
+      - alert: TokenRouterAssignmentNotReady
+        expr: xinference:token_router_assignment_desired_state{state="running"} == 1 and on (router_uid, assignment_id, replica_index, node_id) xinference:token_router_assignment_runtime_ready == 0
+        for: 2m
+        labels:
+          severity: warning
+          component: token-router
+        annotations:
+          summary: "检测到 Token Router 监控异常: TokenRouterAssignmentNotReady"
+          description: "请根据标签检查 Router 控制面、Runtime、资产绑定或模型副本状态。"
+
+      - alert: TokenRouterTokenizerBindingFailed
+        expr: xinference:token_router_tokenizer_binding_state{observed_state="failed"} == 1
+        for: 1m
+        labels:
+          severity: warning
+          component: token-router
+        annotations:
+          summary: "检测到 Token Router 监控异常: TokenRouterTokenizerBindingFailed"
+          description: "请根据标签检查 Router 控制面、Runtime、资产绑定或模型副本状态。"
+
+      - alert: TokenRouterTokenizerBindingStale
+        expr: xinference:token_router_tokenizer_binding_state{observed_state="stale"} == 1
+        for: 2m
+        labels:
+          severity: warning
+          component: token-router
+        annotations:
+          summary: "检测到 Token Router 监控异常: TokenRouterTokenizerBindingStale"
+          description: "请根据标签检查 Router 控制面、Runtime、资产绑定或模型副本状态。"
+
+      - alert: TokenRouterDegraded
+        expr: xinference:token_router_status{status="degraded"} == 1
+        for: 2m
+        labels:
+          severity: warning
+          component: token-router
+        annotations:
+          summary: "检测到 Token Router 监控异常: TokenRouterDegraded"
+          description: "请根据标签检查 Router 控制面、Runtime、资产绑定或模型副本状态。"
+
+      - alert: TokenRouterUnavailable
+        expr: xinference:token_router_desired_replicas > 0 and on (router_uid) xinference:token_router_effective_ready_replicas == 0
+        for: 1m
+        labels:
+          severity: critical
+          component: token-router
+        annotations:
+          summary: "检测到 Token Router 监控异常: TokenRouterUnavailable"
+          description: "请根据标签检查 Router 控制面、Runtime、资产绑定或模型副本状态。"

--- a/monitor/alert/rules.yml
+++ b/monitor/alert/rules.yml
@@ -99,3 +99,105 @@ groups:
         annotations:
           summary: "Banned IP count abnormally high"
           description: "Currently {{ $value }} IPs banned, possible brute-force or abuse."
+
+  - name: xinference-token-router-monitoring-v2
+    rules:
+      - alert: TokenRouterAgentSuspected
+        expr: xinference:token_router_agent_connectivity_status{status="suspected"} == 1
+        for: 30s
+        labels:
+          severity: warning
+          component: token-router
+        annotations:
+          summary: "Token Router monitoring condition detected: TokenRouterAgentSuspected"
+          description: "Check Router control-plane, Runtime, Binding, or replica state for the labeled object."
+
+      - alert: TokenRouterAgentOffline
+        expr: xinference:token_router_agent_connectivity_status{status="offline"} == 1
+        for: 0m
+        labels:
+          severity: warning
+          component: token-router
+        annotations:
+          summary: "Token Router monitoring condition detected: TokenRouterAgentOffline"
+          description: "Check Router control-plane, Runtime, Binding, or replica state for the labeled object."
+
+      - alert: TokenRouterRuntimeUncontrollable
+        expr: xinference:token_router_runtime_effective_ready == 1 and on (router_uid, assignment_id, instance_id) xinference:token_router_runtime_controllable == 0
+        for: 1m
+        labels:
+          severity: warning
+          component: token-router
+        annotations:
+          summary: "Token Router monitoring condition detected: TokenRouterRuntimeUncontrollable"
+          description: "Check Router control-plane, Runtime, Binding, or replica state for the labeled object."
+
+      - alert: TokenRouterRuntimeDown
+        expr: xinference:token_router_runtime_up == 0
+        for: 1m
+        labels:
+          severity: warning
+          component: token-router
+        annotations:
+          summary: "Token Router monitoring condition detected: TokenRouterRuntimeDown"
+          description: "Check Router control-plane, Runtime, Binding, or replica state for the labeled object."
+
+      - alert: TokenRouterRuntimeConfigOutOfSync
+        expr: xinference:token_router_runtime_up == 1 and on (router_uid, assignment_id, instance_id) xinference:token_router_runtime_config_synced == 0
+        for: 1m
+        labels:
+          severity: warning
+          component: token-router
+        annotations:
+          summary: "Token Router monitoring condition detected: TokenRouterRuntimeConfigOutOfSync"
+          description: "Check Router control-plane, Runtime, Binding, or replica state for the labeled object."
+
+      - alert: TokenRouterAssignmentNotReady
+        expr: xinference:token_router_assignment_desired_state{state="running"} == 1 and on (router_uid, assignment_id, replica_index, node_id) xinference:token_router_assignment_runtime_ready == 0
+        for: 2m
+        labels:
+          severity: warning
+          component: token-router
+        annotations:
+          summary: "Token Router monitoring condition detected: TokenRouterAssignmentNotReady"
+          description: "Check Router control-plane, Runtime, Binding, or replica state for the labeled object."
+
+      - alert: TokenRouterTokenizerBindingFailed
+        expr: xinference:token_router_tokenizer_binding_state{observed_state="failed"} == 1
+        for: 1m
+        labels:
+          severity: warning
+          component: token-router
+        annotations:
+          summary: "Token Router monitoring condition detected: TokenRouterTokenizerBindingFailed"
+          description: "Check Router control-plane, Runtime, Binding, or replica state for the labeled object."
+
+      - alert: TokenRouterTokenizerBindingStale
+        expr: xinference:token_router_tokenizer_binding_state{observed_state="stale"} == 1
+        for: 2m
+        labels:
+          severity: warning
+          component: token-router
+        annotations:
+          summary: "Token Router monitoring condition detected: TokenRouterTokenizerBindingStale"
+          description: "Check Router control-plane, Runtime, Binding, or replica state for the labeled object."
+
+      - alert: TokenRouterDegraded
+        expr: xinference:token_router_status{status="degraded"} == 1
+        for: 2m
+        labels:
+          severity: warning
+          component: token-router
+        annotations:
+          summary: "Token Router monitoring condition detected: TokenRouterDegraded"
+          description: "Check Router control-plane, Runtime, Binding, or replica state for the labeled object."
+
+      - alert: TokenRouterUnavailable
+        expr: xinference:token_router_desired_replicas > 0 and on (router_uid) xinference:token_router_effective_ready_replicas == 0
+        for: 1m
+        labels:
+          severity: critical
+          component: token-router
+        annotations:
+          summary: "Token Router monitoring condition detected: TokenRouterUnavailable"
+          description: "Check Router control-plane, Runtime, Binding, or replica state for the labeled object."

--- a/monitor/dashboard/README.md
+++ b/monitor/dashboard/README.md
@@ -166,3 +166,15 @@ The `dcgm-custom-metrics.csv` includes:
 - Xinference with metrics enabled
 - DCGM Exporter for GPU hardware panels
 - node_exporter for host resource panels
+
+## Token Router dashboard
+
+Monitoring V2.1 adds the four localized dashboards under `token-router/`, all using
+UID `xinference-token-router`. The dashboard covers logical Router availability,
+Router Agent host resources, Assignment state, Runtime control-plane and process
+resources, request/backend latency and errors, concurrency pools, tokenization, and
+Tokenizer Asset Bindings.
+
+Prometheus must scrape both the Supervisor metrics endpoint and dynamically discovered
+Runtime endpoints. Configure the Runtime targets with the HTTP-SD example in
+`../metrics/prometheus-token-router-http-sd.yml`.

--- a/monitor/dashboard/README_zh-CN.md
+++ b/monitor/dashboard/README_zh-CN.md
@@ -166,3 +166,13 @@ API Key 与封禁统计。**仅在 `XINFERENCE_AUTH_ADVANCED=true` 时可用。*
 - Xinference 已启用 metrics
 - DCGM Exporter，用于 GPU 硬件面板
 - node_exporter，用于主机资源面板
+
+## Token Router Dashboard
+
+Monitoring V2.1 在 `token-router/` 下新增四语言 Dashboard，统一使用 UID
+`xinference-token-router`。Dashboard 覆盖逻辑 Router 可用性、Router Agent 主机资源、
+Assignment 状态、Runtime 控制面与进程资源、请求/后端延迟和错误、并发池、Tokenization
+以及 Tokenizer 资产绑定。
+
+Prometheus 必须同时抓取 Supervisor 指标和动态发现的 Runtime 指标；Runtime target 请使用
+`../metrics/prometheus-token-router-http-sd.yml` 中的 HTTP-SD 示例配置。

--- a/monitor/dashboard/token-router/xinference-grafana-dashboard-token-router-en.json
+++ b/monitor/dashboard/token-router/xinference-grafana-dashboard-token-router-en.json
@@ -1,0 +1,1727 @@
+{
+  "__inputs": [],
+  "__requires": [],
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "id": 1,
+      "title": "Logical Router Overview",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "panels": []
+    },
+    {
+      "id": 2,
+      "title": "Desired Replicas",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 0,
+        "y": 1
+      },
+      "targets": [
+        {
+          "expr": "sum(xinference:token_router_desired_replicas{cluster=~\"$cluster\",router_uid=~\"$router_uid\"})",
+          "refId": "A"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 3,
+      "title": "Effective Ready",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 4,
+        "y": 1
+      },
+      "targets": [
+        {
+          "expr": "sum(xinference:token_router_effective_ready_replicas{cluster=~\"$cluster\",router_uid=~\"$router_uid\"})",
+          "refId": "A"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 4,
+      "title": "Controllable Ready",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 8,
+        "y": 1
+      },
+      "targets": [
+        {
+          "expr": "sum(xinference:token_router_controllable_ready_replicas{cluster=~\"$cluster\",router_uid=~\"$router_uid\"})",
+          "refId": "A"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 5,
+      "title": "Request QPS",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 12,
+        "y": 1
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(xinference_token_router_route_requests_total{cluster=~\"$cluster\",router_uid=~\"$router_uid\"}[5m]))",
+          "refId": "A"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 6,
+      "title": "Error Rate",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 16,
+        "y": 1
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(xinference_token_router_route_requests_total{cluster=~\"$cluster\",router_uid=~\"$router_uid\",result!=\"completed\"}[5m])) / clamp_min(sum(rate(xinference_token_router_route_requests_total{cluster=~\"$cluster\",router_uid=~\"$router_uid\"}[5m])), 1e-9)",
+          "refId": "A"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 7,
+      "title": "Config Synced",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 20,
+        "y": 1
+      },
+      "targets": [
+        {
+          "expr": "sum(xinference:token_router_config_synced_replicas{cluster=~\"$cluster\",router_uid=~\"$router_uid\"})",
+          "refId": "A"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 8,
+      "title": "Router Agents",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 6
+      },
+      "panels": []
+    },
+    {
+      "id": 9,
+      "title": "Agent Connectivity",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 7
+      },
+      "targets": [
+        {
+          "expr": "xinference:token_router_agent_connectivity_status{cluster=~\"$cluster\",node_id=~\"$node_id\"}",
+          "refId": "A",
+          "legendFormat": "{{node_id}} {{status}}"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 10,
+      "title": "Heartbeat Age",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 7
+      },
+      "targets": [
+        {
+          "expr": "xinference:token_router_agent_heartbeat_age_seconds{cluster=~\"$cluster\",node_id=~\"$node_id\"}",
+          "refId": "A",
+          "legendFormat": "{{node_id}}"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 11,
+      "title": "Host CPU / Memory",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 7
+      },
+      "targets": [
+        {
+          "expr": "xinference:token_router_agent_host_cpu_utilization{cluster=~\"$cluster\",node_id=~\"$node_id\"}",
+          "refId": "A",
+          "legendFormat": "CPU {{node_id}}"
+        },
+        {
+          "expr": "xinference:token_router_agent_host_memory_used_bytes{cluster=~\"$cluster\",node_id=~\"$node_id\"} / clamp_min(xinference:token_router_agent_host_memory_total_bytes{cluster=~\"$cluster\",node_id=~\"$node_id\"}, 1)",
+          "refId": "B",
+          "legendFormat": "Memory {{node_id}}"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 12,
+      "title": "Assignments",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 15
+      },
+      "panels": []
+    },
+    {
+      "id": 13,
+      "title": "Assignment State",
+      "type": "table",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "targets": [
+        {
+          "expr": "xinference:token_router_assignment_info{cluster=~\"$cluster\",router_uid=~\"$router_uid\",node_id=~\"$node_id\",assignment_id=~\"$assignment_id\"}",
+          "refId": "A"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 14,
+      "title": "Ready / Current / Controllable",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "targets": [
+        {
+          "expr": "xinference:token_router_assignment_runtime_ready{cluster=~\"$cluster\",router_uid=~\"$router_uid\",assignment_id=~\"$assignment_id\"}",
+          "refId": "A",
+          "legendFormat": "ready {{assignment_id}}"
+        },
+        {
+          "expr": "xinference:token_router_assignment_current{cluster=~\"$cluster\",router_uid=~\"$router_uid\",assignment_id=~\"$assignment_id\"}",
+          "refId": "B",
+          "legendFormat": "current {{assignment_id}}"
+        },
+        {
+          "expr": "xinference:token_router_assignment_controllable{cluster=~\"$cluster\",router_uid=~\"$router_uid\",assignment_id=~\"$assignment_id\"}",
+          "refId": "C",
+          "legendFormat": "controllable {{assignment_id}}"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 15,
+      "title": "Runtime Control Plane & Process",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 25
+      },
+      "panels": []
+    },
+    {
+      "id": 16,
+      "title": "Runtime Effective / Controllable",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 26
+      },
+      "targets": [
+        {
+          "expr": "xinference:token_router_runtime_effective_ready{cluster=~\"$cluster\",router_uid=~\"$router_uid\",assignment_id=~\"$assignment_id\",instance_id=~\"$instance_id\"}",
+          "refId": "A",
+          "legendFormat": "effective {{instance_id}}"
+        },
+        {
+          "expr": "xinference:token_router_runtime_controllable{cluster=~\"$cluster\",router_uid=~\"$router_uid\",assignment_id=~\"$assignment_id\",instance_id=~\"$instance_id\"}",
+          "refId": "B",
+          "legendFormat": "controllable {{instance_id}}"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 17,
+      "title": "Config Revision Sync",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 26
+      },
+      "targets": [
+        {
+          "expr": "xinference:token_router_runtime_expected_revision{cluster=~\"$cluster\",router_uid=~\"$router_uid\",assignment_id=~\"$assignment_id\"}",
+          "refId": "A",
+          "legendFormat": "expected {{instance_id}}"
+        },
+        {
+          "expr": "xinference:token_router_runtime_acked_revision{cluster=~\"$cluster\",router_uid=~\"$router_uid\",assignment_id=~\"$assignment_id\"}",
+          "refId": "B",
+          "legendFormat": "acked {{instance_id}}"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 18,
+      "title": "Runtime CPU / RSS",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 26
+      },
+      "targets": [
+        {
+          "expr": "xinference_token_router_process_cpu_utilization{cluster=~\"$cluster\",router_uid=~\"$router_uid\",instance_id=~\"$instance_id\"}",
+          "refId": "A",
+          "legendFormat": "CPU {{instance}}"
+        },
+        {
+          "expr": "xinference_token_router_process_resident_memory_bytes{cluster=~\"$cluster\",router_uid=~\"$router_uid\",instance_id=~\"$instance_id\"}",
+          "refId": "B",
+          "legendFormat": "RSS {{instance}}"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 19,
+      "title": "Route Requests",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 34
+      },
+      "panels": []
+    },
+    {
+      "id": 20,
+      "title": "Results QPS",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 35
+      },
+      "targets": [
+        {
+          "expr": "sum by (result) (rate(xinference_token_router_route_requests_total{cluster=~\"$cluster\",router_uid=~\"$router_uid\",pool=~\"$pool\"}[5m]))",
+          "refId": "A",
+          "legendFormat": "{{result}}"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 21,
+      "title": "P95 / P99 End-to-End",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 35
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(xinference_token_router_request_duration_seconds_bucket{cluster=~\"$cluster\",router_uid=~\"$router_uid\",pool=~\"$pool\"}[5m])))",
+          "refId": "A",
+          "legendFormat": "P95"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(xinference_token_router_request_duration_seconds_bucket{cluster=~\"$cluster\",router_uid=~\"$router_uid\",pool=~\"$pool\"}[5m])))",
+          "refId": "B",
+          "legendFormat": "P99"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 22,
+      "title": "In Flight",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 35
+      },
+      "targets": [
+        {
+          "expr": "sum by (pool) (xinference_token_router_requests_in_flight{cluster=~\"$cluster\",router_uid=~\"$router_uid\",pool=~\"$pool\"})",
+          "refId": "A",
+          "legendFormat": "{{pool}}"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 23,
+      "title": "Rules & Backends",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 43
+      },
+      "panels": []
+    },
+    {
+      "id": 24,
+      "title": "Rule Matches",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 44
+      },
+      "targets": [
+        {
+          "expr": "sum by (rule_id,outcome) (rate(xinference_token_router_rule_matches_total{cluster=~\"$cluster\",router_uid=~\"$router_uid\"}[5m]))",
+          "refId": "A",
+          "legendFormat": "{{rule_id}} {{outcome}}"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 25,
+      "title": "Backend Results",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 44
+      },
+      "targets": [
+        {
+          "expr": "sum by (backend_model_uid,result) (rate(xinference_token_router_backend_requests_total{cluster=~\"$cluster\",router_uid=~\"$router_uid\",backend_model_uid=~\"$backend_model_uid\"}[5m]))",
+          "refId": "A",
+          "legendFormat": "{{backend_model_uid}} {{result}}"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 26,
+      "title": "Backend P95 / P99",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 44
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le,backend_model_uid) (rate(xinference_token_router_backend_request_duration_seconds_bucket{cluster=~\"$cluster\",router_uid=~\"$router_uid\",backend_model_uid=~\"$backend_model_uid\"}[5m])))",
+          "refId": "A",
+          "legendFormat": "P95 {{backend_model_uid}}"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (le,backend_model_uid) (rate(xinference_token_router_backend_request_duration_seconds_bucket{cluster=~\"$cluster\",router_uid=~\"$router_uid\",backend_model_uid=~\"$backend_model_uid\"}[5m])))",
+          "refId": "B",
+          "legendFormat": "P99 {{backend_model_uid}}"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 27,
+      "title": "Pools & Tokenization",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 52
+      },
+      "panels": []
+    },
+    {
+      "id": 28,
+      "title": "Pool Capacity",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 53
+      },
+      "targets": [
+        {
+          "expr": "xinference_token_router_pool_limit{cluster=~\"$cluster\",router_uid=~\"$router_uid\",pool=~\"$pool\"}",
+          "refId": "A",
+          "legendFormat": "limit {{pool}}"
+        },
+        {
+          "expr": "xinference_token_router_pool_in_use{cluster=~\"$cluster\",router_uid=~\"$router_uid\",pool=~\"$pool\"}",
+          "refId": "B",
+          "legendFormat": "in use {{pool}}"
+        },
+        {
+          "expr": "xinference_token_router_pool_waiting{cluster=~\"$cluster\",router_uid=~\"$router_uid\",pool=~\"$pool\"}",
+          "refId": "C",
+          "legendFormat": "waiting {{pool}}"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 29,
+      "title": "Pool Reject / Wait",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 53
+      },
+      "targets": [
+        {
+          "expr": "sum by (pool,reason) (rate(xinference_token_router_pool_rejected_total{cluster=~\"$cluster\",router_uid=~\"$router_uid\",pool=~\"$pool\"}[5m]))",
+          "refId": "A",
+          "legendFormat": "reject {{pool}} {{reason}}"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le,pool) (rate(xinference_token_router_pool_wait_duration_seconds_bucket{cluster=~\"$cluster\",router_uid=~\"$router_uid\",pool=~\"$pool\"}[5m])))",
+          "refId": "B",
+          "legendFormat": "wait P95 {{pool}}"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 30,
+      "title": "Tokenization",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 53
+      },
+      "targets": [
+        {
+          "expr": "xinference_token_router_tokenization_active{cluster=~\"$cluster\",router_uid=~\"$router_uid\"}",
+          "refId": "A",
+          "legendFormat": "active"
+        },
+        {
+          "expr": "xinference_token_router_tokenization_waiting{cluster=~\"$cluster\",router_uid=~\"$router_uid\"}",
+          "refId": "B",
+          "legendFormat": "waiting"
+        },
+        {
+          "expr": "rate(xinference_token_router_tokenization_rejected_total{cluster=~\"$cluster\",router_uid=~\"$router_uid\"}[5m])",
+          "refId": "C",
+          "legendFormat": "rejected {{reason}}"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 31,
+      "title": "Tokenizer Asset Bindings",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 61
+      },
+      "panels": []
+    },
+    {
+      "id": 32,
+      "title": "Binding State",
+      "type": "table",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 62
+      },
+      "targets": [
+        {
+          "expr": "xinference:token_router_tokenizer_binding_state{cluster=~\"$cluster\",node_id=~\"$node_id\"}",
+          "refId": "A"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 33,
+      "title": "Binding Ready / Synced",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 62
+      },
+      "targets": [
+        {
+          "expr": "xinference:token_router_tokenizer_binding_ready{cluster=~\"$cluster\",node_id=~\"$node_id\"}",
+          "refId": "A",
+          "legendFormat": "ready {{asset_id}} {{node_id}}"
+        },
+        {
+          "expr": "xinference:token_router_tokenizer_binding_synced{cluster=~\"$cluster\",node_id=~\"$node_id\"}",
+          "refId": "B",
+          "legendFormat": "synced {{asset_id}} {{node_id}}"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": [
+    "xinference",
+    "token-router"
+  ],
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "label": "Datasource",
+        "type": "datasource",
+        "query": "prometheus",
+        "refresh": 1,
+        "options": [],
+        "current": {}
+      },
+      {
+        "name": "cluster",
+        "label": "Cluster",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(xinference:token_router_status, cluster)",
+        "query": {
+          "query": "label_values(xinference:token_router_status, cluster)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true,
+        "refresh": 2,
+        "sort": 1,
+        "options": [],
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "hide": 0,
+        "skipUrlSync": false
+      },
+      {
+        "name": "router_uid",
+        "label": "Router",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(xinference:token_router_status{cluster=~\"$cluster\"}, router_uid)",
+        "query": {
+          "query": "label_values(xinference:token_router_status{cluster=~\"$cluster\"}, router_uid)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true,
+        "refresh": 2,
+        "sort": 1,
+        "options": [],
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "hide": 0,
+        "skipUrlSync": false
+      },
+      {
+        "name": "node_id",
+        "label": "Node",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(xinference:token_router_agent_info{cluster=~\"$cluster\"}, node_id)",
+        "query": {
+          "query": "label_values(xinference:token_router_agent_info{cluster=~\"$cluster\"}, node_id)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true,
+        "refresh": 2,
+        "sort": 1,
+        "options": [],
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "hide": 0,
+        "skipUrlSync": false
+      },
+      {
+        "name": "assignment_id",
+        "label": "Assignment",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(xinference:token_router_assignment_info{cluster=~\"$cluster\",router_uid=~\"$router_uid\"}, assignment_id)",
+        "query": {
+          "query": "label_values(xinference:token_router_assignment_info{cluster=~\"$cluster\",router_uid=~\"$router_uid\"}, assignment_id)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true,
+        "refresh": 2,
+        "sort": 1,
+        "options": [],
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "hide": 0,
+        "skipUrlSync": false
+      },
+      {
+        "name": "instance_id",
+        "label": "Runtime",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(xinference:token_router_runtime_info{cluster=~\"$cluster\",router_uid=~\"$router_uid\"}, instance_id)",
+        "query": {
+          "query": "label_values(xinference:token_router_runtime_info{cluster=~\"$cluster\",router_uid=~\"$router_uid\"}, instance_id)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true,
+        "refresh": 2,
+        "sort": 1,
+        "options": [],
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "hide": 0,
+        "skipUrlSync": false
+      },
+      {
+        "name": "pool",
+        "label": "Pool",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(xinference_token_router_route_requests_total{cluster=~\"$cluster\",router_uid=~\"$router_uid\"}, pool)",
+        "query": {
+          "query": "label_values(xinference_token_router_route_requests_total{cluster=~\"$cluster\",router_uid=~\"$router_uid\"}, pool)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true,
+        "refresh": 2,
+        "sort": 1,
+        "options": [],
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "hide": 0,
+        "skipUrlSync": false
+      },
+      {
+        "name": "backend_model_uid",
+        "label": "Backend",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(xinference_token_router_backend_requests_total{cluster=~\"$cluster\",router_uid=~\"$router_uid\"}, backend_model_uid)",
+        "query": {
+          "query": "label_values(xinference_token_router_backend_requests_total{cluster=~\"$cluster\",router_uid=~\"$router_uid\"}, backend_model_uid)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true,
+        "refresh": 2,
+        "sort": 1,
+        "options": [],
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "hide": 0,
+        "skipUrlSync": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Xinference Token Router",
+  "uid": "xinference-token-router",
+  "version": 1,
+  "weekStart": ""
+}

--- a/monitor/dashboard/token-router/xinference-grafana-dashboard-token-router-ja.json
+++ b/monitor/dashboard/token-router/xinference-grafana-dashboard-token-router-ja.json
@@ -1,0 +1,1727 @@
+{
+  "__inputs": [],
+  "__requires": [],
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "id": 1,
+      "title": "論理 Router 概要",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "panels": []
+    },
+    {
+      "id": 2,
+      "title": "Desired Replicas",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 0,
+        "y": 1
+      },
+      "targets": [
+        {
+          "expr": "sum(xinference:token_router_desired_replicas{cluster=~\"$cluster\",router_uid=~\"$router_uid\"})",
+          "refId": "A"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 3,
+      "title": "Effective Ready",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 4,
+        "y": 1
+      },
+      "targets": [
+        {
+          "expr": "sum(xinference:token_router_effective_ready_replicas{cluster=~\"$cluster\",router_uid=~\"$router_uid\"})",
+          "refId": "A"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 4,
+      "title": "Controllable Ready",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 8,
+        "y": 1
+      },
+      "targets": [
+        {
+          "expr": "sum(xinference:token_router_controllable_ready_replicas{cluster=~\"$cluster\",router_uid=~\"$router_uid\"})",
+          "refId": "A"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 5,
+      "title": "Request QPS",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 12,
+        "y": 1
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(xinference_token_router_route_requests_total{cluster=~\"$cluster\",router_uid=~\"$router_uid\"}[5m]))",
+          "refId": "A"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 6,
+      "title": "Error Rate",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 16,
+        "y": 1
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(xinference_token_router_route_requests_total{cluster=~\"$cluster\",router_uid=~\"$router_uid\",result!=\"completed\"}[5m])) / clamp_min(sum(rate(xinference_token_router_route_requests_total{cluster=~\"$cluster\",router_uid=~\"$router_uid\"}[5m])), 1e-9)",
+          "refId": "A"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 7,
+      "title": "Config Synced",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 20,
+        "y": 1
+      },
+      "targets": [
+        {
+          "expr": "sum(xinference:token_router_config_synced_replicas{cluster=~\"$cluster\",router_uid=~\"$router_uid\"})",
+          "refId": "A"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 8,
+      "title": "Router Agent",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 6
+      },
+      "panels": []
+    },
+    {
+      "id": 9,
+      "title": "Agent Connectivity",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 7
+      },
+      "targets": [
+        {
+          "expr": "xinference:token_router_agent_connectivity_status{cluster=~\"$cluster\",node_id=~\"$node_id\"}",
+          "refId": "A",
+          "legendFormat": "{{node_id}} {{status}}"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 10,
+      "title": "Heartbeat Age",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 7
+      },
+      "targets": [
+        {
+          "expr": "xinference:token_router_agent_heartbeat_age_seconds{cluster=~\"$cluster\",node_id=~\"$node_id\"}",
+          "refId": "A",
+          "legendFormat": "{{node_id}}"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 11,
+      "title": "Host CPU / Memory",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 7
+      },
+      "targets": [
+        {
+          "expr": "xinference:token_router_agent_host_cpu_utilization{cluster=~\"$cluster\",node_id=~\"$node_id\"}",
+          "refId": "A",
+          "legendFormat": "CPU {{node_id}}"
+        },
+        {
+          "expr": "xinference:token_router_agent_host_memory_used_bytes{cluster=~\"$cluster\",node_id=~\"$node_id\"} / clamp_min(xinference:token_router_agent_host_memory_total_bytes{cluster=~\"$cluster\",node_id=~\"$node_id\"}, 1)",
+          "refId": "B",
+          "legendFormat": "Memory {{node_id}}"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 12,
+      "title": "Assignment",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 15
+      },
+      "panels": []
+    },
+    {
+      "id": 13,
+      "title": "Assignment State",
+      "type": "table",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "targets": [
+        {
+          "expr": "xinference:token_router_assignment_info{cluster=~\"$cluster\",router_uid=~\"$router_uid\",node_id=~\"$node_id\",assignment_id=~\"$assignment_id\"}",
+          "refId": "A"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 14,
+      "title": "Ready / Current / Controllable",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "targets": [
+        {
+          "expr": "xinference:token_router_assignment_runtime_ready{cluster=~\"$cluster\",router_uid=~\"$router_uid\",assignment_id=~\"$assignment_id\"}",
+          "refId": "A",
+          "legendFormat": "ready {{assignment_id}}"
+        },
+        {
+          "expr": "xinference:token_router_assignment_current{cluster=~\"$cluster\",router_uid=~\"$router_uid\",assignment_id=~\"$assignment_id\"}",
+          "refId": "B",
+          "legendFormat": "current {{assignment_id}}"
+        },
+        {
+          "expr": "xinference:token_router_assignment_controllable{cluster=~\"$cluster\",router_uid=~\"$router_uid\",assignment_id=~\"$assignment_id\"}",
+          "refId": "C",
+          "legendFormat": "controllable {{assignment_id}}"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 15,
+      "title": "Runtime 制御とプロセス",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 25
+      },
+      "panels": []
+    },
+    {
+      "id": 16,
+      "title": "Runtime Effective / Controllable",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 26
+      },
+      "targets": [
+        {
+          "expr": "xinference:token_router_runtime_effective_ready{cluster=~\"$cluster\",router_uid=~\"$router_uid\",assignment_id=~\"$assignment_id\",instance_id=~\"$instance_id\"}",
+          "refId": "A",
+          "legendFormat": "effective {{instance_id}}"
+        },
+        {
+          "expr": "xinference:token_router_runtime_controllable{cluster=~\"$cluster\",router_uid=~\"$router_uid\",assignment_id=~\"$assignment_id\",instance_id=~\"$instance_id\"}",
+          "refId": "B",
+          "legendFormat": "controllable {{instance_id}}"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 17,
+      "title": "Config Revision Sync",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 26
+      },
+      "targets": [
+        {
+          "expr": "xinference:token_router_runtime_expected_revision{cluster=~\"$cluster\",router_uid=~\"$router_uid\",assignment_id=~\"$assignment_id\"}",
+          "refId": "A",
+          "legendFormat": "expected {{instance_id}}"
+        },
+        {
+          "expr": "xinference:token_router_runtime_acked_revision{cluster=~\"$cluster\",router_uid=~\"$router_uid\",assignment_id=~\"$assignment_id\"}",
+          "refId": "B",
+          "legendFormat": "acked {{instance_id}}"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 18,
+      "title": "Runtime CPU / RSS",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 26
+      },
+      "targets": [
+        {
+          "expr": "xinference_token_router_process_cpu_utilization{cluster=~\"$cluster\",router_uid=~\"$router_uid\",instance_id=~\"$instance_id\"}",
+          "refId": "A",
+          "legendFormat": "CPU {{instance}}"
+        },
+        {
+          "expr": "xinference_token_router_process_resident_memory_bytes{cluster=~\"$cluster\",router_uid=~\"$router_uid\",instance_id=~\"$instance_id\"}",
+          "refId": "B",
+          "legendFormat": "RSS {{instance}}"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 19,
+      "title": "ルートリクエスト",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 34
+      },
+      "panels": []
+    },
+    {
+      "id": 20,
+      "title": "Results QPS",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 35
+      },
+      "targets": [
+        {
+          "expr": "sum by (result) (rate(xinference_token_router_route_requests_total{cluster=~\"$cluster\",router_uid=~\"$router_uid\",pool=~\"$pool\"}[5m]))",
+          "refId": "A",
+          "legendFormat": "{{result}}"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 21,
+      "title": "P95 / P99 End-to-End",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 35
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(xinference_token_router_request_duration_seconds_bucket{cluster=~\"$cluster\",router_uid=~\"$router_uid\",pool=~\"$pool\"}[5m])))",
+          "refId": "A",
+          "legendFormat": "P95"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(xinference_token_router_request_duration_seconds_bucket{cluster=~\"$cluster\",router_uid=~\"$router_uid\",pool=~\"$pool\"}[5m])))",
+          "refId": "B",
+          "legendFormat": "P99"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 22,
+      "title": "In Flight",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 35
+      },
+      "targets": [
+        {
+          "expr": "sum by (pool) (xinference_token_router_requests_in_flight{cluster=~\"$cluster\",router_uid=~\"$router_uid\",pool=~\"$pool\"})",
+          "refId": "A",
+          "legendFormat": "{{pool}}"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 23,
+      "title": "ルールとバックエンド",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 43
+      },
+      "panels": []
+    },
+    {
+      "id": 24,
+      "title": "Rule Matches",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 44
+      },
+      "targets": [
+        {
+          "expr": "sum by (rule_id,outcome) (rate(xinference_token_router_rule_matches_total{cluster=~\"$cluster\",router_uid=~\"$router_uid\"}[5m]))",
+          "refId": "A",
+          "legendFormat": "{{rule_id}} {{outcome}}"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 25,
+      "title": "Backend Results",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 44
+      },
+      "targets": [
+        {
+          "expr": "sum by (backend_model_uid,result) (rate(xinference_token_router_backend_requests_total{cluster=~\"$cluster\",router_uid=~\"$router_uid\",backend_model_uid=~\"$backend_model_uid\"}[5m]))",
+          "refId": "A",
+          "legendFormat": "{{backend_model_uid}} {{result}}"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 26,
+      "title": "Backend P95 / P99",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 44
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le,backend_model_uid) (rate(xinference_token_router_backend_request_duration_seconds_bucket{cluster=~\"$cluster\",router_uid=~\"$router_uid\",backend_model_uid=~\"$backend_model_uid\"}[5m])))",
+          "refId": "A",
+          "legendFormat": "P95 {{backend_model_uid}}"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (le,backend_model_uid) (rate(xinference_token_router_backend_request_duration_seconds_bucket{cluster=~\"$cluster\",router_uid=~\"$router_uid\",backend_model_uid=~\"$backend_model_uid\"}[5m])))",
+          "refId": "B",
+          "legendFormat": "P99 {{backend_model_uid}}"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 27,
+      "title": "プールと Tokenization",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 52
+      },
+      "panels": []
+    },
+    {
+      "id": 28,
+      "title": "Pool Capacity",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 53
+      },
+      "targets": [
+        {
+          "expr": "xinference_token_router_pool_limit{cluster=~\"$cluster\",router_uid=~\"$router_uid\",pool=~\"$pool\"}",
+          "refId": "A",
+          "legendFormat": "limit {{pool}}"
+        },
+        {
+          "expr": "xinference_token_router_pool_in_use{cluster=~\"$cluster\",router_uid=~\"$router_uid\",pool=~\"$pool\"}",
+          "refId": "B",
+          "legendFormat": "in use {{pool}}"
+        },
+        {
+          "expr": "xinference_token_router_pool_waiting{cluster=~\"$cluster\",router_uid=~\"$router_uid\",pool=~\"$pool\"}",
+          "refId": "C",
+          "legendFormat": "waiting {{pool}}"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 29,
+      "title": "Pool Reject / Wait",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 53
+      },
+      "targets": [
+        {
+          "expr": "sum by (pool,reason) (rate(xinference_token_router_pool_rejected_total{cluster=~\"$cluster\",router_uid=~\"$router_uid\",pool=~\"$pool\"}[5m]))",
+          "refId": "A",
+          "legendFormat": "reject {{pool}} {{reason}}"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le,pool) (rate(xinference_token_router_pool_wait_duration_seconds_bucket{cluster=~\"$cluster\",router_uid=~\"$router_uid\",pool=~\"$pool\"}[5m])))",
+          "refId": "B",
+          "legendFormat": "wait P95 {{pool}}"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 30,
+      "title": "Tokenization",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 53
+      },
+      "targets": [
+        {
+          "expr": "xinference_token_router_tokenization_active{cluster=~\"$cluster\",router_uid=~\"$router_uid\"}",
+          "refId": "A",
+          "legendFormat": "active"
+        },
+        {
+          "expr": "xinference_token_router_tokenization_waiting{cluster=~\"$cluster\",router_uid=~\"$router_uid\"}",
+          "refId": "B",
+          "legendFormat": "waiting"
+        },
+        {
+          "expr": "rate(xinference_token_router_tokenization_rejected_total{cluster=~\"$cluster\",router_uid=~\"$router_uid\"}[5m])",
+          "refId": "C",
+          "legendFormat": "rejected {{reason}}"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 31,
+      "title": "Tokenizer アセットバインディング",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 61
+      },
+      "panels": []
+    },
+    {
+      "id": 32,
+      "title": "Binding State",
+      "type": "table",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 62
+      },
+      "targets": [
+        {
+          "expr": "xinference:token_router_tokenizer_binding_state{cluster=~\"$cluster\",node_id=~\"$node_id\"}",
+          "refId": "A"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 33,
+      "title": "Binding Ready / Synced",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 62
+      },
+      "targets": [
+        {
+          "expr": "xinference:token_router_tokenizer_binding_ready{cluster=~\"$cluster\",node_id=~\"$node_id\"}",
+          "refId": "A",
+          "legendFormat": "ready {{asset_id}} {{node_id}}"
+        },
+        {
+          "expr": "xinference:token_router_tokenizer_binding_synced{cluster=~\"$cluster\",node_id=~\"$node_id\"}",
+          "refId": "B",
+          "legendFormat": "synced {{asset_id}} {{node_id}}"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": [
+    "xinference",
+    "token-router"
+  ],
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "label": "Datasource",
+        "type": "datasource",
+        "query": "prometheus",
+        "refresh": 1,
+        "options": [],
+        "current": {}
+      },
+      {
+        "name": "cluster",
+        "label": "Cluster",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(xinference:token_router_status, cluster)",
+        "query": {
+          "query": "label_values(xinference:token_router_status, cluster)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true,
+        "refresh": 2,
+        "sort": 1,
+        "options": [],
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "hide": 0,
+        "skipUrlSync": false
+      },
+      {
+        "name": "router_uid",
+        "label": "Router",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(xinference:token_router_status{cluster=~\"$cluster\"}, router_uid)",
+        "query": {
+          "query": "label_values(xinference:token_router_status{cluster=~\"$cluster\"}, router_uid)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true,
+        "refresh": 2,
+        "sort": 1,
+        "options": [],
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "hide": 0,
+        "skipUrlSync": false
+      },
+      {
+        "name": "node_id",
+        "label": "Node",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(xinference:token_router_agent_info{cluster=~\"$cluster\"}, node_id)",
+        "query": {
+          "query": "label_values(xinference:token_router_agent_info{cluster=~\"$cluster\"}, node_id)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true,
+        "refresh": 2,
+        "sort": 1,
+        "options": [],
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "hide": 0,
+        "skipUrlSync": false
+      },
+      {
+        "name": "assignment_id",
+        "label": "Assignment",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(xinference:token_router_assignment_info{cluster=~\"$cluster\",router_uid=~\"$router_uid\"}, assignment_id)",
+        "query": {
+          "query": "label_values(xinference:token_router_assignment_info{cluster=~\"$cluster\",router_uid=~\"$router_uid\"}, assignment_id)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true,
+        "refresh": 2,
+        "sort": 1,
+        "options": [],
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "hide": 0,
+        "skipUrlSync": false
+      },
+      {
+        "name": "instance_id",
+        "label": "Runtime",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(xinference:token_router_runtime_info{cluster=~\"$cluster\",router_uid=~\"$router_uid\"}, instance_id)",
+        "query": {
+          "query": "label_values(xinference:token_router_runtime_info{cluster=~\"$cluster\",router_uid=~\"$router_uid\"}, instance_id)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true,
+        "refresh": 2,
+        "sort": 1,
+        "options": [],
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "hide": 0,
+        "skipUrlSync": false
+      },
+      {
+        "name": "pool",
+        "label": "Pool",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(xinference_token_router_route_requests_total{cluster=~\"$cluster\",router_uid=~\"$router_uid\"}, pool)",
+        "query": {
+          "query": "label_values(xinference_token_router_route_requests_total{cluster=~\"$cluster\",router_uid=~\"$router_uid\"}, pool)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true,
+        "refresh": 2,
+        "sort": 1,
+        "options": [],
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "hide": 0,
+        "skipUrlSync": false
+      },
+      {
+        "name": "backend_model_uid",
+        "label": "Backend",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(xinference_token_router_backend_requests_total{cluster=~\"$cluster\",router_uid=~\"$router_uid\"}, backend_model_uid)",
+        "query": {
+          "query": "label_values(xinference_token_router_backend_requests_total{cluster=~\"$cluster\",router_uid=~\"$router_uid\"}, backend_model_uid)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true,
+        "refresh": 2,
+        "sort": 1,
+        "options": [],
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "hide": 0,
+        "skipUrlSync": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Xinference Token Router",
+  "uid": "xinference-token-router",
+  "version": 1,
+  "weekStart": ""
+}

--- a/monitor/dashboard/token-router/xinference-grafana-dashboard-token-router-ko.json
+++ b/monitor/dashboard/token-router/xinference-grafana-dashboard-token-router-ko.json
@@ -1,0 +1,1727 @@
+{
+  "__inputs": [],
+  "__requires": [],
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "id": 1,
+      "title": "논리 Router 개요",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "panels": []
+    },
+    {
+      "id": 2,
+      "title": "Desired Replicas",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 0,
+        "y": 1
+      },
+      "targets": [
+        {
+          "expr": "sum(xinference:token_router_desired_replicas{cluster=~\"$cluster\",router_uid=~\"$router_uid\"})",
+          "refId": "A"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 3,
+      "title": "Effective Ready",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 4,
+        "y": 1
+      },
+      "targets": [
+        {
+          "expr": "sum(xinference:token_router_effective_ready_replicas{cluster=~\"$cluster\",router_uid=~\"$router_uid\"})",
+          "refId": "A"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 4,
+      "title": "Controllable Ready",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 8,
+        "y": 1
+      },
+      "targets": [
+        {
+          "expr": "sum(xinference:token_router_controllable_ready_replicas{cluster=~\"$cluster\",router_uid=~\"$router_uid\"})",
+          "refId": "A"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 5,
+      "title": "Request QPS",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 12,
+        "y": 1
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(xinference_token_router_route_requests_total{cluster=~\"$cluster\",router_uid=~\"$router_uid\"}[5m]))",
+          "refId": "A"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 6,
+      "title": "Error Rate",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 16,
+        "y": 1
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(xinference_token_router_route_requests_total{cluster=~\"$cluster\",router_uid=~\"$router_uid\",result!=\"completed\"}[5m])) / clamp_min(sum(rate(xinference_token_router_route_requests_total{cluster=~\"$cluster\",router_uid=~\"$router_uid\"}[5m])), 1e-9)",
+          "refId": "A"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 7,
+      "title": "Config Synced",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 20,
+        "y": 1
+      },
+      "targets": [
+        {
+          "expr": "sum(xinference:token_router_config_synced_replicas{cluster=~\"$cluster\",router_uid=~\"$router_uid\"})",
+          "refId": "A"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 8,
+      "title": "Router Agent",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 6
+      },
+      "panels": []
+    },
+    {
+      "id": 9,
+      "title": "Agent Connectivity",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 7
+      },
+      "targets": [
+        {
+          "expr": "xinference:token_router_agent_connectivity_status{cluster=~\"$cluster\",node_id=~\"$node_id\"}",
+          "refId": "A",
+          "legendFormat": "{{node_id}} {{status}}"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 10,
+      "title": "Heartbeat Age",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 7
+      },
+      "targets": [
+        {
+          "expr": "xinference:token_router_agent_heartbeat_age_seconds{cluster=~\"$cluster\",node_id=~\"$node_id\"}",
+          "refId": "A",
+          "legendFormat": "{{node_id}}"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 11,
+      "title": "Host CPU / Memory",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 7
+      },
+      "targets": [
+        {
+          "expr": "xinference:token_router_agent_host_cpu_utilization{cluster=~\"$cluster\",node_id=~\"$node_id\"}",
+          "refId": "A",
+          "legendFormat": "CPU {{node_id}}"
+        },
+        {
+          "expr": "xinference:token_router_agent_host_memory_used_bytes{cluster=~\"$cluster\",node_id=~\"$node_id\"} / clamp_min(xinference:token_router_agent_host_memory_total_bytes{cluster=~\"$cluster\",node_id=~\"$node_id\"}, 1)",
+          "refId": "B",
+          "legendFormat": "Memory {{node_id}}"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 12,
+      "title": "Assignment",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 15
+      },
+      "panels": []
+    },
+    {
+      "id": 13,
+      "title": "Assignment State",
+      "type": "table",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "targets": [
+        {
+          "expr": "xinference:token_router_assignment_info{cluster=~\"$cluster\",router_uid=~\"$router_uid\",node_id=~\"$node_id\",assignment_id=~\"$assignment_id\"}",
+          "refId": "A"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 14,
+      "title": "Ready / Current / Controllable",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "targets": [
+        {
+          "expr": "xinference:token_router_assignment_runtime_ready{cluster=~\"$cluster\",router_uid=~\"$router_uid\",assignment_id=~\"$assignment_id\"}",
+          "refId": "A",
+          "legendFormat": "ready {{assignment_id}}"
+        },
+        {
+          "expr": "xinference:token_router_assignment_current{cluster=~\"$cluster\",router_uid=~\"$router_uid\",assignment_id=~\"$assignment_id\"}",
+          "refId": "B",
+          "legendFormat": "current {{assignment_id}}"
+        },
+        {
+          "expr": "xinference:token_router_assignment_controllable{cluster=~\"$cluster\",router_uid=~\"$router_uid\",assignment_id=~\"$assignment_id\"}",
+          "refId": "C",
+          "legendFormat": "controllable {{assignment_id}}"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 15,
+      "title": "Runtime 제어 및 프로세스",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 25
+      },
+      "panels": []
+    },
+    {
+      "id": 16,
+      "title": "Runtime Effective / Controllable",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 26
+      },
+      "targets": [
+        {
+          "expr": "xinference:token_router_runtime_effective_ready{cluster=~\"$cluster\",router_uid=~\"$router_uid\",assignment_id=~\"$assignment_id\",instance_id=~\"$instance_id\"}",
+          "refId": "A",
+          "legendFormat": "effective {{instance_id}}"
+        },
+        {
+          "expr": "xinference:token_router_runtime_controllable{cluster=~\"$cluster\",router_uid=~\"$router_uid\",assignment_id=~\"$assignment_id\",instance_id=~\"$instance_id\"}",
+          "refId": "B",
+          "legendFormat": "controllable {{instance_id}}"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 17,
+      "title": "Config Revision Sync",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 26
+      },
+      "targets": [
+        {
+          "expr": "xinference:token_router_runtime_expected_revision{cluster=~\"$cluster\",router_uid=~\"$router_uid\",assignment_id=~\"$assignment_id\"}",
+          "refId": "A",
+          "legendFormat": "expected {{instance_id}}"
+        },
+        {
+          "expr": "xinference:token_router_runtime_acked_revision{cluster=~\"$cluster\",router_uid=~\"$router_uid\",assignment_id=~\"$assignment_id\"}",
+          "refId": "B",
+          "legendFormat": "acked {{instance_id}}"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 18,
+      "title": "Runtime CPU / RSS",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 26
+      },
+      "targets": [
+        {
+          "expr": "xinference_token_router_process_cpu_utilization{cluster=~\"$cluster\",router_uid=~\"$router_uid\",instance_id=~\"$instance_id\"}",
+          "refId": "A",
+          "legendFormat": "CPU {{instance}}"
+        },
+        {
+          "expr": "xinference_token_router_process_resident_memory_bytes{cluster=~\"$cluster\",router_uid=~\"$router_uid\",instance_id=~\"$instance_id\"}",
+          "refId": "B",
+          "legendFormat": "RSS {{instance}}"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 19,
+      "title": "라우팅 요청",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 34
+      },
+      "panels": []
+    },
+    {
+      "id": 20,
+      "title": "Results QPS",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 35
+      },
+      "targets": [
+        {
+          "expr": "sum by (result) (rate(xinference_token_router_route_requests_total{cluster=~\"$cluster\",router_uid=~\"$router_uid\",pool=~\"$pool\"}[5m]))",
+          "refId": "A",
+          "legendFormat": "{{result}}"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 21,
+      "title": "P95 / P99 End-to-End",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 35
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(xinference_token_router_request_duration_seconds_bucket{cluster=~\"$cluster\",router_uid=~\"$router_uid\",pool=~\"$pool\"}[5m])))",
+          "refId": "A",
+          "legendFormat": "P95"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(xinference_token_router_request_duration_seconds_bucket{cluster=~\"$cluster\",router_uid=~\"$router_uid\",pool=~\"$pool\"}[5m])))",
+          "refId": "B",
+          "legendFormat": "P99"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 22,
+      "title": "In Flight",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 35
+      },
+      "targets": [
+        {
+          "expr": "sum by (pool) (xinference_token_router_requests_in_flight{cluster=~\"$cluster\",router_uid=~\"$router_uid\",pool=~\"$pool\"})",
+          "refId": "A",
+          "legendFormat": "{{pool}}"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 23,
+      "title": "규칙 및 백엔드",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 43
+      },
+      "panels": []
+    },
+    {
+      "id": 24,
+      "title": "Rule Matches",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 44
+      },
+      "targets": [
+        {
+          "expr": "sum by (rule_id,outcome) (rate(xinference_token_router_rule_matches_total{cluster=~\"$cluster\",router_uid=~\"$router_uid\"}[5m]))",
+          "refId": "A",
+          "legendFormat": "{{rule_id}} {{outcome}}"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 25,
+      "title": "Backend Results",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 44
+      },
+      "targets": [
+        {
+          "expr": "sum by (backend_model_uid,result) (rate(xinference_token_router_backend_requests_total{cluster=~\"$cluster\",router_uid=~\"$router_uid\",backend_model_uid=~\"$backend_model_uid\"}[5m]))",
+          "refId": "A",
+          "legendFormat": "{{backend_model_uid}} {{result}}"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 26,
+      "title": "Backend P95 / P99",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 44
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le,backend_model_uid) (rate(xinference_token_router_backend_request_duration_seconds_bucket{cluster=~\"$cluster\",router_uid=~\"$router_uid\",backend_model_uid=~\"$backend_model_uid\"}[5m])))",
+          "refId": "A",
+          "legendFormat": "P95 {{backend_model_uid}}"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (le,backend_model_uid) (rate(xinference_token_router_backend_request_duration_seconds_bucket{cluster=~\"$cluster\",router_uid=~\"$router_uid\",backend_model_uid=~\"$backend_model_uid\"}[5m])))",
+          "refId": "B",
+          "legendFormat": "P99 {{backend_model_uid}}"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 27,
+      "title": "풀 및 Tokenization",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 52
+      },
+      "panels": []
+    },
+    {
+      "id": 28,
+      "title": "Pool Capacity",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 53
+      },
+      "targets": [
+        {
+          "expr": "xinference_token_router_pool_limit{cluster=~\"$cluster\",router_uid=~\"$router_uid\",pool=~\"$pool\"}",
+          "refId": "A",
+          "legendFormat": "limit {{pool}}"
+        },
+        {
+          "expr": "xinference_token_router_pool_in_use{cluster=~\"$cluster\",router_uid=~\"$router_uid\",pool=~\"$pool\"}",
+          "refId": "B",
+          "legendFormat": "in use {{pool}}"
+        },
+        {
+          "expr": "xinference_token_router_pool_waiting{cluster=~\"$cluster\",router_uid=~\"$router_uid\",pool=~\"$pool\"}",
+          "refId": "C",
+          "legendFormat": "waiting {{pool}}"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 29,
+      "title": "Pool Reject / Wait",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 53
+      },
+      "targets": [
+        {
+          "expr": "sum by (pool,reason) (rate(xinference_token_router_pool_rejected_total{cluster=~\"$cluster\",router_uid=~\"$router_uid\",pool=~\"$pool\"}[5m]))",
+          "refId": "A",
+          "legendFormat": "reject {{pool}} {{reason}}"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le,pool) (rate(xinference_token_router_pool_wait_duration_seconds_bucket{cluster=~\"$cluster\",router_uid=~\"$router_uid\",pool=~\"$pool\"}[5m])))",
+          "refId": "B",
+          "legendFormat": "wait P95 {{pool}}"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 30,
+      "title": "Tokenization",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 53
+      },
+      "targets": [
+        {
+          "expr": "xinference_token_router_tokenization_active{cluster=~\"$cluster\",router_uid=~\"$router_uid\"}",
+          "refId": "A",
+          "legendFormat": "active"
+        },
+        {
+          "expr": "xinference_token_router_tokenization_waiting{cluster=~\"$cluster\",router_uid=~\"$router_uid\"}",
+          "refId": "B",
+          "legendFormat": "waiting"
+        },
+        {
+          "expr": "rate(xinference_token_router_tokenization_rejected_total{cluster=~\"$cluster\",router_uid=~\"$router_uid\"}[5m])",
+          "refId": "C",
+          "legendFormat": "rejected {{reason}}"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 31,
+      "title": "Tokenizer 자산 바인딩",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 61
+      },
+      "panels": []
+    },
+    {
+      "id": 32,
+      "title": "Binding State",
+      "type": "table",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 62
+      },
+      "targets": [
+        {
+          "expr": "xinference:token_router_tokenizer_binding_state{cluster=~\"$cluster\",node_id=~\"$node_id\"}",
+          "refId": "A"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 33,
+      "title": "Binding Ready / Synced",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 62
+      },
+      "targets": [
+        {
+          "expr": "xinference:token_router_tokenizer_binding_ready{cluster=~\"$cluster\",node_id=~\"$node_id\"}",
+          "refId": "A",
+          "legendFormat": "ready {{asset_id}} {{node_id}}"
+        },
+        {
+          "expr": "xinference:token_router_tokenizer_binding_synced{cluster=~\"$cluster\",node_id=~\"$node_id\"}",
+          "refId": "B",
+          "legendFormat": "synced {{asset_id}} {{node_id}}"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": [
+    "xinference",
+    "token-router"
+  ],
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "label": "Datasource",
+        "type": "datasource",
+        "query": "prometheus",
+        "refresh": 1,
+        "options": [],
+        "current": {}
+      },
+      {
+        "name": "cluster",
+        "label": "Cluster",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(xinference:token_router_status, cluster)",
+        "query": {
+          "query": "label_values(xinference:token_router_status, cluster)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true,
+        "refresh": 2,
+        "sort": 1,
+        "options": [],
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "hide": 0,
+        "skipUrlSync": false
+      },
+      {
+        "name": "router_uid",
+        "label": "Router",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(xinference:token_router_status{cluster=~\"$cluster\"}, router_uid)",
+        "query": {
+          "query": "label_values(xinference:token_router_status{cluster=~\"$cluster\"}, router_uid)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true,
+        "refresh": 2,
+        "sort": 1,
+        "options": [],
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "hide": 0,
+        "skipUrlSync": false
+      },
+      {
+        "name": "node_id",
+        "label": "Node",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(xinference:token_router_agent_info{cluster=~\"$cluster\"}, node_id)",
+        "query": {
+          "query": "label_values(xinference:token_router_agent_info{cluster=~\"$cluster\"}, node_id)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true,
+        "refresh": 2,
+        "sort": 1,
+        "options": [],
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "hide": 0,
+        "skipUrlSync": false
+      },
+      {
+        "name": "assignment_id",
+        "label": "Assignment",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(xinference:token_router_assignment_info{cluster=~\"$cluster\",router_uid=~\"$router_uid\"}, assignment_id)",
+        "query": {
+          "query": "label_values(xinference:token_router_assignment_info{cluster=~\"$cluster\",router_uid=~\"$router_uid\"}, assignment_id)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true,
+        "refresh": 2,
+        "sort": 1,
+        "options": [],
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "hide": 0,
+        "skipUrlSync": false
+      },
+      {
+        "name": "instance_id",
+        "label": "Runtime",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(xinference:token_router_runtime_info{cluster=~\"$cluster\",router_uid=~\"$router_uid\"}, instance_id)",
+        "query": {
+          "query": "label_values(xinference:token_router_runtime_info{cluster=~\"$cluster\",router_uid=~\"$router_uid\"}, instance_id)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true,
+        "refresh": 2,
+        "sort": 1,
+        "options": [],
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "hide": 0,
+        "skipUrlSync": false
+      },
+      {
+        "name": "pool",
+        "label": "Pool",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(xinference_token_router_route_requests_total{cluster=~\"$cluster\",router_uid=~\"$router_uid\"}, pool)",
+        "query": {
+          "query": "label_values(xinference_token_router_route_requests_total{cluster=~\"$cluster\",router_uid=~\"$router_uid\"}, pool)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true,
+        "refresh": 2,
+        "sort": 1,
+        "options": [],
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "hide": 0,
+        "skipUrlSync": false
+      },
+      {
+        "name": "backend_model_uid",
+        "label": "Backend",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(xinference_token_router_backend_requests_total{cluster=~\"$cluster\",router_uid=~\"$router_uid\"}, backend_model_uid)",
+        "query": {
+          "query": "label_values(xinference_token_router_backend_requests_total{cluster=~\"$cluster\",router_uid=~\"$router_uid\"}, backend_model_uid)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true,
+        "refresh": 2,
+        "sort": 1,
+        "options": [],
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "hide": 0,
+        "skipUrlSync": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Xinference Token Router",
+  "uid": "xinference-token-router",
+  "version": 1,
+  "weekStart": ""
+}

--- a/monitor/dashboard/token-router/xinference-grafana-dashboard-token-router-zh.json
+++ b/monitor/dashboard/token-router/xinference-grafana-dashboard-token-router-zh.json
@@ -1,0 +1,1727 @@
+{
+  "__inputs": [],
+  "__requires": [],
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "id": 1,
+      "title": "逻辑 Router 概览",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "panels": []
+    },
+    {
+      "id": 2,
+      "title": "Desired Replicas",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 0,
+        "y": 1
+      },
+      "targets": [
+        {
+          "expr": "sum(xinference:token_router_desired_replicas{cluster=~\"$cluster\",router_uid=~\"$router_uid\"})",
+          "refId": "A"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 3,
+      "title": "Effective Ready",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 4,
+        "y": 1
+      },
+      "targets": [
+        {
+          "expr": "sum(xinference:token_router_effective_ready_replicas{cluster=~\"$cluster\",router_uid=~\"$router_uid\"})",
+          "refId": "A"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 4,
+      "title": "Controllable Ready",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 8,
+        "y": 1
+      },
+      "targets": [
+        {
+          "expr": "sum(xinference:token_router_controllable_ready_replicas{cluster=~\"$cluster\",router_uid=~\"$router_uid\"})",
+          "refId": "A"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 5,
+      "title": "Request QPS",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 12,
+        "y": 1
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(xinference_token_router_route_requests_total{cluster=~\"$cluster\",router_uid=~\"$router_uid\"}[5m]))",
+          "refId": "A"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 6,
+      "title": "Error Rate",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 16,
+        "y": 1
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(xinference_token_router_route_requests_total{cluster=~\"$cluster\",router_uid=~\"$router_uid\",result!=\"completed\"}[5m])) / clamp_min(sum(rate(xinference_token_router_route_requests_total{cluster=~\"$cluster\",router_uid=~\"$router_uid\"}[5m])), 1e-9)",
+          "refId": "A"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 7,
+      "title": "Config Synced",
+      "type": "stat",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 20,
+        "y": 1
+      },
+      "targets": [
+        {
+          "expr": "sum(xinference:token_router_config_synced_replicas{cluster=~\"$cluster\",router_uid=~\"$router_uid\"})",
+          "refId": "A"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 8,
+      "title": "Router Agent 节点",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 6
+      },
+      "panels": []
+    },
+    {
+      "id": 9,
+      "title": "Agent Connectivity",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 7
+      },
+      "targets": [
+        {
+          "expr": "xinference:token_router_agent_connectivity_status{cluster=~\"$cluster\",node_id=~\"$node_id\"}",
+          "refId": "A",
+          "legendFormat": "{{node_id}} {{status}}"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 10,
+      "title": "Heartbeat Age",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 7
+      },
+      "targets": [
+        {
+          "expr": "xinference:token_router_agent_heartbeat_age_seconds{cluster=~\"$cluster\",node_id=~\"$node_id\"}",
+          "refId": "A",
+          "legendFormat": "{{node_id}}"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 11,
+      "title": "Host CPU / Memory",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 7
+      },
+      "targets": [
+        {
+          "expr": "xinference:token_router_agent_host_cpu_utilization{cluster=~\"$cluster\",node_id=~\"$node_id\"}",
+          "refId": "A",
+          "legendFormat": "CPU {{node_id}}"
+        },
+        {
+          "expr": "xinference:token_router_agent_host_memory_used_bytes{cluster=~\"$cluster\",node_id=~\"$node_id\"} / clamp_min(xinference:token_router_agent_host_memory_total_bytes{cluster=~\"$cluster\",node_id=~\"$node_id\"}, 1)",
+          "refId": "B",
+          "legendFormat": "Memory {{node_id}}"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 12,
+      "title": "Assignment 编排",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 15
+      },
+      "panels": []
+    },
+    {
+      "id": 13,
+      "title": "Assignment State",
+      "type": "table",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "targets": [
+        {
+          "expr": "xinference:token_router_assignment_info{cluster=~\"$cluster\",router_uid=~\"$router_uid\",node_id=~\"$node_id\",assignment_id=~\"$assignment_id\"}",
+          "refId": "A"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 14,
+      "title": "Ready / Current / Controllable",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "targets": [
+        {
+          "expr": "xinference:token_router_assignment_runtime_ready{cluster=~\"$cluster\",router_uid=~\"$router_uid\",assignment_id=~\"$assignment_id\"}",
+          "refId": "A",
+          "legendFormat": "ready {{assignment_id}}"
+        },
+        {
+          "expr": "xinference:token_router_assignment_current{cluster=~\"$cluster\",router_uid=~\"$router_uid\",assignment_id=~\"$assignment_id\"}",
+          "refId": "B",
+          "legendFormat": "current {{assignment_id}}"
+        },
+        {
+          "expr": "xinference:token_router_assignment_controllable{cluster=~\"$cluster\",router_uid=~\"$router_uid\",assignment_id=~\"$assignment_id\"}",
+          "refId": "C",
+          "legendFormat": "controllable {{assignment_id}}"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 15,
+      "title": "Runtime 控制面与进程资源",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 25
+      },
+      "panels": []
+    },
+    {
+      "id": 16,
+      "title": "Runtime Effective / Controllable",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 26
+      },
+      "targets": [
+        {
+          "expr": "xinference:token_router_runtime_effective_ready{cluster=~\"$cluster\",router_uid=~\"$router_uid\",assignment_id=~\"$assignment_id\",instance_id=~\"$instance_id\"}",
+          "refId": "A",
+          "legendFormat": "effective {{instance_id}}"
+        },
+        {
+          "expr": "xinference:token_router_runtime_controllable{cluster=~\"$cluster\",router_uid=~\"$router_uid\",assignment_id=~\"$assignment_id\",instance_id=~\"$instance_id\"}",
+          "refId": "B",
+          "legendFormat": "controllable {{instance_id}}"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 17,
+      "title": "Config Revision Sync",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 26
+      },
+      "targets": [
+        {
+          "expr": "xinference:token_router_runtime_expected_revision{cluster=~\"$cluster\",router_uid=~\"$router_uid\",assignment_id=~\"$assignment_id\"}",
+          "refId": "A",
+          "legendFormat": "expected {{instance_id}}"
+        },
+        {
+          "expr": "xinference:token_router_runtime_acked_revision{cluster=~\"$cluster\",router_uid=~\"$router_uid\",assignment_id=~\"$assignment_id\"}",
+          "refId": "B",
+          "legendFormat": "acked {{instance_id}}"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 18,
+      "title": "Runtime CPU / RSS",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 26
+      },
+      "targets": [
+        {
+          "expr": "xinference_token_router_process_cpu_utilization{cluster=~\"$cluster\",router_uid=~\"$router_uid\",instance_id=~\"$instance_id\"}",
+          "refId": "A",
+          "legendFormat": "CPU {{instance}}"
+        },
+        {
+          "expr": "xinference_token_router_process_resident_memory_bytes{cluster=~\"$cluster\",router_uid=~\"$router_uid\",instance_id=~\"$instance_id\"}",
+          "refId": "B",
+          "legendFormat": "RSS {{instance}}"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 19,
+      "title": "路由请求",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 34
+      },
+      "panels": []
+    },
+    {
+      "id": 20,
+      "title": "Results QPS",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 35
+      },
+      "targets": [
+        {
+          "expr": "sum by (result) (rate(xinference_token_router_route_requests_total{cluster=~\"$cluster\",router_uid=~\"$router_uid\",pool=~\"$pool\"}[5m]))",
+          "refId": "A",
+          "legendFormat": "{{result}}"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 21,
+      "title": "P95 / P99 End-to-End",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 35
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(xinference_token_router_request_duration_seconds_bucket{cluster=~\"$cluster\",router_uid=~\"$router_uid\",pool=~\"$pool\"}[5m])))",
+          "refId": "A",
+          "legendFormat": "P95"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(xinference_token_router_request_duration_seconds_bucket{cluster=~\"$cluster\",router_uid=~\"$router_uid\",pool=~\"$pool\"}[5m])))",
+          "refId": "B",
+          "legendFormat": "P99"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 22,
+      "title": "In Flight",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 35
+      },
+      "targets": [
+        {
+          "expr": "sum by (pool) (xinference_token_router_requests_in_flight{cluster=~\"$cluster\",router_uid=~\"$router_uid\",pool=~\"$pool\"})",
+          "refId": "A",
+          "legendFormat": "{{pool}}"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 23,
+      "title": "规则与后端",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 43
+      },
+      "panels": []
+    },
+    {
+      "id": 24,
+      "title": "Rule Matches",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 44
+      },
+      "targets": [
+        {
+          "expr": "sum by (rule_id,outcome) (rate(xinference_token_router_rule_matches_total{cluster=~\"$cluster\",router_uid=~\"$router_uid\"}[5m]))",
+          "refId": "A",
+          "legendFormat": "{{rule_id}} {{outcome}}"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 25,
+      "title": "Backend Results",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 44
+      },
+      "targets": [
+        {
+          "expr": "sum by (backend_model_uid,result) (rate(xinference_token_router_backend_requests_total{cluster=~\"$cluster\",router_uid=~\"$router_uid\",backend_model_uid=~\"$backend_model_uid\"}[5m]))",
+          "refId": "A",
+          "legendFormat": "{{backend_model_uid}} {{result}}"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 26,
+      "title": "Backend P95 / P99",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 44
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le,backend_model_uid) (rate(xinference_token_router_backend_request_duration_seconds_bucket{cluster=~\"$cluster\",router_uid=~\"$router_uid\",backend_model_uid=~\"$backend_model_uid\"}[5m])))",
+          "refId": "A",
+          "legendFormat": "P95 {{backend_model_uid}}"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (le,backend_model_uid) (rate(xinference_token_router_backend_request_duration_seconds_bucket{cluster=~\"$cluster\",router_uid=~\"$router_uid\",backend_model_uid=~\"$backend_model_uid\"}[5m])))",
+          "refId": "B",
+          "legendFormat": "P99 {{backend_model_uid}}"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 27,
+      "title": "并发池与 Tokenization",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 52
+      },
+      "panels": []
+    },
+    {
+      "id": 28,
+      "title": "Pool Capacity",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 53
+      },
+      "targets": [
+        {
+          "expr": "xinference_token_router_pool_limit{cluster=~\"$cluster\",router_uid=~\"$router_uid\",pool=~\"$pool\"}",
+          "refId": "A",
+          "legendFormat": "limit {{pool}}"
+        },
+        {
+          "expr": "xinference_token_router_pool_in_use{cluster=~\"$cluster\",router_uid=~\"$router_uid\",pool=~\"$pool\"}",
+          "refId": "B",
+          "legendFormat": "in use {{pool}}"
+        },
+        {
+          "expr": "xinference_token_router_pool_waiting{cluster=~\"$cluster\",router_uid=~\"$router_uid\",pool=~\"$pool\"}",
+          "refId": "C",
+          "legendFormat": "waiting {{pool}}"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 29,
+      "title": "Pool Reject / Wait",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 53
+      },
+      "targets": [
+        {
+          "expr": "sum by (pool,reason) (rate(xinference_token_router_pool_rejected_total{cluster=~\"$cluster\",router_uid=~\"$router_uid\",pool=~\"$pool\"}[5m]))",
+          "refId": "A",
+          "legendFormat": "reject {{pool}} {{reason}}"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le,pool) (rate(xinference_token_router_pool_wait_duration_seconds_bucket{cluster=~\"$cluster\",router_uid=~\"$router_uid\",pool=~\"$pool\"}[5m])))",
+          "refId": "B",
+          "legendFormat": "wait P95 {{pool}}"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 30,
+      "title": "Tokenization",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 53
+      },
+      "targets": [
+        {
+          "expr": "xinference_token_router_tokenization_active{cluster=~\"$cluster\",router_uid=~\"$router_uid\"}",
+          "refId": "A",
+          "legendFormat": "active"
+        },
+        {
+          "expr": "xinference_token_router_tokenization_waiting{cluster=~\"$cluster\",router_uid=~\"$router_uid\"}",
+          "refId": "B",
+          "legendFormat": "waiting"
+        },
+        {
+          "expr": "rate(xinference_token_router_tokenization_rejected_total{cluster=~\"$cluster\",router_uid=~\"$router_uid\"}[5m])",
+          "refId": "C",
+          "legendFormat": "rejected {{reason}}"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 31,
+      "title": "Tokenizer 资产绑定",
+      "type": "row",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 61
+      },
+      "panels": []
+    },
+    {
+      "id": 32,
+      "title": "Binding State",
+      "type": "table",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 62
+      },
+      "targets": [
+        {
+          "expr": "xinference:token_router_tokenizer_binding_state{cluster=~\"$cluster\",node_id=~\"$node_id\"}",
+          "refId": "A"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    },
+    {
+      "id": 33,
+      "title": "Binding Ready / Synced",
+      "type": "timeseries",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 62
+      },
+      "targets": [
+        {
+          "expr": "xinference:token_router_tokenizer_binding_ready{cluster=~\"$cluster\",node_id=~\"$node_id\"}",
+          "refId": "A",
+          "legendFormat": "ready {{asset_id}} {{node_id}}"
+        },
+        {
+          "expr": "xinference:token_router_tokenizer_binding_synced{cluster=~\"$cluster\",node_id=~\"$node_id\"}",
+          "refId": "B",
+          "legendFormat": "synced {{asset_id}} {{node_id}}"
+        }
+      ],
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": []
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      }
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": [
+    "xinference",
+    "token-router"
+  ],
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "label": "Datasource",
+        "type": "datasource",
+        "query": "prometheus",
+        "refresh": 1,
+        "options": [],
+        "current": {}
+      },
+      {
+        "name": "cluster",
+        "label": "Cluster",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(xinference:token_router_status, cluster)",
+        "query": {
+          "query": "label_values(xinference:token_router_status, cluster)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true,
+        "refresh": 2,
+        "sort": 1,
+        "options": [],
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "hide": 0,
+        "skipUrlSync": false
+      },
+      {
+        "name": "router_uid",
+        "label": "Router",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(xinference:token_router_status{cluster=~\"$cluster\"}, router_uid)",
+        "query": {
+          "query": "label_values(xinference:token_router_status{cluster=~\"$cluster\"}, router_uid)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true,
+        "refresh": 2,
+        "sort": 1,
+        "options": [],
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "hide": 0,
+        "skipUrlSync": false
+      },
+      {
+        "name": "node_id",
+        "label": "Node",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(xinference:token_router_agent_info{cluster=~\"$cluster\"}, node_id)",
+        "query": {
+          "query": "label_values(xinference:token_router_agent_info{cluster=~\"$cluster\"}, node_id)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true,
+        "refresh": 2,
+        "sort": 1,
+        "options": [],
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "hide": 0,
+        "skipUrlSync": false
+      },
+      {
+        "name": "assignment_id",
+        "label": "Assignment",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(xinference:token_router_assignment_info{cluster=~\"$cluster\",router_uid=~\"$router_uid\"}, assignment_id)",
+        "query": {
+          "query": "label_values(xinference:token_router_assignment_info{cluster=~\"$cluster\",router_uid=~\"$router_uid\"}, assignment_id)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true,
+        "refresh": 2,
+        "sort": 1,
+        "options": [],
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "hide": 0,
+        "skipUrlSync": false
+      },
+      {
+        "name": "instance_id",
+        "label": "Runtime",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(xinference:token_router_runtime_info{cluster=~\"$cluster\",router_uid=~\"$router_uid\"}, instance_id)",
+        "query": {
+          "query": "label_values(xinference:token_router_runtime_info{cluster=~\"$cluster\",router_uid=~\"$router_uid\"}, instance_id)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true,
+        "refresh": 2,
+        "sort": 1,
+        "options": [],
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "hide": 0,
+        "skipUrlSync": false
+      },
+      {
+        "name": "pool",
+        "label": "Pool",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(xinference_token_router_route_requests_total{cluster=~\"$cluster\",router_uid=~\"$router_uid\"}, pool)",
+        "query": {
+          "query": "label_values(xinference_token_router_route_requests_total{cluster=~\"$cluster\",router_uid=~\"$router_uid\"}, pool)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true,
+        "refresh": 2,
+        "sort": 1,
+        "options": [],
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "hide": 0,
+        "skipUrlSync": false
+      },
+      {
+        "name": "backend_model_uid",
+        "label": "Backend",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(xinference_token_router_backend_requests_total{cluster=~\"$cluster\",router_uid=~\"$router_uid\"}, backend_model_uid)",
+        "query": {
+          "query": "label_values(xinference_token_router_backend_requests_total{cluster=~\"$cluster\",router_uid=~\"$router_uid\"}, backend_model_uid)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true,
+        "refresh": 2,
+        "sort": 1,
+        "options": [],
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "hide": 0,
+        "skipUrlSync": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Xinference Token Router",
+  "uid": "xinference-token-router",
+  "version": 1,
+  "weekStart": ""
+}

--- a/monitor/filebeat/README.md
+++ b/monitor/filebeat/README.md
@@ -40,3 +40,17 @@ Parsed fields:
 - Worker logs can be large (~100MB/day); in production, consider filtering DEBUG or raising the xinference log level
 - Multiline merging is configured to handle progress bars and Python warnings
 - Log paths must be updated to match actual server paths
+
+## Token Router logs
+
+All six example configurations collect Token Router logs as two independent JSON
+sources:
+
+- `/data/inference/logs/router-agent/router.log*` with `log_type=router_agent`;
+- `/data/inference/logs/router-runtime/*/router.log*` with `log_type=router_runtime`.
+
+The Runtime directory is split by Assignment. Compressed rotation archives are
+excluded to avoid duplicate ingestion. Keep Router Agent and Runtime JSON logging
+enabled (`XINFERENCE_LOG_FORMAT=json`) so identity fields such as `router_uid`,
+`node_id`, `assignment_id`, `assignment_generation`, and `instance_id` remain
+queryable.

--- a/monitor/filebeat/README_zh-CN.md
+++ b/monitor/filebeat/README_zh-CN.md
@@ -40,3 +40,14 @@ docker compose up -d
 - Worker 日志量大(~100MB/天)，生产环境建议过滤 DEBUG 或调高 xinference 日志级别
 - 多行合并已配置，可处理进度条和 Python warning
 - 日志路径需改为实际服务器路径
+
+## Token Router 日志
+
+六份示例配置均将 Token Router 日志作为两个独立 JSON 数据源采集：
+
+- `/data/inference/logs/router-agent/router.log*`，`log_type=router_agent`；
+- `/data/inference/logs/router-runtime/*/router.log*`，`log_type=router_runtime`。
+
+Runtime 日志按 Assignment 分目录保存；压缩轮转归档文件默认排除，避免重复采集。请保持
+Router Agent 和 Runtime 使用 JSON 日志（`XINFERENCE_LOG_FORMAT=json`），以便检索
+`router_uid`、`node_id`、`assignment_id`、`assignment_generation`、`instance_id` 等身份字段。

--- a/monitor/filebeat/filebeat-json-to-es.yml
+++ b/monitor/filebeat/filebeat-json-to-es.yml
@@ -50,6 +50,36 @@ filebeat.inputs:
       cluster: xinference
     fields_under_root: true
 
+  # --- Token Router Agent logs (JSON) ---
+  - type: log
+    id: xinference-token-router-agent
+    enabled: true
+    paths:
+      - /data/inference/logs/router-agent/router.log*
+    exclude_files: ['\.gz$']
+    json.keys_under_root: true
+    json.overwrite_keys: true
+    json.add_error_key: true
+    fields:
+      log_type: router_agent
+      cluster: xinference
+    fields_under_root: true
+
+  # --- Token Router Runtime logs (JSON, one directory per assignment) ---
+  - type: log
+    id: xinference-token-router-runtime
+    enabled: true
+    paths:
+      - /data/inference/logs/router-runtime/*/router.log*
+    exclude_files: ['\.gz$']
+    json.keys_under_root: true
+    json.overwrite_keys: true
+    json.add_error_key: true
+    fields:
+      log_type: router_runtime
+      cluster: xinference
+    fields_under_root: true
+
 processors:
   - drop_fields:
       fields:

--- a/monitor/filebeat/filebeat-json-to-kafka.yml
+++ b/monitor/filebeat/filebeat-json-to-kafka.yml
@@ -50,6 +50,36 @@ filebeat.inputs:
       cluster: xinference
     fields_under_root: true
 
+  # --- Token Router Agent logs (JSON) ---
+  - type: log
+    id: xinference-token-router-agent
+    enabled: true
+    paths:
+      - /data/inference/logs/router-agent/router.log*
+    exclude_files: ['\.gz$']
+    json.keys_under_root: true
+    json.overwrite_keys: true
+    json.add_error_key: true
+    fields:
+      log_type: router_agent
+      cluster: xinference
+    fields_under_root: true
+
+  # --- Token Router Runtime logs (JSON, one directory per assignment) ---
+  - type: log
+    id: xinference-token-router-runtime
+    enabled: true
+    paths:
+      - /data/inference/logs/router-runtime/*/router.log*
+    exclude_files: ['\.gz$']
+    json.keys_under_root: true
+    json.overwrite_keys: true
+    json.add_error_key: true
+    fields:
+      log_type: router_runtime
+      cluster: xinference
+    fields_under_root: true
+
 processors:
   - drop_fields:
       fields:

--- a/monitor/filebeat/filebeat-text-to-es.yml
+++ b/monitor/filebeat/filebeat-text-to-es.yml
@@ -46,12 +46,47 @@ filebeat.inputs:
       cluster: xinference
     fields_under_root: true
 
+  # --- Token Router Agent logs (JSON) ---
+  - type: log
+    id: xinference-token-router-agent
+    enabled: true
+    paths:
+      - /data/inference/logs/router-agent/router.log*
+    exclude_files: ['\.gz$']
+    json.keys_under_root: true
+    json.overwrite_keys: true
+    json.add_error_key: true
+    fields:
+      log_type: router_agent
+      cluster: xinference
+    fields_under_root: true
+
+  # --- Token Router Runtime logs (JSON, one directory per assignment) ---
+  - type: log
+    id: xinference-token-router-runtime
+    enabled: true
+    paths:
+      - /data/inference/logs/router-runtime/*/router.log*
+    exclude_files: ['\.gz$']
+    json.keys_under_root: true
+    json.overwrite_keys: true
+    json.add_error_key: true
+    fields:
+      log_type: router_runtime
+      cluster: xinference
+    fields_under_root: true
+
 processors:
   # Parse text-format application logs (audit logs are already parsed via json.keys_under_root)
   - if:
       not:
-        equals:
-          log_type: "audit"
+        or:
+          - equals:
+              log_type: "audit"
+          - equals:
+              log_type: "router_agent"
+          - equals:
+              log_type: "router_runtime"
     then:
       - dissect:
           tokenizer: "%{@timestamp} %{level} %{module} pid:%{pid} role:%{role} address:%{address} node:%{node} %{msg}"

--- a/monitor/filebeat/filebeat-text-to-kafka.yml
+++ b/monitor/filebeat/filebeat-text-to-kafka.yml
@@ -45,12 +45,47 @@ filebeat.inputs:
       cluster: xinference
     fields_under_root: true
 
+  # --- Token Router Agent logs (JSON) ---
+  - type: log
+    id: xinference-token-router-agent
+    enabled: true
+    paths:
+      - /data/inference/logs/router-agent/router.log*
+    exclude_files: ['\.gz$']
+    json.keys_under_root: true
+    json.overwrite_keys: true
+    json.add_error_key: true
+    fields:
+      log_type: router_agent
+      cluster: xinference
+    fields_under_root: true
+
+  # --- Token Router Runtime logs (JSON, one directory per assignment) ---
+  - type: log
+    id: xinference-token-router-runtime
+    enabled: true
+    paths:
+      - /data/inference/logs/router-runtime/*/router.log*
+    exclude_files: ['\.gz$']
+    json.keys_under_root: true
+    json.overwrite_keys: true
+    json.add_error_key: true
+    fields:
+      log_type: router_runtime
+      cluster: xinference
+    fields_under_root: true
+
 processors:
   # Parse text-format application logs (audit logs are already parsed via json.keys_under_root)
   - if:
       not:
-        equals:
-          log_type: "audit"
+        or:
+          - equals:
+              log_type: "audit"
+          - equals:
+              log_type: "router_agent"
+          - equals:
+              log_type: "router_runtime"
     then:
       - dissect:
           tokenizer: "%{@timestamp} %{level} %{module} pid:%{pid} role:%{role} address:%{address} node:%{node} %{msg}"

--- a/monitor/filebeat/filebeat-to-es.yml
+++ b/monitor/filebeat/filebeat-to-es.yml
@@ -43,6 +43,36 @@ filebeat.inputs:
       cluster: xinference
     fields_under_root: true
 
+  # --- Token Router Agent logs (JSON) ---
+  - type: log
+    id: xinference-token-router-agent
+    enabled: true
+    paths:
+      - /data/inference/logs/router-agent/router.log*
+    exclude_files: ['\.gz$']
+    json.keys_under_root: true
+    json.overwrite_keys: true
+    json.add_error_key: true
+    fields:
+      log_type: router_agent
+      cluster: xinference
+    fields_under_root: true
+
+  # --- Token Router Runtime logs (JSON, one directory per assignment) ---
+  - type: log
+    id: xinference-token-router-runtime
+    enabled: true
+    paths:
+      - /data/inference/logs/router-runtime/*/router.log*
+    exclude_files: ['\.gz$']
+    json.keys_under_root: true
+    json.overwrite_keys: true
+    json.add_error_key: true
+    fields:
+      log_type: router_runtime
+      cluster: xinference
+    fields_under_root: true
+
 processors:
   - dissect:
       tokenizer: "%{_date} %{_time} %{module} %{->}%{pid} [%{_identity}] %{level} %{->}%{message_content}"

--- a/monitor/filebeat/filebeat-to-kafka.yml
+++ b/monitor/filebeat/filebeat-to-kafka.yml
@@ -31,6 +31,36 @@ filebeat.inputs:
       cluster: xinference
     fields_under_root: true
 
+  # --- Token Router Agent logs (JSON) ---
+  - type: log
+    id: xinference-token-router-agent
+    enabled: true
+    paths:
+      - /data/inference/logs/router-agent/router.log*
+    exclude_files: ['\.gz$']
+    json.keys_under_root: true
+    json.overwrite_keys: true
+    json.add_error_key: true
+    fields:
+      log_type: router_agent
+      cluster: xinference
+    fields_under_root: true
+
+  # --- Token Router Runtime logs (JSON, one directory per assignment) ---
+  - type: log
+    id: xinference-token-router-runtime
+    enabled: true
+    paths:
+      - /data/inference/logs/router-runtime/*/router.log*
+    exclude_files: ['\.gz$']
+    json.keys_under_root: true
+    json.overwrite_keys: true
+    json.add_error_key: true
+    fields:
+      log_type: router_runtime
+      cluster: xinference
+    fields_under_root: true
+
 processors:
   - dissect:
       tokenizer: "%{_date} %{_time} %{module} %{->}%{pid} [%{_identity}] %{level} %{->}%{message_content}"

--- a/monitor/metrics/README.md
+++ b/monitor/metrics/README.md
@@ -258,3 +258,25 @@ OTEL metrics are semantically equivalent to the Supervisor-side Prometheus metri
 - OpenTelemetry initialization: `xinference/core/otel.py`
 - `/metrics` route registration in REST API: `xinference/api/restful_api.py`
 - Worker-side metric instrumentation: `xinference/core/model.py`
+
+## Token Router Runtime dynamic discovery
+
+Token Router Runtime ports are assigned dynamically by Router Agents. Do not scan the
+whole port range and do not maintain static Runtime targets. Configure Prometheus HTTP
+service discovery against:
+
+```text
+GET /v1/monitor/prometheus/http-sd/token-router-runtimes
+Required scope: routers:read
+```
+
+A complete scrape example is provided in
+`prometheus-token-router-http-sd.yml`. The Supervisor returns Runtime targets during
+the active and stale-retention window, including starting/degraded instances and
+instances whose Agent control channel is offline but whose Runtime may still serve
+traffic. Targets disappear automatically after the Runtime Registry retention window.
+
+Supervisor `/metrics` is authoritative for Agent, Assignment, Runtime control-plane,
+Tokenizer Binding, and logical Router summary. Runtime `/metrics`
+is authoritative for request, route, backend, pool, tokenization, and Runtime process
+metrics.

--- a/monitor/metrics/README_zh-CN.md
+++ b/monitor/metrics/README_zh-CN.md
@@ -258,3 +258,21 @@ OTEL 指标与 Supervisor 端 Prometheus 指标语义等价，命名采用 OTLP 
 - OpenTelemetry 初始化：`xinference/core/otel.py`
 - REST API 中的 `/metrics` 路由注册：`xinference/api/restful_api.py`
 - Worker 侧指标埋点：`xinference/core/model.py`
+
+## Token Router Runtime 动态发现
+
+Token Router Runtime 端口由 Router Agent 动态分配，不能扫描整个端口池，也不应维护
+静态 Runtime target。Prometheus 应通过以下 Supervisor HTTP 服务发现接口获取目标：
+
+```text
+GET /v1/monitor/prometheus/http-sd/token-router-runtimes
+所需权限：routers:read
+```
+
+完整抓取示例见 `prometheus-token-router-http-sd.yml`。Supervisor 会在 Runtime 有效期及
+stale 保留窗口内持续返回 target，包括 Starting/Degraded 实例，以及 Agent 控制链路离线、
+但数据面仍可能服务的 Runtime；超过 Runtime Registry 保留期后 target 自动删除。
+
+Supervisor `/metrics` 是 Agent、Assignment、Runtime 控制面、Tokenizer Binding、逻辑
+Router 汇总的权威来源；Runtime `/metrics` 是请求、路由、后端、并发池、
+Tokenization 和 Runtime 进程资源指标的权威来源。

--- a/monitor/metrics/prometheus-token-router-http-sd.yml
+++ b/monitor/metrics/prometheus-token-router-http-sd.yml
@@ -1,0 +1,16 @@
+# Prometheus scrape example for dynamically managed Token Router Runtime instances.
+# The Supervisor endpoint requires a token with the routers:read scope.
+scrape_configs:
+  - job_name: xinference-token-router-runtime
+    metrics_path: /metrics
+    scheme: http
+    http_sd_configs:
+      - url: http://xinference-supervisor:9997/v1/monitor/prometheus/http-sd/token-router-runtimes
+        refresh_interval: 15s
+        authorization:
+          type: Bearer
+          credentials: REPLACE_WITH_MONITOR_TOKEN
+    relabel_configs:
+      # Preserve discovery metadata while letting Prometheus set instance to the target.
+      - source_labels: [__address__]
+        target_label: instance

--- a/xinference/api/routers/token_routers.py
+++ b/xinference/api/routers/token_routers.py
@@ -154,7 +154,7 @@ def _require_internal(authorization: str = Header(default="")) -> None:
         raise HTTPException(status_code=401, detail="Invalid Token Router credential")
 
 
-async def _parse_payload(request: Request, payload_model: Type[BaseModel]):
+async def _parse_payload(request: Request, payload_model: Type[BaseModel]) -> BaseModel:
     try:
         body = await request.json()
         return payload_model.parse_obj(body)
@@ -644,6 +644,13 @@ async def runtime_ack(
     return JSONResponse(content=result)
 
 
+async def token_router_prometheus_http_sd(
+    api: "RESTfulAPI",
+) -> JSONResponse:
+    targets = await (await _supervisor(api)).get_token_router_prometheus_http_sd()
+    return JSONResponse(content=targets)
+
+
 async def runtime_unregister(instance_id: str, api: "RESTfulAPI") -> JSONResponse:
     deleted = await (await _supervisor(api)).unregister_token_router_instance(
         instance_id
@@ -784,6 +791,13 @@ def register_routes(api: "RESTfulAPI") -> None:
         validate_tokenizer_asset,
         ["POST"],
         "routers:operate",
+    )
+
+    route(
+        "/v1/monitor/prometheus/http-sd/token-router-runtimes",
+        token_router_prometheus_http_sd,
+        ["GET"],
+        "routers:read",
     )
 
     route("/v1/token_routers", list_routers, ["GET"], "routers:list")

--- a/xinference/api/tests/test_token_router_api.py
+++ b/xinference/api/tests/test_token_router_api.py
@@ -896,6 +896,16 @@ async def test_management_scope_enforcement(tmp_path) -> None:
                 headers={"Authorization": "Bearer reader"},
             )
         ).status_code == 200
+        http_sd_path = "/v1/monitor/prometheus/http-sd/token-router-runtimes"
+        assert (await client.get(http_sd_path)).status_code == 401
+        http_sd = await client.get(
+            http_sd_path, headers={"Authorization": "Bearer reader"}
+        )
+        assert http_sd.status_code == 200
+        assert http_sd.json() == []
+        assert (
+            await client.get(http_sd_path, headers={"Authorization": "Bearer writer"})
+        ).status_code == 403
         assert (
             await client.post(
                 "/v1/token_routers",

--- a/xinference/core/metrics.py
+++ b/xinference/core/metrics.py
@@ -16,7 +16,7 @@ import asyncio
 import logging
 import platform
 from collections import defaultdict
-from typing import Any, Dict, Set, Tuple
+from typing import Any, Dict, Iterable, Set, Tuple
 
 import uvicorn
 from aioprometheus import REGISTRY, Counter, Gauge, Histogram
@@ -158,6 +158,174 @@ model_unexpected_termination = Gauge(
     "xinference:model_unexpected_termination",
     "Replica currently down due to worker failure (value=1). Cleared on redeploy.",
 )
+
+# Token Router Monitoring V2.1 control-plane metrics.  These are snapshots
+# owned by the Supervisor metrics process; Runtime request counters remain on
+# each Runtime's own /metrics endpoint.
+token_router_agent_info = Gauge(
+    "xinference:token_router_agent_info", "Token Router Agent identity (value=1)."
+)
+token_router_agent_connectivity_status = Gauge(
+    "xinference:token_router_agent_connectivity_status",
+    "Token Router Agent connectivity state (one-hot).",
+)
+token_router_agent_management_state = Gauge(
+    "xinference:token_router_agent_management_state",
+    "Token Router Agent management state (one-hot).",
+)
+token_router_agent_schedulable = Gauge(
+    "xinference:token_router_agent_schedulable",
+    "Whether the Token Router Agent is eligible for new assignments.",
+)
+token_router_agent_heartbeat_age_seconds = Gauge(
+    "xinference:token_router_agent_heartbeat_age_seconds",
+    "Seconds since the Token Router Agent heartbeat.",
+)
+token_router_agent_max_instances = Gauge(
+    "xinference:token_router_agent_max_instances", "Token Router Agent capacity."
+)
+token_router_agent_reported_running_instances = Gauge(
+    "xinference:token_router_agent_reported_running_instances",
+    "Runtime instances reported by the Token Router Agent.",
+)
+token_router_agent_reported_available_slots = Gauge(
+    "xinference:token_router_agent_reported_available_slots",
+    "Available Runtime slots reported by the Token Router Agent.",
+)
+token_router_agent_assignment_count = Gauge(
+    "xinference:token_router_agent_assignment_count",
+    "Assignments owned by the Token Router Agent.",
+)
+token_router_agent_host_cpu_utilization = Gauge(
+    "xinference:token_router_agent_host_cpu_utilization",
+    "Token Router Agent host CPU utilization (0-1).",
+)
+token_router_agent_host_cpu_total = Gauge(
+    "xinference:token_router_agent_host_cpu_total",
+    "Token Router Agent host CPU capacity.",
+)
+token_router_agent_host_memory_used_bytes = Gauge(
+    "xinference:token_router_agent_host_memory_used_bytes",
+    "Token Router Agent host memory used in bytes.",
+)
+token_router_agent_host_memory_available_bytes = Gauge(
+    "xinference:token_router_agent_host_memory_available_bytes",
+    "Token Router Agent host memory available in bytes.",
+)
+token_router_agent_host_memory_total_bytes = Gauge(
+    "xinference:token_router_agent_host_memory_total_bytes",
+    "Token Router Agent host memory total in bytes.",
+)
+
+token_router_assignment_info = Gauge(
+    "xinference:token_router_assignment_info",
+    "Token Router Assignment identity (value=1).",
+)
+token_router_assignment_desired_state = Gauge(
+    "xinference:token_router_assignment_desired_state",
+    "Token Router Assignment desired state (one-hot).",
+)
+token_router_assignment_observed_state = Gauge(
+    "xinference:token_router_assignment_observed_state",
+    "Token Router Assignment observed state (one-hot).",
+)
+token_router_assignment_generation = Gauge(
+    "xinference:token_router_assignment_generation",
+    "Token Router Assignment generation.",
+)
+token_router_assignment_config_revision = Gauge(
+    "xinference:token_router_assignment_config_revision",
+    "Token Router Assignment expected configuration revision.",
+)
+token_router_assignment_runtime_ready = Gauge(
+    "xinference:token_router_assignment_runtime_ready",
+    "Whether an associated Runtime reports ready.",
+)
+token_router_assignment_current = Gauge(
+    "xinference:token_router_assignment_current",
+    "Whether an associated Runtime matches the current Assignment generation.",
+)
+token_router_assignment_controllable = Gauge(
+    "xinference:token_router_assignment_controllable",
+    "Whether the associated Runtime can currently be controlled by its Agent.",
+)
+
+token_router_tokenizer_binding_state = Gauge(
+    "xinference:token_router_tokenizer_binding_state",
+    "Tokenizer Asset Binding desired/observed state (value=1).",
+)
+token_router_tokenizer_binding_generation = Gauge(
+    "xinference:token_router_tokenizer_binding_generation",
+    "Tokenizer Asset Binding generation.",
+)
+token_router_tokenizer_binding_synced = Gauge(
+    "xinference:token_router_tokenizer_binding_synced",
+    "Whether desired and observed Tokenizer Asset revisions are synchronized.",
+)
+token_router_tokenizer_binding_ready = Gauge(
+    "xinference:token_router_tokenizer_binding_ready",
+    "Whether the Tokenizer Asset Binding is ready.",
+)
+
+token_router_runtime_info = Gauge(
+    "xinference:token_router_runtime_info",
+    "Token Router Runtime identity and build information (value=1).",
+)
+token_router_runtime_up = Gauge(
+    "xinference:token_router_runtime_up",
+    "Whether the Runtime is online in the Supervisor Registry.",
+)
+token_router_runtime_heartbeat_age_seconds = Gauge(
+    "xinference:token_router_runtime_heartbeat_age_seconds",
+    "Seconds since the Token Router Runtime heartbeat.",
+)
+token_router_runtime_status = Gauge(
+    "xinference:token_router_runtime_status",
+    "Token Router Runtime state (one-hot).",
+)
+token_router_runtime_effective_ready = Gauge(
+    "xinference:token_router_runtime_effective_ready",
+    "Whether the Runtime is valid and effective for serving traffic.",
+)
+token_router_runtime_controllable = Gauge(
+    "xinference:token_router_runtime_controllable",
+    "Whether the Runtime is currently controllable through its Agent.",
+)
+token_router_runtime_expected_revision = Gauge(
+    "xinference:token_router_runtime_expected_revision",
+    "Configuration revision expected by the Supervisor.",
+)
+token_router_runtime_acked_revision = Gauge(
+    "xinference:token_router_runtime_acked_revision",
+    "Configuration revision acknowledged by the Runtime.",
+)
+token_router_runtime_config_synced = Gauge(
+    "xinference:token_router_runtime_config_synced",
+    "Whether Runtime configuration and Assignment generation are current.",
+)
+
+token_router_desired_replicas = Gauge(
+    "xinference:token_router_desired_replicas", "Desired Token Router replicas."
+)
+token_router_effective_ready_replicas = Gauge(
+    "xinference:token_router_effective_ready_replicas",
+    "Effective ready Token Router Runtime replicas.",
+)
+token_router_controllable_ready_replicas = Gauge(
+    "xinference:token_router_controllable_ready_replicas",
+    "Effective Runtime replicas currently controllable through an Agent.",
+)
+token_router_status = Gauge(
+    "xinference:token_router_status", "Logical Token Router status (one-hot)."
+)
+token_router_expected_revision = Gauge(
+    "xinference:token_router_expected_revision",
+    "Logical Token Router expected configuration revision.",
+)
+token_router_config_synced_replicas = Gauge(
+    "xinference:token_router_config_synced_replicas",
+    "Effective Runtime replicas synchronized to the current revision.",
+)
 build_info_gauge = Gauge(
     "xinference:build_info",
     "Xinference build information (value=1).",
@@ -220,6 +388,47 @@ _SUPERVISOR_ONLY_METRICS = {
     "xinference:api_keys_expired_total",
     "xinference:banned_ips_total",
     "xinference:banned_keys_total",
+    "xinference:token_router_agent_info",
+    "xinference:token_router_agent_connectivity_status",
+    "xinference:token_router_agent_management_state",
+    "xinference:token_router_agent_schedulable",
+    "xinference:token_router_agent_heartbeat_age_seconds",
+    "xinference:token_router_agent_max_instances",
+    "xinference:token_router_agent_reported_running_instances",
+    "xinference:token_router_agent_reported_available_slots",
+    "xinference:token_router_agent_assignment_count",
+    "xinference:token_router_agent_host_cpu_utilization",
+    "xinference:token_router_agent_host_cpu_total",
+    "xinference:token_router_agent_host_memory_used_bytes",
+    "xinference:token_router_agent_host_memory_available_bytes",
+    "xinference:token_router_agent_host_memory_total_bytes",
+    "xinference:token_router_assignment_info",
+    "xinference:token_router_assignment_desired_state",
+    "xinference:token_router_assignment_observed_state",
+    "xinference:token_router_assignment_generation",
+    "xinference:token_router_assignment_config_revision",
+    "xinference:token_router_assignment_runtime_ready",
+    "xinference:token_router_assignment_current",
+    "xinference:token_router_assignment_controllable",
+    "xinference:token_router_tokenizer_binding_state",
+    "xinference:token_router_tokenizer_binding_generation",
+    "xinference:token_router_tokenizer_binding_synced",
+    "xinference:token_router_tokenizer_binding_ready",
+    "xinference:token_router_runtime_info",
+    "xinference:token_router_runtime_up",
+    "xinference:token_router_runtime_heartbeat_age_seconds",
+    "xinference:token_router_runtime_status",
+    "xinference:token_router_runtime_effective_ready",
+    "xinference:token_router_runtime_controllable",
+    "xinference:token_router_runtime_expected_revision",
+    "xinference:token_router_runtime_acked_revision",
+    "xinference:token_router_runtime_config_synced",
+    "xinference:token_router_desired_replicas",
+    "xinference:token_router_effective_ready_replicas",
+    "xinference:token_router_controllable_ready_replicas",
+    "xinference:token_router_status",
+    "xinference:token_router_expected_revision",
+    "xinference:token_router_config_synced_replicas",
 }
 
 # ---------------------------------------------------------------------------
@@ -248,6 +457,7 @@ _prev_status_labels: Set[Tuple[str, ...]] = set()
 _prev_model_gpu_mem_labels: Set[Tuple[str, ...]] = set()
 _prev_gpu_binding_labels: Set[Tuple[str, ...]] = set()
 _prev_unexpected_labels: Set[Tuple[str, ...]] = set()
+_prev_extended_labels: Dict[str, Set[Tuple[Tuple[str, str], ...]]] = {}
 
 
 def _drop_series(collector, labels: Dict[str, str]) -> None:
@@ -261,6 +471,24 @@ def _drop_series(collector, labels: Dict[str, str]) -> None:
         collector.values.pop(labels, None)
     except Exception:
         pass
+
+
+def _sync_gauge_series(
+    collector: Gauge,
+    rows: Iterable[tuple[Dict[str, str], int | float]],
+) -> None:
+    """Set a complete Gauge snapshot and remove labelsets absent this frame."""
+
+    current: Set[Tuple[Tuple[str, str], ...]] = set()
+    for raw_labels, value in rows:
+        labels = {str(key): str(label) for key, label in raw_labels.items()}
+        key = tuple(sorted(labels.items()))
+        current.add(key)
+        collector.set(labels, value)
+    previous = _prev_extended_labels.get(collector.name, set())
+    for stale in previous - current:
+        _drop_series(collector, dict(stale))
+    _prev_extended_labels[collector.name] = current
 
 
 def record_metrics(name, op, kwargs):
@@ -614,6 +842,372 @@ def update_cluster_metrics(
             },
         )
     _prev_unexpected_labels = cur_unexpected_labels
+
+    _update_token_router_gauges(cluster_data)
+
+
+def _update_token_router_gauges(cluster_data: Dict[str, Any]) -> None:
+    def labels(item: Dict[str, Any]) -> Dict[str, str]:
+        return {
+            "router_uid": str(item.get("router_uid") or ""),
+            "assignment_id": str(item.get("assignment_id") or ""),
+            "replica_index": str(item.get("replica_index", "")),
+            "node_id": str(item.get("node_id") or ""),
+        }
+
+    agents = cluster_data.get("token_router_agents", [])
+    _sync_gauge_series(
+        token_router_agent_info,
+        [
+            (
+                {
+                    "node_id": str(item.get("node_id") or ""),
+                    "node_host": str(item.get("advertise_host") or ""),
+                    "version": str(item.get("software_version") or ""),
+                    "commit": str(item.get("software_revision") or ""),
+                },
+                1,
+            )
+            for item in agents
+        ],
+    )
+    for collector, field in (
+        (token_router_agent_heartbeat_age_seconds, "heartbeat_age_seconds"),
+        (token_router_agent_max_instances, "max_instances"),
+        (token_router_agent_assignment_count, "assignments"),
+    ):
+        _sync_gauge_series(
+            collector,
+            [
+                ({"node_id": str(i.get("node_id") or "")}, float(i.get(field) or 0))
+                for i in agents
+            ],
+        )
+    _sync_gauge_series(
+        token_router_agent_schedulable,
+        [
+            (
+                {"node_id": str(i.get("node_id") or "")},
+                1 if i.get("can_schedule") else 0,
+            )
+            for i in agents
+        ],
+    )
+    connectivity_rows = []
+    management_rows = []
+    for item in agents:
+        node_id = str(item.get("node_id") or "")
+        connectivity = str(item.get("connectivity_status") or "offline")
+        for state in ("online", "suspected", "offline"):
+            connectivity_rows.append(
+                (
+                    {"node_id": node_id, "status": state},
+                    1 if connectivity == state else 0,
+                )
+            )
+        raw_management = str(
+            item.get("management_state") or item.get("desired_state") or "active"
+        )
+        management = {"active": "enabled", "cordoned": "disabled"}.get(
+            raw_management, raw_management
+        )
+        if management not in {"enabled", "disabled", "draining"}:
+            management = "disabled"
+        for state in ("enabled", "disabled", "draining"):
+            management_rows.append(
+                ({"node_id": node_id, "state": state}, 1 if management == state else 0)
+            )
+    _sync_gauge_series(token_router_agent_connectivity_status, connectivity_rows)
+    _sync_gauge_series(token_router_agent_management_state, management_rows)
+
+    def observed_resource(
+        item: Dict[str, Any], group: str, key: str, default: float = 0
+    ) -> float:
+        resources = (
+            item.get("resources") or (item.get("observed") or {}).get("resources") or {}
+        )
+        section = resources.get(group) or {}
+        try:
+            return float(section.get(key, default))
+        except (TypeError, ValueError):
+            return default
+
+    reported_rows = []
+    available_rows = []
+    cpu_usage_rows = []
+    cpu_total_rows = []
+    mem_used_rows = []
+    mem_available_rows = []
+    mem_total_rows = []
+    for item in agents:
+        node = {"node_id": str(item.get("node_id") or "")}
+        observed = item.get("observed") or {}
+        running = observed.get("running_instances", item.get("running_instances", 0))
+        available = observed.get("available_slots", item.get("available_slots", 0))
+        reported_rows.append((node, float(running or 0)))
+        available_rows.append((node, float(available or 0)))
+        cpu_usage_rows.append((node, observed_resource(item, "cpu", "usage")))
+        cpu_total_rows.append((node, observed_resource(item, "cpu", "total")))
+        mem_used_rows.append(
+            (
+                node,
+                observed_resource(
+                    item,
+                    "memory",
+                    "used",
+                    observed_resource(item, "cpu", "memory_used"),
+                ),
+            )
+        )
+        mem_available_rows.append(
+            (
+                node,
+                observed_resource(
+                    item,
+                    "memory",
+                    "available",
+                    observed_resource(item, "cpu", "memory_available"),
+                ),
+            )
+        )
+        mem_total_rows.append(
+            (
+                node,
+                observed_resource(
+                    item,
+                    "memory",
+                    "total",
+                    observed_resource(item, "cpu", "memory_total"),
+                ),
+            )
+        )
+    for collector, assignment_metric_rows in (
+        (token_router_agent_reported_running_instances, reported_rows),
+        (token_router_agent_reported_available_slots, available_rows),
+        (token_router_agent_host_cpu_utilization, cpu_usage_rows),
+        (token_router_agent_host_cpu_total, cpu_total_rows),
+        (token_router_agent_host_memory_used_bytes, mem_used_rows),
+        (token_router_agent_host_memory_available_bytes, mem_available_rows),
+        (token_router_agent_host_memory_total_bytes, mem_total_rows),
+    ):
+        _sync_gauge_series(collector, assignment_metric_rows)
+
+    assignments = cluster_data.get("token_router_assignments", [])
+    runtimes = cluster_data.get("token_router_runtimes", [])
+    runtimes_by_assignment: Dict[str, list[Dict[str, Any]]] = defaultdict(list)
+    for runtime in runtimes:
+        runtimes_by_assignment[str(runtime.get("assignment_id") or "")].append(runtime)
+    assignment_info_rows = []
+    desired_rows = []
+    observed_rows = []
+    generation_rows = []
+    revision_rows = []
+    ready_rows = []
+    current_rows = []
+    controllable_rows = []
+    for item in assignments:
+        base = labels(item)
+        assignment_info_rows.append((base, 1))
+        desired = str(item.get("desired_state") or "stopped")
+        for state in ("running", "stopped"):
+            desired_rows.append(
+                ({**base, "state": state}, 1 if desired == state else 0)
+            )
+        observed = (
+            "node_lost"
+            if item.get("management_state") == "node_lost"
+            else str(item.get("observed_state") or "pending")
+        )
+        states = (
+            "pending",
+            "starting",
+            "ready",
+            "failed",
+            "crash_loop",
+            "port_conflict",
+            "draining",
+            "stopped",
+            "node_lost",
+        )
+        for state in states:
+            observed_rows.append(
+                ({**base, "state": state}, 1 if observed == state else 0)
+            )
+        generation_rows.append((base, float(item.get("assignment_generation") or 0)))
+        revision_rows.append((base, float(item.get("config_revision") or 0)))
+        linked = runtimes_by_assignment.get(str(item.get("assignment_id") or ""), [])
+        ready_rows.append(
+            (
+                base,
+                (
+                    1
+                    if any(
+                        str(r.get("status")) == "ready" and r.get("online")
+                        for r in linked
+                    )
+                    else 0
+                ),
+            )
+        )
+        current_rows.append((base, 1 if any(r.get("current") for r in linked) else 0))
+        controllable_rows.append(
+            (base, 1 if any(r.get("controllable") for r in linked) else 0)
+        )
+    for collector, runtime_metric_rows in (
+        (token_router_assignment_info, assignment_info_rows),
+        (token_router_assignment_desired_state, desired_rows),
+        (token_router_assignment_observed_state, observed_rows),
+        (token_router_assignment_generation, generation_rows),
+        (token_router_assignment_config_revision, revision_rows),
+        (token_router_assignment_runtime_ready, ready_rows),
+        (token_router_assignment_current, current_rows),
+        (token_router_assignment_controllable, controllable_rows),
+    ):
+        _sync_gauge_series(collector, runtime_metric_rows)
+
+    bindings = cluster_data.get("tokenizer_asset_bindings", [])
+    _sync_gauge_series(
+        token_router_tokenizer_binding_state,
+        [
+            (
+                {
+                    "asset_id": str(i.get("asset_id") or ""),
+                    "node_id": str(i.get("node_id") or ""),
+                    "desired_state": str(i.get("desired_state") or ""),
+                    "observed_state": str(i.get("observed_state") or "unknown"),
+                },
+                1,
+            )
+            for i in bindings
+        ],
+    )
+    _sync_gauge_series(
+        token_router_tokenizer_binding_generation,
+        [
+            (
+                {
+                    "asset_id": str(i.get("asset_id") or ""),
+                    "node_id": str(i.get("node_id") or ""),
+                },
+                float(i.get("generation") or 0),
+            )
+            for i in bindings
+        ],
+    )
+    _sync_gauge_series(
+        token_router_tokenizer_binding_synced,
+        [
+            (
+                {
+                    "asset_id": str(i.get("asset_id") or ""),
+                    "node_id": str(i.get("node_id") or ""),
+                },
+                1 if i.get("synced") else 0,
+            )
+            for i in bindings
+        ],
+    )
+    _sync_gauge_series(
+        token_router_tokenizer_binding_ready,
+        [
+            (
+                {
+                    "asset_id": str(i.get("asset_id") or ""),
+                    "node_id": str(i.get("node_id") or ""),
+                },
+                1 if i.get("ready") else 0,
+            )
+            for i in bindings
+        ],
+    )
+
+    runtime_info_rows = []
+    runtime_up_rows = []
+    runtime_age_rows = []
+    runtime_status_rows = []
+    effective_rows = []
+    runtime_controllable_rows = []
+    expected_rows = []
+    acked_rows = []
+    synced_rows = []
+    for item in runtimes:
+        base = {
+            "router_uid": str(item.get("router_uid") or ""),
+            "assignment_id": str(item.get("assignment_id") or ""),
+            "instance_id": str(item.get("instance_id") or ""),
+        }
+        info = {
+            **labels(item),
+            "instance_id": base["instance_id"],
+            "assignment_generation": str(item.get("assignment_generation") or 0),
+            "version": str(item.get("version") or item.get("software_version") or ""),
+            "commit": str(item.get("commit") or item.get("software_revision") or ""),
+        }
+        runtime_info_rows.append((info, 1))
+        runtime_up_rows.append((base, 1 if item.get("online") else 0))
+        runtime_age_rows.append((base, float(item.get("heartbeat_age_seconds") or 0)))
+        status = str(
+            item.get("status") or ("stale" if not item.get("online") else "starting")
+        )
+        if not item.get("online"):
+            status = "stale"
+        for state in (
+            "starting",
+            "ready",
+            "degraded",
+            "draining",
+            "failed",
+            "stale",
+            "disabled",
+        ):
+            runtime_status_rows.append(
+                ({**base, "status": state}, 1 if status == state else 0)
+            )
+        effective_rows.append((base, 1 if item.get("effective_ready") else 0))
+        runtime_controllable_rows.append((base, 1 if item.get("controllable") else 0))
+        expected_rows.append((base, float(item.get("expected_revision") or 0)))
+        acked_rows.append((base, float(item.get("acked_revision") or 0)))
+        synced_rows.append((base, 1 if item.get("config_synced") else 0))
+    for collector, replica_metric_rows in (
+        (token_router_runtime_info, runtime_info_rows),
+        (token_router_runtime_up, runtime_up_rows),
+        (token_router_runtime_heartbeat_age_seconds, runtime_age_rows),
+        (token_router_runtime_status, runtime_status_rows),
+        (token_router_runtime_effective_ready, effective_rows),
+        (token_router_runtime_controllable, runtime_controllable_rows),
+        (token_router_runtime_expected_revision, expected_rows),
+        (token_router_runtime_acked_revision, acked_rows),
+        (token_router_runtime_config_synced, synced_rows),
+    ):
+        _sync_gauge_series(collector, replica_metric_rows)
+
+    summaries = cluster_data.get("token_router_summaries", [])
+    for collector, field in (
+        (token_router_desired_replicas, "desired_replicas"),
+        (token_router_effective_ready_replicas, "effective_ready_replicas"),
+        (token_router_controllable_ready_replicas, "controllable_ready_replicas"),
+        (token_router_expected_revision, "expected_revision"),
+        (token_router_config_synced_replicas, "config_synced_replicas"),
+    ):
+        _sync_gauge_series(
+            collector,
+            [
+                (
+                    {"router_uid": str(i.get("router_uid") or "")},
+                    float(i.get(field) or 0),
+                )
+                for i in summaries
+            ],
+        )
+    router_status_rows = []
+    for item in summaries:
+        uid = str(item.get("router_uid") or "")
+        current = str(item.get("status") or "unavailable")
+        for state in ("ready", "degraded", "unavailable", "disabled"):
+            router_status_rows.append(
+                ({"router_uid": uid, "status": state}, 1 if current == state else 0)
+            )
+    _sync_gauge_series(token_router_status, router_status_rows)
 
 
 def update_security_gauges(auth_service) -> None:

--- a/xinference/core/monitor_config_store.py
+++ b/xinference/core/monitor_config_store.py
@@ -38,6 +38,7 @@ DEFAULT_KEYS = {
     "cluster_name": "Cluster name (for Grafana var-cluster)",
     "dashboard_overview": "Overview dashboard UID",
     "dashboard_model_load": "Model load dashboard UID",
+    "dashboard_token_router": "Token Router dashboard UID",
     "dashboard_llm_slo": "LLM SLO dashboard UID",
     "dashboard_gpu": "GPU resources dashboard UID",
     "dashboard_host": "Host resources dashboard UID",
@@ -54,6 +55,7 @@ ENV_MAPPING = {
 DEFAULT_UIDS = {
     "dashboard_overview": "xinference-overview",
     "dashboard_model_load": "xinference-model-load",
+    "dashboard_token_router": "xinference-token-router",
     "dashboard_llm_slo": "xinference-llm-slo",
     "dashboard_gpu": "xinference-gpu-resources",
     "dashboard_host": "xinference-host-resources",

--- a/xinference/core/supervisor.py
+++ b/xinference/core/supervisor.py
@@ -1662,6 +1662,120 @@ class SupervisorActor(xo.StatelessActor):
                 "replica_gpu_details": replica_gpu_details,
             }
 
+        token_router_agents: List[Dict[str, Any]] = []
+        token_router_assignments: List[Dict[str, Any]] = []
+        tokenizer_asset_bindings: List[Dict[str, Any]] = []
+        token_router_runtimes: List[Dict[str, Any]] = []
+        token_router_summaries: List[Dict[str, Any]] = []
+        try:
+            token_router_agents = self._token_router_orchestration.list_nodes(
+                include_offline=True
+            )
+            token_router_assignments = (
+                self._token_router_orchestration.list_assignments()
+            )
+            tokenizer_asset_bindings = (
+                self._token_router_orchestration.list_tokenizer_asset_bindings()
+            )
+            assignments_by_id = {
+                str(item.get("assignment_id") or ""): item
+                for item in token_router_assignments
+            }
+            configs = self._token_router_store.list()
+            configs_by_uid = {str(item["router_uid"]): item for item in configs}
+            all_runtimes = self._token_router_registry.list()
+            health_by_uid: Dict[str, Tuple[Set[str], Set[str]]] = {}
+            for config in configs:
+                _, effective, controllable = self._token_router_runtime_health(config)
+                health_by_uid[str(config["router_uid"])] = (
+                    {str(item["instance_id"]) for item in effective},
+                    {str(item["instance_id"]) for item in controllable},
+                )
+
+            for runtime in all_runtimes:
+                item = dict(runtime)
+                router_uid = str(item.get("router_uid") or "")
+                config = configs_by_uid.get(router_uid, {})
+                assignment = assignments_by_id.get(
+                    str(item.get("assignment_id") or ""), {}
+                )
+                effective_ids, controllable_ids = health_by_uid.get(
+                    router_uid, (set(), set())
+                )
+                instance_id = str(item.get("instance_id") or "")
+                try:
+                    current = self._token_router_orchestration.runtime_is_current(item)
+                except (KeyError, TypeError, ValueError):
+                    current = False
+                expected_revision = int(config.get("revision") or 0)
+                acked_revision = int(item.get("acked_revision") or 0)
+                item.update(
+                    {
+                        "replica_index": assignment.get(
+                            "replica_index", item.get("replica_index", "")
+                        ),
+                        "effective_ready": instance_id in effective_ids,
+                        "controllable": instance_id in controllable_ids,
+                        "current": current,
+                        "expected_revision": expected_revision,
+                        "config_synced": (
+                            current
+                            and item.get("online")
+                            and str(item.get("status") or "") == "ready"
+                            and not item.get("config_error")
+                            and acked_revision == expected_revision
+                        ),
+                    }
+                )
+                token_router_runtimes.append(item)
+
+            for binding in tokenizer_asset_bindings:
+                desired_revision = str(binding.get("desired_revision") or "")
+                desired_fingerprint = str(binding.get("desired_fingerprint") or "")
+                observed_revision = str(binding.get("observed_revision") or "")
+                observed_fingerprint = str(binding.get("observed_fingerprint") or "")
+                binding["synced"] = (
+                    desired_revision == observed_revision
+                    and desired_fingerprint == observed_fingerprint
+                )
+                binding["ready"] = (
+                    binding.get("desired_state") == "present"
+                    and binding.get("observed_state") == "ready"
+                    and binding["synced"]
+                )
+
+            runtimes_by_uid: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
+            for runtime in token_router_runtimes:
+                runtimes_by_uid[str(runtime.get("router_uid") or "")].append(runtime)
+            for config in configs:
+                router_uid = str(config["router_uid"])
+                status_item = self._with_token_router_status(config)
+                deployment = status_item["deployment"]
+                runtimes = runtimes_by_uid.get(router_uid, [])
+                token_router_summaries.append(
+                    {
+                        "router_uid": router_uid,
+                        "desired_replicas": int(
+                            deployment.get("desired_replicas") or 0
+                        ),
+                        "effective_ready_replicas": int(
+                            deployment.get("effective_ready_runtimes") or 0
+                        ),
+                        "controllable_ready_replicas": int(
+                            deployment.get("controllable_ready_runtimes") or 0
+                        ),
+                        "status": status_item["status"],
+                        "expected_revision": int(config.get("revision") or 0),
+                        "config_synced_replicas": sum(
+                            bool(item.get("config_synced")) for item in runtimes
+                        ),
+                    }
+                )
+        except Exception:
+            logger.warning(
+                "Failed to build Token Router metrics snapshot", exc_info=True
+            )
+
         return {
             "uptime": int(time.time() - self._uptime) if self._uptime else 0,
             "worker_count": len(self._worker_address_to_worker),
@@ -1679,6 +1793,11 @@ class SupervisorActor(xo.StatelessActor):
                     self._unexpected_down_replicas.items()
                 )
             ],
+            "token_router_agents": token_router_agents,
+            "token_router_assignments": token_router_assignments,
+            "token_router_runtimes": token_router_runtimes,
+            "tokenizer_asset_bindings": tokenizer_asset_bindings,
+            "token_router_summaries": token_router_summaries,
         }
 
     def _get_spec_dicts(
@@ -5866,6 +5985,53 @@ class SupervisorActor(xo.StatelessActor):
         self, router_uid: str, data: Dict[str, Any]
     ) -> Dict[str, Any]:
         return self._token_router_orchestration.update_deployment(router_uid, data)
+
+    async def get_token_router_prometheus_http_sd(
+        self, cluster: str = ""
+    ) -> List[Dict[str, Any]]:
+        """Return Prometheus HTTP-SD targets for retained Runtime instances."""
+        from urllib.parse import urlsplit
+
+        cluster_name = cluster or os.environ.get("XINFERENCE_CLUSTER_NAME", "default")
+        assignments = {
+            str(item.get("assignment_id") or ""): item
+            for item in self._token_router_orchestration.list_assignments()
+        }
+        targets: List[Dict[str, Any]] = []
+        for runtime in self._token_router_registry.list():
+            endpoint = str(runtime.get("endpoint") or "").strip()
+            try:
+                parsed = urlsplit(endpoint)
+                host = parsed.hostname
+                port = parsed.port
+            except ValueError:
+                continue
+            if parsed.scheme not in {"http", "https"} or not host or port is None:
+                continue
+            target = f"[{host}]:{port}" if ":" in host else f"{host}:{port}"
+            assignment = assignments.get(str(runtime.get("assignment_id") or ""), {})
+            targets.append(
+                {
+                    "targets": [target],
+                    "labels": {
+                        "job": "xinference-token-router-runtime",
+                        "cluster": cluster_name,
+                        "router_uid": str(runtime.get("router_uid") or ""),
+                        "node_id": str(runtime.get("node_id") or ""),
+                        "assignment_id": str(runtime.get("assignment_id") or ""),
+                        "replica_index": str(
+                            assignment.get(
+                                "replica_index", runtime.get("replica_index", "")
+                            )
+                        ),
+                        "assignment_generation": str(
+                            runtime.get("assignment_generation") or 0
+                        ),
+                        "instance_id": str(runtime.get("instance_id") or ""),
+                    },
+                }
+            )
+        return targets
 
     async def list_token_router_nodes(
         self, include_offline: bool = True

--- a/xinference/core/tests/test_monitor_config_store.py
+++ b/xinference/core/tests/test_monitor_config_store.py
@@ -38,6 +38,7 @@ def test_get_all_returns_defaults_when_empty(store):
     assert all_cfg["grafana_url"] == ""
     assert all_cfg["dashboard_overview"] == "xinference-overview"
     assert all_cfg["dashboard_model_load"] == "xinference-model-load"
+    assert all_cfg["dashboard_token_router"] == "xinference-token-router"
 
 
 def test_get_all_env_fallback(store, monkeypatch):

--- a/xinference/core/tests/test_monitoring_assets.py
+++ b/xinference/core/tests/test_monitoring_assets.py
@@ -1,0 +1,166 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from pathlib import Path
+from typing import Any, Dict, Iterable, List
+
+import yaml  # type: ignore[import-untyped]
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _load_json(path: Path) -> Dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _panel_signature(dashboard: Dict[str, Any]) -> Dict[int, List[Dict[str, str]]]:
+    signature: Dict[int, List[Dict[str, str]]] = {}
+    for panel in dashboard.get("panels", []):
+        if panel.get("type") == "row":
+            continue
+        targets = []
+        for target in panel.get("targets", []):
+            targets.append(
+                {
+                    "refId": str(target.get("refId", "")),
+                    "expr": str(target.get("expr", "")),
+                }
+            )
+        signature[int(panel["id"])] = targets
+    return signature
+
+
+def _all_filebeat_inputs(config: Dict[str, Any]) -> Iterable[Dict[str, Any]]:
+    inputs = config.get("filebeat.inputs")
+    assert isinstance(inputs, list)
+    return inputs
+
+
+def test_token_router_dashboards_keep_localized_layout_and_promql_in_sync() -> None:
+    paths = sorted(
+        (_REPO_ROOT / "monitor/dashboard/token-router").glob(
+            "xinference-grafana-dashboard-token-router-*.json"
+        )
+    )
+    assert len(paths) == 4
+
+    dashboards = [_load_json(path) for path in paths]
+    assert {dashboard.get("uid") for dashboard in dashboards} == {
+        "xinference-token-router"
+    }
+
+    expected = _panel_signature(dashboards[0])
+    assert expected
+    for dashboard in dashboards:
+        assert _panel_signature(dashboard) == expected
+        for targets in _panel_signature(dashboard).values():
+            for target in targets:
+                assert not target["refId"].startswith("$")
+                assert target["refId"]
+
+
+def test_localized_alert_rules_keep_semantics_in_sync() -> None:
+    paths = [
+        _REPO_ROOT / "monitor/alert/rules.yml",
+        _REPO_ROOT / "monitor/alert/rules-zh-CN.yml",
+        _REPO_ROOT / "monitor/alert/rules-ja.yml",
+        _REPO_ROOT / "monitor/alert/rules-ko.yml",
+    ]
+
+    signatures = []
+    for path in paths:
+        config = yaml.safe_load(path.read_text(encoding="utf-8"))
+        signature = []
+        for group in config["groups"]:
+            for rule in group.get("rules", []):
+                signature.append(
+                    {
+                        "alert": rule["alert"],
+                        "expr": rule["expr"],
+                        "for": rule.get("for", ""),
+                        "severity": rule.get("labels", {}).get("severity", ""),
+                        "component": rule.get("labels", {}).get("component", ""),
+                    }
+                )
+        signatures.append(signature)
+
+    assert signatures[1:] == [signatures[0]] * 3
+    by_name = {item["alert"]: item for item in signatures[0]}
+    assert (
+        "xinference:token_router_runtime_up == 1"
+        in by_name["TokenRouterRuntimeConfigOutOfSync"]["expr"]
+    )
+    token_router_alerts = {
+        name: item for name, item in by_name.items() if name.startswith("TokenRouter")
+    }
+    assert len(token_router_alerts) == 10
+    assert {item["component"] for item in token_router_alerts.values()} == {
+        "token-router"
+    }
+
+
+def test_filebeat_configs_collect_router_json_logs_without_rotated_archives() -> None:
+    paths = sorted((_REPO_ROOT / "monitor/filebeat").glob("filebeat-*.yml"))
+    assert len(paths) == 6
+
+    for path in paths:
+        config = yaml.safe_load(path.read_text(encoding="utf-8"))
+        by_log_type = {
+            item.get("fields", {}).get("log_type"): item
+            for item in _all_filebeat_inputs(config)
+        }
+        for log_type, expected_path in (
+            ("router_agent", "/data/inference/logs/router-agent/router.log*"),
+            ("router_runtime", "/data/inference/logs/router-runtime/*/router.log*"),
+        ):
+            item = by_log_type[log_type]
+            assert expected_path in item["paths"]
+            assert item.get("exclude_files") == [r"\.gz$"]
+            assert item.get("json.keys_under_root") is True
+
+
+def test_token_router_http_sd_example_uses_authenticated_15_second_refresh() -> None:
+    path = _REPO_ROOT / "monitor/metrics/prometheus-token-router-http-sd.yml"
+    config = yaml.safe_load(path.read_text(encoding="utf-8"))
+    scrape = config["scrape_configs"][0]
+    discovery = scrape["http_sd_configs"][0]
+
+    assert scrape["job_name"] == "xinference-token-router-runtime"
+    assert discovery["url"].endswith(
+        "/v1/monitor/prometheus/http-sd/token-router-runtimes"
+    )
+    assert discovery["refresh_interval"] == "15s"
+    assert discovery["authorization"] == {
+        "type": "Bearer",
+        "credentials": "REPLACE_WITH_MONITOR_TOKEN",
+    }
+
+
+def test_alertmanager_inhibition_preserves_router_unavailable() -> None:
+    path = _REPO_ROOT / "monitor/alert/alertmanager-inhibition.yml"
+    config = yaml.safe_load(path.read_text(encoding="utf-8"))
+    rules = config["inhibit_rules"]
+    assert rules
+
+    for rule in rules:
+        targets = " ".join(rule.get("target_matchers", []))
+        assert "TokenRouterUnavailable" not in targets
+
+    agent_rule = next(
+        rule
+        for rule in rules
+        if 'alertname="TokenRouterAgentOffline"' in rule.get("source_matchers", [])
+    )
+    assert agent_rule["equal"] == ["node_id"]

--- a/xinference/core/tests/test_monitoring_v2.py
+++ b/xinference/core/tests/test_monitoring_v2.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from aioprometheus import Gauge
+
+from xinference.core import metrics as metrics_module
+from xinference.core.router_registry import RouterRuntimeRegistry
+from xinference.core.supervisor import SupervisorActor
+
+
+def test_sync_gauge_series_removes_stale_labelsets() -> None:
+    gauge = Gauge("xinference:test_monitoring_v2_stale", "test gauge")
+
+    metrics_module._sync_gauge_series(
+        gauge,
+        [({"router_uid": "router-a", "instance_id": "runtime-a"}, 1)],
+    )
+    assert gauge.get({"router_uid": "router-a", "instance_id": "runtime-a"}) == 1
+
+    metrics_module._sync_gauge_series(gauge, [])
+
+    with pytest.raises(KeyError):
+        gauge.get({"router_uid": "router-a", "instance_id": "runtime-a"})
+
+
+def test_monitoring_v2_exports_effective_and_controllable_separately() -> None:
+    cluster_data = {
+        "token_router_agents": [
+            {
+                "node_id": "agent-a",
+                "advertise_host": "10.0.0.1",
+                "software_version": "1.2.3",
+                "software_revision": "abc123",
+                "connectivity_status": "offline",
+                "management_state": "active",
+                "can_schedule": False,
+                "heartbeat_age_seconds": 50,
+                "max_instances": 20,
+                "assignments": 1,
+                "observed": {
+                    "running_instances": 1,
+                    "available_slots": 19,
+                    "resources": {
+                        "cpu": {"usage": 0.25, "total": 8},
+                        "memory": {
+                            "used": 1024,
+                            "available": 3072,
+                            "total": 4096,
+                        },
+                    },
+                },
+            }
+        ],
+        "token_router_assignments": [
+            {
+                "router_uid": "router-a",
+                "assignment_id": "assignment-a",
+                "replica_index": 0,
+                "node_id": "agent-a",
+                "desired_state": "running",
+                "observed_state": "ready",
+                "management_state": "node_lost",
+                "assignment_generation": 2,
+                "config_revision": 7,
+            }
+        ],
+        "token_router_runtimes": [
+            {
+                "router_uid": "router-a",
+                "assignment_id": "assignment-a",
+                "replica_index": 0,
+                "node_id": "agent-a",
+                "instance_id": "runtime-a",
+                "assignment_generation": 2,
+                "software_version": "1.2.3",
+                "software_revision": "abc123",
+                "online": True,
+                "status": "ready",
+                "heartbeat_age_seconds": 10,
+                "effective_ready": True,
+                "controllable": False,
+                "current": True,
+                "expected_revision": 7,
+                "acked_revision": 7,
+                "config_synced": True,
+            }
+        ],
+        "tokenizer_asset_bindings": [
+            {
+                "asset_id": "asset-a",
+                "node_id": "agent-a",
+                "desired_state": "present",
+                "observed_state": "ready",
+                "generation": 3,
+                "synced": True,
+                "ready": True,
+            }
+        ],
+        "token_router_summaries": [
+            {
+                "router_uid": "router-a",
+                "desired_replicas": 1,
+                "effective_ready_replicas": 1,
+                "controllable_ready_replicas": 0,
+                "status": "degraded",
+                "expected_revision": 7,
+                "config_synced_replicas": 1,
+            }
+        ],
+    }
+
+    metrics_module._update_token_router_gauges(cluster_data)
+
+    runtime_labels = {
+        "router_uid": "router-a",
+        "assignment_id": "assignment-a",
+        "instance_id": "runtime-a",
+    }
+    assert metrics_module.token_router_runtime_effective_ready.get(runtime_labels) == 1
+    assert metrics_module.token_router_runtime_controllable.get(runtime_labels) == 0
+    assert metrics_module.token_router_runtime_config_synced.get(runtime_labels) == 1
+    assert (
+        metrics_module.token_router_agent_connectivity_status.get(
+            {"node_id": "agent-a", "status": "offline"}
+        )
+        == 1
+    )
+    assert (
+        metrics_module.token_router_assignment_observed_state.get(
+            {
+                "router_uid": "router-a",
+                "assignment_id": "assignment-a",
+                "replica_index": "0",
+                "node_id": "agent-a",
+                "state": "node_lost",
+            }
+        )
+        == 1
+    )
+    assert (
+        metrics_module.token_router_status.get(
+            {"router_uid": "router-a", "status": "degraded"}
+        )
+        == 1
+    )
+    metrics_module._update_token_router_gauges({})
+    with pytest.raises(KeyError):
+        metrics_module.token_router_runtime_effective_ready.get(runtime_labels)
+
+
+class _OrchestrationStub:
+    def list_assignments(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "assignment_id": "assignment-a",
+                "replica_index": 0,
+                "assignment_generation": 2,
+            }
+        ]
+
+    @staticmethod
+    def runtime_is_current(instance: dict[str, Any]) -> bool:
+        return int(instance.get("assignment_generation") or 0) == 2
+
+    @staticmethod
+    def runtime_is_controllable(instance: dict[str, Any]) -> bool:
+        return False
+
+
+@pytest.mark.asyncio
+async def test_http_sd_retains_offline_runtime_until_registry_purge(
+    monkeypatch,
+) -> None:
+    now = [100.0]
+    monkeypatch.setattr("xinference.core.router_registry.time.time", lambda: now[0])
+
+    supervisor = SupervisorActor.__new__(SupervisorActor)
+    supervisor._token_router_registry = RouterRuntimeRegistry(
+        heartbeat_timeout_seconds=90, stale_retention_seconds=300
+    )
+    supervisor._token_router_orchestration = _OrchestrationStub()
+    supervisor._token_router_registry.register(
+        "router-a",
+        "runtime-a",
+        {
+            "assignment_id": "assignment-a",
+            "assignment_generation": 2,
+            "node_id": "agent-a",
+            "endpoint": "http://10.0.0.1:10080",
+            "status": "ready",
+            "acked_revision": 7,
+        },
+    )
+
+    _, effective, controllable = supervisor._token_router_runtime_health(
+        {"router_uid": "router-a", "revision": 7}
+    )
+    assert [item["instance_id"] for item in effective] == ["runtime-a"]
+    assert controllable == []
+
+    targets = await supervisor.get_token_router_prometheus_http_sd("cluster-a")
+    assert targets == [
+        {
+            "targets": ["10.0.0.1:10080"],
+            "labels": {
+                "job": "xinference-token-router-runtime",
+                "cluster": "cluster-a",
+                "router_uid": "router-a",
+                "node_id": "agent-a",
+                "assignment_id": "assignment-a",
+                "replica_index": "0",
+                "assignment_generation": "2",
+                "instance_id": "runtime-a",
+            },
+        }
+    ]
+
+    now[0] = 191.0
+    assert supervisor._token_router_registry.list()[0]["online"] is False
+    assert await supervisor.get_token_router_prometheus_http_sd("cluster-a") == targets
+
+    now[0] = 401.0
+    assert await supervisor.get_token_router_prometheus_http_sd("cluster-a") == []

--- a/xinference/router/app.py
+++ b/xinference/router/app.py
@@ -321,8 +321,6 @@ def create_app(config: RouterConfig) -> FastAPI:
         backend_started: float | None = None
         backend_model_uid = ""
 
-        await metrics.request_started(metric_config.router_uid, current_pool)
-
         async def finish_request(
             result: str, pool: str, *, backend_result: str | None = None
         ) -> None:
@@ -375,6 +373,8 @@ def create_app(config: RouterConfig) -> FastAPI:
         metric_config = config
 
         try:
+            await metrics.request_started(metric_config.router_uid, current_pool)
+
             if not _authorized(request, config):
                 await finish_request("auth_rejected", current_pool)
                 logger.warning(
@@ -464,7 +464,7 @@ def create_app(config: RouterConfig) -> FastAPI:
                 )
             capabilities = config.tokenizer_asset_capabilities
             if bool(payload.get("tools")) and "tools" not in capabilities:
-                await metrics.increment("tools_not_allowed", "none")
+                await finish_request("tools_not_allowed", current_pool)
                 return _error(
                     400,
                     "Tool requests are not supported by this Tokenizer asset",
@@ -472,7 +472,7 @@ def create_app(config: RouterConfig) -> FastAPI:
                     headers={"x-request-id": request_id},
                 )
             if "thinking" not in capabilities and _payload_thinking(payload):
-                await metrics.increment("thinking_not_allowed", "none")
+                await finish_request("thinking_not_allowed", current_pool)
                 return _error(
                     400,
                     "Thinking-mode requests are not supported by this "
@@ -490,7 +490,7 @@ def create_app(config: RouterConfig) -> FastAPI:
                     stream=stream,
                 )
                 if budget.enable_thinking and "thinking" not in capabilities:
-                    await metrics.increment("thinking_not_allowed", "none")
+                    await finish_request("thinking_not_allowed", current_pool)
                     return _error(
                         400,
                         "Thinking-mode requests are not supported by this "

--- a/xinference/router/app.py
+++ b/xinference/router/app.py
@@ -36,6 +36,7 @@ from .logging_config import (
     sanitize_log_url,
 )
 from .metrics import RouterMetrics
+from .process_metrics import ProcessMetricsCollector
 from .runtime import RouterDisabled, RouterRuntime, RuntimeSnapshot
 from .tokenization import TokenizationWorkerUnavailable
 from .tokenizer import TokenizationError
@@ -147,7 +148,8 @@ def _router_headers(decision: RouteDecision, request_id: str) -> dict[str, str]:
 
 
 def create_app(config: RouterConfig) -> FastAPI:
-    metrics = RouterMetrics()
+    metrics = RouterMetrics(config.router_uid)
+    process_metrics = ProcessMetricsCollector()
     runtime = RouterRuntime(config, metrics)
 
     @asynccontextmanager
@@ -221,6 +223,7 @@ def create_app(config: RouterConfig) -> FastAPI:
     def sync_state(snapshot: RuntimeSnapshot) -> None:
         # Keep these aliases for diagnostics and compatibility with the
         # standalone prototype tests. Request handling always uses runtime.
+        metrics.set_router_uid(snapshot.config.router_uid)
         app.state.config = snapshot.config
         app.state.tokenization = snapshot.tokenization
         app.state.policy = snapshot.policy
@@ -264,7 +267,26 @@ def create_app(config: RouterConfig) -> FastAPI:
 
     @app.get("/metrics")
     async def prometheus_metrics() -> Response:
-        return Response(await metrics.render(), media_type="text/plain; version=0.0.4")
+        summary = await runtime.summary()
+        process = await asyncio.to_thread(process_metrics.collect)
+        control_plane = getattr(app.state, "control_plane", None)
+        control_metadata = getattr(control_plane, "_runtime_metadata", {})
+        runtime_metadata = {
+            "router_uid": runtime.current.config.router_uid,
+            "assignment_id": getattr(control_plane, "assignment_id", "") or "",
+            "assignment_generation": getattr(control_plane, "assignment_generation", 0)
+            or 0,
+            "software_version": control_metadata.get("software_version", ""),
+            "software_revision": control_metadata.get("software_revision", ""),
+        }
+        return Response(
+            await metrics.render(
+                runtime_summary=summary,
+                process=process,
+                runtime_metadata=runtime_metadata,
+            ),
+            media_type="text/plain; version=0.0.4",
+        )
 
     @app.get("/v1/models")
     async def models(request: Request) -> JSONResponse:
@@ -292,11 +314,44 @@ def create_app(config: RouterConfig) -> FastAPI:
         request_id = request.headers.get("x-request-id") or f"router-{uuid.uuid4()}"
         requested_model: str | None = None
         stream = False
+        metric_config = runtime.current.config
+        current_pool = "none"
+        request_metric_finished = False
+        stream_handed_off = False
+        backend_started: float | None = None
+        backend_model_uid = ""
+
+        await metrics.request_started(metric_config.router_uid, current_pool)
+
+        async def finish_request(
+            result: str, pool: str, *, backend_result: str | None = None
+        ) -> None:
+            nonlocal request_metric_finished
+            if request_metric_finished:
+                return
+            elapsed = time.monotonic() - started
+            await metrics.finish_request(
+                result,
+                pool,
+                duration_seconds=elapsed,
+                route_mode="stream" if stream else "non_stream",
+                router_uid=metric_config.router_uid,
+            )
+            if backend_result is not None and backend_started is not None:
+                await metrics.observe_backend(
+                    backend_model_uid,
+                    backend_result,
+                    time.monotonic() - backend_started,
+                    pool=pool,
+                    router_uid=metric_config.router_uid,
+                )
+            request_metric_finished = True
+
         try:
             snapshot = await runtime.acquire()
         except RouterDisabled:
             current = runtime.current.config
-            await metrics.increment("router_disabled", "none")
+            await finish_request("router_disabled", "none")
             logger.warning(
                 "Route rejected",
                 extra=_route_log_fields(
@@ -317,10 +372,11 @@ def create_app(config: RouterConfig) -> FastAPI:
 
         runtime_release_owned = True
         config = snapshot.config
+        metric_config = config
 
         try:
             if not _authorized(request, config):
-                await metrics.increment("auth_rejected", "none")
+                await finish_request("auth_rejected", current_pool)
                 logger.warning(
                     "Route rejected",
                     extra=_route_log_fields(
@@ -343,7 +399,7 @@ def create_app(config: RouterConfig) -> FastAPI:
                 body = await request.body()
                 payload = await request.json()
             except Exception:
-                await metrics.increment("invalid_json", "none")
+                await finish_request("invalid_json", current_pool)
                 logger.warning(
                     "Route rejected",
                     extra=_route_log_fields(
@@ -362,6 +418,7 @@ def create_app(config: RouterConfig) -> FastAPI:
                     headers={"x-request-id": request_id},
                 )
             if not isinstance(payload, dict):
+                await finish_request("invalid_json", current_pool)
                 logger.warning(
                     "Route rejected",
                     extra=_route_log_fields(
@@ -385,7 +442,7 @@ def create_app(config: RouterConfig) -> FastAPI:
             stream = bool(payload.get("stream", False))
             accepted_models = {config.logical_model, *config.model_aliases}
             if raw_model not in accepted_models:
-                await metrics.increment("unknown_model", "none")
+                await finish_request("unknown_model", current_pool)
                 logger.warning(
                     "Route rejected",
                     extra=_route_log_fields(
@@ -442,7 +499,9 @@ def create_app(config: RouterConfig) -> FastAPI:
                         headers={"x-request-id": request_id},
                     )
             except AdmissionRejected as exc:
-                await metrics.increment(f"tokenization_admission_{exc.reason}", "none")
+                await finish_request(
+                    f"tokenization_admission_{exc.reason}", current_pool
+                )
                 logger.warning(
                     "Route rejected",
                     extra=_route_log_fields(
@@ -466,7 +525,7 @@ def create_app(config: RouterConfig) -> FastAPI:
                     },
                 )
             except TokenizationWorkerUnavailable:
-                await metrics.increment("tokenization_worker_unavailable", "none")
+                await finish_request("tokenization_worker_unavailable", current_pool)
                 logger.exception(
                     "Route rejected because tokenization worker is unavailable",
                     extra=_route_log_fields(
@@ -487,25 +546,25 @@ def create_app(config: RouterConfig) -> FastAPI:
                     headers={"retry-after": "1", "x-request-id": request_id},
                 )
             except ThinkingRejected as exc:
-                await metrics.increment("thinking_rejected", "none")
+                await finish_request("thinking_rejected", current_pool)
                 outcome = "thinking_rejected"
                 status_code = 400
                 message = str(exc)
                 error_type = "thinking_not_allowed"
             except ContextLimitExceeded as exc:
-                await metrics.increment("context_limit_exceeded", "none")
+                await finish_request("context_limit_exceeded", current_pool)
                 outcome = "context_limit_exceeded"
                 status_code = 400
                 message = str(exc)
                 error_type = "context_length_exceeded"
             except RouteRejected as exc:
-                await metrics.increment(exc.reason, "none")
+                await finish_request(exc.reason, current_pool)
                 outcome = exc.reason
                 status_code = 400
                 message = str(exc)
                 error_type = exc.reason
             except TokenizationError as exc:
-                await metrics.increment("tokenization_failed", "none")
+                await finish_request("tokenization_failed", current_pool)
                 outcome = "tokenization_failed"
                 status_code = 400
                 message = str(exc)
@@ -535,6 +594,20 @@ def create_app(config: RouterConfig) -> FastAPI:
                 )
 
             backend = config.backend(decision.backend_id)
+            backend_model_uid = backend.model_uid
+            current_pool = decision.pool
+            await metrics.assign_request_pool(
+                current_pool, router_uid=metric_config.router_uid
+            )
+            await metrics.record_rule_match(
+                decision.rule_id, router_uid=metric_config.router_uid
+            )
+            await metrics.record_backend_selection(
+                decision.rule_id,
+                backend.model_uid,
+                decision.pool,
+                router_uid=metric_config.router_uid,
+            )
             logger.info(
                 "Route selected",
                 extra=_route_log_fields(
@@ -548,10 +621,19 @@ def create_app(config: RouterConfig) -> FastAPI:
             )
 
             gate = snapshot.gates[decision.pool]
+            pool_wait_started = time.monotonic()
             try:
                 await gate.acquire()
             except AdmissionRejected as exc:
-                await metrics.increment(f"admission_{exc.reason}", decision.pool)
+                await metrics.observe_pool_wait(
+                    decision.pool,
+                    time.monotonic() - pool_wait_started,
+                    router_uid=metric_config.router_uid,
+                )
+                await metrics.record_pool_rejected(
+                    decision.pool, exc.reason, router_uid=metric_config.router_uid
+                )
+                await finish_request(f"admission_{exc.reason}", current_pool)
                 logger.warning(
                     "Route rejected",
                     extra=_route_log_fields(
@@ -576,6 +658,11 @@ def create_app(config: RouterConfig) -> FastAPI:
                     },
                 )
 
+            await metrics.observe_pool_wait(
+                decision.pool,
+                time.monotonic() - pool_wait_started,
+                router_uid=metric_config.router_uid,
+            )
             gate_release_owned = True
             backend_payload = dict(payload)
             backend_payload["model"] = backend.model_uid
@@ -586,6 +673,7 @@ def create_app(config: RouterConfig) -> FastAPI:
                 request_id=request_id,
             )
             router_headers = _router_headers(decision, request_id)
+            backend_started = time.monotonic()
             try:
                 if stream:
                     backend_request = snapshot.client.build_request(
@@ -599,7 +687,16 @@ def create_app(config: RouterConfig) -> FastAPI:
                             response_body = await backend_response.aread()
                         finally:
                             await backend_response.aclose()
-                        await metrics.increment("backend_http_error", decision.pool)
+                        backend_result = (
+                            "http_5xx"
+                            if backend_response.status_code >= 500
+                            else "http_4xx"
+                        )
+                        await finish_request(
+                            "backend_http_error",
+                            current_pool,
+                            backend_result=backend_result,
+                        )
                         logger.warning(
                             "Backend returned an HTTP error",
                             extra=_route_log_fields(
@@ -625,24 +722,39 @@ def create_app(config: RouterConfig) -> FastAPI:
 
                     cleanup_task: asyncio.Task[None] | None = None
 
-                    async def release_resources() -> None:
+                    async def release_resources(
+                        final_outcome: str = "cancelled",
+                    ) -> None:
                         nonlocal cleanup_task
 
                         async def _release() -> None:
+                            backend_result = {
+                                "completed": "success",
+                                "client_disconnected": "cancelled",
+                                "cancelled": "cancelled",
+                                "stream_error": "stream_error",
+                            }.get(final_outcome, "stream_error")
                             try:
-                                await backend_response.aclose()
+                                await finish_request(
+                                    final_outcome,
+                                    current_pool,
+                                    backend_result=backend_result,
+                                )
                             finally:
                                 try:
-                                    await gate.release()
+                                    await backend_response.aclose()
                                 finally:
-                                    await runtime.release(snapshot)
-                                    logger.info(
-                                        "request_id=%s backend_id=%s "
-                                        "elapsed_seconds=%.3f released=true",
-                                        request_id,
-                                        decision.pool,
-                                        time.monotonic() - started,
-                                    )
+                                    try:
+                                        await gate.release()
+                                    finally:
+                                        await runtime.release(snapshot)
+                                        logger.info(
+                                            "request_id=%s backend_id=%s "
+                                            "elapsed_seconds=%.3f released=true",
+                                            request_id,
+                                            decision.pool,
+                                            time.monotonic() - started,
+                                        )
 
                         if cleanup_task is None:
                             cleanup_task = asyncio.create_task(_release())
@@ -655,21 +767,14 @@ def create_app(config: RouterConfig) -> FastAPI:
                             async for chunk in backend_response.aiter_raw():
                                 if await request.is_disconnected():
                                     final_outcome = "client_disconnected"
-                                    await metrics.increment(
-                                        "client_disconnected", decision.pool
-                                    )
                                     break
                                 yield chunk
-                            if final_outcome == "completed":
-                                await metrics.increment("completed", decision.pool)
                         except asyncio.CancelledError:
                             final_outcome = "cancelled"
-                            await metrics.increment("cancelled", decision.pool)
                             raise
                         except Exception:
                             final_outcome = "stream_error"
                             log_completion = False
-                            await metrics.increment("stream_error", decision.pool)
                             logger.exception(
                                 "Backend stream failed",
                                 extra=_route_log_fields(
@@ -688,7 +793,7 @@ def create_app(config: RouterConfig) -> FastAPI:
                             )
                             raise
                         finally:
-                            await release_resources()
+                            await release_resources(final_outcome)
                             if log_completion:
                                 log_method = (
                                     logger.info
@@ -724,6 +829,7 @@ def create_app(config: RouterConfig) -> FastAPI:
                         },
                         background=BackgroundTask(release_resources),
                     )
+                    stream_handed_off = True
                     gate_release_owned = False
                     runtime_release_owned = False
                     return response
@@ -733,7 +839,9 @@ def create_app(config: RouterConfig) -> FastAPI:
                 )
                 if backend_response.status_code < 400:
                     outcome = "completed"
-                    await metrics.increment(outcome, decision.pool)
+                    await finish_request(
+                        outcome, current_pool, backend_result="success"
+                    )
                     logger.info(
                         "Route completed",
                         extra=_route_log_fields(
@@ -750,7 +858,14 @@ def create_app(config: RouterConfig) -> FastAPI:
                     )
                 else:
                     outcome = "backend_http_error"
-                    await metrics.increment(outcome, decision.pool)
+                    backend_result = (
+                        "http_5xx"
+                        if backend_response.status_code >= 500
+                        else "http_4xx"
+                    )
+                    await finish_request(
+                        outcome, current_pool, backend_result=backend_result
+                    )
                     logger.warning(
                         "Backend returned an HTTP error",
                         extra=_route_log_fields(
@@ -771,7 +886,9 @@ def create_app(config: RouterConfig) -> FastAPI:
                     headers={**response_headers(backend_response), **router_headers},
                 )
             except httpx.TimeoutException:
-                await metrics.increment("backend_timeout", decision.pool)
+                await finish_request(
+                    "backend_timeout", current_pool, backend_result="timeout"
+                )
                 logger.exception(
                     "Backend timed out",
                     extra=_route_log_fields(
@@ -793,7 +910,11 @@ def create_app(config: RouterConfig) -> FastAPI:
                     headers=router_headers,
                 )
             except httpx.HTTPError:
-                await metrics.increment("backend_unavailable", decision.pool)
+                await finish_request(
+                    "backend_unavailable",
+                    current_pool,
+                    backend_result="connect_error",
+                )
                 logger.exception(
                     "Backend unavailable",
                     extra=_route_log_fields(
@@ -820,6 +941,8 @@ def create_app(config: RouterConfig) -> FastAPI:
         finally:
             if runtime_release_owned:
                 await runtime.release(snapshot)
+            if not stream_handed_off and not request_metric_finished:
+                await finish_request("router_error", current_pool)
 
     return app
 

--- a/xinference/router/control_plane.py
+++ b/xinference/router/control_plane.py
@@ -105,6 +105,8 @@ class RouterControlPlaneClient:
             "assignment_id": assignment_id,
             "assignment_generation": assignment_generation,
             "node_id": node_id,
+            "software_version": __version__,
+            "software_revision": _software_revision() or "",
         }
         if self._process_metrics.started_at is not None:
             self._runtime_metadata["started_at"] = self._process_metrics.started_at
@@ -248,7 +250,7 @@ class RouterControlPlaneClient:
                 "resources": await self._collect_process_resources(),
                 "tokenization": summary["tokenization"],
                 "pools": summary["pools"],
-                "tokenizer_asset": summary["tokenizer_asset"],
+                "tokenizer_asset": summary.get("tokenizer_asset", {}),
             },
         )
         return summary

--- a/xinference/router/metrics.py
+++ b/xinference/router/metrics.py
@@ -1,12 +1,69 @@
 from __future__ import annotations
 
 import asyncio
-from collections import Counter
+from collections import Counter, defaultdict
+from typing import Any, Dict, Iterable, Mapping, Tuple
+
+_DURATION_BUCKETS = (0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60)
+_WAIT_BUCKETS = (0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5)
+
+
+def _escape(value: object) -> str:
+    return str(value).replace("\\", "\\\\").replace("\n", "\\n").replace('"', '\\"')
+
+
+def _labels(values: Mapping[str, object]) -> str:
+    return (
+        "{"
+        + ",".join(f'{key}="{_escape(value)}"' for key, value in values.items())
+        + "}"
+    )
+
+
+class _Histogram:
+    def __init__(self, buckets: Iterable[float]) -> None:
+        self.buckets = tuple(float(value) for value in buckets)
+        self.counts: Dict[Tuple[str, ...], list[int]] = defaultdict(
+            lambda: [0] * len(self.buckets)
+        )
+        self.sums: Dict[Tuple[str, ...], float] = defaultdict(float)
+        self.totals: Counter[Tuple[str, ...]] = Counter()
+
+    def observe(self, key: Tuple[str, ...], value: float) -> None:
+        value = max(0.0, float(value))
+        for index, boundary in enumerate(self.buckets):
+            if value <= boundary:
+                self.counts[key][index] += 1
+        self.sums[key] += value
+        self.totals[key] += 1
+
+    def snapshot(self) -> "_Histogram":
+        copied = _Histogram(self.buckets)
+        copied.counts.update({key: list(value) for key, value in self.counts.items()})
+        copied.sums.update(self.sums)
+        copied.totals.update(self.totals)
+        return copied
 
 
 class RouterMetrics:
-    def __init__(self) -> None:
+    """Concurrency-safe in-process metrics for a single Router Runtime.
+
+    The original ``increment`` and tokenization Summary metrics are retained for
+    compatibility. Monitoring V2.1 metrics are emitted alongside them.
+    """
+
+    def __init__(self, router_uid: str = "") -> None:
+        self._router_uid = router_uid
         self._counters: Counter[tuple[str, ...]] = Counter()
+        self._route_requests: Counter[tuple[str, str, str, str]] = Counter()
+        self._requests_in_flight: Counter[tuple[str, str]] = Counter()
+        self._rule_matches: Counter[tuple[str, str, str]] = Counter()
+        self._backend_selections: Counter[tuple[str, str, str, str]] = Counter()
+        self._backend_requests: Counter[tuple[str, str, str, str]] = Counter()
+        self._pool_rejected: Counter[tuple[str, str, str]] = Counter()
+        self._request_duration = _Histogram(_DURATION_BUCKETS)
+        self._backend_duration = _Histogram(_DURATION_BUCKETS)
+        self._pool_wait_duration = _Histogram(_WAIT_BUCKETS)
         self._tokenization_outcomes: Counter[str] = Counter()
         self._tokenization_rejected: Counter[str] = Counter()
         self._tokenization_duration_count = 0
@@ -19,9 +76,99 @@ class RouterMetrics:
         self._tokenization_waiting = 0
         self._lock = asyncio.Lock()
 
+    def set_router_uid(self, router_uid: str) -> None:
+        self._router_uid = str(router_uid)
+
     async def increment(self, *labels: str) -> None:
+        """Increment the legacy request outcome counter."""
         async with self._lock:
             self._counters[tuple(labels)] += 1
+
+    async def request_started(self, router_uid: str = "", pool: str = "none") -> None:
+        uid = router_uid or self._router_uid
+        async with self._lock:
+            self._requests_in_flight[(uid, pool)] += 1
+
+    async def assign_request_pool(
+        self, pool: str, *, previous_pool: str = "none", router_uid: str = ""
+    ) -> None:
+        """Move one in-flight request from its pre-route bucket to a pool."""
+        uid = router_uid or self._router_uid
+        if pool == previous_pool:
+            return
+        async with self._lock:
+            previous_key = (uid, previous_pool)
+            self._requests_in_flight[previous_key] = max(
+                0, self._requests_in_flight[previous_key] - 1
+            )
+            self._requests_in_flight[(uid, pool)] += 1
+
+    async def finish_request(
+        self,
+        result: str,
+        pool: str,
+        *,
+        duration_seconds: float,
+        route_mode: str = "non_stream",
+        router_uid: str = "",
+    ) -> None:
+        uid = router_uid or self._router_uid
+        key = (uid, result, route_mode, pool)
+        async with self._lock:
+            self._counters[(result, pool)] += 1
+            self._route_requests[key] += 1
+            self._request_duration.observe(key, duration_seconds)
+            in_flight_key = (uid, pool)
+            self._requests_in_flight[in_flight_key] = max(
+                0, self._requests_in_flight[in_flight_key] - 1
+            )
+
+    async def record_rule_match(
+        self, rule_id: str, outcome: str = "selected", *, router_uid: str = ""
+    ) -> None:
+        async with self._lock:
+            self._rule_matches[(router_uid or self._router_uid, rule_id, outcome)] += 1
+
+    async def record_backend_selection(
+        self,
+        rule_id: str,
+        backend_model_uid: str,
+        pool: str = "none",
+        *,
+        router_uid: str = "",
+    ) -> None:
+        async with self._lock:
+            self._backend_selections[
+                (router_uid or self._router_uid, backend_model_uid, rule_id, pool)
+            ] += 1
+
+    async def observe_backend(
+        self,
+        backend_model_uid: str,
+        result: str,
+        duration_seconds: float,
+        *,
+        pool: str = "none",
+        router_uid: str = "",
+    ) -> None:
+        key = (router_uid or self._router_uid, backend_model_uid, result, pool)
+        async with self._lock:
+            self._backend_requests[key] += 1
+            self._backend_duration.observe(key, duration_seconds)
+
+    async def observe_pool_wait(
+        self, pool: str, duration_seconds: float, *, router_uid: str = ""
+    ) -> None:
+        async with self._lock:
+            self._pool_wait_duration.observe(
+                (router_uid or self._router_uid, pool), duration_seconds
+            )
+
+    async def record_pool_rejected(
+        self, pool: str, reason: str, *, router_uid: str = ""
+    ) -> None:
+        async with self._lock:
+            self._pool_rejected[(router_uid or self._router_uid, pool, reason)] += 1
 
     async def increment_tokenization_rejected(self, reason: str) -> None:
         async with self._lock:
@@ -70,9 +217,45 @@ class RouterMetrics:
                 "tokenization_waiting": self._tokenization_waiting,
             }
 
-    async def render(self) -> str:
+    @staticmethod
+    def _render_histogram(
+        lines: list[str],
+        name: str,
+        help_text: str,
+        histogram: _Histogram,
+        label_names: tuple[str, ...],
+    ) -> None:
+        lines.extend([f"# HELP {name} {help_text}", f"# TYPE {name} histogram"])
+        for key in sorted(histogram.totals):
+            base = dict(zip(label_names, key))
+            for boundary, count in zip(histogram.buckets, histogram.counts[key]):
+                lines.append(
+                    f"{name}_bucket{_labels({**base, 'le': boundary})} {count}"
+                )
+            lines.append(
+                f"{name}_bucket{_labels({**base, 'le': '+Inf'})} {histogram.totals[key]}"
+            )
+            lines.append(f"{name}_sum{_labels(base)} {histogram.sums[key]:.9f}")
+            lines.append(f"{name}_count{_labels(base)} {histogram.totals[key]}")
+
+    async def render(
+        self,
+        *,
+        runtime_summary: Mapping[str, Any] | None = None,
+        process: Mapping[str, Any] | None = None,
+        runtime_metadata: Mapping[str, Any] | None = None,
+    ) -> str:
         async with self._lock:
             counters = dict(self._counters)
+            route_requests = dict(self._route_requests)
+            in_flight = dict(self._requests_in_flight)
+            rule_matches = dict(self._rule_matches)
+            backend_selections = dict(self._backend_selections)
+            backend_requests = dict(self._backend_requests)
+            pool_rejected = dict(self._pool_rejected)
+            request_duration = self._request_duration.snapshot()
+            backend_duration = self._backend_duration.snapshot()
+            pool_wait_duration = self._pool_wait_duration.snapshot()
             outcomes = dict(self._tokenization_outcomes)
             rejected = dict(self._tokenization_rejected)
             duration_count = self._tokenization_duration_count
@@ -93,60 +276,220 @@ class RouterMetrics:
             pool = labels[1] if len(labels) > 1 else "none"
             lines.append(
                 "xinference_token_router_requests_total"
-                f'{{event="{event}",pool="{pool}"}} {value}'
+                f'{_labels({"event": event, "pool": pool})} {value}'
             )
 
         lines.extend(
             [
-                "# HELP xinference_token_router_tokenization_active "
-                "Tokenization tasks currently admitted.",
+                "# HELP xinference_token_router_route_requests_total Final Router request results.",
+                "# TYPE xinference_token_router_route_requests_total counter",
+            ]
+        )
+        for (uid, result, route_mode, pool), value in sorted(route_requests.items()):
+            lines.append(
+                "xinference_token_router_route_requests_total"
+                f'{_labels({"router_uid": uid, "result": result, "route_mode": route_mode, "pool": pool})} {value}'
+            )
+        self._render_histogram(
+            lines,
+            "xinference_token_router_request_duration_seconds",
+            "End-to-end Router request duration.",
+            request_duration,
+            ("router_uid", "result", "route_mode", "pool"),
+        )
+        lines.extend(
+            [
+                "# HELP xinference_token_router_requests_in_flight Router requests currently in flight.",
+                "# TYPE xinference_token_router_requests_in_flight gauge",
+            ]
+        )
+        for (uid, pool), value in sorted(in_flight.items()):
+            lines.append(
+                "xinference_token_router_requests_in_flight"
+                f'{_labels({"router_uid": uid, "pool": pool})} {value}'
+            )
+
+        for name, help_text, values, label_names in (
+            (
+                "xinference_token_router_rule_matches_total",
+                "Routing rule matches.",
+                rule_matches,
+                ("router_uid", "rule_id", "outcome"),
+            ),
+            (
+                "xinference_token_router_backend_selections_total",
+                "Backend selections by rule.",
+                backend_selections,
+                ("router_uid", "backend_model_uid", "rule_id", "pool"),
+            ),
+            (
+                "xinference_token_router_backend_requests_total",
+                "Backend request final results.",
+                backend_requests,
+                ("router_uid", "backend_model_uid", "result", "pool"),
+            ),
+            (
+                "xinference_token_router_pool_rejected_total",
+                "Concurrency pool rejections.",
+                pool_rejected,
+                ("router_uid", "pool", "reason"),
+            ),
+        ):
+            lines.extend([f"# HELP {name} {help_text}", f"# TYPE {name} counter"])
+            for key, value in sorted(values.items()):
+                lines.append(f"{name}{_labels(dict(zip(label_names, key)))} {value}")
+        self._render_histogram(
+            lines,
+            "xinference_token_router_backend_request_duration_seconds",
+            "Backend request duration.",
+            backend_duration,
+            ("router_uid", "backend_model_uid", "result", "pool"),
+        )
+        self._render_histogram(
+            lines,
+            "xinference_token_router_pool_wait_duration_seconds",
+            "Concurrency pool wait duration.",
+            pool_wait_duration,
+            ("router_uid", "pool"),
+        )
+
+        summary = runtime_summary or {}
+        uid = str((runtime_metadata or {}).get("router_uid") or self._router_uid)
+        pools = summary.get("pools", {}) if isinstance(summary, Mapping) else {}
+        for metric_name, field, help_text in (
+            (
+                "xinference_token_router_pool_limit",
+                "max_active",
+                "Concurrency pool active limit.",
+            ),
+            (
+                "xinference_token_router_pool_in_use",
+                "active",
+                "Concurrency pool slots in use.",
+            ),
+            (
+                "xinference_token_router_pool_waiting",
+                "waiting",
+                "Requests waiting for a pool slot.",
+            ),
+        ):
+            lines.extend(
+                [f"# HELP {metric_name} {help_text}", f"# TYPE {metric_name} gauge"]
+            )
+            if isinstance(pools, Mapping):
+                for pool, pool_state in sorted(
+                    pools.items(), key=lambda item: str(item[0])
+                ):
+                    if isinstance(pool_state, Mapping):
+                        lines.append(
+                            f"{metric_name}{_labels({'router_uid': uid, 'pool': pool})} {pool_state.get(field, 0)}"
+                        )
+
+        lines.extend(
+            [
+                "# HELP xinference_token_router_tokenization_active Tokenization tasks currently admitted.",
                 "# TYPE xinference_token_router_tokenization_active gauge",
                 f"xinference_token_router_tokenization_active {active}",
-                "# HELP xinference_token_router_tokenization_waiting "
-                "Tokenization tasks waiting for admission.",
+                "# HELP xinference_token_router_tokenization_waiting Tokenization tasks waiting for admission.",
                 "# TYPE xinference_token_router_tokenization_waiting gauge",
                 f"xinference_token_router_tokenization_waiting {waiting}",
-                "# HELP xinference_token_router_tokenization_duration_seconds "
-                "Tokenization execution duration.",
+                "# HELP xinference_token_router_tokenization_duration_seconds Tokenization execution duration.",
                 "# TYPE xinference_token_router_tokenization_duration_seconds summary",
-                "xinference_token_router_tokenization_duration_seconds_count "
-                f"{duration_count}",
-                "xinference_token_router_tokenization_duration_seconds_sum "
-                f"{duration_sum:.9f}",
-                "# HELP xinference_token_router_tokenization_duration_seconds_max "
-                "Maximum observed tokenization duration.",
+                f"xinference_token_router_tokenization_duration_seconds_count {duration_count}",
+                f"xinference_token_router_tokenization_duration_seconds_sum {duration_sum:.9f}",
+                "# HELP xinference_token_router_tokenization_duration_seconds_max Maximum observed tokenization duration.",
                 "# TYPE xinference_token_router_tokenization_duration_seconds_max gauge",
-                "xinference_token_router_tokenization_duration_seconds_max "
-                f"{duration_max:.9f}",
-                "# HELP xinference_token_router_tokenization_input_bytes "
-                "Request body bytes processed by tokenization.",
+                f"xinference_token_router_tokenization_duration_seconds_max {duration_max:.9f}",
+                "# HELP xinference_token_router_tokenization_input_bytes Request body bytes processed by tokenization.",
                 "# TYPE xinference_token_router_tokenization_input_bytes summary",
                 f"xinference_token_router_tokenization_input_bytes_count {input_bytes_count}",
                 f"xinference_token_router_tokenization_input_bytes_sum {input_bytes_sum}",
-                "# HELP xinference_token_router_tokenization_input_bytes_max "
-                "Maximum observed tokenization request body size.",
+                "# HELP xinference_token_router_tokenization_input_bytes_max Maximum observed tokenization request body size.",
                 "# TYPE xinference_token_router_tokenization_input_bytes_max gauge",
                 f"xinference_token_router_tokenization_input_bytes_max {input_bytes_max}",
-                "# HELP xinference_token_router_tokenization_outcomes_total "
-                "Tokenization task outcomes.",
+                "# HELP xinference_token_router_tokenization_outcomes_total Tokenization task outcomes.",
                 "# TYPE xinference_token_router_tokenization_outcomes_total counter",
             ]
         )
         for outcome, value in sorted(outcomes.items()):
             lines.append(
                 "xinference_token_router_tokenization_outcomes_total"
-                f'{{outcome="{outcome}"}} {value}'
+                f'{_labels({"outcome": outcome})} {value}'
             )
         lines.extend(
             [
-                "# HELP xinference_token_router_tokenization_rejected_total "
-                "Tokenization admission rejections.",
+                "# HELP xinference_token_router_tokenization_rejected_total Tokenization admission rejections.",
                 "# TYPE xinference_token_router_tokenization_rejected_total counter",
             ]
         )
         for reason, value in sorted(rejected.items()):
             lines.append(
                 "xinference_token_router_tokenization_rejected_total"
-                f'{{reason="{reason}"}} {value}'
+                f'{_labels({"reason": reason})} {value}'
+            )
+
+        metadata = dict(runtime_metadata or {})
+        try:
+            from xinference import __version__
+        except Exception:  # pragma: no cover
+            __version__ = "unknown"
+        lines.extend(
+            [
+                "# HELP xinference_token_router_build_info Token Router Runtime build information (value=1).",
+                "# TYPE xinference_token_router_build_info gauge",
+                "xinference_token_router_build_info"
+                f'{_labels({"version": metadata.get("software_version", __version__), "commit": metadata.get("software_revision", "")})} 1',
+                "# HELP xinference_token_router_config_revision Active Router configuration revision.",
+                "# TYPE xinference_token_router_config_revision gauge",
+                f"xinference_token_router_config_revision{_labels({'router_uid': uid})} {summary.get('revision', 0)}",
+                "# HELP xinference_token_router_assignment_generation Active Runtime Assignment generation.",
+                "# TYPE xinference_token_router_assignment_generation gauge",
+                "xinference_token_router_assignment_generation"
+                f'{_labels({"router_uid": uid, "assignment_id": metadata.get("assignment_id", "")})} {metadata.get("assignment_generation") or 0}',
+            ]
+        )
+
+        resources = process or {}
+        process_metrics = (
+            (
+                "xinference_token_router_process_cpu_seconds_total",
+                "counter",
+                "cpu_seconds_total",
+            ),
+            ("xinference_token_router_process_cpu_utilization", "gauge", "cpu_cores"),
+            (
+                "xinference_token_router_process_resident_memory_bytes",
+                "gauge",
+                "rss_bytes",
+            ),
+            (
+                "xinference_token_router_process_virtual_memory_bytes",
+                "gauge",
+                "virtual_memory_bytes",
+            ),
+            ("xinference_token_router_process_threads", "gauge", "thread_count"),
+            (
+                "xinference_token_router_process_children",
+                "gauge",
+                "child_process_count",
+            ),
+            (
+                "xinference_token_router_process_start_time_seconds",
+                "gauge",
+                "started_at",
+            ),
+            (
+                "xinference_token_router_process_uptime_seconds",
+                "gauge",
+                "uptime_seconds",
+            ),
+        )
+        for name, metric_type, field in process_metrics:
+            lines.extend(
+                [
+                    f"# HELP {name} Token Router Runtime process-tree {field}.",
+                    f"# TYPE {name} {metric_type}",
+                    f"{name} {resources.get(field, 0)}",
+                ]
             )
         return "\n".join(lines) + "\n"

--- a/xinference/router/process_metrics.py
+++ b/xinference/router/process_metrics.py
@@ -33,11 +33,11 @@ def _cgroup_cpu_quota() -> Optional[float]:
             except (TypeError, ValueError, ZeroDivisionError):
                 pass
 
-    quota_text = _read_text("/sys/fs/cgroup/cpu/cpu.cfs_quota_us")
-    period_text = _read_text("/sys/fs/cgroup/cpu/cpu.cfs_period_us")
-    if quota_text and period_text:
+    quota_raw = _read_text("/sys/fs/cgroup/cpu/cpu.cfs_quota_us")
+    period_raw = _read_text("/sys/fs/cgroup/cpu/cpu.cfs_period_us")
+    if quota_raw and period_raw:
         try:
-            value = float(quota_text) / float(period_text)
+            value = float(quota_raw) / float(period_raw)
             if value > 0:
                 return value
         except (TypeError, ValueError, ZeroDivisionError):
@@ -97,11 +97,11 @@ class ProcessMetricsCollector:
             return default
 
     def _processes(self) -> Iterable[psutil.Process]:
-        if self._process is None:
+        root_process = self._process
+        if root_process is None:
             return
-        process = self._process
-        yield process
-        children = self._safe_call(lambda: process.children(recursive=True), [])
+        yield root_process
+        children = self._safe_call(lambda: root_process.children(recursive=True), [])
         yield from children
 
     def _prime_cpu_baselines(self) -> None:
@@ -109,12 +109,10 @@ class ProcessMetricsCollector:
             self._safe_call(lambda: process.cpu_percent(interval=None), 0.0)
 
     def _cpu_capacity(self) -> float:
-        process = self._process
-        if process is not None:
-            affinity = self._safe_call(
-                lambda: process.cpu_affinity(),  # type: ignore[attr-defined]
-                [],
-            )
+        root_process = self._process
+        if root_process is not None:
+            affinity_fn = getattr(root_process, "cpu_affinity", None)
+            affinity = self._safe_call(affinity_fn, []) if callable(affinity_fn) else []
             if affinity:
                 return float(len(affinity))
 
@@ -143,8 +141,10 @@ class ProcessMetricsCollector:
             return {}
 
         cpu_percent = 0.0
+        cpu_seconds_total = 0.0
         main_rss = 0
         child_rss = 0
+        virtual_memory_bytes = 0
         child_count = 0
         thread_count = 0
 
@@ -155,9 +155,17 @@ class ProcessMetricsCollector:
             if current_cpu is not None:
                 cpu_percent += float(current_cpu)
 
+            cpu_times_fn = getattr(process, "cpu_times", None)
+            cpu_times = (
+                self._safe_call(cpu_times_fn, None) if callable(cpu_times_fn) else None
+            )
+            if cpu_times is not None:
+                cpu_seconds_total += float(cpu_times.user) + float(cpu_times.system)
+
             memory_info = self._safe_call(process.memory_info, None)
             if memory_info is not None:
                 rss = int(memory_info.rss)
+                virtual_memory_bytes += int(getattr(memory_info, "vms", 0))
                 if index == 0:
                     main_rss = rss
                 else:
@@ -174,8 +182,10 @@ class ProcessMetricsCollector:
         result: Dict[str, Any] = {
             "cpu_percent": cpu_percent,
             "cpu_cores": cpu_percent / 100.0,
+            "cpu_seconds_total": cpu_seconds_total,
             "cpu_count": self._cpu_capacity(),
             "rss_bytes": main_rss + child_rss,
+            "virtual_memory_bytes": virtual_memory_bytes,
             "memory_total_bytes": self._memory_capacity(),
             "main_process_rss_bytes": main_rss,
             "child_process_rss_bytes": child_rss,

--- a/xinference/router/tests/test_app.py
+++ b/xinference/router/tests/test_app.py
@@ -210,6 +210,24 @@ async def call_router(
     return response, active, metrics
 
 
+def assert_rejection_metrics(metrics: str, *, router_uid: str, result: str) -> None:
+    assert (
+        "xinference_token_router_route_requests_total"
+        f'{{router_uid="{router_uid}",result="{result}",'
+        'route_mode="non_stream",pool="none"} 1' in metrics
+    )
+    assert (
+        f'xinference_token_router_requests_total{{event="{result}",pool="none"}} 1'
+        in metrics
+    )
+    assert 'result="router_error"' not in metrics
+    assert 'event="router_error",pool="none"' not in metrics
+    assert (
+        "xinference_token_router_requests_in_flight"
+        f'{{router_uid="{router_uid}",pool="none"}} 0' in metrics
+    )
+
+
 @pytest.mark.asyncio
 async def test_stream_connect_error_releases_gate(
     tmp_path: Path, caplog: pytest.LogCaptureFixture
@@ -570,6 +588,55 @@ async def test_auth_rejection_releases_runtime_snapshot(
 
 
 @pytest.mark.asyncio
+async def test_cancelled_runtime_acquire_does_not_leak_in_flight(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    app = create_app(make_config(tmp_path))
+    runtime = app.state.runtime
+    acquire_started = asyncio.Event()
+    original_acquire = runtime.acquire
+
+    async def tracked_acquire():
+        acquire_started.set()
+        return await original_acquire()
+
+    monkeypatch.setattr(runtime, "acquire", tracked_acquire)
+
+    async with app.router.lifespan_context(app):
+        await runtime._lock.acquire()
+        try:
+            async with httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=app), base_url="http://router"
+            ) as client:
+                request_task = asyncio.create_task(
+                    client.post(
+                        "/v1/chat/completions",
+                        headers={"authorization": "Bearer secret"},
+                        json={
+                            "model": "router-model",
+                            "messages": [{"role": "user", "content": "hello"}],
+                            "max_tokens": 8,
+                        },
+                    )
+                )
+                await asyncio.wait_for(acquire_started.wait(), timeout=1)
+                request_task.cancel()
+                with pytest.raises(asyncio.CancelledError):
+                    await request_task
+        finally:
+            runtime._lock.release()
+
+        metrics = await app.state.metrics.render()
+        in_flight = [
+            float(line.rsplit(" ", 1)[1])
+            for line in metrics.splitlines()
+            if line.startswith("xinference_token_router_requests_in_flight{")
+        ]
+        assert all(value == 0 for value in in_flight)
+        assert runtime.current.active_requests == 0
+
+
+@pytest.mark.asyncio
 async def test_v2_tools_rule_routes_to_dynamic_backend_and_sets_headers(
     tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
@@ -678,9 +745,13 @@ async def test_tools_request_rejected_when_asset_lacks_tools_capability(
                     "max_tokens": 8,
                 },
             )
+            metrics = (await client.get("/metrics")).text
 
     assert response.status_code == 400
     assert response.json()["error"]["type"] == "tools_not_allowed"
+    assert_rejection_metrics(
+        metrics, router_uid=config.router_uid, result="tools_not_allowed"
+    )
 
 
 @pytest.mark.asyncio
@@ -712,15 +783,19 @@ async def test_thinking_request_is_rejected_before_tokenization(
                     "max_tokens": 8,
                 },
             )
+            metrics = (await client.get("/metrics")).text
 
     assert response.status_code == 400
     assert response.json()["error"]["type"] == "thinking_not_allowed"
     estimate.assert_not_awaited()
+    assert_rejection_metrics(
+        metrics, router_uid=config.router_uid, result="thinking_not_allowed"
+    )
 
 
 @pytest.mark.asyncio
 async def test_thinking_request_rejected_when_asset_lacks_thinking_capability(
-    tmp_path: Path,
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     from dataclasses import replace
 
@@ -729,6 +804,17 @@ async def test_thinking_request_rejected_when_asset_lacks_thinking_capability(
         tokenizer_asset_capabilities=("chat", "tools"),
     )
     app = create_app(config)
+    tokenization = app.state.runtime.current.tokenization
+    estimate = AsyncMock(
+        return_value=TokenBudget(
+            prompt_tokens=1,
+            output_tokens=8,
+            reserve_tokens=0,
+            total_tokens=9,
+            enable_thinking=True,
+        )
+    )
+    monkeypatch.setattr(tokenization, "estimate", estimate)
     async with app.router.lifespan_context(app):
         async with httpx.AsyncClient(
             transport=httpx.ASGITransport(app=app), base_url="http://router"
@@ -739,10 +825,14 @@ async def test_thinking_request_rejected_when_asset_lacks_thinking_capability(
                 json={
                     "model": "router-model",
                     "messages": [{"role": "user", "content": "hello"}],
-                    "chat_template_kwargs": {"enable_thinking": True},
                     "max_tokens": 8,
                 },
             )
+            metrics = (await client.get("/metrics")).text
 
     assert response.status_code == 400
     assert response.json()["error"]["type"] == "thinking_not_allowed"
+    estimate.assert_awaited_once()
+    assert_rejection_metrics(
+        metrics, router_uid=config.router_uid, result="thinking_not_allowed"
+    )

--- a/xinference/router/tests/test_metrics.py
+++ b/xinference/router/tests/test_metrics.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from xinference.router.metrics import RouterMetrics
+
+
+@pytest.mark.asyncio
+async def test_runtime_metrics_cover_request_routing_pool_and_process() -> None:
+    metrics = RouterMetrics("router-a")
+
+    await metrics.request_started()
+    await metrics.assign_request_pool("short")
+    await metrics.record_rule_match('rule"one')
+    await metrics.record_backend_selection('rule"one', "model-a", "short")
+    await metrics.observe_pool_wait("short", 0.02)
+    await metrics.record_pool_rejected("short", "queue_full")
+    await metrics.observe_backend("model-a", "success", 0.2, pool="short")
+    await metrics.finish_request(
+        "completed",
+        "short",
+        duration_seconds=0.3,
+        route_mode="non_stream",
+    )
+
+    rendered = await metrics.render(
+        runtime_summary={
+            "revision": 7,
+            "pools": {
+                "short": {"max_active": 8, "active": 1, "waiting": 2},
+            },
+        },
+        runtime_metadata={
+            "router_uid": "router-a",
+            "assignment_id": "assignment-a",
+            "assignment_generation": 3,
+            "software_version": "1.2.3",
+            "software_revision": "abc123",
+        },
+        process={
+            "cpu_seconds_total": 12.5,
+            "cpu_cores": 0.75,
+            "rss_bytes": 1024,
+            "virtual_memory_bytes": 4096,
+            "thread_count": 5,
+            "child_process_count": 2,
+            "started_at": 100.0,
+            "uptime_seconds": 60.0,
+        },
+    )
+
+    assert (
+        'xinference_token_router_route_requests_total{router_uid="router-a",result="completed",route_mode="non_stream",pool="short"} 1'
+        in rendered
+    )
+    assert (
+        'xinference_token_router_requests_total{event="completed",pool="short"} 1'
+        in rendered
+    )
+    assert (
+        'xinference_token_router_requests_in_flight{router_uid="router-a",pool="none"} 0'
+        in rendered
+    )
+    assert (
+        'xinference_token_router_requests_in_flight{router_uid="router-a",pool="short"} 0'
+        in rendered
+    )
+    assert (
+        'xinference_token_router_rule_matches_total{router_uid="router-a",rule_id="rule\\"one",outcome="selected"} 1'
+        in rendered
+    )
+    assert (
+        'xinference_token_router_backend_selections_total{router_uid="router-a",backend_model_uid="model-a",rule_id="rule\\"one",pool="short"} 1'
+        in rendered
+    )
+    assert (
+        'xinference_token_router_backend_requests_total{router_uid="router-a",backend_model_uid="model-a",result="success",pool="short"} 1'
+        in rendered
+    )
+    assert (
+        'xinference_token_router_pool_rejected_total{router_uid="router-a",pool="short",reason="queue_full"} 1'
+        in rendered
+    )
+
+    histogram_labels = '{router_uid="router-a",result="completed",route_mode="non_stream",pool="short"}'
+    assert (
+        "xinference_token_router_request_duration_seconds_bucket"
+        + histogram_labels[:-1]
+        + ',le="0.5"} 1'
+        in rendered
+    )
+    assert (
+        "xinference_token_router_request_duration_seconds_bucket"
+        + histogram_labels[:-1]
+        + ',le="0.25"} 0'
+        in rendered
+    )
+    assert (
+        "xinference_token_router_request_duration_seconds_sum"
+        + histogram_labels
+        + " 0.300000000"
+        in rendered
+    )
+    assert (
+        "xinference_token_router_request_duration_seconds_count"
+        + histogram_labels
+        + " 1"
+        in rendered
+    )
+
+    assert (
+        'xinference_token_router_pool_limit{router_uid="router-a",pool="short"} 8'
+        in rendered
+    )
+    assert (
+        'xinference_token_router_build_info{version="1.2.3",commit="abc123"} 1'
+        in rendered
+    )
+    assert (
+        'xinference_token_router_config_revision{router_uid="router-a"} 7' in rendered
+    )
+    assert (
+        'xinference_token_router_assignment_generation{router_uid="router-a",assignment_id="assignment-a"} 3'
+        in rendered
+    )
+    assert "xinference_token_router_process_cpu_seconds_total 12.5" in rendered
+    assert "xinference_token_router_process_virtual_memory_bytes 4096" in rendered
+
+
+@pytest.mark.asyncio
+async def test_render_is_safe_during_concurrent_updates() -> None:
+    metrics = RouterMetrics("router-a")
+
+    async def record(index: int) -> None:
+        pool = "short" if index % 2 == 0 else "long"
+        await metrics.request_started(pool=pool)
+        await metrics.observe_backend("model-a", "success", index / 1000, pool=pool)
+        await metrics.finish_request("completed", pool, duration_seconds=index / 1000)
+
+    async def render_repeatedly() -> None:
+        for _ in range(20):
+            output = await metrics.render()
+            assert (
+                "# TYPE xinference_token_router_request_duration_seconds histogram"
+                in output
+            )
+            await asyncio.sleep(0)
+
+    await asyncio.gather(*(record(index) for index in range(50)), render_repeatedly())
+
+    rendered = await metrics.render()
+    assert rendered.count("xinference_token_router_route_requests_total{") == 2
+    assert (
+        'xinference_token_router_route_requests_total{router_uid="router-a",result="completed",route_mode="non_stream",pool="short"} 25'
+        in rendered
+    )
+    assert (
+        'xinference_token_router_route_requests_total{router_uid="router-a",result="completed",route_mode="non_stream",pool="long"} 25'
+        in rendered
+    )

--- a/xinference/router/tests/test_process_metrics.py
+++ b/xinference/router/tests/test_process_metrics.py
@@ -23,7 +23,10 @@ class FakeProcess:
         *,
         cpu_values: list[float],
         rss: int,
+        vms: int = 0,
         threads: int,
+        cpu_user: float = 0.0,
+        cpu_system: float = 0.0,
         created_at: float = 100.0,
         children: Optional[list["FakeProcess"]] = None,
         failure: Optional[Exception] = None,
@@ -31,7 +34,10 @@ class FakeProcess:
         self.pid = pid
         self._cpu_values = iter(cpu_values)
         self._rss = rss
+        self._vms = vms
         self._threads = threads
+        self._cpu_user = cpu_user
+        self._cpu_system = cpu_system
         self._created_at = created_at
         self._children = children or []
         self._failure = failure
@@ -62,7 +68,11 @@ class FakeProcess:
 
     def memory_info(self) -> SimpleNamespace:
         self._raise_if_failed()
-        return SimpleNamespace(rss=self._rss)
+        return SimpleNamespace(rss=self._rss, vms=self._vms)
+
+    def cpu_times(self) -> SimpleNamespace:
+        self._raise_if_failed()
+        return SimpleNamespace(user=self._cpu_user, system=self._cpu_system)
 
     def num_threads(self) -> int:
         self._raise_if_failed()
@@ -70,15 +80,33 @@ class FakeProcess:
 
 
 def test_collects_recursive_process_tree_resources() -> None:
-    grandchild = FakeProcess(3, cpu_values=[0.0, 20.0], rss=30, threads=3)
+    grandchild = FakeProcess(
+        3,
+        cpu_values=[0.0, 20.0],
+        rss=30,
+        vms=300,
+        threads=3,
+        cpu_user=1.5,
+        cpu_system=0.5,
+    )
     child = FakeProcess(
-        2, cpu_values=[0.0, 30.0], rss=50, threads=4, children=[grandchild]
+        2,
+        cpu_values=[0.0, 30.0],
+        rss=50,
+        vms=500,
+        threads=4,
+        cpu_user=2.0,
+        cpu_system=1.0,
+        children=[grandchild],
     )
     root = FakeProcess(
         1,
         cpu_values=[0.0, 50.0],
         rss=100,
+        vms=1000,
         threads=5,
+        cpu_user=4.0,
+        cpu_system=1.0,
         created_at=100.0,
         children=[child],
     )
@@ -88,8 +116,10 @@ def test_collects_recursive_process_tree_resources() -> None:
     assert resources == {
         "cpu_percent": 100.0,
         "cpu_cores": 1.0,
+        "cpu_seconds_total": 10.0,
         "cpu_count": 4.0,
         "rss_bytes": 180,
+        "virtual_memory_bytes": 1800,
         "memory_total_bytes": 1024,
         "main_process_rss_bytes": 100,
         "child_process_rss_bytes": 80,


### PR DESCRIPTION
## Summary

- add Prometheus metrics for Token Router Runtime requests, routing decisions, backend latency/errors, concurrency pools, tokenization, and process resources
- export Supervisor snapshots for Router Agents, Assignments, Runtime health/config state, Tokenizer Asset Bindings, and logical Router availability
- add authenticated Prometheus HTTP service discovery for dynamically assigned Router Runtime ports
- add localized Token Router Grafana dashboards, synchronized alert rules, Alertmanager inhibition examples, and Filebeat Router log inputs
- expose Token Router monitoring metadata in Monitor Center and document the monitoring setup

## Scope

This PR is intentionally limited to Token Router observability. It does not include the separate generic model-replica lifecycle, placement, recovery, or model-load dashboard changes from the local customization history.

## Dependencies

Depends on #5375
Depends on #5379

Please review now if convenient, but merge only after the dependency PRs have landed.

## Validation

- `pytest` focused monitoring/router/API suite: 42 passed
- `npm ci`
- `npm run lint` (existing repository warnings only)
- `npm run build`
- `pre-commit run --files <all changed files>`
- Python `compileall` for changed runtime, API, metrics, and test modules

A broader combined async test invocation reproduced the repository's existing asyncio teardown hang after its completed tests had passed; the focused changed-code suite above completes successfully.
