### PR TITLE
fix(router): separate runtime and backend credentials

### DIFF
--- a/xinference/api/restful_api.py
+++ b/xinference/api/restful_api.py
@@ -75,6 +75,7 @@ from ..core.replica_config import ReplicaConfig
 from ..core.supervisor import SupervisorActor
 from ..core.utils import CancelMixin
 from ..router.constants import TOKEN_ROUTER_BACKEND_AUTHORIZATION_HEADER
+from ..router.credentials import token_router_data_plane_token
 from ..types import CreateChatCompletion, PeftModelConfig, max_tokens_field
 from .frontend_static import mount_frontend
 from .pdf_ocr import (
@@ -155,9 +156,7 @@ def _token_router_request_headers(
         if key.lower() in _TOKEN_ROUTER_REQUEST_HEADERS
         and key.lower() != "authorization"
     }
-    internal_token = os.getenv("XINFERENCE_TOKEN_ROUTER_DATA_PLANE_TOKEN") or os.getenv(
-        "XINFERENCE_TOKEN_ROUTER_INTERNAL_TOKEN"
-    )
+    internal_token = token_router_data_plane_token()
     external_credential = (
         _request_credential(request) if forward_external_credential else ""
     )

--- a/xinference/api/restful_api.py
+++ b/xinference/api/restful_api.py
@@ -74,6 +74,7 @@ from ..core.http_protocol import create_hardened_http_protocol
 from ..core.replica_config import ReplicaConfig
 from ..core.supervisor import SupervisorActor
 from ..core.utils import CancelMixin
+from ..router.constants import TOKEN_ROUTER_BACKEND_AUTHORIZATION_HEADER
 from ..types import CreateChatCompletion, PeftModelConfig, max_tokens_field
 from .frontend_static import mount_frontend
 from .pdf_ocr import (
@@ -157,11 +158,17 @@ def _token_router_request_headers(
     internal_token = os.getenv("XINFERENCE_TOKEN_ROUTER_DATA_PLANE_TOKEN") or os.getenv(
         "XINFERENCE_TOKEN_ROUTER_INTERNAL_TOKEN"
     )
-    credential = internal_token
-    if not credential and forward_external_credential:
-        credential = _request_credential(request)
-    if credential:
-        headers["authorization"] = f"Bearer {credential}"
+    external_credential = (
+        _request_credential(request) if forward_external_credential else ""
+    )
+    if internal_token:
+        headers["authorization"] = f"Bearer {internal_token}"
+        if external_credential:
+            headers[TOKEN_ROUTER_BACKEND_AUTHORIZATION_HEADER] = (
+                f"Bearer {external_credential}"
+            )
+    elif external_credential:
+        headers["authorization"] = f"Bearer {external_credential}"
     headers["content-type"] = "application/json"
     headers["x-request-id"] = request_id
     return headers

--- a/xinference/api/routers/token_routers.py
+++ b/xinference/api/routers/token_routers.py
@@ -13,6 +13,8 @@ from fastapi.responses import Response
 
 from ..._compat import BaseModel, ValidationError
 from ...constants import XINFERENCE_TOKEN_ROUTER_ENABLED
+from ...router.constants import TOKEN_ROUTER_DATA_PLANE_TOKEN_FIELD
+from ...router.credentials import token_router_data_plane_token
 from ..dependencies import get_api
 from ..responses import JSONResponse
 from ..schemas.router import (
@@ -964,6 +966,9 @@ def register_routes(api: "RESTfulAPI") -> None:
             ) from exc
         if result is None:
             return Response(status_code=204)
+        data_plane_token = token_router_data_plane_token()
+        for assignment in result.get("assignments", []):
+            assignment[TOKEN_ROUTER_DATA_PLANE_TOKEN_FIELD] = data_plane_token
         return JSONResponse(content=result)
 
     async def watch_asset_bindings_handler(

--- a/xinference/api/tests/test_token_router_dispatch.py
+++ b/xinference/api/tests/test_token_router_dispatch.py
@@ -560,6 +560,70 @@ async def test_virtual_chat_stream_is_proxied_with_auth_headers_and_done(monkeyp
 
 
 @pytest.mark.asyncio
+async def test_virtual_chat_separates_internal_and_external_credentials(monkeypatch):
+    resolution = {
+        "matched": True,
+        "available": True,
+        "virtual_model_uid": "virtual-model",
+        "router_uid": "router-a",
+        "instance_id": "instance-a",
+        "endpoint": "http://router:10081",
+    }
+    supervisor = FakeSupervisor(resolution)
+    auth_service = FakeAuthService()
+    api = make_rest_api(supervisor, auth_service)
+    app = make_chat_app(api)
+    real_async_client = httpx.AsyncClient
+    captured = {}
+    monkeypatch.delenv("XINFERENCE_TOKEN_ROUTER_DATA_PLANE_TOKEN", raising=False)
+    monkeypatch.setenv("XINFERENCE_TOKEN_ROUTER_INTERNAL_TOKEN", "internal-token")
+
+    class UpstreamStream(httpx.AsyncByteStream):
+        async def __aiter__(self):
+            yield b'data: {"choices": []}\n\n'
+            yield b"data: [DONE]\n\n"
+
+    def upstream_handler(request):
+        captured["authorization"] = request.headers.get("authorization")
+        captured["backend_authorization"] = request.headers.get(
+            "x-xinference-backend-authorization"
+        )
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            stream=UpstreamStream(),
+        )
+
+    upstream_client = real_async_client(transport=httpx.MockTransport(upstream_handler))
+    monkeypatch.setattr(
+        restful_api_module.httpx, "AsyncClient", lambda **_: upstream_client
+    )
+    transport = httpx.ASGITransport(app=app)
+    async with real_async_client(transport=transport, base_url="http://test") as client:
+        response = await client.post(
+            "/v1/chat/completions",
+            headers={
+                "Authorization": "Bearer external-user-token",
+                # A client-supplied internal header must not be trusted.
+                "X-Xinference-Backend-Authorization": "Bearer forged-token",
+            },
+            json={
+                "model": "virtual-model",
+                "messages": [{"role": "user", "content": "hello"}],
+                "stream": True,
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.content.endswith(b"data: [DONE]\n\n")
+    assert captured == {
+        "authorization": "Bearer internal-token",
+        "backend_authorization": "Bearer external-user-token",
+    }
+    assert auth_service.checked == [("external-user-token", "virtual-model", "LLM")]
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "thinking_fields",
     [

--- a/xinference/api/tests/test_token_router_orchestration_api.py
+++ b/xinference/api/tests/test_token_router_orchestration_api.py
@@ -13,11 +13,15 @@ from xinference.api.tests.test_token_router_api import (
     make_supervisor,
     router_payload,
 )
+from xinference.router.constants import TOKEN_ROUTER_DATA_PLANE_TOKEN_FIELD
 
 
 @pytest.mark.asyncio
 async def test_managed_router_agent_runtime_lifecycle(tmp_path, monkeypatch) -> None:
     monkeypatch.setenv("XINFERENCE_TOKEN_ROUTER_INTERNAL_TOKEN", "internal-secret")
+    monkeypatch.setenv(
+        "XINFERENCE_TOKEN_ROUTER_DATA_PLANE_TOKEN", "supervisor-hop-secret"
+    )
     app = create_app(make_supervisor(tmp_path))
     headers = {"Authorization": "Bearer internal-secret"}
     transport = httpx.ASGITransport(app=app)
@@ -71,6 +75,9 @@ async def test_managed_router_agent_runtime_lifecycle(tmp_path, monkeypatch) -> 
         assert snapshot.status_code == 200
         assert snapshot.json()["full_snapshot"] is True
         assignment = snapshot.json()["assignments"][0]
+        assert (
+            assignment[TOKEN_ROUTER_DATA_PLANE_TOKEN_FIELD] == "supervisor-hop-secret"
+        )
 
         starting = await client.put(
             f"/v1/internal/token-router/assignments/{assignment['assignment_id']}/status",
@@ -119,6 +126,8 @@ async def test_managed_router_agent_runtime_lifecycle(tmp_path, monkeypatch) -> 
         assert assignments.status_code == 200
         assert assignments.json()[0]["observed_state"] == "ready"
         assert assignments.json()[0]["instance_id"] == "instance-a"
+        assert TOKEN_ROUTER_DATA_PLANE_TOKEN_FIELD not in assignments.json()[0]
+        assert "supervisor-hop-secret" not in assignments.text
 
         for instance_id, changes in (
             (

--- a/xinference/router/agent/process_manager.py
+++ b/xinference/router/agent/process_manager.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, Iterable, Optional
 
+from ..constants import TOKEN_ROUTER_DATA_PLANE_TOKEN_FIELD
 from ..logging_config import router_log_extra
 from .control_plane import RouterAgentControlPlaneClient
 
@@ -140,8 +141,8 @@ class RouterRuntimeProcessManager:
             for key in _ALLOWED_ENVIRONMENT
             if (value := os.environ.get(key)) is not None
         }
-        data_plane_token = (
-            os.getenv("XINFERENCE_TOKEN_ROUTER_DATA_PLANE_TOKEN") or self.internal_token
+        data_plane_token = str(
+            assignment.get(TOKEN_ROUTER_DATA_PLANE_TOKEN_FIELD) or self.internal_token
         )
         asset = assignment.get("tokenizer_asset", {})
         env.update(
@@ -203,7 +204,13 @@ class RouterRuntimeProcessManager:
                 if managed is None:
                     managed = ManagedRuntimeProcess(assignment=assignment)
                     self._processes[assignment_id] = managed
-                elif managed.generation != int(assignment["assignment_generation"]):
+                elif managed.generation != int(
+                    assignment["assignment_generation"]
+                ) or self._assignment_data_plane_token(
+                    managed.assignment
+                ) != self._assignment_data_plane_token(
+                    assignment
+                ):
                     await self._stop_locked(managed, report=False)
                     managed = ManagedRuntimeProcess(assignment=assignment)
                     self._processes[assignment_id] = managed
@@ -216,6 +223,11 @@ class RouterRuntimeProcessManager:
                 if assignment_id not in desired:
                     managed = self._processes.pop(assignment_id)
                     await self._stop_locked(managed, report=False)
+
+    def _assignment_data_plane_token(self, assignment: Dict[str, Any]) -> str:
+        return str(
+            assignment.get(TOKEN_ROUTER_DATA_PLANE_TOKEN_FIELD) or self.internal_token
+        )
 
     async def _start_locked(self, managed: ManagedRuntimeProcess) -> None:
         now = time.monotonic()

--- a/xinference/router/agent/process_manager.py
+++ b/xinference/router/agent/process_manager.py
@@ -140,9 +140,13 @@ class RouterRuntimeProcessManager:
             for key in _ALLOWED_ENVIRONMENT
             if (value := os.environ.get(key)) is not None
         }
+        data_plane_token = (
+            os.getenv("XINFERENCE_TOKEN_ROUTER_DATA_PLANE_TOKEN") or self.internal_token
+        )
         asset = assignment.get("tokenizer_asset", {})
         env.update(
             {
+                "XINFERENCE_TOKEN_ROUTER_DATA_PLANE_TOKEN": data_plane_token,
                 "XINFERENCE_TOKEN_ROUTER_INTERNAL_TOKEN": self.internal_token,
                 "XINFERENCE_TOKEN_ROUTER_ASSIGNMENT_ID": str(
                     assignment["assignment_id"]

--- a/xinference/router/backend.py
+++ b/xinference/router/backend.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from typing import Iterable
 
 import httpx
@@ -25,12 +26,21 @@ def request_headers(
 ) -> dict[str, str]:
     headers: dict[str, str] = {}
     backend_authorization = ""
+    internal_token = os.getenv("XINFERENCE_TOKEN_ROUTER_DATA_PLANE_TOKEN") or os.getenv(
+        "XINFERENCE_TOKEN_ROUTER_INTERNAL_TOKEN"
+    )
     for key_bytes, value_bytes in incoming:
         key = key_bytes.decode("latin-1").lower()
         value = value_bytes.decode("latin-1")
         if key == TOKEN_ROUTER_BACKEND_AUTHORIZATION_HEADER:
             backend_authorization = value
         elif key in FORWARDED_REQUEST_HEADERS:
+            if (
+                key == "authorization"
+                and internal_token
+                and value == f"Bearer {internal_token}"
+            ):
+                continue
             headers[key] = value
     if backend_api_key:
         headers["authorization"] = f"Bearer {backend_api_key}"

--- a/xinference/router/backend.py
+++ b/xinference/router/backend.py
@@ -4,6 +4,8 @@ from typing import Iterable
 
 import httpx
 
+from .constants import TOKEN_ROUTER_BACKEND_AUTHORIZATION_HEADER
+
 FORWARDED_REQUEST_HEADERS = {
     "accept",
     "content-type",
@@ -22,12 +24,18 @@ def request_headers(
     incoming: Iterable[tuple[bytes, bytes]], *, backend_api_key: str, request_id: str
 ) -> dict[str, str]:
     headers: dict[str, str] = {}
+    backend_authorization = ""
     for key_bytes, value_bytes in incoming:
         key = key_bytes.decode("latin-1").lower()
-        if key in FORWARDED_REQUEST_HEADERS:
-            headers[key] = value_bytes.decode("latin-1")
+        value = value_bytes.decode("latin-1")
+        if key == TOKEN_ROUTER_BACKEND_AUTHORIZATION_HEADER:
+            backend_authorization = value
+        elif key in FORWARDED_REQUEST_HEADERS:
+            headers[key] = value
     if backend_api_key:
         headers["authorization"] = f"Bearer {backend_api_key}"
+    elif backend_authorization:
+        headers["authorization"] = backend_authorization
     headers["content-type"] = "application/json"
     headers["x-request-id"] = request_id
     return headers

--- a/xinference/router/backend.py
+++ b/xinference/router/backend.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hmac
 import os
 from typing import Iterable
 
@@ -26,8 +27,13 @@ def request_headers(
 ) -> dict[str, str]:
     headers: dict[str, str] = {}
     backend_authorization = ""
-    internal_token = os.getenv("XINFERENCE_TOKEN_ROUTER_DATA_PLANE_TOKEN") or os.getenv(
-        "XINFERENCE_TOKEN_ROUTER_INTERNAL_TOKEN"
+    internal_tokens = tuple(
+        token
+        for name in (
+            "XINFERENCE_TOKEN_ROUTER_DATA_PLANE_TOKEN",
+            "XINFERENCE_TOKEN_ROUTER_INTERNAL_TOKEN",
+        )
+        if (token := os.getenv(name))
     )
     for key_bytes, value_bytes in incoming:
         key = key_bytes.decode("latin-1").lower()
@@ -35,10 +41,9 @@ def request_headers(
         if key == TOKEN_ROUTER_BACKEND_AUTHORIZATION_HEADER:
             backend_authorization = value
         elif key in FORWARDED_REQUEST_HEADERS:
-            if (
-                key == "authorization"
-                and internal_token
-                and value == f"Bearer {internal_token}"
+            if key == "authorization" and any(
+                hmac.compare_digest(value, f"Bearer {token}")
+                for token in internal_tokens
             ):
                 continue
             headers[key] = value

--- a/xinference/router/constants.py
+++ b/xinference/router/constants.py
@@ -1,0 +1,15 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+TOKEN_ROUTER_BACKEND_AUTHORIZATION_HEADER = "x-xinference-backend-authorization"

--- a/xinference/router/credentials.py
+++ b/xinference/router/credentials.py
@@ -12,5 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-TOKEN_ROUTER_BACKEND_AUTHORIZATION_HEADER = "x-xinference-backend-authorization"
-TOKEN_ROUTER_DATA_PLANE_TOKEN_FIELD = "data_plane_token"
+from __future__ import annotations
+
+import os
+
+
+def token_router_data_plane_token() -> str:
+    """Return the credential selected by the Supervisor for Runtime requests."""
+
+    return (
+        os.getenv("XINFERENCE_TOKEN_ROUTER_DATA_PLANE_TOKEN")
+        or os.getenv("XINFERENCE_TOKEN_ROUTER_INTERNAL_TOKEN")
+        or ""
+    )

--- a/xinference/router/tests/test_agent.py
+++ b/xinference/router/tests/test_agent.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
+from unittest.mock import patch
 
 import httpx
 import pytest
@@ -18,6 +20,7 @@ from xinference.router.agent.process_manager import (
     RouterRuntimeProcessManager,
 )
 from xinference.router.agent.service import RouterAgent, RouterAgentConfig
+from xinference.router.backend import request_headers
 
 
 class _ControlPlane:
@@ -253,6 +256,25 @@ def test_runtime_child_environment_is_allowlisted(monkeypatch, tmp_path):
     assert env["XINFERENCE_LOG_MAX_BYTES"] == "4096"
     assert env["XINFERENCE_LOG_BACKUP_COUNT"] == "4"
     assert "UNRELATED_SECRET" not in env
+
+
+def test_runtime_child_environment_preserves_data_plane_credential(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("XINFERENCE_TOKEN_ROUTER_DATA_PLANE_TOKEN", "data-plane-secret")
+    manager = _manager(tmp_path)
+
+    env = manager._child_environment(_assignment())
+
+    assert env["XINFERENCE_TOKEN_ROUTER_DATA_PLANE_TOKEN"] == "data-plane-secret"
+    assert env["XINFERENCE_TOKEN_ROUTER_INTERNAL_TOKEN"] == "internal-secret"
+    with patch.dict(os.environ, env, clear=True):
+        headers = request_headers(
+            [(b"authorization", b"Bearer data-plane-secret")],
+            backend_api_key="",
+            request_id="request-a",
+        )
+    assert "authorization" not in headers
 
 
 @pytest.mark.asyncio

--- a/xinference/router/tests/test_agent.py
+++ b/xinference/router/tests/test_agent.py
@@ -21,6 +21,7 @@ from xinference.router.agent.process_manager import (
 )
 from xinference.router.agent.service import RouterAgent, RouterAgentConfig
 from xinference.router.backend import request_headers
+from xinference.router.constants import TOKEN_ROUTER_DATA_PLANE_TOKEN_FIELD
 
 
 class _ControlPlane:
@@ -258,19 +259,24 @@ def test_runtime_child_environment_is_allowlisted(monkeypatch, tmp_path):
     assert "UNRELATED_SECRET" not in env
 
 
-def test_runtime_child_environment_preserves_data_plane_credential(
+def test_runtime_child_environment_uses_supervisor_data_plane_credential(
     monkeypatch, tmp_path
 ):
-    monkeypatch.setenv("XINFERENCE_TOKEN_ROUTER_DATA_PLANE_TOKEN", "data-plane-secret")
+    monkeypatch.delenv("XINFERENCE_TOKEN_ROUTER_DATA_PLANE_TOKEN", raising=False)
     manager = _manager(tmp_path)
+    assignment = _assignment()
+    assignment[TOKEN_ROUTER_DATA_PLANE_TOKEN_FIELD] = "supervisor-data-plane-secret"
 
-    env = manager._child_environment(_assignment())
+    env = manager._child_environment(assignment)
 
-    assert env["XINFERENCE_TOKEN_ROUTER_DATA_PLANE_TOKEN"] == "data-plane-secret"
+    assert (
+        env["XINFERENCE_TOKEN_ROUTER_DATA_PLANE_TOKEN"]
+        == "supervisor-data-plane-secret"
+    )
     assert env["XINFERENCE_TOKEN_ROUTER_INTERNAL_TOKEN"] == "internal-secret"
     with patch.dict(os.environ, env, clear=True):
         headers = request_headers(
-            [(b"authorization", b"Bearer data-plane-secret")],
+            [(b"authorization", b"Bearer supervisor-data-plane-secret")],
             backend_api_key="",
             request_id="request-a",
         )
@@ -355,6 +361,39 @@ async def test_generation_replacement_and_snapshot_orphan_cleanup(
     await manager.reconcile([])
     assert second.terminate_calls == 1
     assert manager._processes == {}
+
+
+@pytest.mark.asyncio
+async def test_data_plane_credential_change_restarts_runtime(monkeypatch, tmp_path):
+    manager = _manager(tmp_path)
+    monkeypatch.setattr(manager, "_port_available", lambda host, port: True)
+    processes = [_FakeProcess(), _FakeProcess()]
+    environments: list[dict[str, str]] = []
+
+    async def create_subprocess_exec(*args, **kwargs):
+        environments.append(kwargs["env"])
+        return processes.pop(0)
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", create_subprocess_exec)
+    first_assignment = _assignment()
+    first_assignment[TOKEN_ROUTER_DATA_PLANE_TOKEN_FIELD] = "first-hop-secret"
+    await manager.reconcile([first_assignment])
+    first = manager._processes["router-a-0"].process
+
+    second_assignment = _assignment()
+    second_assignment[TOKEN_ROUTER_DATA_PLANE_TOKEN_FIELD] = "second-hop-secret"
+    await manager.reconcile([second_assignment])
+    second = manager._processes["router-a-0"].process
+
+    assert first is not None and first.terminate_calls == 1
+    assert second is not None and second is not first
+    assert environments[0]["XINFERENCE_TOKEN_ROUTER_DATA_PLANE_TOKEN"] == (
+        "first-hop-secret"
+    )
+    assert environments[1]["XINFERENCE_TOKEN_ROUTER_DATA_PLANE_TOKEN"] == (
+        "second-hop-secret"
+    )
+    await manager.shutdown()
 
 
 @pytest.mark.asyncio

--- a/xinference/router/tests/test_app.py
+++ b/xinference/router/tests/test_app.py
@@ -269,6 +269,25 @@ def test_request_headers_does_not_forward_internal_token_without_backend_auth(
     assert "authorization" not in headers
 
 
+@pytest.mark.parametrize(
+    "authorization",
+    ["Bearer data-plane-token", "Bearer internal-token"],
+)
+def test_request_headers_does_not_forward_either_internal_token(
+    monkeypatch: pytest.MonkeyPatch, authorization: str
+) -> None:
+    monkeypatch.setenv("XINFERENCE_TOKEN_ROUTER_DATA_PLANE_TOKEN", "data-plane-token")
+    monkeypatch.setenv("XINFERENCE_TOKEN_ROUTER_INTERNAL_TOKEN", "internal-token")
+
+    headers = request_headers(
+        [(b"authorization", authorization.encode())],
+        backend_api_key="",
+        request_id="request-a",
+    )
+
+    assert "authorization" not in headers
+
+
 def test_request_headers_backend_api_key_has_highest_priority() -> None:
     headers = request_headers(
         [

--- a/xinference/router/tests/test_app.py
+++ b/xinference/router/tests/test_app.py
@@ -228,6 +228,7 @@ def assert_rejection_metrics(metrics: str, *, router_uid: str, result: str) -> N
         f'{{router_uid="{router_uid}",pool="none"}} 0' in metrics
     )
 
+
 def test_request_headers_promotes_backend_user_credential() -> None:
     headers = request_headers(
         [
@@ -243,6 +244,29 @@ def test_request_headers_promotes_backend_user_credential() -> None:
 
     assert headers["authorization"] == "Bearer external-user-token"
     assert "x-xinference-backend-authorization" not in headers
+
+
+@pytest.mark.parametrize(
+    "env_name",
+    [
+        "XINFERENCE_TOKEN_ROUTER_DATA_PLANE_TOKEN",
+        "XINFERENCE_TOKEN_ROUTER_INTERNAL_TOKEN",
+    ],
+)
+def test_request_headers_does_not_forward_internal_token_without_backend_auth(
+    monkeypatch: pytest.MonkeyPatch, env_name: str
+) -> None:
+    monkeypatch.delenv("XINFERENCE_TOKEN_ROUTER_DATA_PLANE_TOKEN", raising=False)
+    monkeypatch.delenv("XINFERENCE_TOKEN_ROUTER_INTERNAL_TOKEN", raising=False)
+    monkeypatch.setenv(env_name, "internal-token")
+
+    headers = request_headers(
+        [(b"authorization", b"Bearer internal-token")],
+        backend_api_key="",
+        request_id="request-a",
+    )
+
+    assert "authorization" not in headers
 
 
 def test_request_headers_backend_api_key_has_highest_priority() -> None:

--- a/xinference/router/tests/test_app.py
+++ b/xinference/router/tests/test_app.py
@@ -11,6 +11,7 @@ from tokenizers import Tokenizer, models, pre_tokenizers
 
 from xinference.router.admission import GateSnapshot
 from xinference.router.app import create_app
+from xinference.router.backend import request_headers
 from xinference.router.config import (
     BackendConfig,
     RouteAction,
@@ -226,6 +227,39 @@ def assert_rejection_metrics(metrics: str, *, router_uid: str, result: str) -> N
         "xinference_token_router_requests_in_flight"
         f'{{router_uid="{router_uid}",pool="none"}} 0' in metrics
     )
+
+def test_request_headers_promotes_backend_user_credential() -> None:
+    headers = request_headers(
+        [
+            (b"authorization", b"Bearer internal-token"),
+            (
+                b"x-xinference-backend-authorization",
+                b"Bearer external-user-token",
+            ),
+        ],
+        backend_api_key="",
+        request_id="request-a",
+    )
+
+    assert headers["authorization"] == "Bearer external-user-token"
+    assert "x-xinference-backend-authorization" not in headers
+
+
+def test_request_headers_backend_api_key_has_highest_priority() -> None:
+    headers = request_headers(
+        [
+            (b"authorization", b"Bearer internal-token"),
+            (
+                b"x-xinference-backend-authorization",
+                b"Bearer external-user-token",
+            ),
+        ],
+        backend_api_key="configured-backend-key",
+        request_id="request-a",
+    )
+
+    assert headers["authorization"] == "Bearer configured-backend-key"
+    assert "x-xinference-backend-authorization" not in headers
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- keep Supervisor-to-Runtime authentication separate from the external user credential
- forward the external credential through a dedicated internal header for backend authentication
- let the Runtime prefer `backend_api_key` and never forward the internal header upstream
- add coverage for forged headers and credential precedence

## Dependency
- Built on merged PR #5375.

## Validation
- `pytest -q xinference/router/tests/test_app.py xinference/api/tests/test_token_router_dispatch.py`
- `pre-commit run --files xinference/router/constants.py xinference/router/backend.py xinference/router/tests/test_app.py xinference/api/restful_api.py xinference/api/tests/test_token_router_dispatch.py`
