### PR TITLE
fix(venv): honor configured sources in post-install hooks

### DIFF
--- a/xinference/core/tests/test_virtual_env_manager.py
+++ b/xinference/core/tests/test_virtual_env_manager.py
@@ -25,6 +25,7 @@ import subprocess
 import sys
 import threading
 import zipfile
+from pathlib import Path
 from unittest import mock
 
 import pytest
@@ -34,6 +35,7 @@ from ..virtual_env_manager import (
     FLASHINFER_AOT_PACKAGES,
     FLASHINFER_AOT_WHEEL_URL,
     FLASHINFER_CUBIN_WHEEL_URL,
+    _run_uv_install_with_source_fallback,
     apply_flashinfer_aot_post_install,
     build_uv_source_options,
     ensure_flashinfer_cubin_matches_post_install,
@@ -41,6 +43,27 @@ from ..virtual_env_manager import (
     get_engine_critical_dependency_specs,
     needs_flashinfer_aot,
 )
+
+
+def _create_test_wheel(tmp_path: Path, package_name: str) -> Path:
+    module_name = package_name.replace("-", "_")
+    wheel_name = f"{module_name}-1.0.0-py3-none-any.whl"
+    wheel_path = tmp_path / wheel_name
+    with zipfile.ZipFile(wheel_path, "w") as wheel:
+        wheel.writestr(f"{module_name}/__init__.py", '__version__ = "1.0.0"\n')
+        wheel.writestr(
+            f"{module_name}-1.0.0.dist-info/METADATA",
+            f"Metadata-Version: 2.1\nName: {package_name}\nVersion: 1.0.0\n",
+        )
+        wheel.writestr(
+            f"{module_name}-1.0.0.dist-info/WHEEL",
+            "Wheel-Version: 1.0\n"
+            "Generator: xinference-test\n"
+            "Root-Is-Purelib: true\n"
+            "Tag: py3-none-any\n",
+        )
+        wheel.writestr(f"{module_name}-1.0.0.dist-info/RECORD", "")
+    return wheel_path
 
 
 class TestNeedsFlashinferAot:
@@ -208,7 +231,23 @@ class TestBuildUvSourceOptions:
             allow_public_install=False,
         )
 
-        assert options == ["--find-links", "/srv/wheels"]
+        assert options == ["--find-links", "/srv/wheels", "--no-index"]
+
+    def test_configured_only_extra_index_replaces_implicit_public_default(self):
+        options = build_uv_source_options(
+            {
+                "extra_index_url": "https://packages.example/simple",
+                "index_strategy": "unsafe-best-match",
+            },
+            allow_public_install=False,
+        )
+
+        assert options == [
+            "--default-index",
+            "https://packages.example/simple",
+            "--index-strategy",
+            "unsafe-best-match",
+        ]
 
     def test_deduplicates_public_fallback(self):
         options = build_uv_source_options(
@@ -227,27 +266,8 @@ class TestBuildUvSourceOptions:
             pytest.skip("uv is required for the resolver-level source priority test")
 
         package_name = "xinference-source-priority-test"
-        wheel_name = "xinference_source_priority_test-1.0.0-py3-none-any.whl"
-        wheel_path = tmp_path / wheel_name
-        with zipfile.ZipFile(wheel_path, "w") as wheel:
-            wheel.writestr(
-                "xinference_source_priority_test/__init__.py",
-                '__version__ = "1.0.0"\n',
-            )
-            wheel.writestr(
-                "xinference_source_priority_test-1.0.0.dist-info/METADATA",
-                "Metadata-Version: 2.1\n"
-                "Name: xinference-source-priority-test\n"
-                "Version: 1.0.0\n",
-            )
-            wheel.writestr(
-                "xinference_source_priority_test-1.0.0.dist-info/WHEEL",
-                "Wheel-Version: 1.0\n"
-                "Generator: xinference-test\n"
-                "Root-Is-Purelib: true\n"
-                "Tag: py3-none-any\n",
-            )
-            wheel.writestr("xinference_source_priority_test-1.0.0.dist-info/RECORD", "")
+        wheel_path = _create_test_wheel(tmp_path, package_name)
+        wheel_name = wheel_path.name
         wheel_bytes = wheel_path.read_bytes()
         fallback_requests = []
 
@@ -305,6 +325,83 @@ class TestBuildUvSourceOptions:
                 check=False,
                 capture_output=True,
                 text=True,
+            )
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join()
+
+        assert result.returncode == 0, result.stderr
+        assert fallback_requests == []
+
+    def test_find_links_miss_retries_with_public_fallback(self):
+        configured_result = mock.MagicMock(returncode=1, stderr="package missing")
+        fallback_result = mock.MagicMock(returncode=0)
+        public_fallback = "https://public.example/simple"
+
+        with mock.patch(
+            "xinference.core.virtual_env_manager.subprocess.run",
+            side_effect=[configured_result, fallback_result],
+        ) as run_mock:
+            result = _run_uv_install_with_source_fallback(
+                ["uv", "pip", "install"],
+                ["example-package==1.0.0"],
+                {"find_links": "/srv/wheels"},
+                public_index_urls=[public_fallback],
+            )
+
+        assert result is fallback_result
+        assert run_mock.call_count == 2
+        configured_cmd = run_mock.call_args_list[0][0][0]
+        fallback_cmd = run_mock.call_args_list[1][0][0]
+        assert "--no-index" in configured_cmd
+        assert public_fallback not in configured_cmd
+        assert "--no-index" not in fallback_cmd
+        assert public_fallback in fallback_cmd
+        find_links_pos = fallback_cmd.index("--find-links")
+        assert fallback_cmd[find_links_pos + 1] == "/srv/wheels"
+
+    def test_find_links_resolves_before_unavailable_public_fallback(self, tmp_path):
+        uv_path = shutil.which("uv")
+        if uv_path is None:
+            pytest.skip("uv is required for the resolver-level source priority test")
+
+        package_name = "xinference-find-links-priority-test"
+        _create_test_wheel(tmp_path, package_name)
+        fallback_requests = []
+
+        class FallbackHandler(http.server.BaseHTTPRequestHandler):
+            def do_GET(self):
+                fallback_requests.append(self.path)
+                self.send_error(503, "public fallback unavailable")
+
+            def log_message(self, format, *args):
+                pass
+
+        server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), FallbackHandler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            public_fallback = (
+                f"http://127.0.0.1:{server.server_address[1]}/fallback/simple"
+            )
+            result = _run_uv_install_with_source_fallback(
+                [
+                    uv_path,
+                    "pip",
+                    "install",
+                    "--dry-run",
+                    "--no-cache",
+                    "--no-deps",
+                    "--python",
+                    sys.executable,
+                ],
+                [f"{package_name}==1.0.0"],
+                {
+                    "find_links": str(tmp_path),
+                    "index_strategy": "unsafe-best-match",
+                },
+                public_index_urls=[public_fallback],
             )
         finally:
             server.shutdown()
@@ -415,6 +512,7 @@ class TestEnsureFlashinferCubinMatchesPostInstall:
 
         cmd = run_mock.call_args[0][0]
         assert ["--find-links", "/srv/wheels"] == cmd[7:9]
+        assert "--no-index" in cmd
         assert FLASHINFER_CUBIN_WHEEL_URL not in cmd
         assert "FLASHINFER_DISABLE_VERSION_CHECK" not in os.environ
 
@@ -609,10 +707,11 @@ class TestApplyFlashinferAotPostInstall:
 
     def test_extra_index_url_merged_from_conf(self, fake_venv_manager):
         """conf['extra_index_url'] should be merged with flashinfer.ai URL."""
-        result = mock.MagicMock()
-        result.returncode = 0
+        configured_result = mock.MagicMock(returncode=1, stderr="package missing")
+        fallback_result = mock.MagicMock(returncode=0)
         with mock.patch(
-            "xinference.core.virtual_env_manager.subprocess.run", return_value=result
+            "xinference.core.virtual_env_manager.subprocess.run",
+            side_effect=[configured_result, fallback_result],
         ) as run_mock:
             apply_flashinfer_aot_post_install(
                 "vllm",
@@ -621,17 +720,18 @@ class TestApplyFlashinferAotPostInstall:
                 {"extra_index_url": ["https://wheels.vllm.ai/0.19.0/cu130"]},
                 "13.0",
             )
-            cmd = run_mock.call_args[0][0]
+            cmd = run_mock.call_args_list[1][0][0]
             cmd_str = " ".join(cmd)
             assert "wheels.vllm.ai" in cmd_str
             assert "flashinfer.ai" in cmd_str
 
     def test_extra_index_url_string_form(self, fake_venv_manager):
         """conf['extra_index_url'] as string should also be handled."""
-        result = mock.MagicMock()
-        result.returncode = 0
+        configured_result = mock.MagicMock(returncode=1, stderr="package missing")
+        fallback_result = mock.MagicMock(returncode=0)
         with mock.patch(
-            "xinference.core.virtual_env_manager.subprocess.run", return_value=result
+            "xinference.core.virtual_env_manager.subprocess.run",
+            side_effect=[configured_result, fallback_result],
         ) as run_mock:
             apply_flashinfer_aot_post_install(
                 "vllm",
@@ -640,13 +740,33 @@ class TestApplyFlashinferAotPostInstall:
                 {"extra_index_url": "https://wheels.vllm.ai/0.19.0/cu130"},
                 "13.0",
             )
-            cmd = run_mock.call_args[0][0]
+            cmd = run_mock.call_args_list[1][0][0]
             cmd_str = " ".join(cmd)
             assert "wheels.vllm.ai" in cmd_str
             assert "flashinfer.ai" in cmd_str
 
-    def test_reuses_configured_source_options(self, fake_venv_manager):
+    def test_configured_source_success_skips_public_fallback(self, fake_venv_manager):
         result = mock.MagicMock(returncode=0)
+        with mock.patch(
+            "xinference.core.virtual_env_manager.subprocess.run", return_value=result
+        ) as run_mock:
+            apply_flashinfer_aot_post_install(
+                "vllm",
+                ["Qwen3_5MoeForConditionalGeneration"],
+                fake_venv_manager,
+                {"find_links": "/srv/wheels"},
+                "13.0",
+            )
+
+        run_mock.assert_called_once()
+        cmd = run_mock.call_args[0][0]
+        assert ["--find-links", "/srv/wheels"] == cmd[8:10]
+        assert "--no-index" in cmd
+        assert FLASHINFER_AOT_WHEEL_URL not in cmd
+
+    def test_reuses_configured_source_options(self, fake_venv_manager):
+        configured_result = mock.MagicMock(returncode=1, stderr="package missing")
+        fallback_result = mock.MagicMock(returncode=0)
         conf = {
             "index_url": "https://packages.example/simple",
             "find_links": "/srv/wheels",
@@ -654,7 +774,8 @@ class TestApplyFlashinferAotPostInstall:
             "index_strategy": "unsafe-best-match",
         }
         with mock.patch(
-            "xinference.core.virtual_env_manager.subprocess.run", return_value=result
+            "xinference.core.virtual_env_manager.subprocess.run",
+            side_effect=[configured_result, fallback_result],
         ) as run_mock:
             apply_flashinfer_aot_post_install(
                 "vllm",
@@ -664,7 +785,7 @@ class TestApplyFlashinferAotPostInstall:
                 "13.0",
             )
 
-        cmd = run_mock.call_args[0][0]
+        cmd = run_mock.call_args_list[1][0][0]
         private_index_pos = cmd.index("--index")
         public_fallback_pos = cmd.index("--default-index")
         assert cmd[private_index_pos + 1] == "https://packages.example/simple"
@@ -696,6 +817,7 @@ class TestApplyFlashinferAotPostInstall:
         cmd = run_mock.call_args[0][0]
         assert "--find-links" in cmd
         assert "/srv/wheels" in cmd
+        assert "--no-index" in cmd
         assert FLASHINFER_AOT_WHEEL_URL not in cmd
 
     def test_offline_mode_without_source_skips_install(self, fake_venv_manager):

--- a/xinference/core/tests/test_virtual_env_manager.py
+++ b/xinference/core/tests/test_virtual_env_manager.py
@@ -45,24 +45,26 @@ from ..virtual_env_manager import (
 )
 
 
-def _create_test_wheel(tmp_path: Path, package_name: str) -> Path:
+def _create_test_wheel(
+    tmp_path: Path, package_name: str, version: str = "1.0.0"
+) -> Path:
     module_name = package_name.replace("-", "_")
-    wheel_name = f"{module_name}-1.0.0-py3-none-any.whl"
+    wheel_name = f"{module_name}-{version}-py3-none-any.whl"
     wheel_path = tmp_path / wheel_name
     with zipfile.ZipFile(wheel_path, "w") as wheel:
-        wheel.writestr(f"{module_name}/__init__.py", '__version__ = "1.0.0"\n')
+        wheel.writestr(f"{module_name}/__init__.py", f'__version__ = "{version}"\n')
         wheel.writestr(
-            f"{module_name}-1.0.0.dist-info/METADATA",
-            f"Metadata-Version: 2.1\nName: {package_name}\nVersion: 1.0.0\n",
+            f"{module_name}-{version}.dist-info/METADATA",
+            f"Metadata-Version: 2.1\nName: {package_name}\nVersion: {version}\n",
         )
         wheel.writestr(
-            f"{module_name}-1.0.0.dist-info/WHEEL",
+            f"{module_name}-{version}.dist-info/WHEEL",
             "Wheel-Version: 1.0\n"
             "Generator: xinference-test\n"
             "Root-Is-Purelib: true\n"
             "Tag: py3-none-any\n",
         )
-        wheel.writestr(f"{module_name}-1.0.0.dist-info/RECORD", "")
+        wheel.writestr(f"{module_name}-{version}.dist-info/RECORD", "")
     return wheel_path
 
 
@@ -358,8 +360,94 @@ class TestBuildUvSourceOptions:
         assert public_fallback not in configured_cmd
         assert "--no-index" not in fallback_cmd
         assert public_fallback in fallback_cmd
-        find_links_pos = fallback_cmd.index("--find-links")
-        assert fallback_cmd[find_links_pos + 1] == "/srv/wheels"
+        assert "--find-links" not in fallback_cmd
+
+    def test_configured_version_miss_uses_public_fallback(self, tmp_path):
+        uv_path = shutil.which("uv")
+        if uv_path is None:
+            pytest.skip("uv is required for the resolver-level fallback test")
+
+        package_name = "xinference-version-miss-fallback-test"
+        private_dir = tmp_path / "private-files"
+        public_dir = tmp_path / "public-files"
+        private_dir.mkdir()
+        public_dir.mkdir()
+        private_wheel = _create_test_wheel(private_dir, package_name, "0.9.0")
+        public_wheel = _create_test_wheel(public_dir, package_name, "1.0.0")
+        private_requests = []
+        public_requests = []
+
+        class SourceHandler(http.server.BaseHTTPRequestHandler):
+            def do_GET(self):
+                if self.path == f"/private/simple/{package_name}/":
+                    private_requests.append(self.path)
+                    wheel_path = private_wheel
+                elif self.path == f"/public/simple/{package_name}/":
+                    public_requests.append(self.path)
+                    wheel_path = public_wheel
+                elif self.path == f"/files/{private_wheel.name}":
+                    wheel_path = private_wheel
+                    self._send_wheel(wheel_path)
+                    return
+                elif self.path == f"/files/{public_wheel.name}":
+                    wheel_path = public_wheel
+                    self._send_wheel(wheel_path)
+                    return
+                else:
+                    self.send_error(404)
+                    return
+
+                body = (
+                    f'<a href="/files/{wheel_path.name}">{wheel_path.name}</a>'
+                ).encode()
+                self.send_response(200)
+                self.send_header("Content-Type", "text/html")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def _send_wheel(self, wheel_path):
+                body = wheel_path.read_bytes()
+                self.send_response(200)
+                self.send_header("Content-Type", "application/octet-stream")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def log_message(self, format, *args):
+                pass
+
+        server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), SourceHandler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            port = server.server_address[1]
+            result = _run_uv_install_with_source_fallback(
+                [
+                    uv_path,
+                    "pip",
+                    "install",
+                    "--dry-run",
+                    "--no-cache",
+                    "--no-deps",
+                    "--python",
+                    sys.executable,
+                ],
+                [f"{package_name}==1.0.0"],
+                {
+                    "index_url": f"http://127.0.0.1:{port}/private/simple",
+                    "index_strategy": "unsafe-best-match",
+                },
+                public_index_urls=[f"http://127.0.0.1:{port}/public/simple"],
+            )
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join()
+
+        assert result.returncode == 0, result.stderr
+        assert len(private_requests) == 1
+        assert len(public_requests) == 1
 
     def test_find_links_resolves_before_unavailable_public_fallback(self, tmp_path):
         uv_path = shutil.which("uv")
@@ -705,8 +793,7 @@ class TestApplyFlashinferAotPostInstall:
             )
         assert os.environ.get("FLASHINFER_DISABLE_VERSION_CHECK") == "1"
 
-    def test_extra_index_url_merged_from_conf(self, fake_venv_manager):
-        """conf['extra_index_url'] should be merged with flashinfer.ai URL."""
+    def test_extra_index_url_used_before_public_fallback(self, fake_venv_manager):
         configured_result = mock.MagicMock(returncode=1, stderr="package missing")
         fallback_result = mock.MagicMock(returncode=0)
         with mock.patch(
@@ -720,13 +807,17 @@ class TestApplyFlashinferAotPostInstall:
                 {"extra_index_url": ["https://wheels.vllm.ai/0.19.0/cu130"]},
                 "13.0",
             )
-            cmd = run_mock.call_args_list[1][0][0]
-            cmd_str = " ".join(cmd)
-            assert "wheels.vllm.ai" in cmd_str
-            assert "flashinfer.ai" in cmd_str
 
-    def test_extra_index_url_string_form(self, fake_venv_manager):
-        """conf['extra_index_url'] as string should also be handled."""
+        configured_cmd = run_mock.call_args_list[0][0][0]
+        fallback_cmd = run_mock.call_args_list[1][0][0]
+        assert "wheels.vllm.ai" in " ".join(configured_cmd)
+        assert "flashinfer.ai" not in " ".join(configured_cmd)
+        assert "wheels.vllm.ai" not in " ".join(fallback_cmd)
+        assert "flashinfer.ai" in " ".join(fallback_cmd)
+
+    def test_extra_index_url_string_used_before_public_fallback(
+        self, fake_venv_manager
+    ):
         configured_result = mock.MagicMock(returncode=1, stderr="package missing")
         fallback_result = mock.MagicMock(returncode=0)
         with mock.patch(
@@ -740,10 +831,13 @@ class TestApplyFlashinferAotPostInstall:
                 {"extra_index_url": "https://wheels.vllm.ai/0.19.0/cu130"},
                 "13.0",
             )
-            cmd = run_mock.call_args_list[1][0][0]
-            cmd_str = " ".join(cmd)
-            assert "wheels.vllm.ai" in cmd_str
-            assert "flashinfer.ai" in cmd_str
+
+        configured_cmd = run_mock.call_args_list[0][0][0]
+        fallback_cmd = run_mock.call_args_list[1][0][0]
+        assert "wheels.vllm.ai" in " ".join(configured_cmd)
+        assert "flashinfer.ai" not in " ".join(configured_cmd)
+        assert "wheels.vllm.ai" not in " ".join(fallback_cmd)
+        assert "flashinfer.ai" in " ".join(fallback_cmd)
 
     def test_configured_source_success_skips_public_fallback(self, fake_venv_manager):
         result = mock.MagicMock(returncode=0)
@@ -764,7 +858,9 @@ class TestApplyFlashinferAotPostInstall:
         assert "--no-index" in cmd
         assert FLASHINFER_AOT_WHEEL_URL not in cmd
 
-    def test_reuses_configured_source_options(self, fake_venv_manager):
+    def test_reuses_configured_source_options_before_public_fallback(
+        self, fake_venv_manager
+    ):
         configured_result = mock.MagicMock(returncode=1, stderr="package missing")
         fallback_result = mock.MagicMock(returncode=0)
         conf = {
@@ -785,20 +881,27 @@ class TestApplyFlashinferAotPostInstall:
                 "13.0",
             )
 
-        cmd = run_mock.call_args_list[1][0][0]
-        private_index_pos = cmd.index("--index")
-        public_fallback_pos = cmd.index("--default-index")
-        assert cmd[private_index_pos + 1] == "https://packages.example/simple"
-        assert cmd[public_fallback_pos + 1] == FLASHINFER_AOT_WHEEL_URL
-        assert private_index_pos < public_fallback_pos
-        assert "--find-links" in cmd
-        assert "/srv/wheels" in cmd
-        assert "--trusted-host" in cmd
-        assert "packages.example" in cmd
-        assert "--index-strategy" in cmd
-        assert "first-index" in cmd
-        assert "unsafe-best-match" not in cmd
-        assert FLASHINFER_AOT_WHEEL_URL in cmd
+        configured_cmd = run_mock.call_args_list[0][0][0]
+        configured_index_pos = configured_cmd.index("--default-index")
+        assert (
+            configured_cmd[configured_index_pos + 1]
+            == "https://packages.example/simple"
+        )
+        assert "--find-links" in configured_cmd
+        assert "/srv/wheels" in configured_cmd
+        assert "--trusted-host" in configured_cmd
+        assert "packages.example" in configured_cmd
+        assert "--index-strategy" in configured_cmd
+        assert "unsafe-best-match" in configured_cmd
+        assert FLASHINFER_AOT_WHEEL_URL not in configured_cmd
+
+        fallback_cmd = run_mock.call_args_list[1][0][0]
+        fallback_index_pos = fallback_cmd.index("--default-index")
+        assert fallback_cmd[fallback_index_pos + 1] == FLASHINFER_AOT_WHEEL_URL
+        assert "https://packages.example/simple" not in fallback_cmd
+        assert "--find-links" not in fallback_cmd
+        assert "--trusted-host" not in fallback_cmd
+        assert "--index-strategy" not in fallback_cmd
 
     def test_offline_mode_uses_configured_find_links(self, fake_venv_manager):
         result = mock.MagicMock(returncode=0)

--- a/xinference/core/tests/test_virtual_env_manager.py
+++ b/xinference/core/tests/test_virtual_env_manager.py
@@ -17,8 +17,14 @@
 See optimize/20260702/2026070209.md for root cause analysis.
 """
 
+import http.server
 import importlib.metadata
 import os
+import shutil
+import subprocess
+import sys
+import threading
+import zipfile
 from unittest import mock
 
 import pytest
@@ -139,7 +145,7 @@ class TestBuildUvSourceOptions:
             "--trusted-host",
             "packages.example",
             "--index-strategy",
-            "unsafe-best-match",
+            "first-index",
         ]
 
     def test_configured_index_precedes_public_fallback(self):
@@ -156,6 +162,8 @@ class TestBuildUvSourceOptions:
             "https://packages.example/simple",
             "--default-index",
             "https://public.example/simple",
+            "--index-strategy",
+            "first-index",
         ]
 
     def test_multiple_public_fallbacks_follow_configured_sources(self):
@@ -174,6 +182,23 @@ class TestBuildUvSourceOptions:
             "https://public-primary.example/simple",
             "--default-index",
             "https://public-default.example/simple",
+            "--index-strategy",
+            "first-index",
+        ]
+
+    def test_preserves_configured_strategy_without_public_fallback(self):
+        options = build_uv_source_options(
+            {
+                "index_url": "https://packages.example/simple",
+                "index_strategy": "unsafe-best-match",
+            }
+        )
+
+        assert options == [
+            "--default-index",
+            "https://packages.example/simple",
+            "--index-strategy",
+            "unsafe-best-match",
         ]
 
     def test_offline_mode_omits_public_fallbacks(self):
@@ -195,6 +220,99 @@ class TestBuildUvSourceOptions:
             "--index",
             "https://public.example/simple",
         ]
+
+    def test_resolver_does_not_consult_unavailable_public_fallback(self, tmp_path):
+        uv_path = shutil.which("uv")
+        if uv_path is None:
+            pytest.skip("uv is required for the resolver-level source priority test")
+
+        package_name = "xinference-source-priority-test"
+        wheel_name = "xinference_source_priority_test-1.0.0-py3-none-any.whl"
+        wheel_path = tmp_path / wheel_name
+        with zipfile.ZipFile(wheel_path, "w") as wheel:
+            wheel.writestr(
+                "xinference_source_priority_test/__init__.py",
+                '__version__ = "1.0.0"\n',
+            )
+            wheel.writestr(
+                "xinference_source_priority_test-1.0.0.dist-info/METADATA",
+                "Metadata-Version: 2.1\n"
+                "Name: xinference-source-priority-test\n"
+                "Version: 1.0.0\n",
+            )
+            wheel.writestr(
+                "xinference_source_priority_test-1.0.0.dist-info/WHEEL",
+                "Wheel-Version: 1.0\n"
+                "Generator: xinference-test\n"
+                "Root-Is-Purelib: true\n"
+                "Tag: py3-none-any\n",
+            )
+            wheel.writestr("xinference_source_priority_test-1.0.0.dist-info/RECORD", "")
+        wheel_bytes = wheel_path.read_bytes()
+        fallback_requests = []
+
+        class SourceHandler(http.server.BaseHTTPRequestHandler):
+            def do_GET(self):
+                if self.path == f"/private/simple/{package_name}/":
+                    body = (f'<a href="/files/{wheel_name}">{wheel_name}</a>').encode()
+                    self.send_response(200)
+                    self.send_header("Content-Type", "text/html")
+                elif self.path == f"/files/{wheel_name}":
+                    body = wheel_bytes
+                    self.send_response(200)
+                    self.send_header("Content-Type", "application/octet-stream")
+                elif self.path.startswith("/fallback/"):
+                    fallback_requests.append(self.path)
+                    self.send_error(503, "public fallback unavailable")
+                    return
+                else:
+                    self.send_error(404)
+                    return
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def log_message(self, format, *args):
+                pass
+
+        server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), SourceHandler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            port = server.server_address[1]
+            private_index = f"http://127.0.0.1:{port}/private/simple"
+            public_fallback = f"http://127.0.0.1:{port}/fallback/simple"
+            options = build_uv_source_options(
+                {
+                    "index_url": private_index,
+                    "index_strategy": "unsafe-best-match",
+                },
+                public_index_urls=[public_fallback],
+            )
+            result = subprocess.run(
+                [
+                    uv_path,
+                    "pip",
+                    "install",
+                    "--dry-run",
+                    "--no-cache",
+                    "--no-deps",
+                    "--python",
+                    sys.executable,
+                    *options,
+                    f"{package_name}==1.0.0",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join()
+
+        assert result.returncode == 0, result.stderr
+        assert fallback_requests == []
 
 
 class TestEnsureFlashinferCubinMatchesPostInstall:
@@ -557,7 +675,8 @@ class TestApplyFlashinferAotPostInstall:
         assert "--trusted-host" in cmd
         assert "packages.example" in cmd
         assert "--index-strategy" in cmd
-        assert "unsafe-best-match" in cmd
+        assert "first-index" in cmd
+        assert "unsafe-best-match" not in cmd
         assert FLASHINFER_AOT_WHEEL_URL in cmd
 
     def test_offline_mode_uses_configured_find_links(self, fake_venv_manager):

--- a/xinference/core/tests/test_virtual_env_manager.py
+++ b/xinference/core/tests/test_virtual_env_manager.py
@@ -29,6 +29,7 @@ from ..virtual_env_manager import (
     FLASHINFER_AOT_WHEEL_URL,
     FLASHINFER_CUBIN_WHEEL_URL,
     apply_flashinfer_aot_post_install,
+    build_uv_source_options,
     ensure_flashinfer_cubin_matches_post_install,
     ensure_sglang_inherited_packages_compatible_post_install,
     get_engine_critical_dependency_specs,
@@ -111,6 +112,57 @@ class TestNeedsFlashinferAot:
         assert "flashinfer.ai" in FLASHINFER_AOT_WHEEL_URL
 
 
+class TestBuildUvSourceOptions:
+    def test_reuses_all_configured_source_options(self):
+        options = build_uv_source_options(
+            {
+                "index_url": "https://packages.example/simple",
+                "extra_index_url": ["https://cuda.example/simple"],
+                "find_links": ["/srv/wheels", "/opt/wheels"],
+                "trusted_host": "packages.example",
+                "index_strategy": "unsafe-best-match",
+            },
+            public_index_urls=["https://public.example/simple"],
+        )
+
+        assert options == [
+            "--index-url",
+            "https://packages.example/simple",
+            "--extra-index-url",
+            "https://cuda.example/simple",
+            "--extra-index-url",
+            "https://public.example/simple",
+            "--find-links",
+            "/srv/wheels",
+            "--find-links",
+            "/opt/wheels",
+            "--trusted-host",
+            "packages.example",
+            "--index-strategy",
+            "unsafe-best-match",
+        ]
+
+    def test_offline_mode_omits_public_fallbacks(self):
+        options = build_uv_source_options(
+            {"find_links": "/srv/wheels"},
+            public_index_urls=["https://public.example/simple"],
+            allow_public_install=False,
+        )
+
+        assert options == ["--find-links", "/srv/wheels"]
+
+    def test_deduplicates_public_fallback(self):
+        options = build_uv_source_options(
+            {"extra_index_url": "https://public.example/simple"},
+            public_index_urls=["https://public.example/simple"],
+        )
+
+        assert options == [
+            "--extra-index-url",
+            "https://public.example/simple",
+        ]
+
+
 class TestEnsureFlashinferCubinMatchesPostInstall:
     @pytest.fixture
     def fake_venv_manager(self):
@@ -189,6 +241,30 @@ class TestEnsureFlashinferCubinMatchesPostInstall:
 
         run_mock.assert_not_called()
         assert os.environ.get("FLASHINFER_DISABLE_VERSION_CHECK") == "1"
+
+    def test_offline_mismatch_uses_configured_find_links(self, fake_venv_manager):
+        result = mock.MagicMock(returncode=0)
+        with (
+            mock.patch(
+                "xinference.core.virtual_env_manager._get_virtualenv_distribution_version",
+                side_effect=["0.6.14", "0.6.6", "0.6.14"],
+            ),
+            mock.patch(
+                "xinference.core.virtual_env_manager.subprocess.run",
+                return_value=result,
+            ) as run_mock,
+        ):
+            ensure_flashinfer_cubin_matches_post_install(
+                "vllm",
+                fake_venv_manager,
+                allow_public_install=False,
+                conf={"find_links": "/srv/wheels"},
+            )
+
+        cmd = run_mock.call_args[0][0]
+        assert ["--find-links", "/srv/wheels"] == cmd[7:9]
+        assert FLASHINFER_CUBIN_WHEEL_URL not in cmd
+        assert "FLASHINFER_DISABLE_VERSION_CHECK" not in os.environ
 
     def test_non_vllm_engine_is_noop(self, fake_venv_manager):
         with mock.patch(
@@ -416,6 +492,71 @@ class TestApplyFlashinferAotPostInstall:
             cmd_str = " ".join(cmd)
             assert "wheels.vllm.ai" in cmd_str
             assert "flashinfer.ai" in cmd_str
+
+    def test_reuses_configured_source_options(self, fake_venv_manager):
+        result = mock.MagicMock(returncode=0)
+        conf = {
+            "index_url": "https://packages.example/simple",
+            "find_links": "/srv/wheels",
+            "trusted_host": "packages.example",
+            "index_strategy": "unsafe-best-match",
+        }
+        with mock.patch(
+            "xinference.core.virtual_env_manager.subprocess.run", return_value=result
+        ) as run_mock:
+            apply_flashinfer_aot_post_install(
+                "vllm",
+                ["Qwen3_5MoeForConditionalGeneration"],
+                fake_venv_manager,
+                conf,
+                "13.0",
+            )
+
+        cmd = run_mock.call_args[0][0]
+        assert "--index-url" in cmd
+        assert "https://packages.example/simple" in cmd
+        assert "--find-links" in cmd
+        assert "/srv/wheels" in cmd
+        assert "--trusted-host" in cmd
+        assert "packages.example" in cmd
+        assert "--index-strategy" in cmd
+        assert "unsafe-best-match" in cmd
+        assert FLASHINFER_AOT_WHEEL_URL in cmd
+
+    def test_offline_mode_uses_configured_find_links(self, fake_venv_manager):
+        result = mock.MagicMock(returncode=0)
+        with mock.patch(
+            "xinference.core.virtual_env_manager.subprocess.run", return_value=result
+        ) as run_mock:
+            apply_flashinfer_aot_post_install(
+                "vllm",
+                ["Qwen3_5MoeForConditionalGeneration"],
+                fake_venv_manager,
+                {"find_links": "/srv/wheels"},
+                "13.0",
+                allow_public_install=False,
+            )
+
+        cmd = run_mock.call_args[0][0]
+        assert "--find-links" in cmd
+        assert "/srv/wheels" in cmd
+        assert FLASHINFER_AOT_WHEEL_URL not in cmd
+
+    def test_offline_mode_without_source_skips_install(self, fake_venv_manager):
+        with mock.patch(
+            "xinference.core.virtual_env_manager.subprocess.run"
+        ) as run_mock:
+            apply_flashinfer_aot_post_install(
+                "vllm",
+                ["Qwen3_5MoeForConditionalGeneration"],
+                fake_venv_manager,
+                {},
+                "13.0",
+                allow_public_install=False,
+            )
+
+        run_mock.assert_not_called()
+        assert "FLASHINFER_DISABLE_VERSION_CHECK" not in os.environ
 
     def test_skipped_for_non_cu130_cuda(self, fake_venv_manager):
         """CUDA 12.x must skip — AOT packages are +cu130 only."""

--- a/xinference/core/tests/test_virtual_env_manager.py
+++ b/xinference/core/tests/test_virtual_env_manager.py
@@ -126,11 +126,11 @@ class TestBuildUvSourceOptions:
         )
 
         assert options == [
-            "--index-url",
-            "https://packages.example/simple",
-            "--extra-index-url",
+            "--index",
             "https://cuda.example/simple",
-            "--extra-index-url",
+            "--index",
+            "https://packages.example/simple",
+            "--default-index",
             "https://public.example/simple",
             "--find-links",
             "/srv/wheels",
@@ -140,6 +140,40 @@ class TestBuildUvSourceOptions:
             "packages.example",
             "--index-strategy",
             "unsafe-best-match",
+        ]
+
+    def test_configured_index_precedes_public_fallback(self):
+        options = build_uv_source_options(
+            {"index_url": "https://packages.example/simple"},
+            public_index_urls=["https://public.example/simple"],
+        )
+
+        # uv prioritizes --index over --default-index. This verifies the
+        # configured corporate mirror is effective before the public fallback,
+        # rather than merely checking that both flags are present.
+        assert options == [
+            "--index",
+            "https://packages.example/simple",
+            "--default-index",
+            "https://public.example/simple",
+        ]
+
+    def test_multiple_public_fallbacks_follow_configured_sources(self):
+        options = build_uv_source_options(
+            {"index_url": "https://packages.example/simple"},
+            public_index_urls=[
+                "https://public-primary.example/simple",
+                "https://public-default.example/simple",
+            ],
+        )
+
+        assert options == [
+            "--index",
+            "https://packages.example/simple",
+            "--index",
+            "https://public-primary.example/simple",
+            "--default-index",
+            "https://public-default.example/simple",
         ]
 
     def test_offline_mode_omits_public_fallbacks(self):
@@ -158,7 +192,7 @@ class TestBuildUvSourceOptions:
         )
 
         assert options == [
-            "--extra-index-url",
+            "--index",
             "https://public.example/simple",
         ]
 
@@ -513,8 +547,11 @@ class TestApplyFlashinferAotPostInstall:
             )
 
         cmd = run_mock.call_args[0][0]
-        assert "--index-url" in cmd
-        assert "https://packages.example/simple" in cmd
+        private_index_pos = cmd.index("--index")
+        public_fallback_pos = cmd.index("--default-index")
+        assert cmd[private_index_pos + 1] == "https://packages.example/simple"
+        assert cmd[public_fallback_pos + 1] == FLASHINFER_AOT_WHEEL_URL
+        assert private_index_pos < public_fallback_pos
         assert "--find-links" in cmd
         assert "/srv/wheels" in cmd
         assert "--trusted-host" in cmd

--- a/xinference/core/virtual_env_manager.py
+++ b/xinference/core/virtual_env_manager.py
@@ -1034,10 +1034,61 @@ def ensure_sglang_inherited_packages_compatible_post_install(
         )
 
 
+def _as_uv_option_values(value: Any) -> List[str]:
+    if not value:
+        return []
+    return [value] if isinstance(value, str) else list(value)
+
+
+def build_uv_source_options(
+    conf: Dict[str, Any],
+    *,
+    public_index_urls: Optional[List[str]] = None,
+    allow_public_install: bool = True,
+) -> List[str]:
+    """Build uv source options from the virtualenv install configuration.
+
+    Post-install hooks invoke ``uv`` directly, so they must explicitly reuse the
+    same package sources as the main virtualenv installation. Administrator-
+    supplied public indexes are appended as fallbacks only when public installs
+    are allowed.
+    """
+    options: List[str] = []
+    index_url = conf.get("index_url")
+    if index_url:
+        options += ["--index-url", index_url]
+
+    extra_index_urls = _as_uv_option_values(conf.get("extra_index_url"))
+    if allow_public_install:
+        configured_urls = {index_url, *extra_index_urls}
+        extra_index_urls.extend(
+            url
+            for url in (public_index_urls or [])
+            if url and url not in configured_urls
+        )
+    for url in extra_index_urls:
+        options += ["--extra-index-url", url]
+
+    for link in _as_uv_option_values(conf.get("find_links")):
+        options += ["--find-links", link]
+    for host in _as_uv_option_values(conf.get("trusted_host")):
+        options += ["--trusted-host", host]
+
+    index_strategy = conf.get("index_strategy")
+    if index_strategy:
+        options += ["--index-strategy", index_strategy]
+    return options
+
+
+def _has_configured_package_source(conf: Dict[str, Any]) -> bool:
+    return any(conf.get(key) for key in ("index_url", "extra_index_url", "find_links"))
+
+
 def ensure_flashinfer_cubin_matches_post_install(
     model_engine: Optional[str],
     virtual_env_manager: Any,
     allow_public_install: bool = True,
+    conf: Optional[Dict[str, Any]] = None,
 ) -> None:
     """Keep FlashInfer's Python package and cubin package on the same version.
 
@@ -1072,7 +1123,8 @@ def ensure_flashinfer_cubin_matches_post_install(
         cubin_version or "not installed",
     )
 
-    if allow_public_install:
+    conf = conf or {}
+    if allow_public_install or _has_configured_package_source(conf):
         uv_path = None
         if hasattr(virtual_env_manager, "_get_uv_path"):
             try:
@@ -1090,10 +1142,13 @@ def ensure_flashinfer_cubin_matches_post_install(
             str(virtual_env_manager.env_path),
             "--no-deps",
             "--upgrade",
-            "--index-url",
-            FLASHINFER_CUBIN_WHEEL_URL,
-            f"flashinfer-cubin=={python_version}",
         ]
+        cmd += build_uv_source_options(
+            conf,
+            public_index_urls=[FLASHINFER_CUBIN_WHEEL_URL],
+            allow_public_install=allow_public_install,
+        )
+        cmd.append(f"flashinfer-cubin=={python_version}")
         try:
             result = subprocess.run(cmd, check=False, capture_output=True, text=True)
             if result.returncode == 0:
@@ -1152,6 +1207,7 @@ def apply_flashinfer_aot_post_install(
     virtual_env_manager: Any,
     conf: Dict[str, Any],
     cuda_version: Optional[str] = None,
+    allow_public_install: bool = True,
 ) -> None:
     """Post-install hook: force-upgrade flashinfer to AOT versions for sm_120.
 
@@ -1178,14 +1234,12 @@ def apply_flashinfer_aot_post_install(
         list(architectures or []),
     )
 
-    extra_urls = conf.get("extra_index_url") or []
-    if isinstance(extra_urls, str):
-        extra_urls = [extra_urls]
-    extra_urls = (
-        list(extra_urls) + [FLASHINFER_AOT_WHEEL_URL]
-        if extra_urls
-        else [FLASHINFER_AOT_WHEEL_URL]
-    )
+    if not allow_public_install and not _has_configured_package_source(conf):
+        logger.info(
+            "Skipping the FlashInfer AOT post-install because public installs "
+            "are disabled and no package source is configured"
+        )
+        return
 
     # Resolve uv path with a fallback. ``_get_uv_path`` is a private method
     # on xoscar's VirtualEnvManager and could be renamed/removed in future
@@ -1209,8 +1263,11 @@ def apply_flashinfer_aot_post_install(
         "--upgrade",
         "--color=always",
     ]
-    for url in extra_urls:
-        cmd += ["--extra-index-url", url]
+    cmd += build_uv_source_options(
+        conf,
+        public_index_urls=[FLASHINFER_AOT_WHEEL_URL],
+        allow_public_install=allow_public_install,
+    )
     cmd += FLASHINFER_AOT_PACKAGES
 
     try:

--- a/xinference/core/virtual_env_manager.py
+++ b/xinference/core/virtual_env_manager.py
@@ -1055,19 +1055,41 @@ def build_uv_source_options(
     """
     options: List[str] = []
     index_url = conf.get("index_url")
-    if index_url:
-        options += ["--index-url", index_url]
-
     extra_index_urls = _as_uv_option_values(conf.get("extra_index_url"))
-    if allow_public_install:
-        configured_urls = {index_url, *extra_index_urls}
-        extra_index_urls.extend(
+
+    # uv gives every --index / --extra-index-url entry higher priority than
+    # --default-index / --index-url. Keep the configured sources in their
+    # original effective order (extra indexes before index_url), then place the
+    # hook-specific public indexes after all of them. The final public index is
+    # the default index so it is a true lowest-priority fallback.
+    configured_index_urls = [*extra_index_urls]
+    if index_url:
+        configured_index_urls.append(index_url)
+    configured_url_set = set(configured_index_urls)
+    public_fallback_urls = (
+        [
             url
             for url in (public_index_urls or [])
-            if url and url not in configured_urls
-        )
-    for url in extra_index_urls:
-        options += ["--extra-index-url", url]
+            if url and url not in configured_url_set
+        ]
+        if allow_public_install
+        else []
+    )
+
+    default_index_url: Optional[str]
+    if public_fallback_urls:
+        priority_index_urls = configured_index_urls + public_fallback_urls[:-1]
+        default_index_url = public_fallback_urls[-1]
+    else:
+        # Preserve uv's existing configured-source semantics when no public
+        # fallback is added: extra_index_url entries outrank index_url.
+        priority_index_urls = extra_index_urls
+        default_index_url = index_url
+
+    for url in priority_index_urls:
+        options += ["--index", url]
+    if default_index_url:
+        options += ["--default-index", default_index_url]
 
     for link in _as_uv_option_values(conf.get("find_links")):
         options += ["--find-links", link]

--- a/xinference/core/virtual_env_manager.py
+++ b/xinference/core/virtual_env_manager.py
@@ -1080,6 +1080,12 @@ def build_uv_source_options(
     if public_fallback_urls:
         priority_index_urls = configured_index_urls + public_fallback_urls[:-1]
         default_index_url = public_fallback_urls[-1]
+    elif not allow_public_install and configured_index_urls:
+        # Avoid uv's implicit PyPI default during a configured-source-only
+        # attempt. Keep the final configured URL as the explicit default while
+        # preserving the effective priority of the preceding URLs.
+        priority_index_urls = configured_index_urls[:-1]
+        default_index_url = configured_index_urls[-1]
     else:
         # Preserve uv's existing configured-source semantics when no public
         # fallback is added: extra_index_url entries outrank index_url.
@@ -1091,8 +1097,14 @@ def build_uv_source_options(
     if default_index_url:
         options += ["--default-index", default_index_url]
 
-    for link in _as_uv_option_values(conf.get("find_links")):
+    find_links = _as_uv_option_values(conf.get("find_links"))
+    for link in find_links:
         options += ["--find-links", link]
+    # ``--find-links`` supplements registry indexes; it does not disable uv's
+    # implicit default index. A configured-source-only attempt must therefore
+    # opt out explicitly when find-links is the only configured source.
+    if not allow_public_install and find_links and not configured_index_urls:
+        options.append("--no-index")
     for host in _as_uv_option_values(conf.get("trusted_host")):
         options += ["--trusted-host", host]
 
@@ -1113,6 +1125,49 @@ def build_uv_source_options(
 
 def _has_configured_package_source(conf: Dict[str, Any]) -> bool:
     return any(conf.get(key) for key in ("index_url", "extra_index_url", "find_links"))
+
+
+def _run_uv_install_with_source_fallback(
+    base_cmd: List[str],
+    packages: List[str],
+    conf: Dict[str, Any],
+    *,
+    public_index_urls: Optional[List[str]] = None,
+    allow_public_install: bool = True,
+) -> subprocess.CompletedProcess:
+    """Run uv with configured sources before consulting public fallbacks."""
+    if (
+        allow_public_install
+        and public_index_urls
+        and _has_configured_package_source(conf)
+    ):
+        configured_cmd = base_cmd + build_uv_source_options(
+            conf, allow_public_install=False
+        )
+        result = subprocess.run(
+            configured_cmd + packages,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            return result
+        logger.info(
+            "Post-install requirements were not satisfied by configured package "
+            "sources; retrying with the allowed public fallback"
+        )
+
+    cmd = base_cmd + build_uv_source_options(
+        conf,
+        public_index_urls=public_index_urls,
+        allow_public_install=allow_public_install,
+    )
+    return subprocess.run(
+        cmd + packages,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
 
 
 def ensure_flashinfer_cubin_matches_post_install(
@@ -1174,14 +1229,14 @@ def ensure_flashinfer_cubin_matches_post_install(
             "--no-deps",
             "--upgrade",
         ]
-        cmd += build_uv_source_options(
-            conf,
-            public_index_urls=[FLASHINFER_CUBIN_WHEEL_URL],
-            allow_public_install=allow_public_install,
-        )
-        cmd.append(f"flashinfer-cubin=={python_version}")
         try:
-            result = subprocess.run(cmd, check=False, capture_output=True, text=True)
+            result = _run_uv_install_with_source_fallback(
+                cmd,
+                [f"flashinfer-cubin=={python_version}"],
+                conf,
+                public_index_urls=[FLASHINFER_CUBIN_WHEEL_URL],
+                allow_public_install=allow_public_install,
+            )
             if result.returncode == 0:
                 repaired_version = _get_virtualenv_distribution_version(
                     virtual_env_manager, "flashinfer-cubin"
@@ -1294,15 +1349,14 @@ def apply_flashinfer_aot_post_install(
         "--upgrade",
         "--color=always",
     ]
-    cmd += build_uv_source_options(
-        conf,
-        public_index_urls=[FLASHINFER_AOT_WHEEL_URL],
-        allow_public_install=allow_public_install,
-    )
-    cmd += FLASHINFER_AOT_PACKAGES
-
     try:
-        result = subprocess.run(cmd, check=False, capture_output=True, text=True)
+        result = _run_uv_install_with_source_fallback(
+            cmd,
+            FLASHINFER_AOT_PACKAGES,
+            conf,
+            public_index_urls=[FLASHINFER_AOT_WHEEL_URL],
+            allow_public_install=allow_public_install,
+        )
         if result.returncode == 0:
             logger.info(
                 "Post-install: flashinfer AOT upgrade SUCCEEDED — "

--- a/xinference/core/virtual_env_manager.py
+++ b/xinference/core/virtual_env_manager.py
@@ -1096,7 +1096,16 @@ def build_uv_source_options(
     for host in _as_uv_option_values(conf.get("trusted_host")):
         options += ["--trusted-host", host]
 
-    index_strategy = conf.get("index_strategy")
+    # ``unsafe-best-match`` queries every index even after a configured source
+    # provides the pinned package. An unavailable hook-specific public fallback
+    # would therefore still fail the whole install. Use first-index semantics
+    # whenever a public fallback is appended so configured sources remain
+    # authoritative; otherwise preserve the caller's existing strategy.
+    index_strategy = (
+        "first-index"
+        if configured_index_urls and public_fallback_urls
+        else conf.get("index_strategy")
+    )
     if index_strategy:
         options += ["--index-strategy", index_strategy]
     return options

--- a/xinference/core/virtual_env_manager.py
+++ b/xinference/core/virtual_env_manager.py
@@ -1136,6 +1136,7 @@ def _run_uv_install_with_source_fallback(
     allow_public_install: bool = True,
 ) -> subprocess.CompletedProcess:
     """Run uv with configured sources before consulting public fallbacks."""
+    source_conf = conf
     if (
         allow_public_install
         and public_index_urls
@@ -1156,9 +1157,14 @@ def _run_uv_install_with_source_fallback(
             "Post-install requirements were not satisfied by configured package "
             "sources; retrying with the allowed public fallback"
         )
+        # Retry against the hook-specific fallback independently. With uv's
+        # first-index semantics, retaining a configured index that contains the
+        # project at a different version would prevent the fallback from ever
+        # being considered.
+        source_conf = {}
 
     cmd = base_cmd + build_uv_source_options(
-        conf,
+        source_conf,
         public_index_urls=public_index_urls,
         allow_public_install=allow_public_install,
     )

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -3372,23 +3372,20 @@ class WorkerActor(xo.StatelessActor):
                 ensure_sglang_inherited_packages_compatible_post_install(
                     model_engine, virtual_env_manager
                 )
-                if XINFERENCE_VIRTUAL_ENV_OFFLINE_INSTALL:
-                    logger.info(
-                        "Skipping the FlashInfer AOT post-install from its public "
-                        "wheel index in explicit offline-install mode"
-                    )
-                else:
-                    apply_flashinfer_aot_post_install(
-                        model_engine,
-                        architectures,
-                        virtual_env_manager,
-                        conf,
-                        cuda_version,
-                    )
+                allow_public_install = not XINFERENCE_VIRTUAL_ENV_OFFLINE_INSTALL
+                apply_flashinfer_aot_post_install(
+                    model_engine,
+                    architectures,
+                    virtual_env_manager,
+                    conf,
+                    cuda_version,
+                    allow_public_install=allow_public_install,
+                )
                 ensure_flashinfer_cubin_matches_post_install(
                     model_engine,
                     virtual_env_manager,
-                    allow_public_install=not XINFERENCE_VIRTUAL_ENV_OFFLINE_INSTALL,
+                    allow_public_install=allow_public_install,
+                    conf=conf,
                 )
 
                 # Apply engine-specific post-install patches.  These mutate files


### PR DESCRIPTION
## Summary

- reuse the virtualenv `index_url`, `extra_index_url`, `find_links`, `trusted_host`, and `index_strategy` settings in FlashInfer post-install commands
- keep hook-specific public indexes as online fallbacks without overriding configured package sources
- allow explicit offline installs to use configured private indexes or local find-links while continuing to block public fallback indexes
- pass the resolved virtualenv install configuration to both FlashInfer post-install hooks

## Motivation

The main virtualenv installation already honors configured package sources, but the FlashInfer AOT and cubin synchronization hooks invoke `uv` directly. Those commands previously ignored part or all of the resolved source configuration, which could break private-mirror and offline installations after the main package install had succeeded.

## Tests

- `pytest -q xinference/core/tests/test_virtual_env_manager.py`
- `pytest -q xinference/core/tests/test_utils.py`
- `pre-commit run --files xinference/core/virtual_env_manager.py xinference/core/worker.py xinference/core/tests/test_virtual_env_manager.py`
