### PR TITLE
fix(router): stabilize managed runtime instance identity

### DIFF
--- a/xinference/api/routers/token_routers.py
+++ b/xinference/api/routers/token_routers.py
@@ -542,7 +542,7 @@ async def register_router_node(
 ) -> JSONResponse:
     try:
         result = await (await _supervisor(api)).register_token_router_node(
-            payload.dict()
+            payload.dict(exclude_unset=True)
         )
     except ValueError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc

--- a/xinference/api/tests/test_token_router_api.py
+++ b/xinference/api/tests/test_token_router_api.py
@@ -17,7 +17,8 @@ from tokenizers import Tokenizer, models, pre_tokenizers
 
 from xinference.api.routers import token_routers
 from xinference.api.routers.token_routers import register_routes
-from xinference.constants import parse_env_bool
+from xinference.api.schemas.router import RouterNodeRegister
+from xinference.constants import parse_env_bool, parse_env_float
 from xinference.core.router_config_store import RouterConfigStore
 from xinference.core.router_orchestration import RouterOrchestrationController
 from xinference.core.router_registry import RouterRuntimeRegistry
@@ -298,6 +299,48 @@ def create_app(
     app.state.api = api
     app.include_router(api._router)
     return app
+
+
+def test_router_node_register_preserves_reported_labels_presence():
+    base = {
+        "node_id": "node-a",
+        "advertise_host": "127.0.0.1",
+        "port_range_start": 12080,
+        "port_range_end": 12089,
+        "max_instances": 5,
+        "labels": {"legacy": "value"},
+    }
+
+    omitted = RouterNodeRegister(**base).dict(exclude_unset=True)
+    explicit_empty = RouterNodeRegister(**base, reported_labels={}).dict(
+        exclude_unset=True
+    )
+
+    assert "reported_labels" not in omitted
+    assert explicit_empty["reported_labels"] == {}
+
+
+@pytest.mark.parametrize(
+    "raw",
+    ["invalid", "nan", "inf", "-inf"],
+)
+def test_parse_env_float_falls_back_for_invalid_or_non_finite_values(
+    monkeypatch, caplog, raw
+):
+    monkeypatch.setenv("XINFERENCE_TEST_FLOAT", raw)
+
+    with caplog.at_level("WARNING", logger="xinference.constants"):
+        assert parse_env_float("XINFERENCE_TEST_FLOAT", 2.5) == 2.5
+
+    assert "XINFERENCE_TEST_FLOAT" in caplog.text
+
+
+def test_parse_env_float_accepts_finite_values_and_defaults_when_unset(monkeypatch):
+    monkeypatch.setenv("XINFERENCE_TEST_FLOAT", " 2.5 ")
+    assert parse_env_float("XINFERENCE_TEST_FLOAT", 1.0) == 2.5
+
+    monkeypatch.delenv("XINFERENCE_TEST_FLOAT")
+    assert parse_env_float("XINFERENCE_TEST_FLOAT", 1.0) == 1.0
 
 
 @pytest.mark.asyncio

--- a/xinference/constants.py
+++ b/xinference/constants.py
@@ -12,8 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
+import math
 import os
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 
 def parse_env_bool(name: str, default: bool) -> bool:
@@ -29,6 +33,32 @@ def parse_env_bool(name: str, default: bool) -> bool:
     raise ValueError(
         f"{name} must be one of true/false, 1/0, yes/no, or on/off; got {raw!r}"
     )
+
+
+def parse_env_float(name: str, default: float) -> float:
+    """Parse a finite float environment variable with a safe fallback."""
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        value = float(raw)
+    except (TypeError, ValueError, OverflowError):
+        logger.warning(
+            "Environment variable %s is invalid (got %r); using default %s",
+            name,
+            raw,
+            default,
+        )
+        return default
+    if not math.isfinite(value):
+        logger.warning(
+            "Environment variable %s must be finite (got %r); using default %s",
+            name,
+            raw,
+            default,
+        )
+        return default
+    return value
 
 
 XINFERENCE_ENV_ENDPOINT = "XINFERENCE_ENDPOINT"
@@ -270,20 +300,20 @@ XINFERENCE_TOKEN_ROUTER_DB_PATH = os.environ.get(
     "XINFERENCE_TOKEN_ROUTER_DB_PATH",
     os.path.join(XINFERENCE_HOME, "token_routers.db"),
 )
-XINFERENCE_TOKEN_ROUTER_HEARTBEAT_TIMEOUT_SECONDS = float(
-    os.environ.get("XINFERENCE_TOKEN_ROUTER_HEARTBEAT_TIMEOUT_SECONDS", "90")
+XINFERENCE_TOKEN_ROUTER_HEARTBEAT_TIMEOUT_SECONDS = parse_env_float(
+    "XINFERENCE_TOKEN_ROUTER_HEARTBEAT_TIMEOUT_SECONDS", 90.0
 )
-XINFERENCE_TOKEN_ROUTER_AGENT_SUSPECT_SECONDS = float(
-    os.environ.get("XINFERENCE_TOKEN_ROUTER_AGENT_SUSPECT_SECONDS", "30")
+XINFERENCE_TOKEN_ROUTER_AGENT_SUSPECT_SECONDS = parse_env_float(
+    "XINFERENCE_TOKEN_ROUTER_AGENT_SUSPECT_SECONDS", 30.0
 )
-XINFERENCE_TOKEN_ROUTER_AGENT_OFFLINE_SECONDS = float(
-    os.environ.get("XINFERENCE_TOKEN_ROUTER_AGENT_OFFLINE_SECONDS", "45")
+XINFERENCE_TOKEN_ROUTER_AGENT_OFFLINE_SECONDS = parse_env_float(
+    "XINFERENCE_TOKEN_ROUTER_AGENT_OFFLINE_SECONDS", 45.0
 )
-XINFERENCE_TOKEN_ROUTER_AGENT_MONITOR_SECONDS = float(
-    os.environ.get("XINFERENCE_TOKEN_ROUTER_AGENT_MONITOR_SECONDS", "5")
+XINFERENCE_TOKEN_ROUTER_AGENT_MONITOR_SECONDS = parse_env_float(
+    "XINFERENCE_TOKEN_ROUTER_AGENT_MONITOR_SECONDS", 5.0
 )
-XINFERENCE_TOKEN_ROUTER_STALE_RETENTION_SECONDS = float(
-    os.environ.get("XINFERENCE_TOKEN_ROUTER_STALE_RETENTION_SECONDS", "300")
+XINFERENCE_TOKEN_ROUTER_STALE_RETENTION_SECONDS = parse_env_float(
+    "XINFERENCE_TOKEN_ROUTER_STALE_RETENTION_SECONDS", 300.0
 )
 XINFERENCE_TOKENIZER_ASSET_CONFIG = os.environ.get(
     "XINFERENCE_TOKENIZER_ASSET_CONFIG", ""

--- a/xinference/core/router_assignment_store.py
+++ b/xinference/core/router_assignment_store.py
@@ -194,6 +194,7 @@ class RouterAssignmentStore:
         effective_instance_id = (
             current["instance_id"] if instance_id is None else instance_id
         )
+        effective_pid = current["pid"] if pid is None else pid
         now = self._now()
         with self._lock, self._connect() as conn:
             conn.execute(
@@ -203,7 +204,7 @@ class RouterAssignmentStore:
                    WHERE assignment_id = ?""",
                 (
                     observed_state,
-                    pid,
+                    effective_pid,
                     effective_instance_id,
                     last_error,
                     json.dumps(

--- a/xinference/core/router_assignment_store.py
+++ b/xinference/core/router_assignment_store.py
@@ -191,6 +191,9 @@ class RouterAssignmentStore:
                 f"Stale Assignment generation {assignment_generation}; current is "
                 f"{current['assignment_generation']}"
             )
+        effective_instance_id = (
+            current["instance_id"] if instance_id is None else instance_id
+        )
         now = self._now()
         with self._lock, self._connect() as conn:
             conn.execute(
@@ -201,7 +204,7 @@ class RouterAssignmentStore:
                 (
                     observed_state,
                     pid,
-                    instance_id,
+                    effective_instance_id,
                     last_error,
                     json.dumps(
                         current["observed"] if observed is None else observed,

--- a/xinference/core/router_node_store.py
+++ b/xinference/core/router_node_store.py
@@ -153,7 +153,9 @@ class RouterNodeStore:
             raise ValueError("max_instances must be greater than zero")
         if maximum > end - start + 1:
             raise ValueError("max_instances exceeds the Router node port range")
-        labels = data.get("reported_labels") or data.get("labels", {})
+        labels = data.get("reported_labels")
+        if labels is None:
+            labels = data.get("labels", {})
         if not isinstance(labels, dict):
             raise ValueError("reported_labels must be an object")
         if not isinstance(data.get("capabilities", {}), dict):
@@ -166,7 +168,10 @@ class RouterNodeStore:
         now = self._now()
         desired_state = current["desired_state"] if current else "active"
         created_at = current["created_at"] if current else now
-        reported_labels = dict(data.get("reported_labels") or data.get("labels", {}))
+        reported_labels_value = data.get("reported_labels")
+        if reported_labels_value is None:
+            reported_labels_value = data.get("labels", {})
+        reported_labels = dict(reported_labels_value)
         managed_labels = current.get("managed_labels", {}) if current else {}
         merged_labels = {**reported_labels, **managed_labels}
         with self._lock, self._connect() as conn:

--- a/xinference/core/tests/test_router_assignment_store.py
+++ b/xinference/core/tests/test_router_assignment_store.py
@@ -29,7 +29,10 @@ def test_report_status_without_instance_id_preserves_existing_value(tmp_path):
         instance_id="router-agent-1-13fdc0e8-34b3-4e7d-ad06-a1db60427557",
     )
     updated = store.report_status("router-a-0", 1, "ready", pid=1234)
+    preserved = store.report_status("router-a-0", 1, "ready")
 
     assert updated["instance_id"] == (
         "router-agent-1-13fdc0e8-34b3-4e7d-ad06-a1db60427557"
     )
+    assert preserved["instance_id"] == updated["instance_id"]
+    assert preserved["pid"] == 1234

--- a/xinference/core/tests/test_router_assignment_store.py
+++ b/xinference/core/tests/test_router_assignment_store.py
@@ -1,0 +1,35 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+
+from xinference.core.router_assignment_store import RouterAssignmentStore
+
+
+def _assignment():
+    return {
+        "assignment_id": "router-a-0",
+        "router_uid": "router-a",
+        "replica_index": 0,
+        "node_id": "node-a",
+        "listen_host": "127.0.0.1",
+        "listen_port": 12080,
+        "public_endpoint": "http://127.0.0.1:12080",
+        "desired_state": "running",
+        "assignment_generation": 1,
+        "config_revision": 1,
+    }
+
+
+def test_report_status_without_instance_id_preserves_existing_value(tmp_path):
+    store = RouterAssignmentStore(str(tmp_path / "assignments.db"))
+    store.create(_assignment())
+
+    store.report_status(
+        "router-a-0",
+        1,
+        "starting",
+        instance_id="router-agent-1-13fdc0e8-34b3-4e7d-ad06-a1db60427557",
+    )
+    updated = store.report_status("router-a-0", 1, "ready", pid=1234)
+
+    assert updated["instance_id"] == (
+        "router-agent-1-13fdc0e8-34b3-4e7d-ad06-a1db60427557"
+    )

--- a/xinference/core/tests/test_router_node_store.py
+++ b/xinference/core/tests/test_router_node_store.py
@@ -1,0 +1,40 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+
+from xinference.core.router_node_store import RouterNodeStore
+
+
+def _node(node_id: str) -> dict:
+    return {
+        "node_id": node_id,
+        "advertise_host": "127.0.0.1",
+        "port_range_start": 12080,
+        "port_range_end": 12089,
+        "max_instances": 5,
+        "labels": {"legacy": "value"},
+        "capabilities": {},
+    }
+
+
+def test_register_uses_legacy_labels_only_when_reported_labels_is_omitted(tmp_path):
+    store = RouterNodeStore(str(tmp_path / "nodes.db"))
+
+    legacy = store.register(_node("legacy"))
+    explicit_empty = store.register({**_node("explicit-empty"), "reported_labels": {}})
+
+    assert legacy["reported_labels"] == {"legacy": "value"}
+    assert explicit_empty["reported_labels"] == {}
+    assert explicit_empty["labels"] == {}
+
+
+def test_register_preserves_managed_labels_with_explicit_empty_reported_labels(
+    tmp_path,
+):
+    store = RouterNodeStore(str(tmp_path / "nodes.db"))
+    store.register(_node("node-a"))
+    store.set_managed_labels("node-a", {"environment": "test"})
+
+    updated = store.register({**_node("node-a"), "reported_labels": {}})
+
+    assert updated["reported_labels"] == {}
+    assert updated["managed_labels"] == {"environment": "test"}
+    assert updated["labels"] == {"environment": "test"}

--- a/xinference/router/agent/process_manager.py
+++ b/xinference/router/agent/process_manager.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import re
 import socket
 import time
 from dataclasses import dataclass, field
@@ -18,6 +19,9 @@ from .control_plane import RouterAgentControlPlaneClient
 logger = logging.getLogger(__name__)
 
 _SHUTDOWN_DRAIN_TIMEOUT_SECONDS = 10.0
+_INSTANCE_UUID_SUFFIX = re.compile(
+    r"(?i)([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$"
+)
 
 _ALLOWED_ENVIRONMENT = (
     "PATH",
@@ -134,6 +138,29 @@ class RouterRuntimeProcessManager:
         finally:
             sock.close()
 
+    @staticmethod
+    def _runtime_instance_id(assignment: Dict[str, Any]) -> Optional[str]:
+        """Return a stable, agent-scoped ID for a managed Runtime.
+
+        Supervisor-created assignments already carry the Runtime instance ID.
+        Preserve its UUID suffix while replacing the old host prefix with the
+        Agent listen host.  Legacy or malformed IDs are deliberately left
+        untouched so that externally managed assignments remain compatible.
+        """
+        listen_host = str(assignment.get("listen_host") or "").strip()
+        instance_id = str(assignment.get("instance_id") or "").strip()
+        if not listen_host or not instance_id:
+            return None
+        match = _INSTANCE_UUID_SUFFIX.search(instance_id)
+        if match is None:
+            return instance_id
+        return f"{listen_host}-{match.group(1).lower()}"
+
+    @staticmethod
+    def _assignment_instance_id(assignment: Dict[str, Any]) -> Optional[str]:
+        value = assignment.get("instance_id")
+        return str(value) if value else None
+
     def _child_environment(self, assignment: Dict[str, Any]) -> Dict[str, str]:
         env = {
             key: value
@@ -164,6 +191,9 @@ class RouterRuntimeProcessManager:
                 "TOKENIZERS_PARALLELISM": os.getenv("TOKENIZERS_PARALLELISM", "false"),
             }
         )
+        instance_id = self._assignment_instance_id(assignment)
+        if instance_id:
+            env["XINFERENCE_TOKEN_ROUTER_INSTANCE_ID"] = instance_id
         if asset:
             env.update(
                 {
@@ -204,7 +234,15 @@ class RouterRuntimeProcessManager:
                     managed = ManagedRuntimeProcess(assignment=assignment)
                     self._processes[assignment_id] = managed
                 else:
+                    previous_instance_id = managed.assignment.get("instance_id")
                     managed.assignment = assignment
+                    if previous_instance_id and not managed.assignment.get(
+                        "instance_id"
+                    ):
+                        managed.assignment["instance_id"] = previous_instance_id
+                runtime_instance_id = self._runtime_instance_id(managed.assignment)
+                if runtime_instance_id is not None:
+                    managed.assignment["instance_id"] = runtime_instance_id
                 if managed.process is None or managed.process.returncode is not None:
                     await self._start_locked(managed)
 
@@ -228,6 +266,7 @@ class RouterRuntimeProcessManager:
                 managed.assignment_id,
                 node_id=self.node_id,
                 assignment_generation=managed.generation,
+                instance_id=self._assignment_instance_id(managed.assignment),
                 observed_state="failed",
                 last_error="Tokenizer Asset Binding is not ready on this Router Agent",
             )
@@ -251,6 +290,7 @@ class RouterRuntimeProcessManager:
                 managed.assignment_id,
                 node_id=self.node_id,
                 assignment_generation=managed.generation,
+                instance_id=self._assignment_instance_id(managed.assignment),
                 observed_state="port_conflict",
                 listen_port=port,
                 last_error=f"Router Runtime port is already in use: {host}:{port}",
@@ -264,6 +304,7 @@ class RouterRuntimeProcessManager:
             managed.assignment_id,
             node_id=self.node_id,
             assignment_generation=managed.generation,
+            instance_id=self._assignment_instance_id(managed.assignment),
             observed_state="starting",
             listen_port=port,
         )
@@ -311,6 +352,7 @@ class RouterRuntimeProcessManager:
             managed.assignment_id,
             node_id=self.node_id,
             assignment_generation=managed.generation,
+            instance_id=self._assignment_instance_id(managed.assignment),
             observed_state="starting",
             pid=process.pid,
             listen_port=port,
@@ -337,6 +379,7 @@ class RouterRuntimeProcessManager:
             managed.assignment_id,
             node_id=self.node_id,
             assignment_generation=managed.generation,
+            instance_id=self._assignment_instance_id(managed.assignment),
             observed_state=state,
             last_error=error,
         )
@@ -415,6 +458,7 @@ class RouterRuntimeProcessManager:
                 managed.assignment_id,
                 node_id=self.node_id,
                 assignment_generation=managed.generation,
+                instance_id=self._assignment_instance_id(managed.assignment),
                 observed_state=state,
                 pid=process.pid,
                 listen_port=int(managed.assignment["listen_port"]),
@@ -439,6 +483,7 @@ class RouterRuntimeProcessManager:
                 managed.assignment_id,
                 node_id=self.node_id,
                 assignment_generation=managed.generation,
+                instance_id=self._assignment_instance_id(managed.assignment),
                 observed_state=observed_state,
                 pid=pid,
             )

--- a/xinference/router/control_plane.py
+++ b/xinference/router/control_plane.py
@@ -10,6 +10,7 @@ import platform
 import socket
 import uuid
 from typing import TYPE_CHECKING, Any, Dict, Optional
+from urllib.parse import urlsplit
 
 import httpx
 
@@ -35,6 +36,14 @@ def _software_revision() -> Optional[str]:
             commit_id = None
         return commit_id.lstrip("g") if commit_id else None
     return full_revisionid or None
+
+
+def _default_instance_id_prefix(listen_host: str, endpoint: str) -> str:
+    host = str(listen_host or "").strip()
+    if host not in {"", "*", "0.0.0.0", "::", "[::]"}:
+        return host
+    endpoint_host = urlsplit(str(endpoint or "")).hostname
+    return endpoint_host or socket.gethostname()
 
 
 def _config_log_fields(config: Any) -> Dict[str, Any]:
@@ -78,7 +87,9 @@ class RouterControlPlaneClient:
         self.router_uid = router_uid
         self.internal_token = internal_token
         self.endpoint = endpoint
-        self.instance_id = instance_id or f"{socket.gethostname()}-{uuid.uuid4()}"
+        self.instance_id = instance_id or (
+            f"{_default_instance_id_prefix(listen_host, endpoint)}-{uuid.uuid4()}"
+        )
         self._revision = 0
         self.listen_host = listen_host
         self.listen_port = listen_port

--- a/xinference/router/service.py
+++ b/xinference/router/service.py
@@ -43,6 +43,7 @@ async def _load_control_plane_config(args: argparse.Namespace):
     generation_value = os.getenv("XINFERENCE_TOKEN_ROUTER_ASSIGNMENT_GENERATION")
     assignment_generation = int(generation_value) if generation_value else None
     node_id = os.getenv("XINFERENCE_TOKEN_ROUTER_NODE_ID") or None
+    instance_id = os.getenv("XINFERENCE_TOKEN_ROUTER_INSTANCE_ID") or None
     assignment_fields = (assignment_id, assignment_generation, node_id)
     if any(value is not None for value in assignment_fields) and not all(
         value is not None for value in assignment_fields
@@ -55,6 +56,7 @@ async def _load_control_plane_config(args: argparse.Namespace):
         args.router_uid,
         internal_token=token,
         endpoint=endpoint,
+        instance_id=instance_id,
         listen_host=args.host,
         listen_port=args.port,
         log_level=args.log_level,

--- a/xinference/router/tests/test_agent.py
+++ b/xinference/router/tests/test_agent.py
@@ -101,6 +101,30 @@ def _manager(tmp_path, control=None, **kwargs):
     )
 
 
+def test_runtime_instance_id_replaces_only_uuid_host_prefix(tmp_path) -> None:
+    manager = _manager(tmp_path)
+    assignment = _assignment()
+    assignment["listen_host"] = "router-agent-1"
+    assignment["instance_id"] = "old-host-name-13fdc0e8-34b3-4e7d-ad06-a1db60427557"
+
+    assert manager._runtime_instance_id(assignment) == (
+        "router-agent-1-13fdc0e8-34b3-4e7d-ad06-a1db60427557"
+    )
+    assert manager._runtime_instance_id({**assignment, "instance_id": "legacy"}) == (
+        "legacy"
+    )
+
+
+def test_runtime_child_environment_contains_stable_instance_id(tmp_path) -> None:
+    manager = _manager(tmp_path)
+    assignment = _assignment()
+    assignment["instance_id"] = "router-agent-1-13fdc0e8-34b3-4e7d-ad06-a1db60427557"
+
+    env = manager._child_environment(assignment)
+
+    assert env["XINFERENCE_TOKEN_ROUTER_INSTANCE_ID"] == assignment["instance_id"]
+
+
 def _assignment(generation=1):
     return {
         "assignment_id": "router-a-0",

--- a/xinference/router/tests/test_control_plane.py
+++ b/xinference/router/tests/test_control_plane.py
@@ -12,6 +12,7 @@ from xinference.router import control_plane as control_plane_module
 from xinference.router.control_plane import (
     RouterControlPlaneClient,
     RouterInstanceNotFound,
+    _default_instance_id_prefix,
 )
 from xinference.router.runtime import RouterRuntime
 
@@ -63,6 +64,19 @@ class FakeRuntime:
                 "fingerprint": "sha256:test-fingerprint",
             },
         }
+
+
+def test_default_instance_id_prefix_uses_listen_host() -> None:
+    assert _default_instance_id_prefix("router-agent-1", "http://runtime:10080") == (
+        "router-agent-1"
+    )
+
+
+def test_default_instance_id_prefix_uses_endpoint_for_wildcard_host() -> None:
+    assert _default_instance_id_prefix("0.0.0.0", "http://runtime.example:10080") == (
+        "runtime.example"
+    )
+    assert _default_instance_id_prefix("::", "")
 
 
 def make_client(*, revision: int = 1) -> RouterControlPlaneClient:


### PR DESCRIPTION
## Summary
- stabilize managed Router Runtime instance IDs across Agent reconciliation and Runtime restarts
- derive the Agent-scoped prefix from the assigned listen host while preserving the UUID suffix
- pass the normalized ID through the Runtime environment and every assignment lifecycle status update
- preserve persisted instance IDs when status reports omit the field
- avoid using wildcard listen addresses directly as standalone instance prefixes

## Dependency
- Depends on #5379 (Router Agent orchestration)

## Validation
- `pytest -q xinference/router/tests/test_agent.py xinference/router/tests/test_control_plane.py xinference/core/tests/test_router_assignment_store.py`
- pre-commit checks for all changed files

`deploy/systemd/` is not included.
