### PR TITLE
feat(image): add GLM-Image support

### DIFF
--- a/doc/source/models/builtin/image/glm-image.rst
+++ b/doc/source/models/builtin/image/glm-image.rst
@@ -1,0 +1,22 @@
+.. _models_builtin_glm-image:
+
+=========
+GLM-Image
+=========
+
+- **Model Name:** GLM-Image
+- **Model Family:** stable_diffusion
+- **Abilities:** text2image, image2image
+- **Available ControlNet:** None
+
+Specifications
+^^^^^^^^^^^^^^
+
+- **Model ID:** zai-org/GLM-Image
+
+Execute the following command to launch the model::
+
+   xinference launch --model-name GLM-Image --model-type image
+
+
+

--- a/doc/source/models/builtin/image/index.rst
+++ b/doc/source/models/builtin/image/index.rst
@@ -31,6 +31,8 @@ The following is a list of built-in image models in Xinference:
   
    flux.2-klein-9b
   
+   glm-image
+
    got-ocr2_0
   
    hidream-o1-image

--- a/doc/source/models/model_abilities/image.rst
+++ b/doc/source/models/model_abilities/image.rst
@@ -51,6 +51,7 @@ The Text-to-image API is supported with the following models in Xinference:
 * hunyuandit-v1.2-distilled
 * cogview4
 * Qwen-Image
+* GLM-Image
 * Ideogram4
 * HiDream-O1-Image
 * HiDream-O1-Image-Dev
@@ -60,6 +61,7 @@ Image-to-image supported models:
 
 * Flux.1-Kontext-dev
 * Qwen-Image-Edit
+* GLM-Image
 * HiDream-O1-Image
 * HiDream-O1-Image-Dev
 
@@ -105,6 +107,7 @@ or the ``vLLM`` engine
 for faster inference:
 
 * FLUX.1-dev
+* GLM-Image (SGLang only)
 * Qwen-Image
 * Qwen-Image-2512
 * Z-Image
@@ -145,6 +148,33 @@ provide the best quality and control.
 To download from ModelScope for an individual launch::
 
    xinference launch --model-name Ideogram4 --model-type image --download_hub modelscope
+
+
+GLM-Image
+-------------------
+
+:ref:`GLM-Image <models_builtin_glm-image>` supports both text-to-image
+generation and single- or multi-reference image-to-image generation through
+the same ``GlmImagePipeline``. Output width and height must both be divisible
+by 32.
+
+The ``diffusers`` engine uses ``diffusers==0.38.0`` and
+``transformers==5.0.0``. Xinference installs these packages automatically when
+per-model virtual environments are enabled.
+
+The Hugging Face source is ``zai-org/GLM-Image`` at revision ``main``. The
+ModelScope source is ``ZhipuAI/GLM-Image`` at revision ``master``.
+
+To download from ModelScope for an individual launch::
+
+   xinference launch --model-name GLM-Image --model-type image --download_hub modelscope
+
+On Linux with NVIDIA GPUs, text-to-image generation can also use SGLang::
+
+   xinference launch --model-name GLM-Image --model-type image --model-engine SGLang
+
+The SGLang engine currently exposes only text-to-image generation. Use the
+default ``diffusers`` engine for image-to-image generation.
 
 
 Quickstart

--- a/xinference/model/image/model_spec.json
+++ b/xinference/model/image/model_spec.json
@@ -2114,5 +2114,49 @@
     },
     "featured": false,
     "updated_at": 1786985658
+  },
+  {
+    "version": 2,
+    "model_name": "GLM-Image",
+    "model_family": "stable_diffusion",
+    "model_description": "GLM-Image is a hybrid autoregressive and diffusion image generation model with strong text rendering and knowledge-intensive generation capabilities.",
+    "model_ability": [
+      "text2image",
+      "image2image"
+    ],
+    "model_src": {
+      "huggingface": {
+        "model_id": "zai-org/GLM-Image",
+        "model_revision": "main"
+      },
+      "modelscope": {
+        "model_id": "ZhipuAI/GLM-Image",
+        "model_revision": "master"
+      }
+    },
+    "default_model_config": {
+      "torch_dtype": "bfloat16"
+    },
+    "default_generate_config": {
+      "num_inference_steps": 50,
+      "guidance_scale": 1.5
+    },
+    "virtualenv": {
+      "packages": [
+        "diffusers==0.38.0 ; #engine# == \"diffusers\"",
+        "transformers==5.0.0 ; #engine# == \"diffusers\"",
+        "accelerate>=1.0.0 ; #engine# == \"diffusers\"",
+        "huggingface-hub>=1.23.0,<2.0 ; #engine# == \"diffusers\"",
+        "tokenizers==0.22.2 ; #engine# == \"diffusers\"",
+        "importlib-metadata ; #engine# == \"diffusers\"",
+        "sglang[diffusion] ; #engine# == \"SGLang\"",
+        "#system_torch# ; #engine# == \"diffusers\"",
+        "#system_torchvision# ; #engine# == \"diffusers\"",
+        "#system_numpy# ; #engine# == \"diffusers\""
+      ],
+      "no_build_isolation": true
+    },
+    "featured": true,
+    "updated_at": 1787142695
   }
 ]

--- a/xinference/model/image/model_spec.json
+++ b/xinference/model/image/model_spec.json
@@ -2149,12 +2149,13 @@
         "huggingface-hub>=1.23.0,<2.0 ; #engine# == \"diffusers\"",
         "tokenizers==0.22.2 ; #engine# == \"diffusers\"",
         "importlib-metadata ; #engine# == \"diffusers\"",
+        "numpy<2.3 ; #engine# == \"SGLang\"",
+        "pandas<3 ; #engine# == \"SGLang\"",
         "sglang[diffusion] ; #engine# == \"SGLang\"",
         "#system_torch# ; #engine# == \"diffusers\"",
         "#system_torchvision# ; #engine# == \"diffusers\"",
         "#system_numpy# ; #engine# == \"diffusers\""
-      ],
-      "no_build_isolation": true
+      ]
     },
     "featured": true,
     "updated_at": 1787142695

--- a/xinference/model/image/sglang/core.py
+++ b/xinference/model/image/sglang/core.py
@@ -32,6 +32,7 @@ logger = logging.getLogger(__name__)
 # Image models verified against the sglang-diffusion compatibility matrix:
 # https://docs.sglang.io/docs/sglang-diffusion/compatibility_matrix
 SGLANG_SUPPORTED_IMAGE_MODELS = (
+    "GLM-Image",
     "Qwen-Image",
     "Qwen-Image-2512",
     "Z-Image",

--- a/xinference/model/image/stable_diffusion/core.py
+++ b/xinference/model/image/stable_diffusion/core.py
@@ -142,6 +142,12 @@ class DiffusionModel(SDAPIDiffusionModelMixin):
             and self._model_spec.model_name.lower() == "ideogram4"  # type: ignore
         )
 
+    def _is_glm_image_model(self) -> bool:
+        if self._model_spec is None:
+            return False
+        model_name = self._model_spec.model_name.lower().replace("_", "-")
+        return model_name.startswith("glm-image")
+
     @staticmethod
     def _get_pipeline_type(ability: str) -> type:
         if ability == "text2image":
@@ -174,9 +180,21 @@ class DiffusionModel(SDAPIDiffusionModelMixin):
         try:
             return self._ability_to_models[ability, controlnet_name]
         except KeyError:
-            model_type = self._get_pipeline_type(ability)
+            pass
 
         assert self._model is not None
+
+        # GLM-Image uses one pipeline for both text-to-image and image-to-image.
+        # AutoPipeline has no GLM-Image conversion mapping.
+        if (
+            ability == "image2image"
+            and controlnet_name is None
+            and self._is_glm_image_model()
+        ):
+            self._ability_to_models[ability, controlnet_name] = self._model
+            return self._model
+
+        model_type = self._get_pipeline_type(ability)
 
         if controlnet_name:
             assert controlnet_path
@@ -246,7 +264,9 @@ class DiffusionModel(SDAPIDiffusionModelMixin):
             return getattr(module, class_name)
 
     def load(self):
-        if "text2image" in self._abilities or "image2image" in self._abilities:
+        if self._is_glm_image_model():
+            from diffusers import GlmImagePipeline as AutoPipelineModel
+        elif "text2image" in self._abilities or "image2image" in self._abilities:
             from diffusers import AutoPipelineForText2Image as AutoPipelineModel
         elif "inpainting" in self._abilities:
             from diffusers import AutoPipelineForInpainting as AutoPipelineModel
@@ -966,14 +986,12 @@ class DiffusionModel(SDAPIDiffusionModelMixin):
                 raise RuntimeError(f"{self._model_uid} does not support image2image")
             model = self._get_model(ability)
 
-        # QwenImageEditPlusPipeline consumes all reference images through its
-        # ``image`` argument.  The OpenAI-compatible endpoint exposes the first
-        # upload as ``image`` and the remaining uploads as ``reference_images``;
-        # combine them here instead of letting the latter be filtered out as an
-        # unsupported pipeline keyword.
-        if (
-            kwargs.get("reference_images")
-            and type(model).__name__ == "QwenImageEditPlusPipeline"
+        # These pipelines consume all reference images through their ``image``
+        # argument. The OpenAI-compatible endpoint exposes the first upload as
+        # ``image`` and the remaining uploads as ``reference_images``.
+        if kwargs.get("reference_images") and (
+            type(model).__name__ == "QwenImageEditPlusPipeline"
+            or self._is_glm_image_model()
         ):
             reference_images = kwargs.pop("reference_images")
             primary_images = image if isinstance(image, list) else [image]
@@ -983,6 +1001,10 @@ class DiffusionModel(SDAPIDiffusionModelMixin):
                 else [reference_images]
             )
             image = primary_images + reference_images
+
+        # GlmImagePipeline expects a list even for one conditioning image.
+        if self._is_glm_image_model() and not isinstance(image, list):
+            image = [image]
 
         if padding_image_to_multiple := kwargs.pop("padding_image_to_multiple", None):
             # Model like SD3 image to image requires image's height and width is times of 16


### PR DESCRIPTION
## Summary

- Register GLM-Image from Hugging Face (`zai-org/GLM-Image`, revision `main`) and ModelScope (`ZhipuAI/GLM-Image`, revision `master`).
- Add Diffusers text-to-image and image-to-image support through `GlmImagePipeline`.
- Add SGLang text-to-image support while restricting its advertised abilities accordingly.
