### PR TITLE
feat(router): route Anthropic Messages through virtual models

### DIFF
--- a/xinference/api/restful_api.py
+++ b/xinference/api/restful_api.py
@@ -133,12 +133,13 @@ _TOKEN_ROUTER_REQUEST_HEADERS = {
 
 
 def _request_credential(request: Request) -> str:
-    authorization = request.headers.get("authorization", "")
+    headers = {key.lower(): value for key, value in request.headers.items()}
+    authorization = headers.get("authorization", "")
     if authorization.lower().startswith("bearer "):
         bearer_token = authorization[7:].strip()
         if bearer_token:
             return bearer_token
-    return request.headers.get("x-api-key", "").strip()
+    return headers.get("x-api-key", "").strip()
 
 
 def _token_router_request_headers(
@@ -672,30 +673,26 @@ class RESTfulAPI(CancelMixin):
         runtime: Dict[str, Any],
         *,
         forward_external_credential: bool = True,
-    ) -> tuple[httpx.AsyncClient, httpx.Response, str]:
+    ) -> tuple[httpx.Response, str]:
         request_id = (
             request.headers.get("request-id")
             or request.headers.get("x-request-id")
             or f"xinf-{uuid.uuid4()}"
         )
         upstream_url = f"{runtime['endpoint']}/v1/chat/completions"
-        client = httpx.AsyncClient(timeout=None, follow_redirects=False)
-        try:
-            upstream_request = client.build_request(
-                "POST",
-                upstream_url,
-                headers=_token_router_request_headers(
-                    request,
-                    request_id,
-                    forward_external_credential=forward_external_credential,
-                ),
-                json=raw_body,
-            )
-            upstream_response = await client.send(upstream_request, stream=True)
-        except httpx.HTTPError:
-            await client.aclose()
-            raise
-        return client, upstream_response, request_id
+        client = self._get_token_router_client()
+        upstream_request = client.build_request(
+            "POST",
+            upstream_url,
+            headers=_token_router_request_headers(
+                request,
+                request_id,
+                forward_external_credential=forward_external_credential,
+            ),
+            json=raw_body,
+        )
+        upstream_response = await client.send(upstream_request, stream=True)
+        return upstream_response, request_id
 
     async def _proxy_token_router_chat_completion(
         self,
@@ -1851,7 +1848,7 @@ class RESTfulAPI(CancelMixin):
                     headers={"Retry-After": "1"},
                 )
             try:
-                client, upstream_response, request_id = (
+                upstream_response, request_id = (
                     await self._open_token_router_chat_completion(
                         request,
                         openai_body,
@@ -1880,7 +1877,6 @@ class RESTfulAPI(CancelMixin):
                     error_payload = {}
                 finally:
                     await upstream_response.aclose()
-                    await client.aclose()
                 error = error_payload.get("error") or {}
                 error_message = (
                     error.get("message") if isinstance(error, dict) else str(error)
@@ -1909,7 +1905,6 @@ class RESTfulAPI(CancelMixin):
                         yield {"error": {"type": "api_error", "message": str(exc)}}
                     finally:
                         await upstream_response.aclose()
-                        await client.aclose()
 
                 return EventSourceResponse(
                     anthropic_stream_events(router_chunks(), model_uid, request_id),
@@ -1929,7 +1924,6 @@ class RESTfulAPI(CancelMixin):
                 return self._anthropic_error(502, str(exc), request_id)
             finally:
                 await upstream_response.aclose()
-                await client.aclose()
 
         try:
             model = await require_model(

--- a/xinference/api/restful_api.py
+++ b/xinference/api/restful_api.py
@@ -1889,6 +1889,13 @@ class RESTfulAPI(CancelMixin):
                 )
 
             if canonical.stream:
+                cleanup_task: asyncio.Task[None] | None = None
+
+                async def release_resources() -> None:
+                    nonlocal cleanup_task
+                    if cleanup_task is None:
+                        cleanup_task = asyncio.create_task(upstream_response.aclose())
+                    await asyncio.shield(cleanup_task)
 
                 async def router_chunks() -> AsyncIterator[Dict[str, Any]]:
                     try:
@@ -1904,12 +1911,13 @@ class RESTfulAPI(CancelMixin):
                         logger.exception("Anthropic Token Router stream failed")
                         yield {"error": {"type": "api_error", "message": str(exc)}}
                     finally:
-                        await upstream_response.aclose()
+                        await release_resources()
 
                 return EventSourceResponse(
                     anthropic_stream_events(router_chunks(), model_uid, request_id),
                     ping=XINFERENCE_SSE_PING_ATTEMPTS_SECONDS,
                     headers={"request-id": request_id},
+                    background=BackgroundTask(release_resources),
                 )
 
             try:

--- a/xinference/api/restful_api.py
+++ b/xinference/api/restful_api.py
@@ -467,7 +467,7 @@ class RESTfulAPI(CancelMixin):
     ):
         if not self._advanced_auth_service:
             return
-        token = request.headers.get("Authorization", "").replace("Bearer ", "")
+        token = _request_credential(request)
         if not token:
             return
         from .oauth2.advanced.crypto import sha256_hex

--- a/xinference/api/restful_api.py
+++ b/xinference/api/restful_api.py
@@ -132,12 +132,35 @@ _TOKEN_ROUTER_REQUEST_HEADERS = {
 }
 
 
-def _token_router_request_headers(request: Request, request_id: str) -> Dict[str, str]:
+def _request_credential(request: Request) -> str:
+    authorization = request.headers.get("authorization", "")
+    if authorization.lower().startswith("bearer "):
+        bearer_token = authorization[7:].strip()
+        if bearer_token:
+            return bearer_token
+    return request.headers.get("x-api-key", "").strip()
+
+
+def _token_router_request_headers(
+    request: Request,
+    request_id: str,
+    *,
+    forward_external_credential: bool = True,
+) -> Dict[str, str]:
     headers = {
         key.lower(): value
         for key, value in request.headers.items()
         if key.lower() in _TOKEN_ROUTER_REQUEST_HEADERS
+        and key.lower() != "authorization"
     }
+    internal_token = os.getenv("XINFERENCE_TOKEN_ROUTER_DATA_PLANE_TOKEN") or os.getenv(
+        "XINFERENCE_TOKEN_ROUTER_INTERNAL_TOKEN"
+    )
+    credential = internal_token
+    if not credential and forward_external_credential:
+        credential = _request_credential(request)
+    if credential:
+        headers["authorization"] = f"Bearer {credential}"
     headers["content-type"] = "application/json"
     headers["x-request-id"] = request_id
     return headers
@@ -418,7 +441,7 @@ class RESTfulAPI(CancelMixin):
     ):
         if not self._advanced_auth_service:
             return
-        token = request.headers.get("Authorization", "").replace("Bearer ", "")
+        token = _request_credential(request)
         if not token:
             return
         if not self._advanced_auth_service.validate_model_access(
@@ -641,6 +664,38 @@ class RESTfulAPI(CancelMixin):
         if client is not None:
             await client.aclose()
             self._token_router_client = None
+
+    async def _open_token_router_chat_completion(
+        self,
+        request: Request,
+        raw_body: Dict[str, Any],
+        runtime: Dict[str, Any],
+        *,
+        forward_external_credential: bool = True,
+    ) -> tuple[httpx.AsyncClient, httpx.Response, str]:
+        request_id = (
+            request.headers.get("request-id")
+            or request.headers.get("x-request-id")
+            or f"xinf-{uuid.uuid4()}"
+        )
+        upstream_url = f"{runtime['endpoint']}/v1/chat/completions"
+        client = httpx.AsyncClient(timeout=None, follow_redirects=False)
+        try:
+            upstream_request = client.build_request(
+                "POST",
+                upstream_url,
+                headers=_token_router_request_headers(
+                    request,
+                    request_id,
+                    forward_external_credential=forward_external_credential,
+                ),
+                json=raw_body,
+            )
+            upstream_response = await client.send(upstream_request, stream=True)
+        except httpx.HTTPError:
+            await client.aclose()
+            raise
+        return client, upstream_response, request_id
 
     async def _proxy_token_router_chat_completion(
         self,
@@ -1776,6 +1831,107 @@ class RESTfulAPI(CancelMixin):
             )
 
         try:
+            supervisor_ref = await self._get_supervisor_ref()
+            token_router_runtime = await supervisor_ref.resolve_token_router_runtime(
+                model_uid
+            )
+        except Exception:
+            logger.exception("Failed to resolve Anthropic model target: %s", model_uid)
+            return self._anthropic_error(
+                500, "Failed to resolve the requested model", request_id
+            )
+
+        openai_body = canonical.to_openai_body()
+        if token_router_runtime is not None:
+            if not token_router_runtime.get("available"):
+                return self._anthropic_error(
+                    503,
+                    f"No ready Token Router runtime is available for virtual model {model_uid}",
+                    request_id,
+                    headers={"Retry-After": "1"},
+                )
+            try:
+                client, upstream_response, request_id = (
+                    await self._open_token_router_chat_completion(
+                        request,
+                        openai_body,
+                        token_router_runtime,
+                        forward_external_credential=False,
+                    )
+                )
+            except httpx.HTTPError:
+                logger.exception(
+                    "Anthropic Token Router connection failed: virtual_model_uid=%s",
+                    model_uid,
+                )
+                return self._anthropic_error(
+                    502,
+                    "Token Router runtime is temporarily unavailable",
+                    request_id,
+                    headers={"Retry-After": "1"},
+                )
+
+            if upstream_response.status_code >= 400:
+                retry_after = upstream_response.headers.get("retry-after")
+                try:
+                    raw_error = await upstream_response.aread()
+                    error_payload = json.loads(raw_error) if raw_error else {}
+                except Exception:
+                    error_payload = {}
+                finally:
+                    await upstream_response.aclose()
+                    await client.aclose()
+                error = error_payload.get("error") or {}
+                error_message = (
+                    error.get("message") if isinstance(error, dict) else str(error)
+                )
+                return self._anthropic_error(
+                    upstream_response.status_code,
+                    error_message or "Token Router request failed",
+                    request_id,
+                    headers={"Retry-After": retry_after} if retry_after else None,
+                )
+
+            if canonical.stream:
+
+                async def router_chunks() -> AsyncIterator[Dict[str, Any]]:
+                    try:
+                        async for chunk in self._iter_openai_sse_bytes(
+                            upstream_response.aiter_raw()
+                        ):
+                            if await request.is_disconnected():
+                                break
+                            yield chunk
+                    except asyncio.CancelledError:
+                        raise
+                    except Exception as exc:
+                        logger.exception("Anthropic Token Router stream failed")
+                        yield {"error": {"type": "api_error", "message": str(exc)}}
+                    finally:
+                        await upstream_response.aclose()
+                        await client.aclose()
+
+                return EventSourceResponse(
+                    anthropic_stream_events(router_chunks(), model_uid, request_id),
+                    ping=XINFERENCE_SSE_PING_ATTEMPTS_SECONDS,
+                    headers={"request-id": request_id},
+                )
+
+            try:
+                raw_response = await upstream_response.aread()
+                openai_response = json.loads(raw_response)
+                return JSONResponse(
+                    content=openai_to_anthropic(openai_response, model_uid),
+                    headers={"request-id": request_id},
+                )
+            except (json.JSONDecodeError, AnthropicProtocolError) as exc:
+                logger.error("Invalid Token Router response: %s", exc)
+                return self._anthropic_error(502, str(exc), request_id)
+            finally:
+                await upstream_response.aclose()
+                await client.aclose()
+
+        try:
             model = await require_model(
                 self._get_supervisor_ref, model_uid, self._report_error_event
             )
@@ -1787,7 +1943,6 @@ class RESTfulAPI(CancelMixin):
             logger.error(exc, exc_info=True)
             return self._anthropic_error(500, str(exc), request_id)
 
-        openai_body = canonical.to_openai_body()
         kwargs = {
             key: value
             for key, value in openai_body.items()

--- a/xinference/api/tests/conftest.py
+++ b/xinference/api/tests/conftest.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+from sse_starlette.sse import AppStatus
+
+
+@pytest.fixture(autouse=True)
+def reset_sse_starlette_exit_event() -> Iterator[None]:
+    if not hasattr(AppStatus, "should_exit_event"):
+        yield
+        return
+
+    setattr(AppStatus, "should_exit_event", None)
+    try:
+        yield
+    finally:
+        setattr(AppStatus, "should_exit_event", None)

--- a/xinference/api/tests/test_anthropic_messages.py
+++ b/xinference/api/tests/test_anthropic_messages.py
@@ -14,8 +14,12 @@ def make_rest_api():
     api._advanced_auth_service = None
     api._uid_to_model_name = {}
 
+    class FakeSupervisor:
+        async def resolve_token_router_runtime(self, model_uid):
+            return None
+
     async def get_supervisor_ref(_self):
-        return object()
+        return FakeSupervisor()
 
     api._get_supervisor_ref = MethodType(get_supervisor_ref, api)
     return api

--- a/xinference/api/tests/test_token_router_audit.py
+++ b/xinference/api/tests/test_token_router_audit.py
@@ -1,11 +1,15 @@
-from types import MethodType
+from types import MethodType, SimpleNamespace
+from unittest.mock import MagicMock
 
 import httpx
 import pytest
-from fastapi import FastAPI, Response
+from fastapi import FastAPI, Request, Response
 
+from xinference.api.oauth2.advanced import audit as audit_module
 from xinference.api.oauth2.advanced.audit import classify_endpoint, should_skip_audit
+from xinference.api.oauth2.advanced.crypto import sha256_hex
 from xinference.api.restful_api import RESTfulAPI
+from xinference.core import metrics as core_metrics
 
 
 def test_internal_token_router_endpoints_skip_audit():
@@ -56,4 +60,96 @@ async def test_token_router_management_request_records_final_audit_status():
     endpoint, status, latency_s = recorded[0]
     assert endpoint == "/v1/token_routers/router-1/enable"
     assert status == "error"
+    assert latency_s >= 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("model_access_allowed", "expected_status_code", "expected_audit_status"),
+    [(True, 200, "success"), (False, 403, "denied")],
+)
+async def test_anthropic_x_api_key_records_inference_audit(
+    monkeypatch,
+    model_access_allowed,
+    expected_status_code,
+    expected_audit_status,
+):
+    token = "external-anthropic-key"
+    entry = SimpleNamespace(
+        user_id=7,
+        name="anthropic-key",
+        key_prefix="sk-test",
+    )
+    auth_service = SimpleNamespace(
+        cache=MagicMock(),
+        db=MagicMock(),
+        validate_model_access=MagicMock(return_value=model_access_allowed),
+    )
+    auth_service.cache.get.return_value = entry
+    auth_service.db.get_user_by_id.return_value = {"username": "anthropic-user"}
+
+    recorded = []
+    requests_total = MagicMock()
+    request_duration = MagicMock()
+    monkeypatch.setattr(
+        audit_module, "record_audit_event", lambda **kwargs: recorded.append(kwargs)
+    )
+    monkeypatch.setattr(core_metrics, "api_key_requests_total", requests_total)
+    monkeypatch.setattr(
+        core_metrics, "api_key_request_duration_seconds", request_duration
+    )
+
+    api = RESTfulAPI.__new__(RESTfulAPI)
+    api._advanced_auth_service = auth_service
+    api._uid_to_model_name = {"virtual-model": "resolved-model"}
+    app = FastAPI()
+    app.middleware("http")(api._audit_middleware)
+
+    @app.post("/v1/messages")
+    async def create_message(request: Request) -> Response:
+        api._check_model_access(request, "virtual-model", "LLM")
+        return Response(status_code=200)
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.post("/v1/messages", headers={"x-api-key": token})
+
+    assert response.status_code == expected_status_code
+    auth_service.validate_model_access.assert_called_once_with(
+        token, "virtual-model", "LLM"
+    )
+    auth_service.cache.get.assert_called_once_with(sha256_hex(token))
+    assert len(recorded) == 1
+    assert recorded[0] == {
+        "user": "anthropic-user",
+        "api_key_name": "anthropic-key",
+        "api_key_prefix": "sk-test",
+        "model_id": "virtual-model",
+        "model_name": "resolved-model",
+        "model_type": "LLM",
+        "endpoint": "/v1/messages",
+        "status": expected_audit_status,
+        "latency_ms": recorded[0]["latency_ms"],
+        "client_ip": "127.0.0.1",
+        "category": "inference",
+        "auth_type": "api_key",
+    }
+    assert recorded[0]["latency_ms"] >= 0
+    requests_total.inc.assert_called_once_with(
+        {
+            "user": "anthropic-user",
+            "api_key_name": "anthropic-key",
+            "model_id": "virtual-model",
+            "model_name": "resolved-model",
+            "model_type": "LLM",
+            "status": expected_audit_status,
+        }
+    )
+    request_duration.observe.assert_called_once()
+    duration_labels, latency_s = request_duration.observe.call_args.args
+    assert duration_labels == {
+        "model_id": "virtual-model",
+        "model_type": "LLM",
+        "model_name": "resolved-model",
+    }
     assert latency_s >= 0

--- a/xinference/api/tests/test_token_router_dispatch.py
+++ b/xinference/api/tests/test_token_router_dispatch.py
@@ -923,6 +923,9 @@ async def test_anthropic_virtual_non_stream_uses_openai_data_plane(monkeypatch):
         },
     }
     assert auth_service.checked == [("external-anthropic-key", "virtual-model", "LLM")]
+    assert api._token_router_client is upstream_client
+    assert not upstream_client.is_closed
+    await api._close_token_router_client()
     assert upstream_client.is_closed
 
 
@@ -970,6 +973,9 @@ async def test_anthropic_virtual_uses_internal_router_token(monkeypatch):
 
     assert response.status_code == 200
     assert captured["authorization"] == "Bearer internal-token"
+    assert not upstream_client.is_closed
+    await api._close_token_router_client()
+    assert upstream_client.is_closed
 
 
 @pytest.mark.asyncio
@@ -1040,6 +1046,9 @@ async def test_anthropic_virtual_stream_returns_native_event_sequence(monkeypatc
     assert '"model": "virtual-model"' in response.text
     assert '"stop_reason": "end_turn"' in response.text
     assert captured["stream_closed"] is True
+    assert api._token_router_client is upstream_client
+    assert not upstream_client.is_closed
+    await api._close_token_router_client()
     assert upstream_client.is_closed
 
 
@@ -1088,3 +1097,6 @@ async def test_anthropic_virtual_router_error_is_converted(monkeypatch):
         "message": "busy",
     }
     assert response.json()["request_id"] == response.headers["request-id"]
+    assert not upstream_client.is_closed
+    await api._close_token_router_client()
+    assert upstream_client.is_closed

--- a/xinference/api/tests/test_token_router_dispatch.py
+++ b/xinference/api/tests/test_token_router_dispatch.py
@@ -979,6 +979,80 @@ async def test_anthropic_virtual_uses_internal_router_token(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_anthropic_stream_background_closes_uniterated_upstream_once():
+    resolution = {
+        "matched": True,
+        "available": True,
+        "virtual_model_uid": "virtual-model",
+        "router_uid": "router-a",
+        "instance_id": "instance-a",
+        "endpoint": "http://router:10081",
+    }
+    api = make_rest_api(FakeSupervisor(resolution))
+    close_calls = 0
+
+    class UpstreamStream(httpx.AsyncByteStream):
+        async def __aiter__(self):
+            yield b"data: [DONE]\n\n"
+
+        async def aclose(self):
+            nonlocal close_calls
+            close_calls += 1
+
+    upstream_request = httpx.Request("POST", "http://router:10081/v1/chat/completions")
+    upstream_response = httpx.Response(
+        200,
+        headers={"content-type": "text/event-stream"},
+        stream=UpstreamStream(),
+        request=upstream_request,
+    )
+
+    class FakeClient:
+        def build_request(self, *args, **kwargs):
+            return upstream_request
+
+        async def send(self, request, *, stream):
+            assert stream is True
+            return upstream_response
+
+    api._get_token_router_client = lambda: FakeClient()
+    body = json.dumps(
+        {
+            "model": "virtual-model",
+            "messages": [{"role": "user", "content": "hello"}],
+            "max_tokens": 32,
+            "stream": True,
+        }
+    ).encode()
+
+    async def receive():
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    request = Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/v1/messages",
+            "root_path": "",
+            "headers": [(b"anthropic-version", b"2023-06-01")],
+            "query_string": b"",
+            "scheme": "http",
+            "server": ("test", 80),
+            "client": ("127.0.0.1", 1234),
+        },
+        receive,
+    )
+
+    response = await api.create_message(request)
+
+    assert close_calls == 0
+    assert response.background is not None
+    await response.background()
+    await response.background()
+    assert close_calls == 1
+
+
+@pytest.mark.asyncio
 async def test_anthropic_virtual_stream_returns_native_event_sequence(monkeypatch):
     resolution = {
         "matched": True,

--- a/xinference/api/tests/test_token_router_dispatch.py
+++ b/xinference/api/tests/test_token_router_dispatch.py
@@ -336,6 +336,13 @@ def make_chat_app(api):
     return app
 
 
+def make_anthropic_app(api):
+    app = FastAPI()
+    app.add_api_route("/v1/messages", api.create_message, methods=["POST"])
+    app.add_api_route("/anthropic/v1/messages", api.create_message, methods=["POST"])
+    return app
+
+
 @pytest.mark.asyncio
 async def test_virtual_chat_stream_is_proxied_with_auth_headers_and_done(monkeypatch):
     resolution = {
@@ -835,3 +842,249 @@ async def test_list_models_hides_persisted_virtual_models_when_router_disabled(
     payload = json.loads(response.body)
 
     assert [item["id"] for item in payload["data"]] == ["physical-model"]
+
+
+@pytest.mark.asyncio
+async def test_anthropic_virtual_non_stream_uses_openai_data_plane(monkeypatch):
+    resolution = {
+        "matched": True,
+        "available": True,
+        "virtual_model_uid": "virtual-model",
+        "router_uid": "router-a",
+        "instance_id": "instance-a",
+        "endpoint": "http://router:10081",
+    }
+    auth_service = FakeAuthService()
+    api = make_rest_api(FakeSupervisor(resolution), auth_service)
+    app = make_anthropic_app(api)
+    real_async_client = httpx.AsyncClient
+    captured = {}
+    monkeypatch.delenv("XINFERENCE_TOKEN_ROUTER_DATA_PLANE_TOKEN", raising=False)
+    monkeypatch.delenv("XINFERENCE_TOKEN_ROUTER_INTERNAL_TOKEN", raising=False)
+
+    def upstream_handler(request):
+        captured["url"] = str(request.url)
+        captured["authorization"] = request.headers.get("authorization")
+        captured["x_api_key"] = request.headers.get("x-api-key")
+        captured["payload"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json={
+                "choices": [
+                    {
+                        "message": {"content": "routed answer"},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {"prompt_tokens": 11, "completion_tokens": 3},
+            },
+        )
+
+    upstream_client = real_async_client(transport=httpx.MockTransport(upstream_handler))
+    monkeypatch.setattr(
+        restful_api_module.httpx, "AsyncClient", lambda **_: upstream_client
+    )
+    transport = httpx.ASGITransport(app=app)
+    async with real_async_client(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/v1/messages",
+            headers={
+                "anthropic-version": "2023-06-01",
+                "x-api-key": "external-anthropic-key",
+                "x-request-id": "request-anthropic-a",
+            },
+            json={
+                "model": "virtual-model",
+                "system": "Be concise.",
+                "messages": [{"role": "user", "content": "hello"}],
+                "max_tokens": 64,
+                "stop_sequences": ["END"],
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.headers["request-id"] == "request-anthropic-a"
+    assert response.json()["model"] == "virtual-model"
+    assert response.json()["stop_reason"] == "end_turn"
+    assert response.json()["content"] == [{"type": "text", "text": "routed answer"}]
+    assert captured == {
+        "url": "http://router:10081/v1/chat/completions",
+        "authorization": None,
+        "x_api_key": None,
+        "payload": {
+            "model": "virtual-model",
+            "messages": [
+                {"role": "system", "content": "Be concise."},
+                {"role": "user", "content": "hello"},
+            ],
+            "max_tokens": 64,
+            "stream": False,
+            "stop": ["END"],
+        },
+    }
+    assert auth_service.checked == [("external-anthropic-key", "virtual-model", "LLM")]
+    assert upstream_client.is_closed
+
+
+@pytest.mark.asyncio
+async def test_anthropic_virtual_uses_internal_router_token(monkeypatch):
+    resolution = {
+        "matched": True,
+        "available": True,
+        "virtual_model_uid": "virtual-model",
+        "router_uid": "router-a",
+        "instance_id": "instance-a",
+        "endpoint": "http://router:10081",
+    }
+    api = make_rest_api(FakeSupervisor(resolution))
+    app = make_anthropic_app(api)
+    real_async_client = httpx.AsyncClient
+    captured = {}
+    monkeypatch.setenv("XINFERENCE_TOKEN_ROUTER_DATA_PLANE_TOKEN", "internal-token")
+
+    def upstream_handler(request):
+        captured["authorization"] = request.headers.get("authorization")
+        return httpx.Response(
+            200,
+            json={"choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}]},
+        )
+
+    upstream_client = real_async_client(transport=httpx.MockTransport(upstream_handler))
+    monkeypatch.setattr(
+        restful_api_module.httpx, "AsyncClient", lambda **_: upstream_client
+    )
+    transport = httpx.ASGITransport(app=app)
+    async with real_async_client(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/v1/messages",
+            headers={
+                "anthropic-version": "2023-06-01",
+                "Authorization": "Bearer external-token",
+            },
+            json={
+                "model": "virtual-model",
+                "messages": [{"role": "user", "content": "hello"}],
+                "max_tokens": 32,
+            },
+        )
+
+    assert response.status_code == 200
+    assert captured["authorization"] == "Bearer internal-token"
+
+
+@pytest.mark.asyncio
+async def test_anthropic_virtual_stream_returns_native_event_sequence(monkeypatch):
+    resolution = {
+        "matched": True,
+        "available": True,
+        "virtual_model_uid": "virtual-model",
+        "router_uid": "router-a",
+        "instance_id": "instance-a",
+        "endpoint": "http://router:10081",
+    }
+    api = make_rest_api(FakeSupervisor(resolution))
+    app = make_anthropic_app(api)
+    real_async_client = httpx.AsyncClient
+    captured = {}
+
+    class UpstreamStream(httpx.AsyncByteStream):
+        async def __aiter__(self):
+            yield b'data: {"choices":[{"delta":{"content":"hello"},"finish_reason":null}]}\n\n'
+            yield b'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\n'
+            yield b'data: {"choices":[],"usage":{"prompt_tokens":5,"completion_tokens":1}}\n\n'
+            yield b"data: [DONE]\n\n"
+
+        async def aclose(self):
+            captured["stream_closed"] = True
+
+    def upstream_handler(request):
+        captured["payload"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            stream=UpstreamStream(),
+        )
+
+    upstream_client = real_async_client(transport=httpx.MockTransport(upstream_handler))
+    monkeypatch.setattr(
+        restful_api_module.httpx, "AsyncClient", lambda **_: upstream_client
+    )
+    transport = httpx.ASGITransport(app=app)
+    async with real_async_client(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/v1/messages",
+            headers={"anthropic-version": "2023-06-01"},
+            json={
+                "model": "virtual-model",
+                "messages": [{"role": "user", "content": "hello"}],
+                "max_tokens": 32,
+                "stream": True,
+            },
+        )
+
+    assert response.status_code == 200
+    assert captured["payload"]["stream_options"] == {"include_usage": True}
+    event_names = [
+        line.removeprefix("event: ")
+        for line in response.text.splitlines()
+        if line.startswith("event: ")
+    ]
+    assert event_names == [
+        "message_start",
+        "content_block_start",
+        "content_block_delta",
+        "content_block_stop",
+        "message_delta",
+        "message_stop",
+    ]
+    assert '"model": "virtual-model"' in response.text
+    assert '"stop_reason": "end_turn"' in response.text
+    assert captured["stream_closed"] is True
+    assert upstream_client.is_closed
+
+
+@pytest.mark.asyncio
+async def test_anthropic_virtual_router_error_is_converted(monkeypatch):
+    resolution = {
+        "matched": True,
+        "available": True,
+        "virtual_model_uid": "virtual-model",
+        "router_uid": "router-a",
+        "instance_id": "instance-a",
+        "endpoint": "http://router:10081",
+    }
+    api = make_rest_api(FakeSupervisor(resolution))
+    app = make_anthropic_app(api)
+    real_async_client = httpx.AsyncClient
+
+    def upstream_handler(request):
+        return httpx.Response(
+            429,
+            headers={"retry-after": "7"},
+            json={"error": {"type": "rate_limit_error", "message": "busy"}},
+        )
+
+    upstream_client = real_async_client(transport=httpx.MockTransport(upstream_handler))
+    monkeypatch.setattr(
+        restful_api_module.httpx, "AsyncClient", lambda **_: upstream_client
+    )
+    transport = httpx.ASGITransport(app=app)
+    async with real_async_client(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/v1/messages",
+            headers={"anthropic-version": "2023-06-01"},
+            json={
+                "model": "virtual-model",
+                "messages": [{"role": "user", "content": "hello"}],
+                "max_tokens": 32,
+            },
+        )
+
+    assert response.status_code == 429
+    assert response.headers["retry-after"] == "7"
+    assert response.json()["type"] == "error"
+    assert response.json()["error"] == {
+        "type": "rate_limit_error",
+        "message": "busy",
+    }
+    assert response.json()["request_id"] == response.headers["request-id"]


### PR DESCRIPTION
## Summary

- route Anthropic Messages requests for Token Router virtual model UIDs through the existing OpenAI-compatible Router data plane
- reuse the canonical Anthropic request/response/SSE adapter from #5389
- convert Router OpenAI errors and streams back into native Anthropic protocol responses
- keep external Anthropic `x-api-key`/Bearer credentials at the Supervisor boundary; only a configured internal Router token is forwarded
- close upstream responses and per-request HTTP clients on success, error, disconnect, and stream completion

## Dependencies

- Depends on #5375
- Depends on #5389

This branch intentionally contains both dependency histories so it can be tested before they merge. After the dependencies merge, it will be rebased onto the latest official `main` so this PR's diff contains only the Anthropic Token Router integration.

## Tests

- `pytest -q xinference/api/tests/test_token_router_dispatch.py -k anthropic`
- `pytest -q xinference/api/tests/test_anthropic_messages.py xinference/api/tests/test_anthropic_protocol.py`
- `pre-commit run --files xinference/api/restful_api.py xinference/api/tests/test_anthropic_messages.py xinference/api/tests/test_token_router_dispatch.py`
