### PR TITLE
ENH(ui): make image previews adaptive

### DIFF
--- a/frontend/src/components/pages/running-model-detail/panels/result-panels.tsx
+++ b/frontend/src/components/pages/running-model-detail/panels/result-panels.tsx
@@ -163,10 +163,12 @@ function BlobMediaPreview({
   blob,
   type,
   className,
+  thumbnailClassName,
 }: {
   blob: Blob;
   type: MediaType;
   className: string;
+  thumbnailClassName?: string;
 }) {
   const [url, setUrl] = useState<string>();
 
@@ -190,15 +192,36 @@ function BlobMediaPreview({
       url={url}
       title={blob instanceof File ? blob.name : undefined}
       className={className}
+      thumbnailClassName={thumbnailClassName}
     />
   );
 }
 
 function MediaResultPanel({ result, type }: { result: unknown; type: MediaType }) {
   const isAudio = type === 'audio';
-  const mediaClassName = isAudio ? 'w-full max-w-full' : 'h-72 w-full max-w-full';
+  const isImage = type === 'image';
+  const mediaClassName = isAudio
+    ? 'w-full max-w-full'
+    : isImage
+      ? 'h-fit w-fit max-h-72 max-w-full'
+      : 'h-72 w-full max-w-full';
+  const thumbnailClassName = isImage
+    ? 'h-auto max-h-72 w-auto max-w-full object-contain'
+    : undefined;
+  const resultLayoutClassName = isAudio
+    ? 'grid'
+    : isImage
+      ? 'flex flex-wrap items-start'
+      : 'grid grid-cols-2';
   if (result instanceof Blob) {
-    return <BlobMediaPreview blob={result} type={type} className={mediaClassName} />;
+    return (
+      <BlobMediaPreview
+        blob={result}
+        type={type}
+        className={mediaClassName}
+        thumbnailClassName={thumbnailClassName}
+      />
+    );
   }
 
   const mediaResults = extractMediaResults(result, type);
@@ -208,7 +231,7 @@ function MediaResultPanel({ result, type }: { result: unknown; type: MediaType }
   }
 
   return (
-    <div className={cn('grid gap-2', !isAudio && 'grid-cols-2')}>
+    <div className={cn('gap-2', resultLayoutClassName)}>
       {mediaResults.map((item, index) => (
         <MediaPreview
           key={item.title || index}
@@ -216,6 +239,7 @@ function MediaResultPanel({ result, type }: { result: unknown; type: MediaType }
           url={item.url}
           title={item.title}
           className={mediaClassName}
+          thumbnailClassName={thumbnailClassName}
         />
       ))}
     </div>

--- a/frontend/src/components/ui/media-preview.tsx
+++ b/frontend/src/components/ui/media-preview.tsx
@@ -13,6 +13,7 @@ export interface MediaPreviewProps {
   url?: string;
   title?: string;
   className?: string;
+  thumbnailClassName?: string;
 }
 
 function normalizeType(type?: MediaPreviewType) {
@@ -23,7 +24,13 @@ function normalizeType(type?: MediaPreviewType) {
   return 'document';
 }
 
-export function MediaPreview({ type, url, title, className }: MediaPreviewProps) {
+export function MediaPreview({
+  type,
+  url,
+  title,
+  className,
+  thumbnailClassName,
+}: MediaPreviewProps) {
   const [open, setOpen] = useState(false);
   const mediaType = normalizeType(type);
 
@@ -91,9 +98,18 @@ export function MediaPreview({ type, url, title, className }: MediaPreviewProps)
         </span>
         {mediaType === 'image' ? (
           // eslint-disable-next-line @next/next/no-img-element -- Runtime media URLs can be data URLs returned by the model.
-          <img src={url} alt={title || label} className="h-full w-full object-cover" />
+          <img
+            src={url}
+            alt={title || label}
+            className={cn('h-full w-full object-cover', thumbnailClassName)}
+          />
         ) : (
-          <video src={url} muted playsInline className="h-full w-full bg-black object-cover" />
+          <video
+            src={url}
+            muted
+            playsInline
+            className={cn('h-full w-full bg-black object-cover', thumbnailClassName)}
+          />
         )}
         {mediaType === 'image' && (
           <a
@@ -109,7 +125,7 @@ export function MediaPreview({ type, url, title, className }: MediaPreviewProps)
       </div>
 
       <Dialog open={open} onOpenChange={setOpen}>
-        <DialogContent className="max-h-[calc(100vh-4rem)] max-w-[calc(100vw-4rem)] p-4">
+        <DialogContent className="w-fit max-h-[calc(100vh-4rem)] max-w-[calc(100vw-4rem)] p-4 sm:max-w-[calc(100vw-4rem)]">
           <DialogHeader>
             <DialogTitle>{title || label}</DialogTitle>
           </DialogHeader>


### PR DESCRIPTION
## Summary

Improve image generation previews in the Web UI so images remain easy to inspect across different aspect ratios.

## Changes

- Preserve the original aspect ratio of generated image thumbnails.
- Constrain thumbnails with maximum width and height without cropping.
- Use `object-contain` for complete image previews.
- Arrange multiple image results in a compact wrapping layout.
- Remove excessive spacing between portrait thumbnails.
- Allow the detail dialog to exceed the default `sm:max-w-lg` limit.
- Size the detail dialog to fit the displayed image while keeping it within the viewport.
- Keep existing video, audio, and chat preview behavior unchanged.

## Motivation

Generated portrait images were previously cropped into landscape thumbnail containers. Multiple results also occupied equal-width grid columns, creating large empty gaps. The detail dialog was either too small or unnecessarily stretched across the viewport.

This change makes both thumbnails and detail previews follow the image dimensions more closely.

<img width="1169" height="593" alt="ccb78c390b5b6e05749846eff8503c12" src="https://github.com/user-attachments/assets/06582d41-aa36-48ad-bc8f-8f37e4e00b15" />
<img width="1891" height="615" alt="4f913ba9f3e1fa7f261586a522d75870" src="https://github.com/user-attachments/assets/487723e0-faf7-49c9-84f2-a01119d3e5c7" />
<img width="1904" height="936" alt="1a17e28b760682c03b451f054941143f" src="https://github.com/user-attachments/assets/d06a5042-622a-47ed-84b9-aa7b6e05456a" />
<img width="1825" height="1067" alt="1b183b249b06443841d0afe4b56a2b6a" src="https://github.com/user-attachments/assets/8108fcfd-9118-4dad-963f-18664a540fbd" />
