### PR TITLE
feat(venv): install Jina flash-attn wheel from find-links

### DIFF
--- a/xinference/core/tests/test_virtual_env_manager.py
+++ b/xinference/core/tests/test_virtual_env_manager.py
@@ -36,11 +36,14 @@ from ..virtual_env_manager import (
     FLASHINFER_AOT_WHEEL_URL,
     FLASHINFER_CUBIN_WHEEL_URL,
     _run_uv_install_with_source_fallback,
+    _validate_flash_attn_install,
+    apply_flash_attn_wheel_post_install,
     apply_flashinfer_aot_post_install,
     build_uv_source_options,
     ensure_flashinfer_cubin_matches_post_install,
     ensure_sglang_inherited_packages_compatible_post_install,
     get_engine_critical_dependency_specs,
+    is_flash_attn_requirement,
     merge_virtual_env_find_links,
     needs_flashinfer_aot,
     validate_virtual_env_find_links,
@@ -500,6 +503,173 @@ class TestBuildUvSourceOptions:
 
         assert result.returncode == 0, result.stderr
         assert fallback_requests == []
+
+
+class TestApplyFlashAttnWheelPostInstall:
+    @pytest.fixture
+    def fake_venv_manager(self):
+        manager = mock.MagicMock()
+        manager._get_uv_path.return_value = "/fake/uv"
+        manager.get_python_path.return_value = "/fake/venv/bin/python"
+        manager.env_path = "/fake/venv"
+        return manager
+
+    @pytest.mark.parametrize(
+        "requirement",
+        [
+            "flash_attn==2.8.3.post1+cvte1",
+            "flash-attn==2.8.3.post1+cvte1",
+            "Flash_Attn==2.8.3.post1+cvte1",
+        ],
+    )
+    def test_recognizes_canonical_requirement_names(self, requirement):
+        assert is_flash_attn_requirement(requirement)
+
+    @pytest.mark.parametrize(
+        "requirement",
+        ["my-flash-attn-wrapper", "not_flash_attn", "flashinfer-python"],
+    )
+    def test_does_not_match_unrelated_requirements(self, requirement):
+        assert not is_flash_attn_requirement(requirement)
+
+    def test_non_jina_model_is_noop(self, fake_venv_manager):
+        with (
+            mock.patch(
+                "xinference.core.virtual_env_manager._validate_flash_attn_install"
+            ) as validate_mock,
+            mock.patch(
+                "xinference.core.virtual_env_manager.subprocess.run"
+            ) as run_mock,
+        ):
+            apply_flash_attn_wheel_post_install(
+                "another-model",
+                ["flash-attn==2.8.3.post1+cvte1"],
+                fake_venv_manager,
+                {"find_links": ["/wheels"]},
+                True,
+            )
+
+        validate_mock.assert_not_called()
+        run_mock.assert_not_called()
+
+    def test_no_find_links_warns_and_uses_native_attention(
+        self, fake_venv_manager, caplog
+    ):
+        with mock.patch(
+            "xinference.core.virtual_env_manager._validate_flash_attn_install",
+            return_value=False,
+        ):
+            apply_flash_attn_wheel_post_install(
+                "jina-embeddings-v3",
+                ["flash-attn==2.8.3.post1+cvte1"],
+                fake_venv_manager,
+                {},
+                True,
+            )
+
+        assert "no Find Links source was configured" in caplog.text
+        assert "native attention" in caplog.text
+
+    def test_find_links_install_uses_binary_reinstall_and_validates(
+        self, fake_venv_manager
+    ):
+        with (
+            mock.patch(
+                "xinference.core.virtual_env_manager._validate_flash_attn_install",
+                return_value=True,
+            ) as validate_mock,
+            mock.patch(
+                "xinference.core.virtual_env_manager.subprocess.run",
+                return_value=mock.MagicMock(returncode=0),
+            ) as run_mock,
+        ):
+            apply_flash_attn_wheel_post_install(
+                "jina-embeddings-v3",
+                ["flash-attn==2.8.3.post1+cvte1"],
+                fake_venv_manager,
+                {
+                    "index_url": "https://mirror.example/simple",
+                    "find_links": ["/wheels/jina"],
+                },
+                True,
+            )
+
+        command = run_mock.call_args.args[0]
+        assert command[:5] == [
+            "/fake/uv",
+            "pip",
+            "install",
+            "--python",
+            "/fake/venv/bin/python",
+        ]
+        for option in ("--no-deps", "--reinstall", "--only-binary=:all:"):
+            assert option in command
+        assert command[command.index("--find-links") + 1] == "/wheels/jina"
+        assert "--no-index" not in command
+        assert command[-1] == "flash-attn==2.8.3.post1+cvte1"
+        validate_mock.assert_called_once_with(
+            fake_venv_manager, ["flash-attn==2.8.3.post1+cvte1"]
+        )
+
+    def test_find_links_install_failure_is_fatal(self, fake_venv_manager):
+        with mock.patch(
+            "xinference.core.virtual_env_manager.subprocess.run",
+            return_value=mock.MagicMock(returncode=1),
+        ):
+            with pytest.raises(RuntimeError, match="installation failed"):
+                apply_flash_attn_wheel_post_install(
+                    "jina-embeddings-v3",
+                    ["flash-attn==2.8.3.post1+cvte1"],
+                    fake_venv_manager,
+                    {"find_links": ["/wheels/jina"]},
+                    True,
+                )
+
+    def test_validation_failure_after_install_is_fatal(self, fake_venv_manager):
+        with (
+            mock.patch(
+                "xinference.core.virtual_env_manager.subprocess.run",
+                return_value=mock.MagicMock(returncode=0),
+            ),
+            mock.patch(
+                "xinference.core.virtual_env_manager._validate_flash_attn_install",
+                return_value=False,
+            ),
+        ):
+            with pytest.raises(RuntimeError, match="validation failed"):
+                apply_flash_attn_wheel_post_install(
+                    "jina-embeddings-v3",
+                    ["flash-attn==2.8.3.post1+cvte1"],
+                    fake_venv_manager,
+                    {"find_links": ["/wheels/jina"]},
+                    True,
+                )
+
+    def test_validation_uses_clean_process_and_checks_version(
+        self, fake_venv_manager, monkeypatch
+    ):
+        monkeypatch.setenv("VIRTUAL_ENV", "/parent/venv")
+        monkeypatch.setenv("PYTHONPATH", "/parent/pythonpath")
+        monkeypatch.setenv("PYTHONHOME", "/parent/pythonhome")
+        result = mock.MagicMock(
+            returncode=0,
+            stdout='{"version": "2.8.3.post1+cvte1"}\n',
+        )
+        with mock.patch(
+            "xinference.core.virtual_env_manager.subprocess.run", return_value=result
+        ) as run_mock:
+            assert _validate_flash_attn_install(
+                fake_venv_manager, ["flash-attn==2.8.3.post1+cvte1"]
+            )
+
+        command = run_mock.call_args.args[0]
+        assert command[:2] == ["/fake/venv/bin/python", "-c"]
+        assert 'metadata.distribution("flash-attn")' in command[2]
+        assert "from flash_attn import flash_attn_func" in command[2]
+        child_env = run_mock.call_args.kwargs["env"]
+        assert "VIRTUAL_ENV" not in child_env
+        assert "PYTHONPATH" not in child_env
+        assert "PYTHONHOME" not in child_env
 
 
 class TestValidateVirtualEnvFindLinks:

--- a/xinference/core/tests/test_virtual_env_manager.py
+++ b/xinference/core/tests/test_virtual_env_manager.py
@@ -611,12 +611,19 @@ class TestApplyFlashAttnWheelPostInstall:
             fake_venv_manager, ["flash-attn==2.8.3.post1+cvte1"]
         )
 
-    def test_find_links_install_failure_is_fatal(self, fake_venv_manager):
+    def test_find_links_install_failure_is_fatal_and_redacts_output(
+        self, fake_venv_manager, caplog
+    ):
+        result = mock.MagicMock(
+            returncode=1,
+            stdout="Downloading https://user:password@example.com/wheel",
+            stderr="authentication failed: token=secret-token",
+        )
         with mock.patch(
             "xinference.core.virtual_env_manager.subprocess.run",
-            return_value=mock.MagicMock(returncode=1),
+            return_value=result,
         ):
-            with pytest.raises(RuntimeError, match="installation failed"):
+            with pytest.raises(RuntimeError, match="installation failed") as exc_info:
                 apply_flash_attn_wheel_post_install(
                     "jina-embeddings-v3",
                     ["flash-attn==2.8.3.post1+cvte1"],
@@ -624,6 +631,16 @@ class TestApplyFlashAttnWheelPostInstall:
                     {"find_links": ["/wheels/jina"]},
                     True,
                 )
+
+        message = str(exc_info.value)
+        assert "stdout=" in message
+        assert "stderr=" in message
+        assert "https://***@example.com/wheel" in message
+        assert "token=***" in message
+        assert "password" not in message
+        assert "secret-token" not in message
+        assert "https://***@example.com/wheel" in caplog.text
+        assert "secret-token" not in caplog.text
 
     def test_validation_failure_after_install_is_fatal(self, fake_venv_manager):
         with (
@@ -670,6 +687,22 @@ class TestApplyFlashAttnWheelPostInstall:
         assert "VIRTUAL_ENV" not in child_env
         assert "PYTHONPATH" not in child_env
         assert "PYTHONHOME" not in child_env
+
+    def test_validation_failure_logs_subprocess_output(self, fake_venv_manager, caplog):
+        result = mock.MagicMock(
+            returncode=1,
+            stdout="validation stdout",
+            stderr="ImportError: libcudart.so not found",
+        )
+        with mock.patch(
+            "xinference.core.virtual_env_manager.subprocess.run", return_value=result
+        ):
+            assert not _validate_flash_attn_install(
+                fake_venv_manager, ["flash-attn==2.8.3.post1+cvte1"]
+            )
+
+        assert "validation stdout" in caplog.text
+        assert "ImportError: libcudart.so not found" in caplog.text
 
 
 class TestValidateVirtualEnvFindLinks:

--- a/xinference/core/tests/test_worker.py
+++ b/xinference/core/tests/test_worker.py
@@ -1406,6 +1406,100 @@ def test_prepare_virtual_env_without_engine_vars():
     assert "model_engine" not in kwargs
 
 
+def test_prepare_virtual_env_jina_flash_attn_uses_dedicated_hook_and_fingerprint(
+    tmp_path, monkeypatch
+):
+    import xinference.core.virtual_env_manager as virtual_env_manager_module
+
+    manager = DummyVirtualEnvManager()
+    manager.env_path = str(tmp_path / "jina-venv")
+    os.makedirs(manager.env_path)
+    base_packages = ["pkgA==1.0.0", "flash-attn==2.8.3.post1+cvte1"]
+    hook_calls = []
+
+    monkeypatch.setattr(
+        virtual_env_manager_module,
+        "apply_flash_attn_wheel_post_install",
+        lambda *args: hook_calls.append(args),
+    )
+    monkeypatch.setattr(
+        WorkerActor, "_is_cuda_device_available", staticmethod(lambda: True)
+    )
+
+    first_settings = VirtualEnvSettings(
+        packages=base_packages,
+        inherit_pip_config=False,
+        find_links=["/wheels/jina"],
+    )
+    for _ in range(2):
+        WorkerActor._prepare_virtual_env(
+            manager,
+            first_settings,
+            None,
+            model_engine=None,
+            model_name="jina-embeddings-v3",
+        )
+
+    changed_settings = VirtualEnvSettings(
+        packages=["pkgA==1.0.0", "flash-attn==2.8.4"],
+        inherit_pip_config=False,
+        find_links=["/wheels/jina"],
+    )
+    WorkerActor._prepare_virtual_env(
+        manager,
+        changed_settings,
+        None,
+        model_engine=None,
+        model_name="jina-embeddings-v3",
+    )
+
+    assert [call[0] for call in manager.calls] == [
+        ["pkgA==1.0.0"],
+        ["pkgA==1.0.0"],
+    ]
+    assert [call[1] for call in hook_calls] == [
+        ["flash-attn==2.8.3.post1+cvte1"],
+        ["flash-attn==2.8.4"],
+    ]
+    assert hook_calls[0][3]["find_links"] == ["/wheels/jina"]
+    assert hook_calls[0][4] is True
+    assert os.path.exists(os.path.join(manager.env_path, ".xinference_setup_done"))
+
+
+def test_prepare_virtual_env_non_jina_keeps_flash_attn_in_regular_install(
+    tmp_path, monkeypatch
+):
+    import xinference.core.virtual_env_manager as virtual_env_manager_module
+
+    manager = DummyVirtualEnvManager()
+    manager.env_path = str(tmp_path / "other-venv")
+    os.makedirs(manager.env_path)
+    hook_calls = []
+    monkeypatch.setattr(
+        virtual_env_manager_module,
+        "apply_flash_attn_wheel_post_install",
+        lambda *args: hook_calls.append(args),
+    )
+
+    WorkerActor._prepare_virtual_env(
+        manager,
+        VirtualEnvSettings(
+            packages=["pkgA==1.0.0", "flash-attn==2.8.3.post1+cvte1"],
+            inherit_pip_config=False,
+        ),
+        None,
+        model_engine=None,
+        model_name="another-model",
+    )
+
+    assert manager.calls[0][0] == [
+        "pkgA==1.0.0",
+        "flash-attn==2.8.3.post1+cvte1",
+    ]
+    assert hook_calls[0][0] == "another-model"
+    assert hook_calls[0][1] == []
+
+
 def test_prepare_virtual_env_inherit_pip_config(monkeypatch):
     manager = DummyVirtualEnvManager()
     settings = VirtualEnvSettings(packages=["pkgA==1.0.0"], inherit_pip_config=True)

--- a/xinference/core/virtual_env_manager.py
+++ b/xinference/core/virtual_env_manager.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import logging
 import os
 import re
@@ -1125,6 +1126,179 @@ def build_uv_source_options(
     if index_strategy:
         options += ["--index-strategy", index_strategy]
     return options
+
+
+def is_flash_attn_requirement(spec: str) -> bool:
+    """Return whether *spec* targets the flash-attn distribution."""
+    from packaging.requirements import InvalidRequirement, Requirement
+    from packaging.utils import canonicalize_name
+
+    try:
+        requirement = Requirement(spec)
+    except InvalidRequirement:
+        return False
+    return canonicalize_name(requirement.name) == "flash-attn"
+
+
+def _validate_flash_attn_install(
+    virtual_env_manager: Any, flash_attn_packages: List[str]
+) -> bool:
+    """Validate flash-attn metadata and CUDA imports in a fresh venv process."""
+    from packaging.requirements import InvalidRequirement, Requirement
+
+    python_path = resolve_virtualenv_python_path(virtual_env_manager)
+    if not python_path:
+        logger.warning("flash-attn validation has no virtualenv Python")
+        return False
+
+    validation_script = """
+import importlib.metadata as metadata
+import json
+import pathlib
+import sys
+
+prefix = pathlib.Path(sys.prefix).resolve()
+distribution = metadata.distribution("flash-attn")
+distribution_path = pathlib.Path(distribution.locate_file("")).resolve()
+if prefix != distribution_path and prefix not in distribution_path.parents:
+    raise RuntimeError(
+        f"flash-attn distribution resolved outside the model virtualenv: "
+        f"{distribution_path}"
+    )
+
+import flash_attn
+from flash_attn import flash_attn_func
+
+module_path = pathlib.Path(flash_attn.__file__).resolve()
+if prefix != module_path and prefix not in module_path.parents:
+    raise RuntimeError(
+        f"flash_attn module resolved outside the model virtualenv: {module_path}"
+    )
+if not callable(flash_attn_func):
+    raise RuntimeError("flash_attn.flash_attn_func is not callable")
+
+print(json.dumps({"version": distribution.version}, sort_keys=True))
+"""
+    env = os.environ.copy()
+    for variable in ("VIRTUAL_ENV", "PYTHONPATH", "PYTHONHOME"):
+        env.pop(variable, None)
+    try:
+        result = subprocess.run(
+            [python_path, "-c", validation_script],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+    except OSError:
+        logger.warning("flash-attn validation process could not be started")
+        return False
+    if result.returncode != 0:
+        logger.warning(
+            "flash-attn validation failed in %s", virtual_env_manager.env_path
+        )
+        return False
+
+    try:
+        payload = json.loads(result.stdout.strip().splitlines()[-1])
+        installed_version = str(payload["version"])
+    except (IndexError, KeyError, TypeError, ValueError):
+        logger.warning(
+            "flash-attn validation returned invalid metadata in %s",
+            virtual_env_manager.env_path,
+        )
+        return False
+
+    for spec in flash_attn_packages:
+        try:
+            requirement = Requirement(spec)
+        except InvalidRequirement:
+            logger.warning("Invalid flash-attn requirement during validation: %s", spec)
+            return False
+        if requirement.specifier and not requirement.specifier.contains(
+            installed_version, prereleases=True
+        ):
+            logger.warning(
+                "Installed flash-attn %s does not satisfy %s",
+                installed_version,
+                spec,
+            )
+            return False
+
+    logger.info(
+        "flash-attn %s import and version validation succeeded in %s",
+        installed_version,
+        virtual_env_manager.env_path,
+    )
+    return True
+
+
+def apply_flash_attn_wheel_post_install(
+    model_name: Optional[str],
+    flash_attn_packages: List[str],
+    virtual_env_manager: Any,
+    conf: Dict[str, Any],
+    cuda_available: bool,
+) -> None:
+    """Install Jina's flash-attn requirement from configured Wheel sources."""
+    if (
+        model_name != "jina-embeddings-v3"
+        or not cuda_available
+        or not flash_attn_packages
+    ):
+        return
+
+    python_path = resolve_virtualenv_python_path(virtual_env_manager)
+    if not python_path:
+        raise RuntimeError("flash-attn post-install has no virtualenv Python")
+
+    if not conf.get("find_links"):
+        if not _validate_flash_attn_install(virtual_env_manager, flash_attn_packages):
+            logger.warning(
+                "flash-attn is not installed or invalid for %s, and no Find "
+                "Links source was configured. The model will use PyTorch "
+                "native attention (higher GPU memory usage).",
+                model_name,
+            )
+        return
+
+    uv_path = None
+    if hasattr(virtual_env_manager, "_get_uv_path"):
+        try:
+            uv_path = virtual_env_manager._get_uv_path()
+        except Exception:
+            pass
+    if not uv_path:
+        uv_path = shutil.which("uv") or "uv"
+
+    command = [
+        uv_path,
+        "pip",
+        "install",
+        "--python",
+        python_path,
+        "--no-deps",
+        "--reinstall",
+        "--only-binary=:all:",
+        *build_uv_source_options(conf),
+        *flash_attn_packages,
+    ]
+    try:
+        result = subprocess.run(command, check=False, capture_output=True, text=True)
+    except OSError as exc:
+        raise RuntimeError(
+            "flash-attn Wheel installation could not be started"
+        ) from exc
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"flash-attn Wheel installation failed for {flash_attn_packages}"
+        )
+
+    if not _validate_flash_attn_install(virtual_env_manager, flash_attn_packages):
+        raise RuntimeError(
+            "flash-attn Wheel installation completed, but fresh-process "
+            "version/path/CUDA import validation failed."
+        )
 
 
 def validate_virtual_env_find_links(

--- a/xinference/core/virtual_env_manager.py
+++ b/xinference/core/virtual_env_manager.py
@@ -1140,6 +1140,28 @@ def is_flash_attn_requirement(spec: str) -> bool:
     return canonicalize_name(requirement.name) == "flash-attn"
 
 
+_SUBPROCESS_OUTPUT_LIMIT = 2048
+
+
+def _format_subprocess_output(output: Any) -> str:
+    """Prepare bounded subprocess output for logs and user-facing errors."""
+    if not isinstance(output, str) or not output:
+        return "<empty>"
+
+    sanitized = output.strip()
+    sanitized = re.sub(r"(?i)([a-z][a-z0-9+.-]*://)[^/@\s]+@", r"\1***@", sanitized)
+    sanitized = re.sub(
+        r"(?i)\b(password|passwd|token|api[-_]?key|access[-_]?key)=" r"([^&\s]+)",
+        r"\1=***",
+        sanitized,
+    )
+    sanitized = re.sub(r"(?i)(\bBearer\s+)[^\s,;]+", r"\1***", sanitized)
+    sanitized = sanitized.replace("\r", "\\r").replace("\n", "\\n")
+    if len(sanitized) > _SUBPROCESS_OUTPUT_LIMIT:
+        sanitized = sanitized[:_SUBPROCESS_OUTPUT_LIMIT] + "...<truncated>"
+    return sanitized or "<empty>"
+
+
 def _validate_flash_attn_install(
     virtual_env_manager: Any, flash_attn_packages: List[str]
 ) -> bool:
@@ -1195,7 +1217,12 @@ print(json.dumps({"version": distribution.version}, sort_keys=True))
         return False
     if result.returncode != 0:
         logger.warning(
-            "flash-attn validation failed in %s", virtual_env_manager.env_path
+            "flash-attn validation failed in %s with exit code %s. "
+            "stdout=%r, stderr=%r",
+            virtual_env_manager.env_path,
+            result.returncode,
+            _format_subprocess_output(result.stdout),
+            _format_subprocess_output(result.stderr),
         )
         return False
 
@@ -1290,8 +1317,19 @@ def apply_flash_attn_wheel_post_install(
             "flash-attn Wheel installation could not be started"
         ) from exc
     if result.returncode != 0:
+        stdout = _format_subprocess_output(result.stdout)
+        stderr = _format_subprocess_output(result.stderr)
+        logger.error(
+            "flash-attn Wheel installation failed for %s with exit code %s. "
+            "stdout=%r, stderr=%r",
+            flash_attn_packages,
+            result.returncode,
+            stdout,
+            stderr,
+        )
         raise RuntimeError(
-            f"flash-attn Wheel installation failed for {flash_attn_packages}"
+            f"flash-attn Wheel installation failed for {flash_attn_packages} "
+            f"with exit code {result.returncode}. stdout={stdout!r}, stderr={stderr!r}"
         )
 
     if not _validate_flash_attn_install(virtual_env_manager, flash_attn_packages):

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -120,6 +120,7 @@ from .virtual_env_manager import (
     get_engine_critical_dependency_specs,
     get_engine_model_format_virtualenv_packages,
     is_cuda_compatible,
+    is_flash_attn_requirement,
     merge_virtual_env_find_links,
     pin_sentence_transformers_numpy_abi,
     resolve_virtualenv_python_path,
@@ -3330,16 +3331,37 @@ class WorkerActor(xo.StatelessActor):
             variables["engine"] = engine_value
             variables["model_engine"] = engine_value
 
+        setup_packages = packages.copy()
+        if model_name == "jina-embeddings-v3":
+            flash_attn_packages = [
+                package
+                for package in setup_packages
+                if is_flash_attn_requirement(package)
+            ]
+            regular_packages = [
+                package
+                for package in setup_packages
+                if not is_flash_attn_requirement(package)
+            ]
+        else:
+            # flash-attn is a normal dependency for all other models. Only Jina
+            # uses the dedicated binary-only Find Links installation below.
+            flash_attn_packages = []
+            regular_packages = setup_packages
+        flash_attn_cuda_available = bool(flash_attn_packages) and (
+            cls._is_cuda_device_available()
+        )
+
         logger.info(
             "Installing packages %s in virtual env %s, with settings(%s)",
-            packages,
+            setup_packages,
             virtual_env_manager.env_path,
             ", ".join([f"{k}={v}" for k, v in conf.items() if v]),
         )
         venv_path = str(virtual_env_manager.env_path)
         with _exclusive_venv_path_lock(venv_path):
             if not _should_skip_venv_setup(
-                venv_path, packages, conf, variables, architectures
+                venv_path, setup_packages, conf, variables, architectures
             ):
                 if modern_sglang_kernel:
                     # SGLang 0.5.11 renamed the distribution while retaining the
@@ -3348,7 +3370,19 @@ class WorkerActor(xo.StatelessActor):
                     cls._uninstall_venv_package(virtual_env_manager, "sgl-kernel")
                 if force_reinstall_xllamacpp:
                     cls._uninstall_venv_package(virtual_env_manager, "xllamacpp")
-                virtual_env_manager.install_packages(packages, **conf, **variables)
+                virtual_env_manager.install_packages(
+                    regular_packages, **conf, **variables
+                )
+
+                from .virtual_env_manager import apply_flash_attn_wheel_post_install
+
+                apply_flash_attn_wheel_post_install(
+                    model_name,
+                    flash_attn_packages,
+                    virtual_env_manager,
+                    conf,
+                    flash_attn_cuda_available,
+                )
 
                 # deepdoc-lib[gpu] currently depends on both onnxruntime (base)
                 # and onnxruntime-gpu (extra). They install the same Python module,
@@ -3414,7 +3448,7 @@ class WorkerActor(xo.StatelessActor):
                         )
 
                 _mark_venv_setup_done(
-                    venv_path, packages, conf, variables, architectures
+                    venv_path, setup_packages, conf, variables, architectures
                 )
             else:
                 logger.info(

--- a/xinference/model/embedding/model_spec.json
+++ b/xinference/model/embedding/model_spec.json
@@ -1460,7 +1460,8 @@
         "accelerate>=0.28.0",
         "#system_torchvision# ; #engine# == \"sentence_transformers\"",
         "#system_torch# ; #engine# == \"sentence_transformers\"",
-        "transformers==4.52.0"
+        "transformers==4.52.0",
+        "flash-attn==2.8.3.post1+cvte1"
       ]
     }
   },

--- a/xinference/model/embedding/tests/test_embedding_models.py
+++ b/xinference/model/embedding/tests/test_embedding_models.py
@@ -116,6 +116,16 @@ def test_jina_v5_requires_transformers_5_compatible_sentence_transformers():
     assert matched_families
 
 
+def test_jina_v3_pins_custom_flash_attn_wheel():
+    from .. import _install
+
+    _install()
+    family = BUILTIN_EMBEDDING_MODELS["jina-embeddings-v3"][0]
+
+    assert family.virtualenv is not None
+    assert "flash-attn==2.8.3.post1+cvte1" in family.virtualenv.packages
+
+
 def test_bce_embedding_vllm_engine_params_with_virtualenv():
     from ....model.utils import (
         _collect_virtualenv_engine_markers,


### PR DESCRIPTION
## Summary

- pin `flash-attn==2.8.3.post1+cvte1` for `jina-embeddings-v3`
- install the Jina flash-attn package separately from configured local Find Links using a binary-only, no-dependency reinstall
- validate the installed distribution version, virtualenv ownership, and CUDA import in a fresh process
- fall back to PyTorch native attention with a warning when no Find Links source is configured
- keep flash-attn in the regular package installation path for every non-Jina model
- keep the complete original package list in virtualenv setup fingerprints so flash-attn version/source changes invalidate setup deduplication

## Dependencies

Depends on #5387.

Transitively depends on #5386.

This branch temporarily contains the dependency commits. It will be rebased onto official `main` after the prerequisite PRs merge.

## Safety and compatibility

- the dedicated hook is limited to `jina-embeddings-v3`
- configured Find Links installation or post-install validation failures are fatal
- absence of Find Links is non-fatal and preserves Jina's native-attention fallback
- no global `--no-index` is added
- non-Jina models retain their existing flash-attn installation behavior
- no Wheel binaries or deployment-specific paths are included

## Validation

- `pytest -q xinference/core/tests/test_virtual_env_manager.py xinference/core/tests/test_worker.py` — 150 passed
- focused Jina flash-attn and model-spec tests — 15 passed
- `pre-commit run --files ...` — passed
- `python -m json.tool xinference/model/embedding/model_spec.json` — passed
- `git diff --check` — passed
