### PR TITLE
fix(image): pin Qwen Layered dependencies

### DIFF
--- a/xinference/model/image/model_spec.json
+++ b/xinference/model/image/model_spec.json
@@ -1445,7 +1445,8 @@
     "virtualenv": {
       "packages": [
         "#diffusers_dependencies# ; #engine# == \"diffusers\"",
-        "transformers>=4.51.3",
+        "transformers>=4.51.3,<5",
+        "bitsandbytes>=0.49.2,<0.50 ; #engine# == \"diffusers\"",
         "#system_torch#",
         "#system_numpy#"
       ],


### PR DESCRIPTION
Require bitsandbytes for default text encoder quantization and keep transformers below the unsupported 5.x series.

## Summary

- Pin `transformers` to `>=4.51.3,<5` for Qwen-Image-Layered.
- Add `bitsandbytes>=0.49.2,<0.50` to its Diffusers virtual environment.

## Problem

Qwen-Image-Layered enables text encoder quantization through
`quantize_text_encoder`. The Diffusers backend uses BitsAndBytes 8-bit
quantization by default, but the model virtual environment did not install
`bitsandbytes`.

This caused model launch to fail with:

```text
Failed to import module 'bitsandbytes'
```

The previous open-ended `transformers>=4.51.3` constraint could also install
an incompatible future major release.

## Impact

Qwen-Image-Layered can now create its isolated virtual environment with all
dependencies required by the default text encoder quantization configuration.

The BitsAndBytes dependency is limited to the Diffusers engine. Other model
cards are unaffected.
