### PR TITLE
feat(ui): add per-launch virtualenv find-links

### DIFF
--- a/frontend/src/components/pages/launch-model/launch-dialog/advanced-config.tsx
+++ b/frontend/src/components/pages/launch-model/launch-dialog/advanced-config.tsx
@@ -133,6 +133,14 @@ const AdvancedConfig: FC<AdvancedConfigProps> = ({
         </div>
 
         <div className="p-2">
+          <CommonFormList
+            name="virtual_env_find_links"
+            label={t('launchModel.virtualEnvFindLinks')}
+            onlyValue
+          />
+        </div>
+
+        <div className="p-2">
           <CommonFormList name="envs" label={t('launchModel.envVariable')} />
         </div>
       </ConfigSection>

--- a/frontend/src/components/pages/launch-model/utils.tsx
+++ b/frontend/src/components/pages/launch-model/utils.tsx
@@ -461,6 +461,7 @@ export function transformFormToFetch(values: FormValues) {
   applyNestedFormListObject(nextValues, 'peft_model_config', 'image_lora_load_kwargs');
   applyNestedFormListObject(nextValues, 'peft_model_config', 'image_lora_fuse_kwargs');
   transformOnlyValueFormListToArray(nextValues, 'virtual_env_packages');
+  transformOnlyValueFormListToArray(nextValues, 'virtual_env_find_links');
   deleteNestedEmptyArrayField(nextValues, 'peft_model_config', 'lora_list');
 
   if (nextValues?.enable_virtual_env === 'unset') {
@@ -545,6 +546,7 @@ export function transformFetchToForm(values: FormValues) {
   restoreFormListObject(nextValues, 'quantization_config');
   restoreFormListObject(nextValues, 'envs');
   transformArrayToOnlyValueFormList(nextValues, 'virtual_env_packages');
+  transformArrayToOnlyValueFormList(nextValues, 'virtual_env_find_links');
   restoreKwargsFormList(nextValues);
   restoreNestedFormListObject(nextValues, 'peft_model_config', 'image_lora_load_kwargs');
   restoreNestedFormListObject(nextValues, 'peft_model_config', 'image_lora_fuse_kwargs');
@@ -783,6 +785,12 @@ export function generateCommandLineStatement(params: FormValues) {
           .map((pkg) => `--virtual-env-package ${quoteCommandValue(pkg)}`);
       }
 
+      if (key === 'virtual_env_find_links' && Array.isArray(value)) {
+        return value
+          .filter((path) => !isEmptyCommandValue(path))
+          .map((path) => `--virtual-env-find-link ${quoteCommandValue(path)}`);
+      }
+
       if (key === 'enable_virtual_env') {
         if (value === true) return '--enable-virtual-env';
         if (value === false) return '--disable-virtual-env';
@@ -817,6 +825,7 @@ export function parseXinferenceCommand(command: string) {
   };
   const quantizationConfig: Record<string, unknown> = {};
   const virtualEnvPackages: string[] = [];
+  const virtualEnvFindLinks: string[] = [];
   const envs: Record<string, unknown> = {};
   const args =
     tokens[0] === 'xinference' && tokens[1] === 'launch'
@@ -898,6 +907,13 @@ export function parseXinferenceCommand(command: string) {
       continue;
     }
 
+    if (normalizedKey === 'virtual_env_find_link') {
+      if (value) {
+        virtualEnvFindLinks.push(value);
+      }
+      continue;
+    }
+
     if (normalizedKey === 'env') {
       setObjectPair(envs, valueTokens);
       continue;
@@ -925,6 +941,10 @@ export function parseXinferenceCommand(command: string) {
 
   if (virtualEnvPackages.length > 0) {
     params.virtual_env_packages = virtualEnvPackages;
+  }
+
+  if (virtualEnvFindLinks.length > 0) {
+    params.virtual_env_find_links = virtualEnvFindLinks;
   }
 
   if (Object.keys(envs).length > 0) {

--- a/frontend/src/constants/launch.ts
+++ b/frontend/src/constants/launch.ts
@@ -155,5 +155,6 @@ export const ALL_FORM_KEYS = [
   'multimodal_projector',
   'enable_virtual_env',
   'virtual_env_packages',
+  'virtual_env_find_links',
   'envs',
 ];

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -551,6 +551,7 @@ const en = {
     virtualEnvConfig: 'Virtual Environments Config',
     modelVirtualEnv: 'Model Virtual Environments',
     virtualEnvPackage: 'Virtual Environment Packages',
+    virtualEnvFindLinks: 'Local Wheel Directories',
     envVariable: 'Environment Variables',
     envVariableConfig: 'Environment Variable Config',
     additionalQuantizationParametersForInferenceEngine:

--- a/frontend/src/i18n/locales/ja.ts
+++ b/frontend/src/i18n/locales/ja.ts
@@ -537,6 +537,7 @@ const ja = {
     virtualEnvConfig: '仮想環境の設定',
     modelVirtualEnv: 'モデルの仮想環境',
     virtualEnvPackage: '仮想環境パッケージ',
+    virtualEnvFindLinks: 'ローカル Wheel ディレクトリ',
     envVariable: '環境変数',
     envVariableConfig: '環境変数の設定',
     additionalQuantizationParametersForInferenceEngine:

--- a/frontend/src/i18n/locales/ko.ts
+++ b/frontend/src/i18n/locales/ko.ts
@@ -536,6 +536,7 @@ const ko = {
     virtualEnvConfig: '가상 환경 설정',
     modelVirtualEnv: '모델 가상 환경',
     virtualEnvPackage: '가상 환경 패키지',
+    virtualEnvFindLinks: '로컬 Wheel 디렉터리',
     envVariable: '환경 변수',
     envVariableConfig: '환경 변수 설정',
     additionalQuantizationParametersForInferenceEngine: '추론 엔진에 전달되는 추가 양자화 매개변수',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -529,6 +529,7 @@ const zh = {
     virtualEnvConfig: '虚拟空间配置',
     modelVirtualEnv: '模型虚拟空间',
     virtualEnvPackage: '虚拟空间安装包',
+    virtualEnvFindLinks: '本地 Wheel 目录',
     envVariable: '环境变量',
     envVariableConfig: '环境变量配置',
     additionalQuantizationParametersForInferenceEngine: '传递给推理引擎的量化参数',


### PR DESCRIPTION
## Summary

- add a repeatable Local Wheel Directories field to the model launch runtime-environment form
- serialize `virtual_env_find_links` into launch requests and restore it into form state
- include the field in launch parameter filtering
- generate repeated `--virtual-env-find-link` CLI arguments and parse them back from launch commands
- add English, Chinese, Japanese, and Korean labels

## Dependency

Depends on #5387, which adds the secure backend, client, and CLI support for per-launch find-links.

This PR is intentionally stacked on #5387 (and transitively #5386). Shared commits will disappear from this PR after the dependencies are merged.

## Validation

- `npx prettier --check` on all modified frontend files
- `npx eslint .` (passed with 56 pre-existing warnings and no errors)
- `npm run build`
- `pre-commit run --files <modified files>`
