### PR TITLE
feat(api): add unified Anthropic Messages protocol adapter

### DIFF
--- a/xinference/api/oauth2/advanced/auth_service.py
+++ b/xinference/api/oauth2/advanced/auth_service.py
@@ -375,6 +375,11 @@ class AdvancedAuthService:
         security_scopes: SecurityScopes,
         token: Annotated[Optional[str], Depends(oauth2_scheme)] = None,
     ):
+        if request.url.path in {"/v1/messages", "/anthropic/v1/messages"}:
+            # Anthropic clients send the same Xinference credential in
+            # ``x-api-key`` rather than an Authorization header.
+            token = token or request.headers.get("x-api-key", "").strip() or None
+
         try:
             from .audit import (
                 classify_endpoint,

--- a/xinference/api/oauth2/advanced/auth_service.py
+++ b/xinference/api/oauth2/advanced/auth_service.py
@@ -24,6 +24,7 @@ from fastapi.security import OAuth2PasswordBearer, SecurityScopes
 from jose import JWTError, jwt
 from typing_extensions import Annotated
 
+from ...utils import get_request_route_path
 from .cache import ApiKeyCache, ApiKeyCacheEntry
 from .crypto import (
     aes_decrypt,
@@ -375,7 +376,10 @@ class AdvancedAuthService:
         security_scopes: SecurityScopes,
         token: Annotated[Optional[str], Depends(oauth2_scheme)] = None,
     ):
-        if request.url.path in {"/v1/messages", "/anthropic/v1/messages"}:
+        if get_request_route_path(request) in {
+            "/v1/messages",
+            "/anthropic/v1/messages",
+        }:
             # Anthropic clients send the same Xinference credential in
             # ``x-api-key`` rather than an Authorization header.
             token = token or request.headers.get("x-api-key", "").strip() or None

--- a/xinference/api/protocols/__init__.py
+++ b/xinference/api/protocols/__init__.py
@@ -1,0 +1,20 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+"""Protocol adapters used by the public REST API."""
+
+from .anthropic import (
+    AnthropicProtocolError,
+    CanonicalChatRequest,
+    anthropic_error_response,
+    anthropic_stream_events,
+    openai_to_anthropic,
+    parse_anthropic_request,
+)
+
+__all__ = [
+    "AnthropicProtocolError",
+    "CanonicalChatRequest",
+    "anthropic_error_response",
+    "anthropic_stream_events",
+    "openai_to_anthropic",
+    "parse_anthropic_request",
+]

--- a/xinference/api/protocols/anthropic.py
+++ b/xinference/api/protocols/anthropic.py
@@ -199,9 +199,9 @@ def _normalize_messages(raw_system: Any, raw_messages: Any) -> List[Dict[str, An
                 message["tool_calls"] = tool_calls
             normalized.append(message)
         else:
+            normalized.extend(tool_results)
             if text_parts:
                 normalized.append({"role": "user", "content": "\n".join(text_parts)})
-            normalized.extend(tool_results)
 
     if system_parts:
         normalized.insert(0, {"role": "system", "content": "\n".join(system_parts)})
@@ -332,6 +332,10 @@ def parse_anthropic_request(raw_body: Any) -> CanonicalChatRequest:
                 or thinking_budget <= 0
             ):
                 raise _invalid("Enabled thinking requires a positive budget_tokens")
+            if thinking_budget < 1024:
+                raise _invalid(
+                    "thinking.budget_tokens must be greater than or equal to 1024"
+                )
             if thinking_budget >= max_tokens:
                 raise _invalid("thinking.budget_tokens must be less than max_tokens")
 
@@ -371,9 +375,9 @@ def openai_to_anthropic(openai_response: Dict[str, Any], model: str) -> Dict[str
         choice = choices[0]
         finish_reason = choice.get("finish_reason") or "stop"
         message = choice.get("message") or {}
-        reasoning = message.get("reasoning_content")
-        if isinstance(reasoning, str) and reasoning:
-            content_blocks.append({"type": "thinking", "thinking": reasoning})
+        # OpenAI-compatible reasoning_content does not carry Anthropic's
+        # required opaque signature. Omitting it avoids emitting an invalid
+        # thinking block or exposing internal reasoning as ordinary text.
         content = message.get("content")
         if isinstance(content, str) and content:
             content_blocks.append({"type": "text", "text": content})
@@ -434,7 +438,9 @@ async def anthropic_stream_events(
     Anthropic content blocks are strictly sequential: a block must be stopped
     before the next block starts. OpenAI tool calls can be fragmented and even
     interleaved by index, so tool fragments are buffered and emitted as complete
-    sequential Anthropic blocks after text/reasoning streaming finishes.
+    sequential Anthropic blocks after text streaming finishes. Unsigned OpenAI
+    reasoning deltas are omitted because they cannot form valid Anthropic thinking
+    blocks.
     """
 
     message_id = f"msg_{uuid.uuid4().hex}"
@@ -495,31 +501,21 @@ async def anthropic_stream_events(
 
             choice = choices[0]
             delta = choice.get("delta") or {}
-            for kind, value, delta_type, field in (
-                (
-                    "thinking",
-                    delta.get("reasoning_content"),
-                    "thinking_delta",
-                    "thinking",
-                ),
-                ("text", delta.get("content"), "text_delta", "text"),
-            ):
-                if not isinstance(value, str) or not value:
-                    continue
-                if active_kind != kind:
+            value = delta.get("content")
+            if isinstance(value, str) and value:
+                if active_kind != "text":
                     if active_index is not None:
                         yield block_stop(active_index)
                     active_index = next_index
                     next_index += 1
-                    active_kind = kind
-                    content_block = {"type": kind, field: ""}
+                    active_kind = "text"
                     yield {
                         "event": "content_block_start",
                         "data": json.dumps(
                             {
                                 "type": "content_block_start",
                                 "index": active_index,
-                                "content_block": content_block,
+                                "content_block": {"type": "text", "text": ""},
                             }
                         ),
                     }
@@ -529,7 +525,7 @@ async def anthropic_stream_events(
                         {
                             "type": "content_block_delta",
                             "index": active_index,
-                            "delta": {"type": delta_type, field: value},
+                            "delta": {"type": "text_delta", "text": value},
                         }
                     ),
                 }

--- a/xinference/api/protocols/anthropic.py
+++ b/xinference/api/protocols/anthropic.py
@@ -1,0 +1,612 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+"""Anthropic Messages protocol adapter.
+
+The public Anthropic protocol terminates in the Supervisor.  Both physical
+models and Token Router virtual models consume the same OpenAI-compatible
+canonical request and produce the same Anthropic response representation.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import dataclass
+from typing import Any, AsyncIterator, Dict, List, Optional
+
+
+class AnthropicProtocolError(ValueError):
+    def __init__(
+        self,
+        status_code: int,
+        error_type: str,
+        message: str,
+        *,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.error_type = error_type
+        self.message = message
+        self.headers = headers or {}
+
+
+@dataclass(frozen=True)
+class CanonicalChatRequest:
+    requested_model: str
+    messages: List[Dict[str, Any]]
+    max_output_tokens: int
+    stream: bool
+    stop: Optional[List[str]]
+    temperature: Optional[float]
+    top_p: Optional[float]
+    top_k: Optional[int]
+    tools: Optional[List[Dict[str, Any]]]
+    tool_choice: Any
+    metadata: Dict[str, Any]
+    thinking_enabled: Optional[bool]
+    thinking_budget_tokens: Optional[int]
+
+    def to_openai_body(self) -> Dict[str, Any]:
+        body: Dict[str, Any] = {
+            "model": self.requested_model,
+            "messages": self.messages,
+            "max_tokens": self.max_output_tokens,
+            "stream": self.stream,
+        }
+        if self.stop:
+            body["stop"] = self.stop
+        if self.temperature is not None:
+            body["temperature"] = self.temperature
+        if self.top_p is not None:
+            body["top_p"] = self.top_p
+        if self.top_k is not None:
+            body["top_k"] = self.top_k
+        if self.tools:
+            body["tools"] = self.tools
+        if self.tool_choice is not None:
+            body["tool_choice"] = self.tool_choice
+        if self.thinking_enabled is not None:
+            chat_template_kwargs: Dict[str, Any] = {
+                "enable_thinking": self.thinking_enabled,
+                "thinking": self.thinking_enabled,
+            }
+            if self.thinking_budget_tokens is not None:
+                # Preserve Anthropic's requested reasoning budget for backends
+                # and custom chat templates that support a token budget.
+                chat_template_kwargs["thinking_budget"] = self.thinking_budget_tokens
+            body["chat_template_kwargs"] = chat_template_kwargs
+        if self.stream:
+            # Accurate Anthropic message_delta usage requires a final OpenAI
+            # usage chunk. Backends that support this option will emit one.
+            body["stream_options"] = {"include_usage": True}
+        return body
+
+
+def _invalid(message: str) -> AnthropicProtocolError:
+    return AnthropicProtocolError(400, "invalid_request_error", message)
+
+
+def _text_from_blocks(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        raise _invalid("Message content must be a string or an array of blocks")
+    parts: List[str] = []
+    for block in content:
+        if not isinstance(block, dict):
+            raise _invalid("Anthropic content blocks must be JSON objects")
+        block_type = block.get("type")
+        if block_type == "text":
+            text = block.get("text")
+            if not isinstance(text, str):
+                raise _invalid("Anthropic text blocks require a string 'text' field")
+            if text.startswith("x-anthropic-billing-header"):
+                continue
+            parts.append(text)
+        else:
+            raise _invalid(f"Unsupported Anthropic content block type: {block_type}")
+    return "\n".join(parts)
+
+
+def _normalize_messages(raw_system: Any, raw_messages: Any) -> List[Dict[str, Any]]:
+    if not isinstance(raw_messages, list) or not raw_messages:
+        raise _invalid("Please specify at least one message")
+
+    system_parts: List[str] = []
+    if raw_system is not None:
+        system_text = _text_from_blocks(raw_system)
+        if system_text:
+            system_parts.append(system_text)
+
+    normalized: List[Dict[str, Any]] = []
+    for raw_message in raw_messages:
+        if not isinstance(raw_message, dict):
+            raise _invalid("Every Anthropic message must be a JSON object")
+        role = raw_message.get("role")
+        content = raw_message.get("content")
+        if role == "system":
+            text = _text_from_blocks(content)
+            if text:
+                system_parts.append(text)
+            continue
+        if role not in {"user", "assistant"}:
+            raise _invalid(f"Unsupported Anthropic message role: {role}")
+
+        if isinstance(content, str):
+            normalized.append({"role": role, "content": content})
+            continue
+        if not isinstance(content, list):
+            raise _invalid("Message content must be a string or an array of blocks")
+
+        text_parts: List[str] = []
+        tool_calls: List[Dict[str, Any]] = []
+        tool_results: List[Dict[str, Any]] = []
+        for block in content:
+            if not isinstance(block, dict):
+                raise _invalid("Anthropic content blocks must be JSON objects")
+            block_type = block.get("type")
+            if block_type == "text":
+                block_text = block.get("text")
+                if not isinstance(block_text, str):
+                    raise _invalid(
+                        "Anthropic text blocks require a string 'text' field"
+                    )
+                if not block_text.startswith("x-anthropic-billing-header"):
+                    text_parts.append(block_text)
+            elif block_type == "tool_use" and role == "assistant":
+                tool_id = block.get("id")
+                name = block.get("name")
+                input_data = block.get("input", {})
+                if not isinstance(tool_id, str) or not isinstance(name, str):
+                    raise _invalid("tool_use blocks require string 'id' and 'name'")
+                tool_calls.append(
+                    {
+                        "id": tool_id,
+                        "type": "function",
+                        "function": {
+                            "name": name,
+                            "arguments": json.dumps(input_data, ensure_ascii=False),
+                        },
+                    }
+                )
+            elif block_type == "tool_result" and role == "user":
+                tool_id = block.get("tool_use_id")
+                if not isinstance(tool_id, str):
+                    raise _invalid("tool_result blocks require a string 'tool_use_id'")
+                result_content = block.get("content", "")
+                if isinstance(result_content, list):
+                    result_content = _text_from_blocks(result_content)
+                elif not isinstance(result_content, str):
+                    result_content = json.dumps(result_content, ensure_ascii=False)
+                tool_results.append(
+                    {
+                        "role": "tool",
+                        "tool_call_id": tool_id,
+                        "content": result_content,
+                    }
+                )
+            else:
+                raise _invalid(
+                    f"Unsupported Anthropic content block type: {block_type}"
+                )
+
+        if role == "assistant":
+            message: Dict[str, Any] = {
+                "role": "assistant",
+                "content": "\n".join(text_parts) or None,
+            }
+            if tool_calls:
+                message["tool_calls"] = tool_calls
+            normalized.append(message)
+        else:
+            if text_parts:
+                normalized.append({"role": "user", "content": "\n".join(text_parts)})
+            normalized.extend(tool_results)
+
+    if system_parts:
+        normalized.insert(0, {"role": "system", "content": "\n".join(system_parts)})
+    if not normalized or normalized[-1].get("role") not in {
+        "user",
+        "assistant",
+        "tool",
+    }:
+        raise _invalid("Please specify the prompt")
+    return normalized
+
+
+def _normalize_tools(raw_tools: Any) -> Optional[List[Dict[str, Any]]]:
+    if raw_tools is None:
+        return None
+    if not isinstance(raw_tools, list):
+        raise _invalid("The 'tools' field must be an array")
+    tools: List[Dict[str, Any]] = []
+    for tool in raw_tools:
+        if not isinstance(tool, dict):
+            raise _invalid("Every tool must be a JSON object")
+        if tool.get("type") == "function" and isinstance(tool.get("function"), dict):
+            tools.append(tool)
+            continue
+        name = tool.get("name")
+        schema = tool.get("input_schema")
+        if not isinstance(name, str) or not isinstance(schema, dict):
+            raise _invalid("Anthropic tools require 'name' and object 'input_schema'")
+        function: Dict[str, Any] = {"name": name, "parameters": schema}
+        if isinstance(tool.get("description"), str):
+            function["description"] = tool["description"]
+        tools.append({"type": "function", "function": function})
+    return tools or None
+
+
+def _normalize_tool_choice(raw_choice: Any) -> Any:
+    if raw_choice is None:
+        return None
+    if isinstance(raw_choice, str):
+        return {"any": "required"}.get(raw_choice, raw_choice)
+    if not isinstance(raw_choice, dict):
+        raise _invalid("The 'tool_choice' field must be a string or object")
+    choice_type = raw_choice.get("type")
+    if choice_type == "auto":
+        return "auto"
+    if choice_type == "any":
+        return "required"
+    if choice_type == "none":
+        return "none"
+    if choice_type in {"tool", "function"}:
+        name = raw_choice.get("name")
+        if name is None and isinstance(raw_choice.get("function"), dict):
+            name = raw_choice["function"].get("name")
+        if not isinstance(name, str) or not name:
+            raise _invalid("A named tool_choice requires a tool name")
+        return {"type": "function", "function": {"name": name}}
+    raise _invalid(f"Unsupported Anthropic tool_choice type: {choice_type}")
+
+
+def _optional_number(
+    raw_body: Dict[str, Any],
+    name: str,
+    *,
+    minimum: float,
+    maximum: Optional[float] = None,
+) -> Optional[float]:
+    value = raw_body.get(name)
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise _invalid(f"The '{name}' field must be a number")
+    number = float(value)
+    if number < minimum or (maximum is not None and number > maximum):
+        if maximum is None:
+            raise _invalid(f"The '{name}' field must be at least {minimum}")
+        raise _invalid(f"The '{name}' field must be between {minimum} and {maximum}")
+    return number
+
+
+def parse_anthropic_request(raw_body: Any) -> CanonicalChatRequest:
+    if not isinstance(raw_body, dict):
+        raise _invalid("Request body must be a JSON object")
+    model = raw_body.get("model")
+    if not isinstance(model, str) or not model.strip():
+        raise _invalid("The 'model' field is required")
+    max_tokens = raw_body.get("max_tokens")
+    if (
+        isinstance(max_tokens, bool)
+        or not isinstance(max_tokens, int)
+        or max_tokens <= 0
+    ):
+        raise _invalid("The 'max_tokens' field must be a positive integer")
+    stream = raw_body.get("stream", False)
+    if not isinstance(stream, bool):
+        raise _invalid("The 'stream' field must be a boolean")
+    temperature = _optional_number(raw_body, "temperature", minimum=0.0, maximum=1.0)
+    top_p = _optional_number(raw_body, "top_p", minimum=0.0, maximum=1.0)
+    top_k = raw_body.get("top_k")
+    if top_k is not None and (
+        isinstance(top_k, bool) or not isinstance(top_k, int) or top_k <= 0
+    ):
+        raise _invalid("The 'top_k' field must be a positive integer")
+    stop_sequences = raw_body.get("stop_sequences")
+    if stop_sequences is not None:
+        if not isinstance(stop_sequences, list) or not all(
+            isinstance(item, str) for item in stop_sequences
+        ):
+            raise _invalid("The 'stop_sequences' field must be an array of strings")
+    metadata = raw_body.get("metadata") or {}
+    if not isinstance(metadata, dict):
+        raise _invalid("The 'metadata' field must be an object")
+
+    thinking = raw_body.get("thinking")
+    thinking_enabled: Optional[bool] = None
+    thinking_budget: Optional[int] = None
+    if thinking is not None:
+        if not isinstance(thinking, dict):
+            raise _invalid("The 'thinking' field must be an object")
+        thinking_type = thinking.get("type")
+        if thinking_type not in {"enabled", "disabled"}:
+            raise _invalid("Unsupported thinking type")
+        thinking_enabled = thinking_type == "enabled"
+        if thinking_enabled:
+            thinking_budget = thinking.get("budget_tokens")
+            if (
+                isinstance(thinking_budget, bool)
+                or not isinstance(thinking_budget, int)
+                or thinking_budget <= 0
+            ):
+                raise _invalid("Enabled thinking requires a positive budget_tokens")
+            if thinking_budget >= max_tokens:
+                raise _invalid("thinking.budget_tokens must be less than max_tokens")
+
+    return CanonicalChatRequest(
+        requested_model=model.strip(),
+        messages=_normalize_messages(raw_body.get("system"), raw_body.get("messages")),
+        max_output_tokens=max_tokens,
+        stream=stream,
+        stop=stop_sequences,
+        temperature=temperature,
+        top_p=top_p,
+        top_k=top_k,
+        tools=_normalize_tools(raw_body.get("tools")),
+        tool_choice=_normalize_tool_choice(raw_body.get("tool_choice")),
+        metadata=metadata,
+        thinking_enabled=thinking_enabled,
+        thinking_budget_tokens=thinking_budget,
+    )
+
+
+def _stop_reason(finish_reason: Any, stop_sequence: Any = None) -> str:
+    if stop_sequence:
+        return "stop_sequence"
+    return {
+        "stop": "end_turn",
+        "length": "max_tokens",
+        "tool_calls": "tool_use",
+    }.get(finish_reason, "end_turn")
+
+
+def openai_to_anthropic(openai_response: Dict[str, Any], model: str) -> Dict[str, Any]:
+    content_blocks: List[Dict[str, Any]] = []
+    finish_reason: Any = "stop"
+    stop_sequence = openai_response.get("stop_sequence")
+    choices = openai_response.get("choices") or []
+    if choices:
+        choice = choices[0]
+        finish_reason = choice.get("finish_reason") or "stop"
+        message = choice.get("message") or {}
+        reasoning = message.get("reasoning_content")
+        if isinstance(reasoning, str) and reasoning:
+            content_blocks.append({"type": "thinking", "thinking": reasoning})
+        content = message.get("content")
+        if isinstance(content, str) and content:
+            content_blocks.append({"type": "text", "text": content})
+        elif isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict) and isinstance(block.get("text"), str):
+                    content_blocks.append({"type": "text", "text": block["text"]})
+        for tool_call in message.get("tool_calls") or []:
+            function = tool_call.get("function") or {}
+            arguments = function.get("arguments", "{}")
+            try:
+                input_data = (
+                    json.loads(arguments) if isinstance(arguments, str) else arguments
+                )
+            except json.JSONDecodeError as exc:
+                raise AnthropicProtocolError(
+                    500,
+                    "api_error",
+                    "The model returned invalid tool arguments",
+                ) from exc
+            if not isinstance(input_data, dict):
+                raise AnthropicProtocolError(
+                    500,
+                    "api_error",
+                    "The model returned non-object tool arguments",
+                )
+            content_blocks.append(
+                {
+                    "type": "tool_use",
+                    "id": tool_call.get("id") or f"toolu_{uuid.uuid4().hex}",
+                    "name": function.get("name", ""),
+                    "input": input_data,
+                }
+            )
+    usage = openai_response.get("usage") or {}
+    return {
+        "id": f"msg_{uuid.uuid4().hex}",
+        "type": "message",
+        "role": "assistant",
+        "content": content_blocks,
+        "model": model,
+        "stop_reason": _stop_reason(finish_reason, stop_sequence),
+        "stop_sequence": stop_sequence,
+        "usage": {
+            "input_tokens": int(usage.get("prompt_tokens") or 0),
+            "output_tokens": int(usage.get("completion_tokens") or 0),
+        },
+    }
+
+
+def anthropic_error_response(
+    error_type: str, message: str, request_id: str
+) -> Dict[str, Any]:
+    return {
+        "type": "error",
+        "error": {"type": error_type, "message": message},
+        "request_id": request_id,
+    }
+
+
+async def anthropic_stream_events(
+    chunks: AsyncIterator[Dict[str, Any]], model: str, request_id: str
+) -> AsyncIterator[Dict[str, str]]:
+    """Convert OpenAI chat-completion chunks into Anthropic SSE events.
+
+    Anthropic content blocks are strictly sequential: a block must be stopped
+    before the next block starts. OpenAI tool calls can be fragmented and even
+    interleaved by index, so tool fragments are buffered and emitted as complete
+    sequential Anthropic blocks after text/reasoning streaming finishes.
+    """
+
+    message_id = f"msg_{uuid.uuid4().hex}"
+    yield {
+        "event": "message_start",
+        "data": json.dumps(
+            {
+                "type": "message_start",
+                "message": {
+                    "id": message_id,
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [],
+                    "model": model,
+                    "stop_reason": None,
+                    "stop_sequence": None,
+                    "usage": {"input_tokens": 0, "output_tokens": 0},
+                },
+            }
+        ),
+    }
+
+    next_index = 0
+    active_index: Optional[int] = None
+    active_kind: Optional[str] = None
+    finish_reason: Any = "stop"
+    stop_sequence: Any = None
+    output_tokens = 0
+    tool_buffers: Dict[int, Dict[str, Any]] = {}
+
+    def block_stop(index: int) -> Dict[str, str]:
+        return {
+            "event": "content_block_stop",
+            "data": json.dumps({"type": "content_block_stop", "index": index}),
+        }
+
+    async for chunk in chunks:
+        if "error" in chunk:
+            error = chunk.get("error") or {}
+            yield {
+                "event": "error",
+                "data": json.dumps(
+                    anthropic_error_response(
+                        error.get("type", "api_error"),
+                        error.get("message", "Upstream stream failed"),
+                        request_id,
+                    )
+                ),
+            }
+            return
+
+        usage = chunk.get("usage") or {}
+        output_tokens = int(usage.get("completion_tokens") or output_tokens)
+        choices = chunk.get("choices") or []
+        if not choices:
+            continue
+
+        choice = choices[0]
+        delta = choice.get("delta") or {}
+        for kind, value, delta_type, field in (
+            ("thinking", delta.get("reasoning_content"), "thinking_delta", "thinking"),
+            ("text", delta.get("content"), "text_delta", "text"),
+        ):
+            if not isinstance(value, str) or not value:
+                continue
+            if active_kind != kind:
+                if active_index is not None:
+                    yield block_stop(active_index)
+                active_index = next_index
+                next_index += 1
+                active_kind = kind
+                content_block = {"type": kind, field: ""}
+                yield {
+                    "event": "content_block_start",
+                    "data": json.dumps(
+                        {
+                            "type": "content_block_start",
+                            "index": active_index,
+                            "content_block": content_block,
+                        }
+                    ),
+                }
+            yield {
+                "event": "content_block_delta",
+                "data": json.dumps(
+                    {
+                        "type": "content_block_delta",
+                        "index": active_index,
+                        "delta": {"type": delta_type, field: value},
+                    }
+                ),
+            }
+
+        for tool_call in delta.get("tool_calls") or []:
+            try:
+                source_index = int(tool_call.get("index") or 0)
+            except (TypeError, ValueError):
+                source_index = 0
+            state = tool_buffers.setdefault(
+                source_index,
+                {"id": None, "name": "", "argument_fragments": []},
+            )
+            if tool_call.get("id"):
+                state["id"] = tool_call["id"]
+            function = tool_call.get("function") or {}
+            if function.get("name"):
+                state["name"] = function["name"]
+            arguments = function.get("arguments")
+            if isinstance(arguments, str) and arguments:
+                state["argument_fragments"].append(arguments)
+
+        if choice.get("finish_reason") is not None:
+            finish_reason = choice["finish_reason"]
+            stop_sequence = choice.get("stop_sequence") or stop_sequence
+
+    if active_index is not None:
+        yield block_stop(active_index)
+
+    for source_index in sorted(tool_buffers):
+        state = tool_buffers[source_index]
+        block_index = next_index
+        next_index += 1
+        yield {
+            "event": "content_block_start",
+            "data": json.dumps(
+                {
+                    "type": "content_block_start",
+                    "index": block_index,
+                    "content_block": {
+                        "type": "tool_use",
+                        "id": state["id"] or f"toolu_{uuid.uuid4().hex}",
+                        "name": state["name"],
+                        "input": {},
+                    },
+                }
+            ),
+        }
+        for arguments in state["argument_fragments"]:
+            yield {
+                "event": "content_block_delta",
+                "data": json.dumps(
+                    {
+                        "type": "content_block_delta",
+                        "index": block_index,
+                        "delta": {
+                            "type": "input_json_delta",
+                            "partial_json": arguments,
+                        },
+                    }
+                ),
+            }
+        yield block_stop(block_index)
+
+    yield {
+        "event": "message_delta",
+        "data": json.dumps(
+            {
+                "type": "message_delta",
+                "delta": {
+                    "stop_reason": _stop_reason(finish_reason, stop_sequence),
+                    "stop_sequence": stop_sequence,
+                },
+                "usage": {"output_tokens": output_tokens},
+            }
+        ),
+    }
+    yield {"event": "message_stop", "data": json.dumps({"type": "message_stop"})}

--- a/xinference/api/protocols/anthropic.py
+++ b/xinference/api/protocols/anthropic.py
@@ -388,18 +388,10 @@ def openai_to_anthropic(openai_response: Dict[str, Any], model: str) -> Dict[str
                 input_data = (
                     json.loads(arguments) if isinstance(arguments, str) else arguments
                 )
-            except json.JSONDecodeError as exc:
-                raise AnthropicProtocolError(
-                    500,
-                    "api_error",
-                    "The model returned invalid tool arguments",
-                ) from exc
+            except json.JSONDecodeError:
+                input_data = {}
             if not isinstance(input_data, dict):
-                raise AnthropicProtocolError(
-                    500,
-                    "api_error",
-                    "The model returned non-object tool arguments",
-                )
+                input_data = {}
             content_blocks.append(
                 {
                     "type": "tool_use",
@@ -479,84 +471,95 @@ async def anthropic_stream_events(
             "data": json.dumps({"type": "content_block_stop", "index": index}),
         }
 
-    async for chunk in chunks:
-        if "error" in chunk:
-            error = chunk.get("error") or {}
-            yield {
-                "event": "error",
-                "data": json.dumps(
-                    anthropic_error_response(
-                        error.get("type", "api_error"),
-                        error.get("message", "Upstream stream failed"),
-                        request_id,
-                    )
-                ),
-            }
-            return
-
-        usage = chunk.get("usage") or {}
-        output_tokens = int(usage.get("completion_tokens") or output_tokens)
-        choices = chunk.get("choices") or []
-        if not choices:
-            continue
-
-        choice = choices[0]
-        delta = choice.get("delta") or {}
-        for kind, value, delta_type, field in (
-            ("thinking", delta.get("reasoning_content"), "thinking_delta", "thinking"),
-            ("text", delta.get("content"), "text_delta", "text"),
-        ):
-            if not isinstance(value, str) or not value:
-                continue
-            if active_kind != kind:
-                if active_index is not None:
-                    yield block_stop(active_index)
-                active_index = next_index
-                next_index += 1
-                active_kind = kind
-                content_block = {"type": kind, field: ""}
+    try:
+        async for chunk in chunks:
+            if "error" in chunk:
+                error = chunk.get("error") or {}
                 yield {
-                    "event": "content_block_start",
+                    "event": "error",
+                    "data": json.dumps(
+                        anthropic_error_response(
+                            error.get("type", "api_error"),
+                            error.get("message", "Upstream stream failed"),
+                            request_id,
+                        )
+                    ),
+                }
+                return
+
+            usage = chunk.get("usage") or {}
+            output_tokens = int(usage.get("completion_tokens") or output_tokens)
+            choices = chunk.get("choices") or []
+            if not choices:
+                continue
+
+            choice = choices[0]
+            delta = choice.get("delta") or {}
+            for kind, value, delta_type, field in (
+                (
+                    "thinking",
+                    delta.get("reasoning_content"),
+                    "thinking_delta",
+                    "thinking",
+                ),
+                ("text", delta.get("content"), "text_delta", "text"),
+            ):
+                if not isinstance(value, str) or not value:
+                    continue
+                if active_kind != kind:
+                    if active_index is not None:
+                        yield block_stop(active_index)
+                    active_index = next_index
+                    next_index += 1
+                    active_kind = kind
+                    content_block = {"type": kind, field: ""}
+                    yield {
+                        "event": "content_block_start",
+                        "data": json.dumps(
+                            {
+                                "type": "content_block_start",
+                                "index": active_index,
+                                "content_block": content_block,
+                            }
+                        ),
+                    }
+                yield {
+                    "event": "content_block_delta",
                     "data": json.dumps(
                         {
-                            "type": "content_block_start",
+                            "type": "content_block_delta",
                             "index": active_index,
-                            "content_block": content_block,
+                            "delta": {"type": delta_type, field: value},
                         }
                     ),
                 }
-            yield {
-                "event": "content_block_delta",
-                "data": json.dumps(
-                    {
-                        "type": "content_block_delta",
-                        "index": active_index,
-                        "delta": {"type": delta_type, field: value},
-                    }
-                ),
-            }
 
-        for tool_call in delta.get("tool_calls") or []:
-            try:
-                source_index = int(tool_call.get("index") or 0)
-            except (TypeError, ValueError):
-                source_index = 0
-            state = tool_buffers.setdefault(
-                source_index,
-                {"id": None, "name": "", "argument_fragments": []},
-            )
-            if tool_call.get("id"):
-                state["id"] = tool_call["id"]
-            function = tool_call.get("function") or {}
-            if function.get("name"):
-                state["name"] = function["name"]
-            arguments = function.get("arguments")
-            if isinstance(arguments, str) and arguments:
-                state["argument_fragments"].append(arguments)
+            for tool_call in delta.get("tool_calls") or []:
+                try:
+                    source_index = int(tool_call.get("index") or 0)
+                except (TypeError, ValueError):
+                    source_index = 0
+                state = tool_buffers.setdefault(
+                    source_index,
+                    {"id": None, "name": "", "argument_fragments": []},
+                )
+                if tool_call.get("id"):
+                    state["id"] = tool_call["id"]
+                function = tool_call.get("function") or {}
+                if function.get("name"):
+                    state["name"] = function["name"]
+                arguments = function.get("arguments")
+                if isinstance(arguments, str) and arguments:
+                    state["argument_fragments"].append(arguments)
 
-        if choice.get("finish_reason") is not None:
-            finish_reason = choice["finish_reason"]
-            stop_sequence = choice.get("stop_sequence") or stop_sequence
+            if choice.get("finish_reason") is not None:
+                finish_reason = choice["finish_reason"]
+                stop_sequence = choice.get("stop_sequence") or stop_sequence
+
+    finally:
+        close = getattr(chunks, "aclose", None)
+        if close is not None:
+            await close()
 
     if active_index is not None:
         yield block_stop(active_index)

--- a/xinference/api/restful_api.py
+++ b/xinference/api/restful_api.py
@@ -74,12 +74,7 @@ from ..core.http_protocol import create_hardened_http_protocol
 from ..core.replica_config import ReplicaConfig
 from ..core.supervisor import SupervisorActor
 from ..core.utils import CancelMixin
-from ..types import (
-    CreateChatCompletion,
-    CreateMessage,
-    PeftModelConfig,
-    max_tokens_field,
-)
+from ..types import CreateChatCompletion, PeftModelConfig, max_tokens_field
 from .frontend_static import mount_frontend
 from .pdf_ocr import (
     DEFAULT_PDF_OCR_DPI,
@@ -89,6 +84,13 @@ from .pdf_ocr import (
     merge_ocr_page_results,
     rasterize_pdf,
     validate_pdf_for_parse,
+)
+from .protocols import (
+    AnthropicProtocolError,
+    anthropic_error_response,
+    anthropic_stream_events,
+    openai_to_anthropic,
+    parse_anthropic_request,
 )
 from .responses import JSONResponse
 from .schemas import (
@@ -178,6 +180,9 @@ def _normalize_token_router_chat_payload(
     if max_completion_tokens is not None:
         normalized["max_tokens"] = max_completion_tokens
     return normalized
+
+
+_SUPPORTED_ANTHROPIC_VERSIONS = {"2023-06-01"}
 
 
 _AUDIO_RESPONSE_MEDIA_TYPES = {
@@ -1460,6 +1465,89 @@ class RESTfulAPI(CancelMixin):
             logger.error(e, exc_info=True)
             raise HTTPException(status_code=500, detail=str(e))
 
+    @staticmethod
+    async def _iter_openai_sse_bytes(
+        byte_stream: AsyncIterator[bytes],
+    ) -> AsyncIterator[Dict[str, Any]]:
+        buffer = b""
+        async for chunk in byte_stream:
+            buffer += chunk
+            while b"\n" in buffer:
+                line, buffer = buffer.split(b"\n", 1)
+                line = line.strip()
+                if not line or not line.startswith(b"data:"):
+                    continue
+                payload = line[5:].strip()
+                if not payload or payload == b"[DONE]":
+                    continue
+                try:
+                    value = json.loads(payload)
+                except json.JSONDecodeError:
+                    logger.warning("Ignoring malformed OpenAI SSE payload")
+                    continue
+                if isinstance(value, dict):
+                    yield value
+        line = buffer.strip()
+        if line.startswith(b"data:"):
+            payload = line[5:].strip()
+            if payload and payload != b"[DONE]":
+                try:
+                    value = json.loads(payload)
+                except json.JSONDecodeError:
+                    return
+                if isinstance(value, dict):
+                    yield value
+
+    @classmethod
+    async def _iter_model_openai_chunks(
+        cls, iterator: Any
+    ) -> AsyncIterator[Dict[str, Any]]:
+        async def _items() -> AsyncIterator[Any]:
+            if hasattr(iterator, "__aiter__"):
+                async for item in iterator:
+                    yield item
+            elif isinstance(iterator, (str, bytes, dict)):
+                yield iterator
+            else:
+                for item in iterator:
+                    yield item
+
+        async for item in _items():
+            if isinstance(item, dict) and "data" not in item:
+                yield item
+                continue
+            payload = item.get("data") if isinstance(item, dict) else item
+            if isinstance(payload, bytes):
+                payload_bytes = payload
+                payload_text = payload.decode("utf-8", errors="replace")
+            elif isinstance(payload, str):
+                payload_text = payload
+                payload_bytes = payload.encode("utf-8")
+            else:
+                continue
+
+            if any(
+                line.lstrip().startswith("data:") for line in payload_text.splitlines()
+            ):
+
+                async def _single_payload() -> AsyncIterator[bytes]:
+                    yield payload_bytes
+
+                async for value in cls._iter_openai_sse_bytes(_single_payload()):
+                    yield value
+                continue
+
+            payload_text = payload_text.strip()
+            if not payload_text or payload_text == "[DONE]":
+                continue
+            try:
+                value = json.loads(payload_text)
+            except json.JSONDecodeError:
+                yield {"choices": [{"delta": {"content": payload_text}}]}
+                continue
+            if isinstance(value, dict):
+                yield value
+
     async def _get_model_last_error(self, replica_model_uid: bytes, e: Exception):
         if not isinstance(e, xo.ServerClosed):
             return e
@@ -1605,131 +1693,134 @@ class RESTfulAPI(CancelMixin):
             normalized.insert(0, {"role": "system", "content": "\n".join(system_parts)})
         return normalized
 
-    async def create_message(self, request: Request) -> Response:
-        raw_body = await request.json()
-        body = CreateMessage.parse_obj(raw_body)
+    @staticmethod
+    def _anthropic_error_type(status_code: int) -> str:
+        return {
+            400: "invalid_request_error",
+            401: "authentication_error",
+            403: "permission_error",
+            404: "not_found_error",
+            413: "request_too_large",
+            429: "rate_limit_error",
+            504: "timeout_error",
+            529: "overloaded_error",
+        }.get(status_code, "api_error")
 
-        exclude = {
-            "model",
-            "messages",
-            "stream",
-            "stop_sequences",
-            "metadata",
-            "tool_choice",
-            "tools",
-        }
-        raw_kwargs = {k: v for k, v in raw_body.items() if k not in exclude}
-        kwargs = body.dict(exclude_unset=True, exclude=exclude)
-
-        # guided_decoding params
-        kwargs.update(self.extract_guided_params(raw_body=raw_body))
-
-        # TODO: Decide if this default value override is necessary #1061
-        if body.max_tokens is None:
-            kwargs["max_tokens"] = max_tokens_field.default
-
-        messages = body.messages and list(body.messages)
-
-        # Fold the top-level `system` prompt and any inline `role: system`
-        # messages into a leading OpenAI-style system message, then drop the
-        # consumed `system` field so it is not forwarded as a stray generation
-        # parameter (which the chat backend discards anyway).
-        messages = self._normalize_anthropic_messages(raw_body.get("system"), messages)
-        raw_kwargs.pop("system", None)
-
-        if not messages or messages[-1].get("role") not in ["user", "assistant"]:
-            raise HTTPException(
-                status_code=400, detail="Invalid input. Please specify the prompt."
-            )
-
-        # Handle tools parameter
-        if hasattr(body, "tools") and body.tools:
-            kwargs["tools"] = list(body.tools)
-
-        # Handle tool_choice parameter
-        if hasattr(body, "tool_choice") and body.tool_choice:
-            kwargs["tool_choice"] = body.tool_choice
-
-        # Get model mapping
-        try:
-            running_models = await (await self._get_supervisor_ref()).list_models()
-        except Exception as e:
-            logger.error(f"Failed to get model mapping: {e}", exc_info=True)
-            raise HTTPException(status_code=500, detail="Failed to get model mapping")
-
-        if not running_models:
-            raise HTTPException(
-                status_code=400,
-                detail=f"No running models available. Please start a model in xinference first.",
-            )
-
-        requested_model_id = body.model
-        if "claude" in requested_model_id:
-            requested_model_id = list(running_models.keys())[0]
-
-        if requested_model_id not in running_models:
-            raise HTTPException(
-                status_code=400,
-                detail=f"Model '{requested_model_id}' is not available. Available models: {list(running_models.keys())}",
-            )
-        else:
-            model_uid = requested_model_id
-
-        self._set_trace_model(model_uid)
-        self._set_trace_model_type("llm")
-        self._check_model_access(request, model_uid, "LLM")
-
-        model = await require_model(
-            self._get_supervisor_ref, model_uid, self._report_error_event
+    @classmethod
+    def _anthropic_error(
+        cls,
+        status_code: int,
+        message: str,
+        request_id: str,
+        *,
+        error_type: Optional[str] = None,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> JSONResponse:
+        response_headers = {"request-id": request_id}
+        if headers:
+            response_headers.update(headers)
+        return JSONResponse(
+            status_code=status_code,
+            headers=response_headers,
+            content=anthropic_error_response(
+                error_type or cls._anthropic_error_type(status_code),
+                message,
+                request_id,
+            ),
         )
 
-        if body.stream:
+    async def create_message(self, request: Request) -> Response:
+        request_id = (
+            request.headers.get("request-id")
+            or request.headers.get("x-request-id")
+            or f"req_{uuid.uuid4().hex}"
+        )
+        anthropic_version = request.headers.get("anthropic-version")
+        if request.url.path == "/v1/messages" and not anthropic_version:
+            return self._anthropic_error(
+                400, "The anthropic-version header is required", request_id
+            )
+        if (
+            anthropic_version is not None
+            and anthropic_version not in _SUPPORTED_ANTHROPIC_VERSIONS
+        ):
+            return self._anthropic_error(
+                400,
+                f"Unsupported anthropic-version header: {anthropic_version}",
+                request_id,
+            )
 
-            async def stream_results():
-                iterator = None
+        try:
+            canonical = parse_anthropic_request(await request.json())
+        except AnthropicProtocolError as exc:
+            return self._anthropic_error(
+                exc.status_code,
+                exc.message,
+                request_id,
+                error_type=exc.error_type,
+                headers=exc.headers,
+            )
+        except Exception:
+            return self._anthropic_error(
+                400, "Request body must be valid JSON", request_id
+            )
+
+        model_uid = canonical.requested_model
+        self._set_trace_model(model_uid)
+        self._set_trace_model_type("llm")
+        try:
+            self._check_model_access(request, model_uid, "LLM")
+        except HTTPException as exc:
+            return self._anthropic_error(
+                exc.status_code, str(exc.detail), request_id, headers=exc.headers
+            )
+
+        try:
+            model = await require_model(
+                self._get_supervisor_ref, model_uid, self._report_error_event
+            )
+        except HTTPException as exc:
+            return self._anthropic_error(
+                exc.status_code, str(exc.detail), request_id, headers=exc.headers
+            )
+        except Exception as exc:
+            logger.error(exc, exc_info=True)
+            return self._anthropic_error(500, str(exc), request_id)
+
+        openai_body = canonical.to_openai_body()
+        kwargs = {
+            key: value
+            for key, value in openai_body.items()
+            if key not in {"model", "messages"}
+        }
+        raw_kwargs = dict(kwargs)
+
+        if canonical.stream:
+            iterator = None
+            try:
+                iterator = await model.chat(
+                    canonical.messages, kwargs, raw_params=raw_kwargs
+                )
+            except Exception as exc:
+                exc = await self._get_model_last_error(model.uid, exc)
+                logger.error(exc, exc_info=True)
+                await self._report_error_event(model_uid, str(exc))
+                status_code = 429 if "Rate limit reached" in str(exc) else 500
+                return self._anthropic_error(status_code, str(exc), request_id)
+
+            async def physical_chunks() -> AsyncIterator[Dict[str, Any]]:
                 try:
-                    try:
-                        iterator = await model.chat(
-                            messages, kwargs, raw_params=raw_kwargs
-                        )
-                    except RuntimeError as re:
-                        self.handle_request_limit_error(re)
-
-                    # Check if iterator is actually an async iterator
-                    if hasattr(iterator, "__aiter__"):
-                        async for item in iterator:
-                            yield item
-                    elif isinstance(iterator, (str, bytes)):
-                        # Handle case where chat returns bytes/string instead of iterator
-                        if isinstance(iterator, bytes):
-                            try:
-                                content = iterator.decode("utf-8")
-                            except UnicodeDecodeError:
-                                content = str(iterator)
-                        else:
-                            content = iterator
-                        yield dict(data=json.dumps({"content": content}))
-                    else:
-                        # Fallback: try to iterate normally
-                        try:
-                            for item in iterator:
-                                yield item
-                        except TypeError:
-                            # If not iterable, yield as single result
-                            yield dict(data=json.dumps({"content": str(iterator)}))
-
-                    yield "[DONE]"
+                    async for chunk in self._iter_model_openai_chunks(iterator):
+                        if await request.is_disconnected():
+                            break
+                        yield chunk
                 except asyncio.CancelledError:
-                    logger.info(
-                        f"Disconnected from client (via refresh/close) {request.client} during chat."
-                    )
-                    return
-                except Exception as ex:
-                    ex = await self._get_model_last_error(model.uid, ex)
-                    logger.exception("Message stream got an error: %s", ex)
-                    await self._report_error_event(model_uid, str(ex))
-                    yield dict(data=json.dumps({"error": str(ex)}))
-                    return
+                    raise
+                except Exception as exc:
+                    exc = await self._get_model_last_error(model.uid, exc)
+                    logger.exception("Anthropic physical model stream failed")
+                    await self._report_error_event(model_uid, str(exc))
+                    yield {"error": {"type": "api_error", "message": str(exc)}}
                 finally:
                     if iterator is not None:
                         from xoscar.api import IteratorWrapper
@@ -1742,25 +1833,33 @@ class RESTfulAPI(CancelMixin):
                             await model.decrease_serve_count()
 
             return EventSourceResponse(
-                stream_results(), ping=XINFERENCE_SSE_PING_ATTEMPTS_SECONDS
+                anthropic_stream_events(physical_chunks(), model_uid, request_id),
+                ping=XINFERENCE_SSE_PING_ATTEMPTS_SECONDS,
+                headers={"request-id": request_id},
             )
-        else:
-            try:
-                data = await model.chat(messages, kwargs, raw_params=raw_kwargs)
-                # Convert OpenAI format to Anthropic format
-                openai_response = json.loads(data)
-                anthropic_response = self._convert_openai_to_anthropic(
-                    openai_response, body.model
-                )
-                return Response(
-                    json.dumps(anthropic_response), media_type="application/json"
-                )
-            except Exception as e:
-                e = await self._get_model_last_error(model.uid, e)
-                logger.error(e, exc_info=True)
-                await self._report_error_event(model_uid, str(e))
-                self.handle_request_limit_error(e)
-                raise HTTPException(status_code=500, detail=str(e))
+
+        try:
+            data = await model.chat(canonical.messages, kwargs, raw_params=raw_kwargs)
+            if isinstance(data, bytes):
+                data = data.decode("utf-8")
+            openai_response = json.loads(data) if isinstance(data, str) else data
+            return JSONResponse(
+                content=openai_to_anthropic(openai_response, model_uid),
+                headers={"request-id": request_id},
+            )
+        except AnthropicProtocolError as exc:
+            return self._anthropic_error(
+                exc.status_code,
+                exc.message,
+                request_id,
+                error_type=exc.error_type,
+            )
+        except Exception as exc:
+            exc = await self._get_model_last_error(model.uid, exc)
+            logger.error(exc, exc_info=True)
+            await self._report_error_event(model_uid, str(exc))
+            status_code = 429 if "Rate limit reached" in str(exc) else 500
+            return self._anthropic_error(status_code, str(exc), request_id)
 
     async def create_embedding(self, request: Request) -> Response:
         payload = await request.json()
@@ -3334,94 +3433,32 @@ class RESTfulAPI(CancelMixin):
         return kwargs
 
     def _convert_openai_to_anthropic(self, openai_response: dict, model: str) -> dict:
-        """
-        Convert OpenAI response format to Anthropic response format.
+        """Compatibility wrapper for existing callers and tests."""
+        response = dict(openai_response)
+        try:
+            result = openai_to_anthropic(response, model)
+        except AnthropicProtocolError:
+            # Preserve the historical helper behavior for malformed tool JSON.
+            for choice in response.get("choices", []):
+                message = choice.get("message") or {}
+                for tool_call in message.get("tool_calls") or []:
+                    function = tool_call.get("function") or {}
+                    try:
+                        json.loads(function.get("arguments", "{}"))
+                    except (TypeError, json.JSONDecodeError):
+                        function["arguments"] = "{}"
+            result = openai_to_anthropic(response, model)
 
-        Args:
-            openai_response: OpenAI format response
-            model: Model name
-
-        Returns:
-            Anthropic format response
-        """
-
-        # Extract content and tool calls from OpenAI response
-        content_blocks = []
-        stop_reason = "stop"
-
-        if "choices" in openai_response and len(openai_response["choices"]) > 0:
-            choice = openai_response["choices"][0]
-            message = choice.get("message", {})
-
-            # Handle content text
-            content = message.get("content", "")
-            if content:
-                if isinstance(content, str):
-                    # If content is a string, use it directly
-                    content_blocks.append({"type": "text", "text": content})
-                elif isinstance(content, list):
-                    # If content is a list, extract text from each content block
-                    for content_block in content:
-                        if isinstance(content_block, dict):
-                            if content_block.get("type") == "text":
-                                text = content_block.get("text", "")
-                                if text:
-                                    content_blocks.append(
-                                        {"type": "text", "text": text}
-                                    )
-                            elif "text" in content_block:
-                                # Handle different content block format
-                                text = content_block.get("text", "")
-                                if text:
-                                    content_blocks.append(
-                                        {"type": "text", "text": text}
-                                    )
-
-            # Handle tool calls
-            tool_calls = message.get("tool_calls", [])
-            for tool_call in tool_calls:
-                function = tool_call.get("function", {})
-                arguments = function.get("arguments", "{}")
-                try:
-                    input_data = json.loads(arguments)
-                except json.JSONDecodeError:
-                    input_data = {}
-                tool_use_block = {
-                    "type": "tool_use",
-                    "cache_control": {"type": "ephemeral"},
-                    "id": tool_call.get("id", str(uuid.uuid4())),
-                    "name": function.get("name", ""),
-                    "input": input_data,
-                }
-                content_blocks.append(tool_use_block)
-
-            # Set stop reason based on finish reason
-            finish_reason = choice.get("finish_reason", "stop")
-            if finish_reason == "tool_calls":
-                stop_reason = "tool_use"
-
-        # Build Anthropic response
-        anthropic_response = {
-            "id": str(uuid.uuid4()),
-            "type": "message",
-            "role": "assistant",
-            "content": content_blocks,
-            "model": model,
-            "stop_reason": stop_reason,
-            "stop_sequence": None,
-            "usage": {
-                "input_tokens": openai_response.get("usage", {}).get(
-                    "prompt_tokens", 0
-                ),
-                "output_tokens": openai_response.get("usage", {}).get(
-                    "completion_tokens", 0
-                ),
-                "cache_creation_input_tokens": 0,
-                "cache_read_input_tokens": 0,
-            },
-        }
-
-        return anthropic_response
+        # Keep the private helper's historical shape while the public endpoint
+        # uses the canonical Anthropic representation from the protocol module.
+        if result["stop_reason"] == "end_turn":
+            result["stop_reason"] = "stop"
+        for block in result["content"]:
+            if block.get("type") == "tool_use":
+                block["cache_control"] = {"type": "ephemeral"}
+        result["usage"].setdefault("cache_creation_input_tokens", 0)
+        result["usage"].setdefault("cache_read_input_tokens", 0)
+        return result
 
 
 def run(

--- a/xinference/api/restful_api.py
+++ b/xinference/api/restful_api.py
@@ -107,7 +107,7 @@ from .schemas import (
     TextToVideoRequest,
     UpdateModelRequest,
 )
-from .utils import require_model
+from .utils import get_request_route_path, require_model
 
 logger = logging.getLogger(__name__)
 
@@ -1736,7 +1736,7 @@ class RESTfulAPI(CancelMixin):
             or f"req_{uuid.uuid4().hex}"
         )
         anthropic_version = request.headers.get("anthropic-version")
-        if request.url.path == "/v1/messages" and not anthropic_version:
+        if get_request_route_path(request) == "/v1/messages" and not anthropic_version:
             return self._anthropic_error(
                 400, "The anthropic-version header is required", request_id
             )

--- a/xinference/api/routers/llm.py
+++ b/xinference/api/routers/llm.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 from fastapi import Security
 
-from ...types import ANTHROPIC_AVAILABLE, AnthropicMessage, ChatCompletion, Completion
+from ...types import ChatCompletion, Completion
 
 if TYPE_CHECKING:
     from ..restful_api import RESTfulAPI
@@ -25,32 +25,27 @@ def register_routes(api: "RESTfulAPI") -> None:
         dependencies=([Security(auth, scopes=["models:read"])] if is_auth else None),
     )
 
-    if ANTHROPIC_AVAILABLE:
+    for path in ("/v1/messages", "/anthropic/v1/messages"):
         router.add_api_route(
-            "/anthropic/v1/messages",
+            path,
             api.create_message,
             methods=["POST"],
-            response_model=AnthropicMessage,
             dependencies=(
                 [Security(auth, scopes=["models:read"])] if is_auth else None
             ),
         )
-        router.add_api_route(
-            "/anthropic/v1/models",
-            api.anthropic_list_models,
-            methods=["GET"],
-            dependencies=(
-                [Security(auth, scopes=["models:list"])] if is_auth else None
-            ),
-        )
-        router.add_api_route(
-            "/anthropic/v1/models/{model_id}",
-            api.anthropic_get_model,
-            methods=["GET"],
-            dependencies=(
-                [Security(auth, scopes=["models:list"])] if is_auth else None
-            ),
-        )
+    router.add_api_route(
+        "/anthropic/v1/models",
+        api.anthropic_list_models,
+        methods=["GET"],
+        dependencies=([Security(auth, scopes=["models:list"])] if is_auth else None),
+    )
+    router.add_api_route(
+        "/anthropic/v1/models/{model_id}",
+        api.anthropic_get_model,
+        methods=["GET"],
+        dependencies=([Security(auth, scopes=["models:list"])] if is_auth else None),
+    )
 
     router.add_api_route(
         "/v1/chat/completions",

--- a/xinference/api/tests/test_anthropic_auth.py
+++ b/xinference/api/tests/test_anthropic_auth.py
@@ -1,0 +1,82 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi.security import SecurityScopes
+
+from xinference.api.oauth2.advanced.auth_service import AdvancedAuthService
+from xinference.api.oauth2.advanced.crypto import get_password_hash
+
+
+@pytest.mark.asyncio
+async def test_advanced_auth_accepts_x_api_key_as_credential(tmp_path):
+    service = AdvancedAuthService(
+        db_path=str(tmp_path / "auth.db"),
+        jwt_secret_key="unit-test-secret",
+        encryption_key="unit-test-encryption-key",
+    )
+    user_id = service.db.create_user(
+        username="anthropic-user",
+        password_hash=get_password_hash("pass"),
+        source="local",
+        enabled=1,
+        must_change_password=0,
+        permissions=["models:read"],
+    )
+    token = service.create_access_token(user_id, "anthropic-user", ["models:read"])
+    request = MagicMock()
+    request.url.path = "/v1/messages"
+    request.method = "POST"
+    request.headers = {
+        "x-api-key": token,
+        "content-type": "application/json",
+        "content-length": "76",
+    }
+    request.client.host = "127.0.0.1"
+    request.body = AsyncMock(
+        return_value=b'{"model":"model","max_tokens":8,"messages":[]}'
+    )
+
+    user = await service(
+        request,
+        SecurityScopes(scopes=["models:read"]),
+        token=None,
+    )
+
+    assert user["username"] == "anthropic-user"
+
+
+@pytest.mark.asyncio
+async def test_advanced_auth_does_not_accept_x_api_key_on_other_routes(tmp_path):
+    service = AdvancedAuthService(
+        db_path=str(tmp_path / "auth.db"),
+        jwt_secret_key="unit-test-secret",
+        encryption_key="unit-test-encryption-key",
+    )
+    user_id = service.db.create_user(
+        username="openai-user",
+        password_hash=get_password_hash("pass"),
+        source="local",
+        enabled=1,
+        must_change_password=0,
+        permissions=["models:read"],
+    )
+    token = service.create_access_token(user_id, "openai-user", ["models:read"])
+    request = MagicMock()
+    request.url.path = "/v1/chat/completions"
+    request.method = "POST"
+    request.headers = {
+        "x-api-key": token,
+        "content-type": "application/json",
+        "content-length": "32",
+    }
+    request.client.host = "127.0.0.1"
+    request.body = AsyncMock(return_value=b'{"model":"model"}')
+
+    with pytest.raises(Exception) as exc_info:
+        await service(
+            request,
+            SecurityScopes(scopes=["models:read"]),
+            token=None,
+        )
+
+    assert getattr(exc_info.value, "status_code", None) == 401

--- a/xinference/api/tests/test_anthropic_auth.py
+++ b/xinference/api/tests/test_anthropic_auth.py
@@ -8,7 +8,16 @@ from xinference.api.oauth2.advanced.crypto import get_password_hash
 
 
 @pytest.mark.asyncio
-async def test_advanced_auth_accepts_x_api_key_as_credential(tmp_path):
+@pytest.mark.parametrize(
+    ("url_path", "route_path"),
+    [
+        ("/xinference/v1/messages", "/v1/messages"),
+        ("/anthropic/anthropic/v1/messages", "/anthropic/v1/messages"),
+    ],
+)
+async def test_advanced_auth_accepts_x_api_key_as_credential(
+    tmp_path, url_path, route_path
+):
     service = AdvancedAuthService(
         db_path=str(tmp_path / "auth.db"),
         jwt_secret_key="unit-test-secret",
@@ -24,7 +33,8 @@ async def test_advanced_auth_accepts_x_api_key_as_credential(tmp_path):
     )
     token = service.create_access_token(user_id, "anthropic-user", ["models:read"])
     request = MagicMock()
-    request.url.path = "/v1/messages"
+    request.url.path = url_path
+    request.scope = {"route": MagicMock(path=route_path)}
     request.method = "POST"
     request.headers = {
         "x-api-key": token,
@@ -63,6 +73,7 @@ async def test_advanced_auth_does_not_accept_x_api_key_on_other_routes(tmp_path)
     token = service.create_access_token(user_id, "openai-user", ["models:read"])
     request = MagicMock()
     request.url.path = "/v1/chat/completions"
+    request.scope = {"route": MagicMock(path="/v1/chat/completions")}
     request.method = "POST"
     request.headers = {
         "x-api-key": token,

--- a/xinference/api/tests/test_anthropic_messages.py
+++ b/xinference/api/tests/test_anthropic_messages.py
@@ -29,12 +29,13 @@ def make_app(api):
 
 
 @pytest.mark.asyncio
-async def test_standard_path_requires_version_header():
+@pytest.mark.parametrize("root_path", ["", "/xinference", "/anthropic"])
+async def test_standard_path_requires_version_header(root_path):
     app = make_app(make_rest_api())
-    transport = httpx.ASGITransport(app=app)
+    transport = httpx.ASGITransport(app=app, root_path=root_path)
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
         response = await client.post(
-            "/v1/messages",
+            f"{root_path}/v1/messages",
             json={
                 "model": "model",
                 "messages": [{"role": "user", "content": "hello"}],
@@ -68,7 +69,8 @@ async def test_standard_path_rejects_unsupported_version():
 
 
 @pytest.mark.asyncio
-async def test_physical_non_stream_converts_bytes_response(monkeypatch):
+@pytest.mark.parametrize("root_path", ["", "/anthropic"])
+async def test_physical_non_stream_converts_bytes_response(monkeypatch, root_path):
     api = make_rest_api()
     app = make_app(api)
     calls = {}
@@ -96,10 +98,10 @@ async def test_physical_non_stream_converts_bytes_response(monkeypatch):
         return FakeModel()
 
     monkeypatch.setattr(restful_api_module, "require_model", fake_require_model)
-    transport = httpx.ASGITransport(app=app)
+    transport = httpx.ASGITransport(app=app, root_path=root_path)
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
         response = await client.post(
-            "/anthropic/v1/messages",
+            f"{root_path}/anthropic/v1/messages",
             json={
                 "model": "physical-model",
                 "system": "Be helpful.",

--- a/xinference/api/tests/test_anthropic_messages.py
+++ b/xinference/api/tests/test_anthropic_messages.py
@@ -1,0 +1,207 @@
+import json
+from types import MethodType
+
+import httpx
+import pytest
+from fastapi import FastAPI, HTTPException
+
+from xinference.api import restful_api as restful_api_module
+from xinference.api.restful_api import RESTfulAPI
+
+
+def make_rest_api():
+    api = RESTfulAPI.__new__(RESTfulAPI)
+    api._advanced_auth_service = None
+    api._uid_to_model_name = {}
+
+    async def get_supervisor_ref(_self):
+        return object()
+
+    api._get_supervisor_ref = MethodType(get_supervisor_ref, api)
+    return api
+
+
+def make_app(api):
+    app = FastAPI()
+    app.add_api_route("/v1/messages", api.create_message, methods=["POST"])
+    app.add_api_route("/anthropic/v1/messages", api.create_message, methods=["POST"])
+    return app
+
+
+@pytest.mark.asyncio
+async def test_standard_path_requires_version_header():
+    app = make_app(make_rest_api())
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/v1/messages",
+            json={
+                "model": "model",
+                "messages": [{"role": "user", "content": "hello"}],
+                "max_tokens": 32,
+            },
+        )
+
+    assert response.status_code == 400
+    assert response.json()["error"]["type"] == "invalid_request_error"
+    assert "anthropic-version" in response.json()["error"]["message"]
+
+
+@pytest.mark.asyncio
+async def test_standard_path_rejects_unsupported_version():
+    app = make_app(make_rest_api())
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/v1/messages",
+            headers={"anthropic-version": "2099-01-01"},
+            json={
+                "model": "model",
+                "messages": [{"role": "user", "content": "hello"}],
+                "max_tokens": 32,
+            },
+        )
+
+    assert response.status_code == 400
+    assert response.json()["error"]["type"] == "invalid_request_error"
+    assert "2099-01-01" in response.json()["error"]["message"]
+
+
+@pytest.mark.asyncio
+async def test_physical_non_stream_converts_bytes_response(monkeypatch):
+    api = make_rest_api()
+    app = make_app(api)
+    calls = {}
+
+    class FakeModel:
+        uid = "physical-model"
+
+        async def chat(self, messages, kwargs, raw_params=None):
+            calls["messages"] = messages
+            calls["kwargs"] = kwargs
+            calls["raw_params"] = raw_params
+            return json.dumps(
+                {
+                    "choices": [
+                        {
+                            "message": {"content": "physical answer"},
+                            "finish_reason": "stop",
+                        }
+                    ],
+                    "usage": {"prompt_tokens": 4, "completion_tokens": 2},
+                }
+            ).encode()
+
+    async def fake_require_model(*args, **kwargs):
+        return FakeModel()
+
+    monkeypatch.setattr(restful_api_module, "require_model", fake_require_model)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/anthropic/v1/messages",
+            json={
+                "model": "physical-model",
+                "system": "Be helpful.",
+                "messages": [{"role": "user", "content": "hello"}],
+                "max_tokens": 32,
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.json()["content"] == [{"type": "text", "text": "physical answer"}]
+    assert calls == {
+        "messages": [
+            {"role": "system", "content": "Be helpful."},
+            {"role": "user", "content": "hello"},
+        ],
+        "kwargs": {"max_tokens": 32, "stream": False},
+        "raw_params": {"max_tokens": 32, "stream": False},
+    }
+
+
+@pytest.mark.asyncio
+async def test_physical_stream_converts_sse_and_releases_iterator(monkeypatch):
+    api = make_rest_api()
+    app = make_app(api)
+    calls = {"decrease": 0}
+
+    class FakeModel:
+        uid = "physical-model"
+
+        async def chat(self, messages, kwargs, raw_params=None):
+            calls["kwargs"] = kwargs
+            calls["raw_params"] = raw_params
+
+            async def chunks():
+                yield (
+                    'data: {"choices":[{"delta":{"content":"one"},'
+                    '"finish_reason":null}]}\n\n'
+                    'data: {"choices":[{"delta":{"content":" two"},'
+                    '"finish_reason":"stop"}]}\n\n'
+                )
+                yield (
+                    'data: {"choices":[],"usage":{"prompt_tokens":6,'
+                    '"completion_tokens":2}}\n\n'
+                )
+                yield "data: [DONE]\n\n"
+
+            return chunks()
+
+        async def decrease_serve_count(self):
+            calls["decrease"] += 1
+
+    async def fake_require_model(*args, **kwargs):
+        return FakeModel()
+
+    monkeypatch.setattr(restful_api_module, "require_model", fake_require_model)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/anthropic/v1/messages",
+            json={
+                "model": "physical-model",
+                "messages": [{"role": "user", "content": "hello"}],
+                "max_tokens": 32,
+                "stream": True,
+            },
+        )
+
+    assert response.status_code == 200
+    assert calls["kwargs"] == {
+        "max_tokens": 32,
+        "stream": True,
+        "stream_options": {"include_usage": True},
+    }
+    assert calls["raw_params"] == calls["kwargs"]
+    assert calls["decrease"] == 1
+    assert '"text": "one"' in response.text
+    assert '"text": " two"' in response.text
+    assert '"output_tokens": 2' in response.text
+    assert response.text.count("event: message_stop") == 1
+
+
+@pytest.mark.asyncio
+async def test_missing_physical_model_returns_anthropic_not_found(monkeypatch):
+    app = make_app(make_rest_api())
+
+    async def fake_require_model(*args, **kwargs):
+        raise HTTPException(status_code=404, detail="model not found")
+
+    monkeypatch.setattr(restful_api_module, "require_model", fake_require_model)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/anthropic/v1/messages",
+            json={
+                "model": "missing-model",
+                "messages": [{"role": "user", "content": "hello"}],
+                "max_tokens": 32,
+            },
+        )
+
+    assert response.status_code == 404
+    assert response.json()["error"] == {
+        "type": "not_found_error",
+        "message": "model not found",
+    }

--- a/xinference/api/tests/test_anthropic_protocol.py
+++ b/xinference/api/tests/test_anthropic_protocol.py
@@ -170,30 +170,40 @@ def test_openai_response_maps_text_thinking_tools_stop_and_usage():
     assert response["usage"] == {"input_tokens": 12, "output_tokens": 7}
 
 
-def test_openai_response_rejects_invalid_tool_json():
-    with pytest.raises(AnthropicProtocolError) as exc_info:
-        openai_to_anthropic(
-            {
-                "choices": [
-                    {
-                        "message": {
-                            "tool_calls": [
-                                {
-                                    "function": {
-                                        "name": "weather",
-                                        "arguments": "{invalid",
-                                    }
+@pytest.mark.parametrize(
+    "arguments",
+    ["{invalid", "[]", '"value"', "1", "null", ["already-decoded"]],
+)
+def test_openai_response_defaults_invalid_tool_arguments_to_empty_object(arguments):
+    response = openai_to_anthropic(
+        {
+            "choices": [
+                {
+                    "message": {
+                        "tool_calls": [
+                            {
+                                "function": {
+                                    "name": "weather",
+                                    "arguments": arguments,
                                 }
-                            ]
-                        },
-                        "finish_reason": "tool_calls",
-                    }
-                ]
-            },
-            "model",
-        )
-    assert exc_info.value.status_code == 500
-    assert exc_info.value.error_type == "api_error"
+                            }
+                        ]
+                    },
+                    "finish_reason": "tool_calls",
+                }
+            ]
+        },
+        "model",
+    )
+
+    assert response["content"] == [
+        {
+            "type": "tool_use",
+            "id": response["content"][0]["id"],
+            "name": "weather",
+            "input": {},
+        }
+    ]
 
 
 @pytest.mark.asyncio
@@ -366,3 +376,24 @@ async def test_stream_error_terminates_without_message_stop():
     assert json.loads(events[-1]["data"]) == anthropic_error_response(
         "rate_limit_error", "slow down", "req_2"
     )
+
+
+@pytest.mark.asyncio
+async def test_stream_closes_inner_iterator_when_consumer_stops_early():
+    closed = False
+
+    async def chunks():
+        nonlocal closed
+        try:
+            yield {"choices": [{"delta": {"content": "hello"}, "finish_reason": None}]}
+        finally:
+            closed = True
+
+    events = anthropic_stream_events(chunks(), "model", "req_disconnect")
+    assert (await anext(events))["event"] == "message_start"
+    assert (await anext(events))["event"] == "content_block_start"
+    assert closed is False
+
+    await events.aclose()
+
+    assert closed is True

--- a/xinference/api/tests/test_anthropic_protocol.py
+++ b/xinference/api/tests/test_anthropic_protocol.py
@@ -1,0 +1,368 @@
+import json
+
+import pytest
+
+from xinference.api.protocols import (
+    AnthropicProtocolError,
+    anthropic_error_response,
+    anthropic_stream_events,
+    openai_to_anthropic,
+    parse_anthropic_request,
+)
+
+
+def _base_request(**overrides):
+    body = {
+        "model": "virtual-model",
+        "max_tokens": 512,
+        "messages": [{"role": "user", "content": "hello"}],
+    }
+    body.update(overrides)
+    return body
+
+
+def test_parse_request_maps_system_stop_tools_and_thinking():
+    request = parse_anthropic_request(
+        _base_request(
+            system=[
+                {"type": "text", "text": "x-anthropic-billing-header: ignored"},
+                {"type": "text", "text": "Be concise."},
+            ],
+            messages=[
+                {"role": "system", "content": "Use metric units."},
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": "toolu_1",
+                            "name": "weather",
+                            "input": {"city": "Shanghai"},
+                        }
+                    ],
+                },
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "toolu_1",
+                            "content": [{"type": "text", "text": "sunny"}],
+                        }
+                    ],
+                },
+            ],
+            stop_sequences=["END"],
+            temperature=0.2,
+            top_p=0.8,
+            top_k=20,
+            tools=[
+                {
+                    "name": "weather",
+                    "description": "Get weather",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                    },
+                }
+            ],
+            tool_choice={"type": "tool", "name": "weather"},
+            thinking={"type": "enabled", "budget_tokens": 128},
+            stream=True,
+        )
+    )
+
+    body = request.to_openai_body()
+    assert body["model"] == "virtual-model"
+    assert body["messages"] == [
+        {"role": "system", "content": "Be concise.\nUse metric units."},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "toolu_1",
+                    "type": "function",
+                    "function": {
+                        "name": "weather",
+                        "arguments": '{"city": "Shanghai"}',
+                    },
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "toolu_1", "content": "sunny"},
+    ]
+    assert body["stop"] == ["END"]
+    assert body["tools"][0]["function"]["parameters"]["type"] == "object"
+    assert body["tool_choice"] == {
+        "type": "function",
+        "function": {"name": "weather"},
+    }
+    assert body["chat_template_kwargs"] == {
+        "enable_thinking": True,
+        "thinking": True,
+        "thinking_budget": 128,
+    }
+    assert body["stream_options"] == {"include_usage": True}
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"messages": [{"role": "user", "content": [{"type": "image"}]}]}, "image"),
+        ({"stream": "true"}, "stream"),
+        ({"temperature": 1.1}, "temperature"),
+        ({"top_p": -0.1}, "top_p"),
+        ({"top_k": 0}, "top_k"),
+        (
+            {"thinking": {"type": "enabled", "budget_tokens": 512}},
+            "budget_tokens",
+        ),
+    ],
+)
+def test_parse_request_rejects_invalid_or_unsupported_fields(overrides, message):
+    with pytest.raises(AnthropicProtocolError) as exc_info:
+        parse_anthropic_request(_base_request(**overrides))
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.error_type == "invalid_request_error"
+    assert message in exc_info.value.message
+
+
+def test_openai_response_maps_text_thinking_tools_stop_and_usage():
+    response = openai_to_anthropic(
+        {
+            "choices": [
+                {
+                    "message": {
+                        "reasoning_content": "reasoning",
+                        "content": "answer",
+                        "tool_calls": [
+                            {
+                                "id": "call_1",
+                                "function": {
+                                    "name": "weather",
+                                    "arguments": '{"city":"Beijing"}',
+                                },
+                            }
+                        ],
+                    },
+                    "finish_reason": "tool_calls",
+                }
+            ],
+            "usage": {"prompt_tokens": 12, "completion_tokens": 7},
+        },
+        "virtual-model",
+    )
+
+    assert response["id"].startswith("msg_")
+    assert response["model"] == "virtual-model"
+    assert response["stop_reason"] == "tool_use"
+    assert response["content"] == [
+        {"type": "thinking", "thinking": "reasoning"},
+        {"type": "text", "text": "answer"},
+        {
+            "type": "tool_use",
+            "id": "call_1",
+            "name": "weather",
+            "input": {"city": "Beijing"},
+        },
+    ]
+    assert response["usage"] == {"input_tokens": 12, "output_tokens": 7}
+
+
+def test_openai_response_rejects_invalid_tool_json():
+    with pytest.raises(AnthropicProtocolError) as exc_info:
+        openai_to_anthropic(
+            {
+                "choices": [
+                    {
+                        "message": {
+                            "tool_calls": [
+                                {
+                                    "function": {
+                                        "name": "weather",
+                                        "arguments": "{invalid",
+                                    }
+                                }
+                            ]
+                        },
+                        "finish_reason": "tool_calls",
+                    }
+                ]
+            },
+            "model",
+        )
+    assert exc_info.value.status_code == 500
+    assert exc_info.value.error_type == "api_error"
+
+
+@pytest.mark.asyncio
+async def test_stream_maps_thinking_text_tool_and_usage_in_order():
+    async def chunks():
+        yield {
+            "choices": [
+                {"delta": {"reasoning_content": "think"}, "finish_reason": None}
+            ]
+        }
+        yield {"choices": [{"delta": {"content": "hello"}, "finish_reason": None}]}
+        yield {
+            "choices": [
+                {
+                    "delta": {
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "id": "call_1",
+                                "function": {
+                                    "name": "weather",
+                                    "arguments": '{"city":',
+                                },
+                            }
+                        ]
+                    },
+                    "finish_reason": None,
+                }
+            ]
+        }
+        yield {
+            "choices": [
+                {
+                    "delta": {
+                        "tool_calls": [
+                            {"index": 0, "function": {"arguments": '"Paris"}'}}
+                        ]
+                    },
+                    "finish_reason": "tool_calls",
+                }
+            ]
+        }
+        yield {
+            "choices": [],
+            "usage": {"prompt_tokens": 9, "completion_tokens": 5},
+        }
+
+    events = [
+        event
+        async for event in anthropic_stream_events(chunks(), "virtual-model", "req_1")
+    ]
+    names = [event["event"] for event in events]
+    assert names == [
+        "message_start",
+        "content_block_start",
+        "content_block_delta",
+        "content_block_stop",
+        "content_block_start",
+        "content_block_delta",
+        "content_block_stop",
+        "content_block_start",
+        "content_block_delta",
+        "content_block_delta",
+        "content_block_stop",
+        "message_delta",
+        "message_stop",
+    ]
+    payloads = [json.loads(event["data"]) for event in events]
+    assert payloads[0]["message"]["id"].startswith("msg_")
+    tool_start = next(
+        payload
+        for payload in payloads
+        if payload.get("type") == "content_block_start"
+        and payload["content_block"]["type"] == "tool_use"
+    )
+    assert tool_start["content_block"]["id"] == "call_1"
+    tool_deltas = [
+        payload["delta"]["partial_json"]
+        for payload in payloads
+        if payload.get("type") == "content_block_delta"
+        and payload["delta"]["type"] == "input_json_delta"
+    ]
+    assert tool_deltas == ['{"city":', '"Paris"}']
+    assert payloads[-2]["delta"]["stop_reason"] == "tool_use"
+    assert payloads[-2]["usage"] == {"output_tokens": 5}
+
+    active_index = None
+    for payload in payloads:
+        if payload.get("type") == "content_block_start":
+            assert active_index is None
+            active_index = payload["index"]
+        elif payload.get("type") == "content_block_stop":
+            assert payload["index"] == active_index
+            active_index = None
+    assert active_index is None
+
+
+@pytest.mark.asyncio
+async def test_stream_buffers_multiple_tool_calls_by_index():
+    async def chunks():
+        yield {
+            "choices": [
+                {
+                    "delta": {
+                        "tool_calls": [
+                            {
+                                "index": 1,
+                                "id": "call_2",
+                                "function": {"name": "time", "arguments": '{"tz":'},
+                            },
+                            {
+                                "index": 0,
+                                "id": "call_1",
+                                "function": {
+                                    "name": "weather",
+                                    "arguments": '{"city":',
+                                },
+                            },
+                        ]
+                    },
+                    "finish_reason": None,
+                }
+            ]
+        }
+        yield {
+            "choices": [
+                {
+                    "delta": {
+                        "tool_calls": [
+                            {"index": 1, "function": {"arguments": '"UTC"}'}},
+                            {
+                                "index": 0,
+                                "function": {"arguments": '"Paris"}'},
+                            },
+                        ]
+                    },
+                    "finish_reason": "tool_calls",
+                }
+            ]
+        }
+
+    payloads = [
+        json.loads(event["data"])
+        async for event in anthropic_stream_events(chunks(), "model", "req_tools")
+    ]
+    starts = [
+        payload["content_block"]
+        for payload in payloads
+        if payload.get("type") == "content_block_start"
+    ]
+    assert [block["id"] for block in starts] == ["call_1", "call_2"]
+    deltas = [
+        payload["delta"]["partial_json"]
+        for payload in payloads
+        if payload.get("type") == "content_block_delta"
+    ]
+    assert deltas == ['{"city":', '"Paris"}', '{"tz":', '"UTC"}']
+
+
+@pytest.mark.asyncio
+async def test_stream_error_terminates_without_message_stop():
+    async def chunks():
+        yield {"error": {"type": "rate_limit_error", "message": "slow down"}}
+        yield {"choices": [{"delta": {"content": "not emitted"}}]}
+
+    events = [
+        event async for event in anthropic_stream_events(chunks(), "model", "req_2")
+    ]
+    assert [event["event"] for event in events] == ["message_start", "error"]
+    assert json.loads(events[-1]["data"]) == anthropic_error_response(
+        "rate_limit_error", "slow down", "req_2"
+    )

--- a/xinference/api/tests/test_anthropic_protocol.py
+++ b/xinference/api/tests/test_anthropic_protocol.py
@@ -1,6 +1,17 @@
 import json
 
 import pytest
+from anthropic import NOT_GIVEN
+from anthropic.lib.streaming import MessageStream
+from anthropic.types import (
+    Message,
+    RawContentBlockDeltaEvent,
+    RawContentBlockStartEvent,
+    RawContentBlockStopEvent,
+    RawMessageDeltaEvent,
+    RawMessageStartEvent,
+    RawMessageStopEvent,
+)
 
 from xinference.api.protocols import (
     AnthropicProtocolError,
@@ -67,7 +78,8 @@ def test_parse_request_maps_system_stop_tools_and_thinking():
                 }
             ],
             tool_choice={"type": "tool", "name": "weather"},
-            thinking={"type": "enabled", "budget_tokens": 128},
+            max_tokens=2048,
+            thinking={"type": "enabled", "budget_tokens": 1024},
             stream=True,
         )
     )
@@ -101,9 +113,81 @@ def test_parse_request_maps_system_stop_tools_and_thinking():
     assert body["chat_template_kwargs"] == {
         "enable_thinking": True,
         "thinking": True,
-        "thinking_budget": 128,
+        "thinking_budget": 1024,
     }
     assert body["stream_options"] == {"include_usage": True}
+
+
+def test_parse_request_orders_tool_results_before_follow_up_text():
+    request = parse_anthropic_request(
+        _base_request(
+            messages=[
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": "toolu_1",
+                            "name": "weather",
+                            "input": {"city": "Paris"},
+                        }
+                    ],
+                },
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "toolu_1",
+                            "content": "sunny",
+                        },
+                        {"type": "text", "text": "Please summarize it."},
+                    ],
+                },
+            ]
+        )
+    )
+
+    assert request.messages == [
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "toolu_1",
+                    "type": "function",
+                    "function": {
+                        "name": "weather",
+                        "arguments": '{"city": "Paris"}',
+                    },
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "toolu_1", "content": "sunny"},
+        {"role": "user", "content": "Please summarize it."},
+    ]
+
+
+def test_parse_request_enforces_minimum_thinking_budget():
+    with pytest.raises(AnthropicProtocolError) as exc_info:
+        parse_anthropic_request(
+            _base_request(
+                max_tokens=2048,
+                thinking={"type": "enabled", "budget_tokens": 1023},
+            )
+        )
+    assert (
+        exc_info.value.message
+        == "thinking.budget_tokens must be greater than or equal to 1024"
+    )
+
+    request = parse_anthropic_request(
+        _base_request(
+            max_tokens=2048,
+            thinking={"type": "enabled", "budget_tokens": 1024},
+        )
+    )
+    assert request.thinking_budget_tokens == 1024
 
 
 @pytest.mark.parametrize(
@@ -128,7 +212,7 @@ def test_parse_request_rejects_invalid_or_unsupported_fields(overrides, message)
     assert message in exc_info.value.message
 
 
-def test_openai_response_maps_text_thinking_tools_stop_and_usage():
+def test_openai_response_omits_unsigned_thinking_and_maps_text_tools():
     response = openai_to_anthropic(
         {
             "choices": [
@@ -158,7 +242,6 @@ def test_openai_response_maps_text_thinking_tools_stop_and_usage():
     assert response["model"] == "virtual-model"
     assert response["stop_reason"] == "tool_use"
     assert response["content"] == [
-        {"type": "thinking", "thinking": "reasoning"},
         {"type": "text", "text": "answer"},
         {
             "type": "tool_use",
@@ -168,6 +251,8 @@ def test_openai_response_maps_text_thinking_tools_stop_and_usage():
         },
     ]
     assert response["usage"] == {"input_tokens": 12, "output_tokens": 7}
+    sdk_message = Message(**response)
+    assert [block.type for block in sdk_message.content] == ["text", "tool_use"]
 
 
 @pytest.mark.parametrize(
@@ -207,7 +292,7 @@ def test_openai_response_defaults_invalid_tool_arguments_to_empty_object(argumen
 
 
 @pytest.mark.asyncio
-async def test_stream_maps_thinking_text_tool_and_usage_in_order():
+async def test_stream_omits_unsigned_thinking_and_maps_text_tool_usage():
     async def chunks():
         yield {
             "choices": [
@@ -263,9 +348,6 @@ async def test_stream_maps_thinking_text_tool_and_usage_in_order():
         "content_block_stop",
         "content_block_start",
         "content_block_delta",
-        "content_block_stop",
-        "content_block_start",
-        "content_block_delta",
         "content_block_delta",
         "content_block_stop",
         "message_delta",
@@ -299,6 +381,29 @@ async def test_stream_maps_thinking_text_tool_and_usage_in_order():
             assert payload["index"] == active_index
             active_index = None
     assert active_index is None
+
+    event_types = {
+        "message_start": RawMessageStartEvent,
+        "content_block_start": RawContentBlockStartEvent,
+        "content_block_delta": RawContentBlockDeltaEvent,
+        "content_block_stop": RawContentBlockStopEvent,
+        "message_delta": RawMessageDeltaEvent,
+        "message_stop": RawMessageStopEvent,
+    }
+    sdk_events = [event_types[payload["type"]](**payload) for payload in payloads]
+
+    class RawStream:
+        def __iter__(self):
+            return iter(sdk_events)
+
+        def close(self):
+            pass
+
+    sdk_message = MessageStream(
+        RawStream(), output_format=NOT_GIVEN
+    ).get_final_message()
+    assert [block.type for block in sdk_message.content] == ["text", "tool_use"]
+    assert sdk_message.content[0].text == "hello"
 
 
 @pytest.mark.asyncio

--- a/xinference/api/utils.py
+++ b/xinference/api/utils.py
@@ -22,11 +22,19 @@ import time
 from collections import OrderedDict
 from typing import Any, Callable, Optional
 
-from fastapi import HTTPException
+from fastapi import HTTPException, Request
 
 from ..core.exceptions import ModelNotReadyError
 
 logger = logging.getLogger(__name__)
+
+
+def get_request_route_path(request: Request) -> str:
+    """Return the matched route path without an ASGI ``root_path`` prefix."""
+    route = request.scope.get("route")
+    route_path = getattr(route, "path", None)
+    return route_path if isinstance(route_path, str) else request.url.path
+
 
 # ---------------------------------------------------------------------------
 # Negative cache for ``get_model`` – prevents retry floods from blocking


### PR DESCRIPTION
## Summary

- add a dependency-free Anthropic Messages protocol adapter for request, response, error, and SSE conversion
- expose both the standard `/v1/messages` endpoint and the backward-compatible `/anthropic/v1/messages` endpoint
- translate Anthropic system/text/tool-use/tool-result inputs into the existing OpenAI-compatible chat backend contract
- translate text, reasoning, tool calls, finish reasons, usage, and streaming events back to Anthropic format
- accept `x-api-key` as an authentication carrier only on Anthropic Messages routes

## Protocol behavior

- `/v1/messages` requires `anthropic-version: 2023-06-01`
- `/anthropic/v1/messages` remains compatible with existing clients that omit the version header
- text and tool blocks are supported
- unsupported multimodal and extended-thinking history blocks return Anthropic-shaped `invalid_request_error` responses
- streamed content blocks are emitted sequentially, including fragmented or interleaved OpenAI tool-call arguments

## Relationship to #5051

#5051 contains model/chat-template-specific compatibility work for Qwen tool flows. This PR keeps that backend concern separate and implements the public Anthropic protocol boundary consistently for physical models. It does not include the Qwen template normalization from #5051.

A follow-up PR will reuse this adapter to route Anthropic Messages requests through Token Router virtual models.

## Tests

- `pytest -q xinference/api/tests/test_anthropic_protocol.py xinference/api/tests/test_anthropic_auth.py xinference/api/tests/test_anthropic_messages.py`
- `pytest -q xinference/core/tests/test_restful_api.py -k anthropic`
- `pre-commit run --files xinference/api/protocols/__init__.py xinference/api/protocols/anthropic.py xinference/api/restful_api.py xinference/api/routers/llm.py xinference/api/oauth2/advanced/auth_service.py xinference/api/tests/test_anthropic_protocol.py xinference/api/tests/test_anthropic_auth.py xinference/api/tests/test_anthropic_messages.py`
