### PR TITLE
feat(router): expose virtual model running details

### DIFF
--- a/xinference/api/restful_api.py
+++ b/xinference/api/restful_api.py
@@ -1060,7 +1060,9 @@ class RESTfulAPI(CancelMixin):
 
     async def describe_model(self, model_uid: str) -> JSONResponse:
         try:
-            data = await (await self._get_supervisor_ref()).describe_model(model_uid)
+            data = await (await self._get_supervisor_ref()).describe_running_model(
+                model_uid
+            )
             return JSONResponse(content=data)
         except ModelNotReadyError as e:
             raise HTTPException(

--- a/xinference/api/tests/test_token_router_api.py
+++ b/xinference/api/tests/test_token_router_api.py
@@ -1173,3 +1173,40 @@ async def test_disabled_feature_rejects_public_and_internal_apis(
             "code": "TOKEN_ROUTER_DISABLED",
             "message": "Token Router feature is disabled",
         }
+@pytest.mark.asyncio
+async def test_public_router_responses_normalize_sparse_configs_without_persisting(
+    tmp_path,
+) -> None:
+    supervisor = make_supervisor(tmp_path)
+    legacy_config = supervisor._token_router_store.create(
+        "legacy-sparse",
+        {"virtual_model_uid": "legacy-virtual", "backends": {}},
+    )
+    typed_config = supervisor._token_router_store.create(
+        "typed-sparse",
+        {
+            "virtual_model_uid": "typed-virtual",
+            "config_version": 2,
+            "backends": [],
+            "routing": {},
+        },
+    )
+
+    legacy = await supervisor.get_token_router("legacy-sparse")
+    typed = await supervisor.get_token_router("typed-sparse")
+    assert legacy is not None and typed is not None
+    assert legacy["model_aliases"] == []
+    assert legacy["tokenization"]["executor"] == "process"
+    assert legacy["backends"]["short"]["admission"]["max_queue"] == 0
+    assert legacy["routing"]["overflow_policy"] == "reject"
+    assert legacy["deployment"]["management_mode"] == "external"
+    assert typed["config_version"] == 2
+    assert typed["backends"] == []
+    assert typed["routing"]["rules"] == []
+    assert typed["routing"]["default_action"] == {
+        "type": "reject",
+        "reason": "configuration_error",
+    }
+    assert typed["deployment"]["management_mode"] == "external"
+    assert supervisor._token_router_store.get("legacy-sparse") == legacy_config
+    assert supervisor._token_router_store.get("typed-sparse") == typed_config

--- a/xinference/api/tests/test_token_router_api.py
+++ b/xinference/api/tests/test_token_router_api.py
@@ -1173,6 +1173,8 @@ async def test_disabled_feature_rejects_public_and_internal_apis(
             "code": "TOKEN_ROUTER_DISABLED",
             "message": "Token Router feature is disabled",
         }
+
+
 @pytest.mark.asyncio
 async def test_public_router_responses_normalize_sparse_configs_without_persisting(
     tmp_path,

--- a/xinference/api/tests/test_token_router_dispatch.py
+++ b/xinference/api/tests/test_token_router_dispatch.py
@@ -268,6 +268,29 @@ async def test_describe_running_model_supports_virtual_and_physical_models(tmp_p
 
 
 @pytest.mark.asyncio
+async def test_describe_running_model_honors_disabled_feature_gate(
+    tmp_path, monkeypatch
+):
+    supervisor = make_supervisor(tmp_path)
+    create_enabled_router(supervisor)
+    fallback_calls = []
+
+    async def describe_physical(_self, model_uid):
+        fallback_calls.append(model_uid)
+        return {"model_name": model_uid, "model_kind": "physical"}
+
+    supervisor.describe_model = MethodType(describe_physical, supervisor)
+    monkeypatch.setattr(
+        "xinference.core.supervisor.XINFERENCE_TOKEN_ROUTER_ENABLED", False
+    )
+
+    model = await supervisor.describe_running_model("virtual-model")
+
+    assert model == {"model_name": "virtual-model", "model_kind": "physical"}
+    assert fallback_calls == ["virtual-model"]
+
+
+@pytest.mark.asyncio
 async def test_managed_runtime_remains_available_but_degraded_when_agent_is_offline(
     tmp_path,
 ):

--- a/xinference/api/tests/test_token_router_dispatch.py
+++ b/xinference/api/tests/test_token_router_dispatch.py
@@ -178,14 +178,48 @@ async def test_list_virtual_models_only_exposes_enabled_sanitized_models(tmp_pat
 
     models = await supervisor.list_virtual_models()
     assert list(models) == ["virtual-model"]
-    assert models["virtual-model"] == {
-        "model_name": "virtual-model",
-        "model_type": "LLM",
-        "model_engine": "token_router",
-        "router_uid": "router-a",
-        "router_status": "ready",
-    }
+    model = models["virtual-model"]
+    assert model["model_name"] == "virtual-model"
+    assert model["model_type"] == "LLM"
+    assert model["model_engine"] == "token_router"
+    assert model["model_ability"] == ["chat"]
+    assert model["model_kind"] == "virtual"
+    assert model["virtual_model_type"] == "token_router"
+    assert model["router_uid"] == "router-a"
+    assert model["router_status"] == "ready"
+    assert model["runtime_instances"] == 1
+    assert model["online_instances"] == 1
+    assert model["ready_instances"] == 1
+    assert model["backend_count"] == 0
     assert "endpoint" not in json.dumps(models)
+    assert "api_key" not in json.dumps(models)
+
+
+@pytest.mark.asyncio
+async def test_describe_running_model_supports_virtual_and_physical_models(tmp_path):
+    supervisor = make_supervisor(tmp_path)
+    config = create_enabled_router(supervisor)
+    register_ready_runtime(
+        supervisor, "instance-a", "http://secret-router:10081", config["revision"]
+    )
+
+    async def describe_physical(_self, model_uid):
+        return {"model_name": model_uid, "model_type": "LLM", "replica": 1}
+
+    supervisor.describe_model = MethodType(describe_physical, supervisor)
+
+    virtual = await supervisor.describe_running_model("virtual-model")
+    physical = await supervisor.describe_running_model("physical-model")
+
+    assert virtual["model_kind"] == "virtual"
+    assert virtual["model_ability"] == ["chat"]
+    assert virtual["router_uid"] == "router-a"
+    assert "endpoint" not in json.dumps(virtual)
+    assert physical == {
+        "model_name": "physical-model",
+        "model_type": "LLM",
+        "replica": 1,
+    }
 
 
 @pytest.mark.asyncio
@@ -290,10 +324,18 @@ async def test_managed_stopped_deployment_is_disabled_and_not_dispatched(tmp_pat
 
 
 class FakeSupervisor:
-    def __init__(self, resolution, *, physical_models=None, virtual_models=None):
+    def __init__(
+        self,
+        resolution,
+        *,
+        physical_models=None,
+        virtual_models=None,
+        running_model_details=None,
+    ):
         self.resolution = resolution
         self.physical_models = physical_models or {}
         self.virtual_models = virtual_models or {}
+        self.running_model_details = running_model_details or {}
         self.resolved_model_uids = []
 
     async def resolve_token_router_runtime(self, model_uid):
@@ -305,6 +347,11 @@ class FakeSupervisor:
 
     async def list_virtual_models(self):
         return dict(self.virtual_models)
+
+    async def describe_running_model(self, model_uid):
+        if model_uid not in self.running_model_details:
+            raise ValueError(f"Model not found in the model list, uid: {model_uid}")
+        return dict(self.running_model_details[model_uid])
 
 
 class FakeAuthService:
@@ -334,6 +381,27 @@ def make_chat_app(api):
         "/v1/chat/completions", api.create_chat_completion, methods=["POST"]
     )
     return app
+
+
+@pytest.mark.asyncio
+async def test_describe_virtual_model_returns_public_router_metadata():
+    detail = {
+        "model_name": "virtual-model",
+        "model_type": "LLM",
+        "model_engine": "token_router",
+        "model_ability": ["chat"],
+        "model_kind": "virtual",
+        "virtual_model_type": "token_router",
+        "router_uid": "router-a",
+        "router_status": "ready",
+    }
+    supervisor = FakeSupervisor(None, running_model_details={"virtual-model": detail})
+    api = make_rest_api(supervisor)
+
+    response = await api.describe_model("virtual-model")
+
+    assert response.status_code == 200
+    assert json.loads(response.body) == detail
 
 
 @pytest.mark.asyncio

--- a/xinference/api/tests/test_token_router_dispatch.py
+++ b/xinference/api/tests/test_token_router_dispatch.py
@@ -137,6 +137,51 @@ async def test_resolve_rejects_stale_error_and_invalid_runtime(tmp_path):
     assert resolution["available"] is False
 
 
+@pytest.mark.parametrize("revision", [None, "invalid"])
+def test_runtime_health_rejects_invalid_config_revision(tmp_path, revision):
+    supervisor = make_supervisor(tmp_path)
+    register_ready_runtime(supervisor, "instance-a", "http://router-a:10081", 1)
+    config = {
+        "router_uid": "router-a",
+        "virtual_model_uid": "virtual-model",
+        "enabled": True,
+        "revision": revision,
+    }
+
+    instances, effective, controllable = supervisor._token_router_runtime_health(config)
+    model = supervisor._build_token_router_model_info(config)
+
+    assert len(instances) == 1
+    assert effective == []
+    assert controllable == []
+    assert model["router_status"] == "syncing"
+    assert model["ready_instances"] == 0
+
+
+def test_runtime_health_missing_router_uid_does_not_list_other_instances(tmp_path):
+    supervisor = make_supervisor(tmp_path)
+    register_ready_runtime(supervisor, "instance-a", "http://router-a:10081", 1)
+
+    instances, effective, controllable = supervisor._token_router_runtime_health(
+        {"revision": 1}
+    )
+
+    assert instances == []
+    assert effective == []
+    assert controllable == []
+
+
+def test_build_virtual_model_info_tolerates_missing_uids(tmp_path):
+    supervisor = make_supervisor(tmp_path)
+
+    model = supervisor._build_token_router_model_info({"enabled": False, "revision": 1})
+
+    assert model["model_name"] == ""
+    assert model["router_uid"] == ""
+    assert model["router_status"] == "disabled"
+    assert model["runtime_instances"] == 0
+
+
 @pytest.mark.asyncio
 async def test_resolve_rejects_offline_and_non_ready_runtime(tmp_path, monkeypatch):
     now = [100.0]

--- a/xinference/core/supervisor.py
+++ b/xinference/core/supervisor.py
@@ -5067,9 +5067,10 @@ class SupervisorActor(xo.StatelessActor):
     @log_async(logger=logger)
     async def describe_running_model(self, model_uid: str) -> Dict[str, Any]:
         """Describe either a public virtual model or an existing physical model."""
-        config = self._token_router_store.get_by_virtual_model_uid(model_uid)
-        if config is not None and config.get("enabled"):
-            return self._build_token_router_model_info(config)
+        if XINFERENCE_TOKEN_ROUTER_ENABLED:
+            config = self._token_router_store.get_by_virtual_model_uid(model_uid)
+            if config is not None and config.get("enabled"):
+                return self._build_token_router_model_info(config)
         return await self.describe_model(model_uid)
 
     async def resolve_token_router_runtime(

--- a/xinference/core/supervisor.py
+++ b/xinference/core/supervisor.py
@@ -5061,15 +5061,16 @@ class SupervisorActor(xo.StatelessActor):
             virtual_model_uid = config.get("virtual_model_uid")
             if not isinstance(virtual_model_uid, str) or not virtual_model_uid:
                 continue
-            item = self._with_token_router_status(config)
-            result[virtual_model_uid] = {
-                "model_name": virtual_model_uid,
-                "model_type": config.get("model_type", "LLM"),
-                "model_engine": "token_router",
-                "router_uid": config["router_uid"],
-                "router_status": item["status"],
-            }
+            result[virtual_model_uid] = self._build_token_router_model_info(config)
         return result
+
+    @log_async(logger=logger)
+    async def describe_running_model(self, model_uid: str) -> Dict[str, Any]:
+        """Describe either a public virtual model or an existing physical model."""
+        config = self._token_router_store.get_by_virtual_model_uid(model_uid)
+        if config is not None and config.get("enabled"):
+            return self._build_token_router_model_info(config)
+        return await self.describe_model(model_uid)
 
     async def resolve_token_router_runtime(
         self, virtual_model_uid: str
@@ -5838,9 +5839,148 @@ class SupervisorActor(xo.StatelessActor):
                 controllable.append(instance)
         return instances, effective, controllable
 
-    def _with_token_router_status(self, config: Dict[str, Any]) -> Dict[str, Any]:
+    @staticmethod
+    def _normalize_token_router_public_config(
+        config: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """Return a schema-complete copy for UI-facing Router responses.
+
+        Router configurations are persisted across upgrades. Older records may
+        not contain fields introduced by newer UI revisions, so public detail
+        responses must be safe to render without changing the stored payload or
+        the runtime routing semantics.
+        """
         item = dict(config)
+        item.setdefault("model_type", "LLM")
+        item.setdefault("route_profile", "llm_chat")
+        item.setdefault(
+            "strategy",
+            "typed_rules" if isinstance(item.get("backends"), list) else "token_budget",
+        )
+        model_aliases = item.get("model_aliases")
+        item["model_aliases"] = (
+            list(model_aliases) if isinstance(model_aliases, list) else []
+        )
+
+        tokenization = item.get("tokenization")
+        normalized_tokenization = (
+            dict(tokenization) if isinstance(tokenization, dict) else {}
+        )
+        normalized_tokenization.setdefault("executor", "process")
+        normalized_tokenization.setdefault("multiprocessing_start_method", "spawn")
+        normalized_tokenization.setdefault("max_workers", 2)
+        normalized_tokenization.setdefault("max_active", 2)
+        normalized_tokenization.setdefault("max_queue", 8)
+        normalized_tokenization.setdefault("queue_timeout_seconds", 5)
+        normalized_tokenization.setdefault("retry_after_seconds", 1)
+        item["tokenization"] = normalized_tokenization
+
+        backends = item.get("backends")
+        typed = item.get("config_version") == 2 or isinstance(backends, list)
+        if typed:
+            normalized_backends = []
+            for index, backend in enumerate(
+                backends if isinstance(backends, list) else []
+            ):
+                normalized = dict(backend) if isinstance(backend, dict) else {}
+                normalized.setdefault("id", f"backend-{index + 1}")
+                normalized.setdefault("model_uid", "")
+                normalized.setdefault("max_context_tokens", 0)
+                admission = normalized.get("admission")
+                normalized_admission = (
+                    dict(admission) if isinstance(admission, dict) else {}
+                )
+                normalized_admission.setdefault("max_active", 0)
+                normalized_admission.setdefault("max_queue", 0)
+                normalized_admission.setdefault("queue_timeout_seconds", 5)
+                normalized_admission.setdefault("retry_after_seconds", 1)
+                normalized["admission"] = normalized_admission
+                normalized_backends.append(normalized)
+            item["backends"] = normalized_backends
+
+            routing = item.get("routing")
+            normalized_routing = dict(routing) if isinstance(routing, dict) else {}
+            normalized_routing.setdefault("evaluation_mode", "first_match")
+            normalized_routing.setdefault("context_reserve_tokens", 0)
+            normalized_routing.setdefault("default_output_tokens", 0)
+            rules = normalized_routing.get("rules")
+            normalized_routing["rules"] = list(rules) if isinstance(rules, list) else []
+            normalized_routing.setdefault(
+                "default_action", {"type": "reject", "reason": "configuration_error"}
+            )
+            item["routing"] = normalized_routing
+        else:
+            source_backends = backends if isinstance(backends, dict) else {}
+            normalized_legacy_backends: Dict[str, Dict[str, Any]] = {}
+            for backend_id in ("short", "long"):
+                backend = source_backends.get(backend_id)
+                normalized = dict(backend) if isinstance(backend, dict) else {}
+                normalized.setdefault("model_uid", "")
+                normalized.setdefault("max_context_tokens", 0)
+                admission = normalized.get("admission")
+                normalized_admission = (
+                    dict(admission) if isinstance(admission, dict) else {}
+                )
+                normalized_admission.setdefault("max_active", 0)
+                normalized_admission.setdefault("max_queue", 0)
+                normalized_admission.setdefault("queue_timeout_seconds", 5)
+                normalized_admission.setdefault("retry_after_seconds", 1)
+                normalized["admission"] = normalized_admission
+                normalized_legacy_backends[backend_id] = normalized
+            item["backends"] = normalized_legacy_backends
+
+            routing = item.get("routing")
+            normalized_routing = dict(routing) if isinstance(routing, dict) else {}
+            normalized_routing.setdefault("short_threshold_tokens", 0)
+            normalized_routing.setdefault("context_reserve_tokens", 0)
+            normalized_routing.setdefault("default_output_tokens", 0)
+            normalized_routing.setdefault("thinking_policy", "short")
+            normalized_routing.setdefault("overflow_policy", "reject")
+            item["routing"] = normalized_routing
+
+        deployment = item.get("deployment")
+        normalized_deployment = dict(deployment) if isinstance(deployment, dict) else {}
+        normalized_deployment.setdefault("router_uid", item.get("router_uid", ""))
+        normalized_deployment.setdefault("management_mode", "external")
+        normalized_deployment.setdefault("desired_replicas", 0)
+        normalized_deployment.setdefault("desired_state", "running")
+        normalized_deployment.setdefault("placement", {})
+        normalized_deployment.setdefault("rollout", {})
+        normalized_deployment.setdefault("deployment_generation", 1)
+        normalized_deployment.setdefault("observed_ready_assignments", 0)
+        normalized_deployment.setdefault("effective_ready_runtimes", 0)
+        normalized_deployment.setdefault("controllable_ready_runtimes", 0)
+        normalized_deployment.setdefault("ready_replicas", 0)
+        normalized_deployment.setdefault("pending_replicas", 0)
+        normalized_deployment.setdefault("assignments", 0)
+        item["deployment"] = normalized_deployment
+        return item
+
+    @staticmethod
+    def _token_router_backend_count(config: Dict[str, Any]) -> int:
+        backends = config.get("backends")
+        if isinstance(backends, list):
+            return sum(
+                isinstance(backend, dict) and bool(backend.get("model_uid"))
+                for backend in backends
+            )
+        if isinstance(backends, dict):
+            return sum(
+                isinstance(backend, dict) and bool(backend.get("model_uid"))
+                for backend in backends.values()
+            )
+        return 0
+
+    @staticmethod
+    def _safe_public_int(value: Any, default: int = 0) -> int:
+        try:
+            return int(value)
+        except (TypeError, ValueError, OverflowError):
+            return default
+
+    def _with_token_router_status(self, config: Dict[str, Any]) -> Dict[str, Any]:
         instances, effective, controllable = self._token_router_runtime_health(config)
+        item = self._normalize_token_router_public_config(config)
         online = [instance for instance in instances if instance["online"]]
         if not config["enabled"]:
             status = "disabled"
@@ -5877,6 +6017,40 @@ class SupervisorActor(xo.StatelessActor):
         item["online_instances"] = len(online)
         item["deployment"] = deployment
         return item
+
+    def _build_token_router_model_info(self, config: Dict[str, Any]) -> Dict[str, Any]:
+        """Build the sanitized public model descriptor for a Token Router."""
+        item = self._with_token_router_status(config)
+        deployment = item["deployment"]
+        public_deployment = {
+            "management_mode": deployment.get("management_mode", "external"),
+            "desired_state": deployment.get("desired_state", "running"),
+            "desired_replicas": self._safe_public_int(
+                deployment.get("desired_replicas")
+            ),
+            "ready_replicas": self._safe_public_int(deployment.get("ready_replicas")),
+            "pending_replicas": self._safe_public_int(
+                deployment.get("pending_replicas")
+            ),
+        }
+        return {
+            "model_name": config["virtual_model_uid"],
+            "model_type": config.get("model_type", "LLM"),
+            "model_engine": "token_router",
+            "model_ability": ["chat"],
+            "model_kind": "virtual",
+            "virtual_model_type": "token_router",
+            "router_uid": config["router_uid"],
+            "router_status": item["status"],
+            "route_profile": config.get("route_profile", "llm_chat"),
+            "runtime_instances": self._safe_public_int(item.get("runtime_instances")),
+            "online_instances": self._safe_public_int(item.get("online_instances")),
+            "ready_instances": self._safe_public_int(
+                deployment.get("effective_ready_runtimes")
+            ),
+            "backend_count": self._token_router_backend_count(config),
+            "deployment": public_deployment,
+        }
 
     async def get_token_router_status(
         self, router_uid: str

--- a/xinference/core/supervisor.py
+++ b/xinference/core/supervisor.py
@@ -5810,26 +5810,33 @@ class SupervisorActor(xo.StatelessActor):
         """Return all, effectively ready, and controllably ready Runtimes.
 
         This is the single source of truth shared by status reporting and the
-        request dispatch path.  An Agent outage does not by itself invalidate a
+        request dispatch path. An Agent outage does not by itself invalidate a
         healthy Runtime data plane, but it removes that Runtime from the
         controllable subset.
         """
 
-        instances = self._token_router_registry.list(config["router_uid"])
+        router_uid = config.get("router_uid")
+        if not isinstance(router_uid, str) or not router_uid:
+            # RouterRuntimeRegistry.list(None) returns every instance. Treat a
+            # malformed config as unavailable instead of leaking another Router's
+            # runtime state into this one.
+            instances: List[Dict[str, Any]] = []
+        else:
+            instances = self._token_router_registry.list(router_uid)
+        config_revision = self._safe_public_int(config.get("revision"), 0)
+        revision_is_valid = config_revision > 0
         effective: List[Dict[str, Any]] = []
         controllable: List[Dict[str, Any]] = []
         for instance in instances:
+            acked_revision = self._safe_public_int(instance.get("acked_revision"), 0)
             endpoint = instance.get("endpoint")
-            try:
-                acked_revision = int(instance.get("acked_revision", 0))
-            except (TypeError, ValueError):
-                acked_revision = 0
             if not (
                 instance.get("online")
                 and self._token_router_orchestration.runtime_is_current(instance)
                 and instance.get("status") == "ready"
                 and not instance.get("config_error")
-                and acked_revision >= int(config["revision"])
+                and revision_is_valid
+                and acked_revision >= config_revision
                 and isinstance(endpoint, str)
                 and endpoint.startswith(("http://", "https://"))
             ):
@@ -5982,25 +5989,39 @@ class SupervisorActor(xo.StatelessActor):
         instances, effective, controllable = self._token_router_runtime_health(config)
         item = self._normalize_token_router_public_config(config)
         online = [instance for instance in instances if instance["online"]]
-        if not config["enabled"]:
+        config_revision = self._safe_public_int(config.get("revision"), 0)
+        if not config.get("enabled"):
             status = "disabled"
+        elif config_revision <= 0:
+            status = "syncing"
         elif not effective:
             status = "unavailable"
         elif len(effective) < len(online) or len(controllable) < len(effective):
             status = "degraded"
         else:
             status = "ready"
-        deployment = self._token_router_orchestration.deployment_summary(
-            config["router_uid"],
-            effective_ready_runtimes=effective,
-            controllable_ready_runtimes=controllable,
-        )
+        router_uid = config.get("router_uid")
+        if isinstance(router_uid, str) and router_uid:
+            deployment = self._token_router_orchestration.deployment_summary(
+                router_uid,
+                effective_ready_runtimes=effective,
+                controllable_ready_runtimes=controllable,
+            )
+        else:
+            # A malformed legacy record must remain safe to inspect and must not
+            # create deployment state under an empty Router UID.
+            deployment = dict(item.get("deployment") or {})
+            deployment["effective_ready_runtimes"] = len(effective)
+            deployment["controllable_ready_runtimes"] = len(controllable)
+            deployment["ready_replicas"] = len(effective)
+            desired = self._safe_public_int(deployment.get("desired_replicas"))
+            deployment["pending_replicas"] = max(desired - len(effective), 0)
         if (
             deployment["management_mode"] == "managed"
             and deployment["desired_state"] == "stopped"
         ):
             status = "disabled"
-        elif deployment["management_mode"] == "managed" and config["enabled"]:
+        elif deployment["management_mode"] == "managed" and config.get("enabled"):
             desired = deployment["desired_replicas"]
             ready = deployment["effective_ready_runtimes"]
             manageable = deployment["controllable_ready_runtimes"]
@@ -6022,6 +6043,12 @@ class SupervisorActor(xo.StatelessActor):
         """Build the sanitized public model descriptor for a Token Router."""
         item = self._with_token_router_status(config)
         deployment = item["deployment"]
+        virtual_model_uid = config.get("virtual_model_uid")
+        if not isinstance(virtual_model_uid, str):
+            virtual_model_uid = ""
+        router_uid = config.get("router_uid")
+        if not isinstance(router_uid, str):
+            router_uid = ""
         public_deployment = {
             "management_mode": deployment.get("management_mode", "external"),
             "desired_state": deployment.get("desired_state", "running"),
@@ -6034,13 +6061,13 @@ class SupervisorActor(xo.StatelessActor):
             ),
         }
         return {
-            "model_name": config["virtual_model_uid"],
+            "model_name": virtual_model_uid,
             "model_type": config.get("model_type", "LLM"),
             "model_engine": "token_router",
             "model_ability": ["chat"],
             "model_kind": "virtual",
             "virtual_model_type": "token_router",
-            "router_uid": config["router_uid"],
+            "router_uid": router_uid,
             "router_status": item["status"],
             "route_profile": config.get("route_profile", "llm_chat"),
             "runtime_instances": self._safe_public_int(item.get("runtime_instances")),


### PR DESCRIPTION
## Summary
- expose Token Router virtual models through the Running Model detail contract
- declare virtual models as chat-capable and identify their virtual model type
- include sanitized runtime, backend, status, and deployment summaries
- normalize sparse legacy and typed Router configurations without mutating persistence
- route `GET /v1/models/{model_uid}` through the unified running-model descriptor

## Dependency
- Built on merged PR #5375.

## Validation
- `pytest -q xinference/api/tests/test_token_router_dispatch.py xinference/api/tests/test_token_router_api.py`
- `pre-commit run --files xinference/core/supervisor.py xinference/api/restful_api.py xinference/api/tests/test_token_router_dispatch.py xinference/api/tests/test_token_router_api.py`
