### PR TITLE
feat: add media seed controls and dimension swap

### DIFF
--- a/frontend/src/components/pages/running-model-detail/capability-config.tsx
+++ b/frontend/src/components/pages/running-model-detail/capability-config.tsx
@@ -50,6 +50,7 @@ import {
   stringValue,
   uploadList,
 } from './utils';
+import { parseScalarSeed } from './seed-utils';
 
 function appendKwargsIfPresent(formData: FormData, kwargs: Record<string, unknown>) {
   if (isEmpty(kwargs)) {
@@ -84,6 +85,7 @@ const imageDefaults = {
   padding_image_to_multiple: -1,
   strength: 0.6,
   sampler_name: 'default',
+  seed: '-1',
 };
 
 const videoDefaults = {
@@ -96,11 +98,13 @@ const videoDefaults = {
   fps: 8,
   num_inference_steps: 25,
   guidance_scale: 7.5,
+  seed: -1,
 };
 
 const imageKwargsExample = {
   guidance_scale: 7.5,
   num_inference_steps: 25,
+  seed: [11],
 };
 
 const videoKwargsExample = {
@@ -110,10 +114,14 @@ const videoKwargsExample = {
   fps: 8,
   num_inference_steps: 25,
   guidance_scale: 7.5,
+  seed: 11,
 };
 
 function commonImageBody({ modelUid, values, requestId }: TransformContext, fallbackSize?: string) {
-  const kwargs = buildGenerationKwargs(values, requestId, { excludeKeys: ['width', 'height'] });
+  const kwargs = buildGenerationKwargs(values, requestId, {
+    excludeKeys: ['width', 'height'],
+    seedMode: 'image-list',
+  });
 
   return withKwargsIfPresent(
     {
@@ -133,6 +141,7 @@ function appendCommonMediaFormData(formData: FormData, context: TransformContext
   const size = sizeFromValues(values);
   const kwargs = buildGenerationKwargs(values, context.requestId, {
     excludeKeys: ['width', 'height'],
+    seedMode: 'image-list',
   });
 
   formData.append('model', modelUid);
@@ -671,12 +680,19 @@ export const CAPABILITY_CONFIGS: Partial<Record<ModelAbility, CapabilityConfig>>
         },
         { key: 'voice', value: 'Voice ID', comment: 'Optional' },
         { key: 'speed', value: 1, comment: 'Optional' },
+        {
+          key: 'kwargs',
+          value: { seed: 11 },
+          stringify: true,
+          comment: 'Optional(other key/value)',
+        },
       ],
     },
     initialValues: {
       input: '',
       voice: '',
       speed: 1,
+      seed: -1,
       prompt_speech: [],
       prompt_text: '',
       instruct: '',
@@ -695,6 +711,11 @@ export const CAPABILITY_CONFIGS: Partial<Record<ModelAbility, CapabilityConfig>>
       const kwargs: Record<string, unknown> = {};
       const promptText = stringValue(values.prompt_text).trim();
       const instruct = stringValue(values.instruct).trim();
+      const seed = parseScalarSeed(values.seed);
+
+      if (seed !== undefined) {
+        kwargs.seed = seed;
+      }
 
       if (promptSpeech) {
         if (promptText) {
@@ -774,7 +795,7 @@ export const CAPABILITY_CONFIGS: Partial<Record<ModelAbility, CapabilityConfig>>
     initialValues: {
       input: '',
       instruct: '',
-      seed: 0,
+      seed: -1,
       duration: 60,
     },
     formPanel: SpeechPanel,
@@ -787,7 +808,7 @@ export const CAPABILITY_CONFIGS: Partial<Record<ModelAbility, CapabilityConfig>>
       response_format: 'wav',
       kwargs: JSON.stringify({
         instruct: stringValue(values.instruct),
-        seed: numberValue(values.seed, 0),
+        seed: parseScalarSeed(values.seed) ?? -1,
         duration: numberValue(values.duration, 60),
       }),
     }),

--- a/frontend/src/components/pages/running-model-detail/image-seed-utils.ts
+++ b/frontend/src/components/pages/running-model-detail/image-seed-utils.ts
@@ -1,0 +1,48 @@
+import { createRandomSeed, MAX_SEED } from './seed-utils';
+
+export const MAX_IMAGE_SEED = MAX_SEED;
+
+const normalizeImageCount = (count: unknown): number => {
+  const parsed = Number(count);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.round(parsed) : 1;
+};
+
+/** Parse only seeds supplied by the user; backend pads missing positions. */
+export const parseImageSeeds = (value: unknown, count: unknown): number[] => {
+  const imageCount = normalizeImageCount(count);
+  const text = typeof value === 'string' ? value : value == null ? '' : String(value);
+  const tokens = text.trim() === '' ? [] : text.replaceAll('，', ',').split(',');
+
+  if (tokens.length > imageCount) {
+    throw new Error(`Enter no more than ${imageCount} seeds.`);
+  }
+
+  return tokens.map((token) => {
+    const normalized = token.trim();
+    if (normalized === '') return -1;
+    if (!/^-?\d+$/.test(normalized)) {
+      throw new Error('Seeds must be integers separated by commas.');
+    }
+
+    const seed = Number(normalized);
+    if (!Number.isSafeInteger(seed) || seed < -1 || seed > MAX_IMAGE_SEED) {
+      throw new Error(`Each seed must be -1 or an integer from 0 to ${MAX_IMAGE_SEED}.`);
+    }
+    return seed;
+  });
+};
+
+export const createRandomImageSeed = (): number => {
+  return createRandomSeed();
+};
+
+/** Generate a fresh seed for every image when the random button is clicked. */
+export const generateRandomImageSeeds = (
+  count: unknown,
+  randomSeed: () => number = createRandomImageSeed
+): number[] => {
+  const imageCount = normalizeImageCount(count);
+  return Array.from({ length: imageCount }, () => randomSeed());
+};
+
+export const formatImageSeeds = (seeds: number[]): string => seeds.join(', ');

--- a/frontend/src/components/pages/running-model-detail/panels/form-panels.tsx
+++ b/frontend/src/components/pages/running-model-detail/panels/form-panels.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
-import { Plus, Trash2 } from 'lucide-react';
+import { ArrowLeftRight, Plus, Trash2 } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
 import { FileUpload } from '@/components/ui/file-upload';
@@ -121,15 +121,32 @@ function ImageGenerationFields({
     form.setFieldValue('seed', formatImageSeeds(generateRandomImageSeeds(imageCount)));
   };
 
+  const swapDimensions = () => {
+    const width = form.getFieldValue('width');
+    const height = form.getFieldValue('height');
+    form.setFieldsValue({ width: height, height: width });
+  };
+
   return (
     <>
-      <div className="grid grid-cols-2 gap-3">
+      <div className="grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-end gap-2">
         <FormField name="width" label="Width" normalize={normalizeNumberInput}>
           <Input type="number" />
         </FormField>
+        <Button
+          aria-label="Swap width and height"
+          title="Swap width and height"
+          variant="outline"
+          size="icon"
+          onClick={swapDimensions}
+        >
+          <ArrowLeftRight />
+        </Button>
         <FormField name="height" label="Height" normalize={normalizeNumberInput}>
           <Input type="number" />
         </FormField>
+      </div>
+      <div className="grid grid-cols-2 gap-3">
         <FormField name="n" label="Number of Images" normalize={normalizeNumberInput}>
           <Input type="number" min={1} max={10} />
         </FormField>
@@ -198,32 +215,51 @@ function ImageGenerationFields({
 }
 
 function VideoFields({ form }: Pick<CapabilityFormProps, 'form'>) {
+  const swapDimensions = () => {
+    const width = form.getFieldValue('width');
+    const height = form.getFieldValue('height');
+    form.setFieldsValue({ width: height, height: width });
+  };
+
   return (
-    <div className="grid grid-cols-2 gap-3">
-      <FormField name="width" label="Width" normalize={normalizeNumberInput}>
-        <Input type="number" />
-      </FormField>
-      <FormField name="height" label="Height" normalize={normalizeNumberInput}>
-        <Input type="number" />
-      </FormField>
-      <FormField name="num_frames" label="Frames" normalize={normalizeNumberInput}>
-        <Input type="number" />
-      </FormField>
-      <FormField name="fps" label="FPS" normalize={normalizeNumberInput}>
-        <Input type="number" />
-      </FormField>
-      <FormField
-        name="num_inference_steps"
-        label="Inference Steps"
-        normalize={normalizeNumberInput}
-      >
-        <Input type="number" />
-      </FormField>
-      <FormField name="guidance_scale" label="Guidance Scale" normalize={normalizeNumberInput}>
-        <Input type="number" min={1} max={20} step={0.1} />
-      </FormField>
-      <ScalarSeedField form={form} />
-    </div>
+    <>
+      <div className="grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-end gap-2">
+        <FormField name="width" label="Width" normalize={normalizeNumberInput}>
+          <Input type="number" />
+        </FormField>
+        <Button
+          aria-label="Swap width and height"
+          title="Swap width and height"
+          variant="outline"
+          size="icon"
+          onClick={swapDimensions}
+        >
+          <ArrowLeftRight />
+        </Button>
+        <FormField name="height" label="Height" normalize={normalizeNumberInput}>
+          <Input type="number" />
+        </FormField>
+      </div>
+      <div className="grid grid-cols-2 gap-3">
+        <FormField name="num_frames" label="Frames" normalize={normalizeNumberInput}>
+          <Input type="number" />
+        </FormField>
+        <FormField name="fps" label="FPS" normalize={normalizeNumberInput}>
+          <Input type="number" />
+        </FormField>
+        <FormField
+          name="num_inference_steps"
+          label="Inference Steps"
+          normalize={normalizeNumberInput}
+        >
+          <Input type="number" />
+        </FormField>
+        <FormField name="guidance_scale" label="Guidance Scale" normalize={normalizeNumberInput}>
+          <Input type="number" min={1} max={20} step={0.1} />
+        </FormField>
+        <ScalarSeedField form={form} />
+      </div>
+    </>
   );
 }
 

--- a/frontend/src/components/pages/running-model-detail/panels/form-panels.tsx
+++ b/frontend/src/components/pages/running-model-detail/panels/form-panels.tsx
@@ -30,6 +30,13 @@ import {
   isIndexTTSEmotionModel,
   parseIndexTTSEmotionVector,
 } from '../emotion-vector-utils';
+import {
+  formatImageSeeds,
+  generateRandomImageSeeds,
+  MAX_IMAGE_SEED,
+  parseImageSeeds,
+} from '../image-seed-utils';
+import { createRandomSeed, MAX_SEED, parseScalarSeed } from '../seed-utils';
 import type { CapabilityFormProps } from '../types';
 
 const DOCUMENT_BACKEND_OPTIONS = ['pipeline', 'vlm-auto-engine', 'hybrid-auto-engine'].map(
@@ -66,7 +73,54 @@ function PromptFields() {
   );
 }
 
-function ImageGenerationFields({ includeImageParams = false }: { includeImageParams?: boolean }) {
+function ScalarSeedField({ form }: Pick<CapabilityFormProps, 'form'>) {
+  return (
+    <div className="flex items-end gap-2">
+      <FormField
+        className="flex-1"
+        name="seed"
+        label="Seed"
+        placeholder="-1 = random"
+        normalize={normalizeNumberInput}
+        rules={[
+          {
+            validator: (value) => {
+              try {
+                parseScalarSeed(value);
+                return true;
+              } catch {
+                return false;
+              }
+            },
+            message: `Seed must be -1 or an integer from 0 to ${MAX_SEED}.`,
+          },
+        ]}
+      >
+        <Input type="number" min={-1} max={MAX_SEED} step={1} />
+      </FormField>
+      <Button
+        variant="outline"
+        size="icon"
+        aria-label="Generate random seed"
+        title="Generate random seed"
+        onClick={() => form.setFieldValue('seed', createRandomSeed())}
+      >
+        <span aria-hidden="true">🎲</span>
+      </Button>
+    </div>
+  );
+}
+
+function ImageGenerationFields({
+  form,
+  includeImageParams = false,
+}: Pick<CapabilityFormProps, 'form'> & { includeImageParams?: boolean }) {
+  const imageCount = Math.max(1, Math.round(Number(useWatch('n', form)) || 1));
+
+  const generateRandomSeeds = () => {
+    form.setFieldValue('seed', formatImageSeeds(generateRandomImageSeeds(imageCount)));
+  };
+
   return (
     <>
       <div className="grid grid-cols-2 gap-3">
@@ -104,6 +158,38 @@ function ImageGenerationFields({ includeImageParams = false }: { includeImagePar
           </>
         )}
       </div>
+      <div className="flex items-end gap-2">
+        <FormField
+          className="flex-1"
+          name="seed"
+          label="Seed(s)"
+          placeholder="Comma-separated; missing or -1 = random. For 4 images: 11, 22 = 11, 22, -1, -1"
+          rules={[
+            {
+              validator: (value) => {
+                try {
+                  parseImageSeeds(value, imageCount);
+                  return true;
+                } catch {
+                  return false;
+                }
+              },
+              message: `Use up to ${imageCount} comma-separated seeds; each must be -1 or 0-${MAX_IMAGE_SEED}.`,
+            },
+          ]}
+        >
+          <Input />
+        </FormField>
+        <Button
+          aria-label="Generate new random image seeds"
+          title="Generate a new random seed for every image"
+          variant="outline"
+          size="icon"
+          onClick={generateRandomSeeds}
+        >
+          <span aria-hidden="true">🎲</span>
+        </Button>
+      </div>
       <FormField name="sampler_name" label="Sampling Method">
         <Select options={SAMPLING_METHOD_OPTIONS} allowClear={false} showSearch />
       </FormField>
@@ -111,7 +197,7 @@ function ImageGenerationFields({ includeImageParams = false }: { includeImagePar
   );
 }
 
-function VideoFields() {
+function VideoFields({ form }: Pick<CapabilityFormProps, 'form'>) {
   return (
     <div className="grid grid-cols-2 gap-3">
       <FormField name="width" label="Width" normalize={normalizeNumberInput}>
@@ -136,6 +222,7 @@ function VideoFields() {
       <FormField name="guidance_scale" label="Guidance Scale" normalize={normalizeNumberInput}>
         <Input type="number" min={1} max={20} step={0.1} />
       </FormField>
+      <ScalarSeedField form={form} />
     </div>
   );
 }
@@ -269,16 +356,16 @@ export function OcrPanel() {
   );
 }
 
-export function TextToImagePanel() {
+export function TextToImagePanel({ form }: CapabilityFormProps) {
   return (
     <>
       <PromptFields />
-      <ImageGenerationFields />
+      <ImageGenerationFields form={form} />
     </>
   );
 }
 
-export function ImageToImagePanel() {
+export function ImageToImagePanel({ form }: CapabilityFormProps) {
   return (
     <>
       <FormField name="image" rules={[{ required: true }]}>
@@ -289,7 +376,7 @@ export function ImageToImagePanel() {
         />
       </FormField>
       <PromptFields />
-      <ImageGenerationFields includeImageParams />
+      <ImageGenerationFields form={form} includeImageParams />
     </>
   );
 }
@@ -309,33 +396,33 @@ export function InpaintingPanel({ form }: CapabilityFormProps) {
       </FormField>
       <FormField name="mask_image" hidden />
       <PromptFields />
-      <ImageGenerationFields includeImageParams />
+      <ImageGenerationFields form={form} includeImageParams />
     </>
   );
 }
 
-export function TextToVideoPanel() {
+export function TextToVideoPanel({ form }: CapabilityFormProps) {
   return (
     <>
       <PromptFields />
-      <VideoFields />
+      <VideoFields form={form} />
     </>
   );
 }
 
-export function ImageToVideoPanel() {
+export function ImageToVideoPanel({ form }: CapabilityFormProps) {
   return (
     <>
       <FormField name="image" rules={[{ required: true }]}>
         <FileUpload accept="image/*" label="Upload first frame image" />
       </FormField>
       <PromptFields />
-      <VideoFields />
+      <VideoFields form={form} />
     </>
   );
 }
 
-export function FirstLastFrameVideoPanel() {
+export function FirstLastFrameVideoPanel({ form }: CapabilityFormProps) {
   return (
     <>
       <div className="grid gap-3 md:grid-cols-2">
@@ -347,7 +434,7 @@ export function FirstLastFrameVideoPanel() {
         </FormField>
       </div>
       <PromptFields />
-      <VideoFields />
+      <VideoFields form={form} />
     </>
   );
 }
@@ -516,27 +603,14 @@ export function SpeechPanel({ form, model }: CapabilityFormProps) {
           </FormField>
         </div>
       )}
-      {isMusicGeneration && (
-        <div className="grid grid-cols-2 gap-3">
-          <div className="flex items-end gap-2">
-            <FormField name="seed" label="Seed" normalize={normalizeNumberInput} className="flex-1">
-              <Input type="number" />
-            </FormField>
-            <Button
-              variant="outline"
-              size="icon"
-              aria-label="Generate random seed"
-              title="Generate random seed"
-              onClick={() => form.setFieldValue('seed', Math.floor(Math.random() * 2 ** 31))}
-            >
-              <span aria-hidden="true">🎲</span>
-            </Button>
-          </div>
+      <div className={isMusicGeneration ? 'grid grid-cols-2 gap-3' : undefined}>
+        <ScalarSeedField form={form} />
+        {isMusicGeneration && (
           <FormField name="duration" label="Duration (seconds)" normalize={normalizeNumberInput}>
             <Input type="number" />
           </FormField>
-        </div>
-      )}
+        )}
+      </div>
       {showPromptSpeech && (
         <FormField name="prompt_speech">
           <FileUpload

--- a/frontend/src/components/pages/running-model-detail/seed-utils.test.ts
+++ b/frontend/src/components/pages/running-model-detail/seed-utils.test.ts
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { MAX_SEED, parseScalarSeed } from './seed-utils';
+
+test('parseScalarSeed accepts random and explicit seeds', () => {
+  assert.equal(parseScalarSeed(-1), -1);
+  assert.equal(parseScalarSeed('11'), 11);
+  assert.equal(parseScalarSeed(MAX_SEED), MAX_SEED);
+  assert.equal(parseScalarSeed(''), undefined);
+});
+
+test('parseScalarSeed rejects invalid seeds', () => {
+  assert.throws(() => parseScalarSeed(-2), /must be -1/);
+  assert.throws(() => parseScalarSeed('1.5'), /must be -1/);
+  assert.throws(() => parseScalarSeed(MAX_SEED + 1), /must be -1/);
+});

--- a/frontend/src/components/pages/running-model-detail/seed-utils.ts
+++ b/frontend/src/components/pages/running-model-detail/seed-utils.ts
@@ -1,0 +1,21 @@
+export const MAX_SEED = 2 ** 31 - 1;
+
+export const parseScalarSeed = (value: unknown): number | undefined => {
+  if (value === undefined || value === null || value === '') return undefined;
+
+  const normalized = typeof value === 'string' ? value.trim() : value;
+  if (normalized === '') return undefined;
+
+  const seed = Number(normalized);
+  if (!Number.isSafeInteger(seed) || seed < -1 || seed > MAX_SEED) {
+    throw new Error(`Seed must be -1 or an integer from 0 to ${MAX_SEED}.`);
+  }
+  return seed;
+};
+
+export const createRandomSeed = (): number => {
+  if (typeof crypto !== 'undefined' && typeof crypto.getRandomValues === 'function') {
+    return crypto.getRandomValues(new Uint32Array(1))[0] & MAX_SEED;
+  }
+  return Math.floor(Math.random() * (MAX_SEED + 1));
+};

--- a/frontend/src/components/pages/running-model-detail/utils.ts
+++ b/frontend/src/components/pages/running-model-detail/utils.ts
@@ -4,6 +4,9 @@ import type { FormValues } from '@/types/form';
 import type { ChatChoicesMessage } from '@/types/services';
 import type { FileUploadValue } from '@/types/common';
 
+import { parseImageSeeds } from './image-seed-utils';
+import { parseScalarSeed } from './seed-utils';
+
 const SUB_CAPABILITIES = new Set<ModelAbility>([
   ModelAbility.Text2audioVoiceCloning,
   ModelAbility.Text2audioVoiceDesign,
@@ -70,6 +73,7 @@ export function appendIfPresent(formData: FormData, key: string, value: unknown)
 
 interface BuildGenerationKwargsOptions {
   excludeKeys?: string[];
+  seedMode?: 'image-list' | 'scalar';
 }
 
 export function buildGenerationKwargs(
@@ -77,7 +81,7 @@ export function buildGenerationKwargs(
   requestId?: string,
   options: BuildGenerationKwargsOptions = {}
 ) {
-  const kwargs: Record<string, string | number | boolean> = {};
+  const kwargs: Record<string, string | number | boolean | number[]> = {};
   const excludedKeys = new Set(options.excludeKeys || []);
   const guidanceScale = positiveNumber(values.guidance_scale);
   const numInferenceSteps = positiveNumber(values.num_inference_steps);
@@ -107,6 +111,16 @@ export function buildGenerationKwargs(
 
   if (samplerName && samplerName !== 'default') {
     kwargs.sampler_name = samplerName;
+  }
+
+  if (Object.prototype.hasOwnProperty.call(values, 'seed')) {
+    if (options.seedMode === 'image-list') {
+      const imageCount = Math.max(1, Math.round(numberValue(values.n, 1)));
+      kwargs.seed = parseImageSeeds(values.seed, imageCount);
+    } else {
+      const seed = parseScalarSeed(values.seed);
+      if (seed !== undefined) kwargs.seed = seed;
+    }
   }
 
   ['num_frames', 'fps', 'width', 'height'].forEach((key) => {

--- a/xinference/core/model.py
+++ b/xinference/core/model.py
@@ -1060,8 +1060,25 @@ class ModelActor(xo.StatelessActor, CancelMixin):
         self._require_ready()
         kwargs.pop("request_id", None)
         if hasattr(self._model, "speech"):
+            from ..model.utils import resolve_media_seed
+
+            if "seed" in kwargs:
+                seed = resolve_media_seed(kwargs["seed"])
+                if seed is None:
+                    kwargs.pop("seed")
+                else:
+                    kwargs["seed"] = seed
+
+            speech = self._model.speech
+            parameters = inspect.signature(speech).parameters
+            accepts_kwargs = any(
+                parameter.kind == inspect.Parameter.VAR_KEYWORD
+                for parameter in parameters.values()
+            )
+            if "seed" not in parameters and not accepts_kwargs:
+                kwargs.pop("seed", None)
             return await self._call_wrapper_binary(
-                self._model.speech,
+                speech,
                 input,
                 voice,
                 response_format,

--- a/xinference/model/audio/chattts.py
+++ b/xinference/model/audio/chattts.py
@@ -74,13 +74,15 @@ class ChatTTSModel:
         response_format: str = "mp3",
         speed: float = 1.0,
         stream: bool = False,
+        **kwargs,
     ):
         import ChatTTS
         import numpy as np
         import torch
 
-        from .utils import audio_stream_generator, audio_to_bytes
+        from .utils import apply_audio_seed, audio_stream_generator, audio_to_bytes
 
+        requested_seed = apply_audio_seed(kwargs)
         rnd_spk_emb = None
 
         if len(voice) > 400:
@@ -95,7 +97,7 @@ class ChatTTSModel:
                 logger.info("Fallback to random speaker due to %s", e)
 
         if rnd_spk_emb is None:
-            seed = _voice_seed(voice)
+            seed = requested_seed if requested_seed is not None else _voice_seed(voice)
 
             set_all_random_seed(seed)
             torch.backends.cudnn.deterministic = True

--- a/xinference/model/audio/chattts.py
+++ b/xinference/model/audio/chattts.py
@@ -17,7 +17,7 @@ import logging
 from io import BytesIO
 from typing import TYPE_CHECKING, Optional
 
-from ..utils import set_all_random_seed
+from ..utils import resolve_media_seed, set_all_random_seed
 
 if TYPE_CHECKING:
     from .core import AudioModelFamilyV2
@@ -80,9 +80,9 @@ class ChatTTSModel:
         import numpy as np
         import torch
 
-        from .utils import apply_audio_seed, audio_stream_generator, audio_to_bytes
+        from .utils import audio_stream_generator, audio_to_bytes
 
-        requested_seed = apply_audio_seed(kwargs)
+        requested_seed = resolve_media_seed(kwargs.pop("seed", None))
         rnd_spk_emb = None
 
         if len(voice) > 400:
@@ -97,15 +97,18 @@ class ChatTTSModel:
                 logger.info("Fallback to random speaker due to %s", e)
 
         if rnd_spk_emb is None:
-            seed = requested_seed if requested_seed is not None else _voice_seed(voice)
+            speaker_seed = _voice_seed(voice)
 
-            set_all_random_seed(seed)
+            set_all_random_seed(speaker_seed)
             torch.backends.cudnn.deterministic = True
             torch.backends.cudnn.benchmark = False
 
             assert self._model is not None
             rnd_spk_emb = self._model.sample_random_speaker()
             logger.info("Speech by voice %s", voice)
+
+        if requested_seed is not None:
+            set_all_random_seed(requested_seed)
 
         default = 5
         infer_speed = int(default * speed)

--- a/xinference/model/audio/f5tts.py
+++ b/xinference/model/audio/f5tts.py
@@ -162,8 +162,12 @@ class F5TTSModel:
         import soundfile
         import tomli
 
+        from .utils import apply_audio_seed
+
         if stream:
             raise Exception("F5-TTS does not support stream generation.")
+
+        apply_audio_seed(kwargs)
 
         prompt_speech: Optional[bytes] = kwargs.pop("prompt_speech", None)
         prompt_text: Optional[str] = kwargs.pop("prompt_text", None)

--- a/xinference/model/audio/kokoro.py
+++ b/xinference/model/audio/kokoro.py
@@ -96,8 +96,11 @@ class KokoroModel:
     ):
         import soundfile
 
+        from .utils import apply_audio_seed
+
         if stream:
             raise Exception("Kokoro does not support stream mode.")
+        apply_audio_seed(kwargs)
         assert self._model is not None
         if not voice:
             voice = "af_alloy"

--- a/xinference/model/audio/kokoro_mlx.py
+++ b/xinference/model/audio/kokoro_mlx.py
@@ -85,8 +85,11 @@ class KokoroMLXModel(MLXModelThreadMixin):
     ):
         import soundfile
 
+        from .utils import apply_mlx_audio_seed
+
         if stream:
             raise Exception("Kokoro does not support stream mode.")
+        apply_mlx_audio_seed(kwargs)
         assert self._model is not None
 
         if not voice:

--- a/xinference/model/audio/kokoro_zh.py
+++ b/xinference/model/audio/kokoro_zh.py
@@ -97,8 +97,11 @@ class KokoroZHModel:
     ):
         import soundfile
 
+        from .utils import apply_audio_seed
+
         if stream:
             raise Exception("Kokoro does not support stream mode.")
+        apply_audio_seed(kwargs)
         assert self._model is not None
         if not voice:
             voice = "zf_001"

--- a/xinference/model/audio/megatts.py
+++ b/xinference/model/audio/megatts.py
@@ -70,8 +70,11 @@ class MegaTTSModel:
     ):
         import soundfile
 
+        from .utils import apply_audio_seed
+
         if stream:
             raise Exception("MegaTTS3 does not support stream generation.")
+        apply_audio_seed(kwargs)
         if voice:
             raise Exception(
                 "MegaTTS3 does not support voice, please specify prompt_speech and prompt_latent."

--- a/xinference/model/audio/melotts.py
+++ b/xinference/model/audio/melotts.py
@@ -84,8 +84,11 @@ class MeloTTSModel:
     ):
         import soundfile
 
+        from .utils import apply_audio_seed
+
         if stream:
             raise Exception("MeloTTS does not support stream mode.")
+        apply_audio_seed(kwargs)
         assert self._model is not None
         speaker_ids = self._model.hps.data.spk2id
         if not voice:

--- a/xinference/model/audio/mlx_audio.py
+++ b/xinference/model/audio/mlx_audio.py
@@ -447,6 +447,9 @@ class MLXAudioTTSModel(MLXModelThreadMixin):
         kwargs: Dict[str, Any],
         temp_files: List[str],
     ) -> Dict[str, Any]:
+        from .utils import apply_mlx_audio_seed
+
+        apply_mlx_audio_seed(kwargs)
         generate_kwargs = dict(kwargs)
         prompt_speech = generate_kwargs.pop("prompt_speech", None)
         prompt_text = generate_kwargs.pop("prompt_text", None)

--- a/xinference/model/audio/qwen3_tts.py
+++ b/xinference/model/audio/qwen3_tts.py
@@ -85,8 +85,12 @@ class Qwen3TTSModel:
 
         import soundfile
 
+        from .utils import apply_audio_seed
+
         if stream:
             raise Exception("qwen-tts does not support stream generation.")
+
+        apply_audio_seed(kwargs)
 
         prompt_speech: Optional[bytes] = kwargs.pop("prompt_speech", None)
         prompt_text: Optional[str] = kwargs.pop("prompt_text", None)

--- a/xinference/model/audio/utils.py
+++ b/xinference/model/audio/utils.py
@@ -26,6 +26,26 @@ from packaging import version
 logger = logging.getLogger(__name__)
 
 
+def apply_audio_seed(kwargs: dict) -> typing.Optional[int]:
+    """Consume a generic audio seed and seed Python, NumPy, and Torch RNGs."""
+    from ..utils import resolve_media_seed, set_all_random_seed
+
+    seed = resolve_media_seed(kwargs.pop("seed", None))
+    if seed is not None:
+        set_all_random_seed(seed)
+    return seed
+
+
+def apply_mlx_audio_seed(kwargs: dict) -> typing.Optional[int]:
+    """Consume a generic audio seed and seed MLX's RNG."""
+    seed = apply_audio_seed(kwargs)
+    if seed is not None:
+        import mlx.core as mx
+
+        mx.random.seed(seed)
+    return seed
+
+
 class MLXModelThreadMixin:
     """Pin every call into an MLX model to a single dedicated thread.
 

--- a/xinference/model/audio/voxcpm.py
+++ b/xinference/model/audio/voxcpm.py
@@ -311,7 +311,9 @@ class VoxCPMModel:
     ):
         assert self._model is not None
 
-        from .utils import audio_stream_generator
+        from .utils import apply_audio_seed, audio_stream_generator
+
+        apply_audio_seed(kwargs)
 
         temp_files = []
         cleanup_temp_files = True

--- a/xinference/model/image/hidream_o1.py
+++ b/xinference/model/image/hidream_o1.py
@@ -25,7 +25,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Union
 import PIL.Image
 
 from .sdapi import SDAPIDiffusionModelMixin
-from .utils import handle_image_result
+from .utils import handle_image_result, resolve_image_seed_list
 
 if TYPE_CHECKING:
     from ...core.progress_tracker import Progressor
@@ -253,7 +253,8 @@ class HiDreamO1Model(SDAPIDiffusionModelMixin):
         progressor: Optional["Progressor"] = kwargs.pop("progressor", None)
         config = self._prepare_generate_config(len(references), kwargs)
         seed = config.pop("seed", 32)
-        if seed is None or seed == -1:
+        seeds = resolve_image_seed_list(seed, n)
+        if seeds is None and (seed is None or seed == -1):
             seed = random.SystemRandom().randrange(0, 2**31)
         layout_bboxes = config.get("layout_bboxes")
         if layout_bboxes is not None and not isinstance(layout_bboxes, str):
@@ -299,7 +300,11 @@ class HiDreamO1Model(SDAPIDiffusionModelMixin):
                             ref_image_paths=ref_paths,
                             height=height,
                             width=width,
-                            seed=int(seed) + image_index,
+                            seed=(
+                                seeds[image_index]
+                                if seeds is not None
+                                else int(seed) + image_index
+                            ),
                             callback=report_progress,
                             **generate_kwargs,
                         )

--- a/xinference/model/image/scheduler/flux.py
+++ b/xinference/model/image/scheduler/flux.py
@@ -23,7 +23,7 @@ import numpy as np
 import torch
 import xoscar as xo
 
-from ..utils import handle_image_result
+from ..utils import handle_image_result, resolve_image_seed_list
 
 if TYPE_CHECKING:
     from ..stable_diffusion.core import DiffusionModel
@@ -308,7 +308,10 @@ def _batch_text_to_image_internal(
         if r.is_encode:
             generate_kwargs = model_cls._model_spec.default_generate_config.copy()
             generate_kwargs.update({k: v for k, v in r.kwargs.items() if v is not None})
+            seed = generate_kwargs.pop("seed", None)
             model_cls._filter_kwargs(model_cls._model, generate_kwargs)
+            if seed is not None:
+                generate_kwargs["seed"] = seed
             r.set_generate_kwargs(generate_kwargs)
 
             # check max_sequence_length
@@ -335,7 +338,15 @@ def _batch_text_to_image_internal(
             guidance_scale = r.generate_kwargs.get("guidance_scale", 7.0)
             generator = None
             seed = r.generate_kwargs.get("seed", None)
-            if seed is not None:
+            seeds = resolve_image_seed_list(seed, num_images_per_prompt)
+            if seeds is not None:
+                generator = [
+                    torch.Generator(  # type: ignore
+                        device=available_device
+                    ).manual_seed(value)
+                    for value in seeds
+                ]
+            elif seed is not None:
                 generator = torch.Generator(device=available_device)  # type: ignore
                 if seed != -1:
                     generator = generator.manual_seed(seed)

--- a/xinference/model/image/sensenova_u1.py
+++ b/xinference/model/image/sensenova_u1.py
@@ -23,7 +23,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Tuple, Un
 import PIL.Image
 
 from .sdapi import SDAPIDiffusionModelMixin
-from .utils import handle_image_result
+from .utils import handle_image_result, resolve_image_seed_list
 
 if TYPE_CHECKING:
     from ...types import LoRA
@@ -270,20 +270,37 @@ class SenseNovaU1Model(SDAPIDiffusionModelMixin):
         import torch
 
         width, height = self._parse_size(size)
+        seeds = resolve_image_seed_list(kwargs.get("seed"), n)
         generate_config = self._filter_generate_config(
             self._get_generate_config(kwargs), image_to_image=False
         )
         with torch.inference_mode(), self._offload_context() as model:
-            output = model.t2i_generate(
-                self._tokenizer,
-                prompt,
-                image_size=(width, height),
-                batch_size=n,
-                **generate_config,
-            )
-        if generate_config.get("think_mode"):
-            output = output[0]
-        return handle_image_result(response_format, self._to_pil(output))
+            if seeds is None:
+                output = model.t2i_generate(
+                    self._tokenizer,
+                    prompt,
+                    image_size=(width, height),
+                    batch_size=n,
+                    **generate_config,
+                )
+                if generate_config.get("think_mode"):
+                    output = output[0]
+                result_images = self._to_pil(output)
+            else:
+                result_images = []
+                for seed in seeds:
+                    per_image_config = {**generate_config, "seed": seed}
+                    output = model.t2i_generate(
+                        self._tokenizer,
+                        prompt,
+                        image_size=(width, height),
+                        batch_size=1,
+                        **per_image_config,
+                    )
+                    if per_image_config.get("think_mode"):
+                        output = output[0]
+                    result_images.extend(self._to_pil(output))
+        return handle_image_result(response_format, result_images)
 
     @staticmethod
     def _convert_to_rgb(image: PIL.Image.Image) -> PIL.Image.Image:
@@ -402,18 +419,36 @@ class SenseNovaU1Model(SDAPIDiffusionModelMixin):
             width, height = self._auto_output_size(images[0], target_pixels)
             self._validate_size(width, height)
 
+        seeds = resolve_image_seed_list(kwargs.get("seed"), n)
         generate_config = self._filter_generate_config(
             self._get_generate_config(kwargs), image_to_image=True
         )
         with torch.inference_mode(), self._offload_context() as model:
-            output = model.it2i_generate(
-                self._tokenizer,
-                prompt,
-                images,
-                image_size=(width, height),
-                batch_size=n,
-                **generate_config,
-            )
-        if generate_config.get("think_mode"):
-            output = output[0]
-        return handle_image_result(response_format, self._to_pil(output))
+            if seeds is None:
+                output = model.it2i_generate(
+                    self._tokenizer,
+                    prompt,
+                    images,
+                    image_size=(width, height),
+                    batch_size=n,
+                    **generate_config,
+                )
+                if generate_config.get("think_mode"):
+                    output = output[0]
+                result_images = self._to_pil(output)
+            else:
+                result_images = []
+                for seed in seeds:
+                    per_image_config = {**generate_config, "seed": seed}
+                    output = model.it2i_generate(
+                        self._tokenizer,
+                        prompt,
+                        images,
+                        image_size=(width, height),
+                        batch_size=1,
+                        **per_image_config,
+                    )
+                    if per_image_config.get("think_mode"):
+                        output = output[0]
+                    result_images.extend(self._to_pil(output))
+        return handle_image_result(response_format, result_images)

--- a/xinference/model/image/sglang/core.py
+++ b/xinference/model/image/sglang/core.py
@@ -22,7 +22,7 @@ import uuid
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from ....types import LoRA
-from ..utils import handle_image_result
+from ..utils import handle_image_result, resolve_image_seed_list
 
 if TYPE_CHECKING:
     from ..core import ImageModelFamilyV2
@@ -241,12 +241,21 @@ class SGLangDiffusionModel:
             self._model_spec.default_generate_config or {}  # type: ignore
         ).copy()
         generate_config.update({k: v for k, v in kwargs.items() if v is not None})
-        sampling_params_kwargs = self._build_sampling_params(
-            prompt, n, width, height, generate_config
+        seeds = resolve_image_seed_list(generate_config.get("seed"), n)
+        configs = (
+            [{**generate_config, "seed": seed} for seed in seeds]
+            if seeds is not None
+            else [generate_config]
         )
-        result = await asyncio.to_thread(
-            self._model.generate,
-            sampling_params_kwargs=sampling_params_kwargs,
-        )
-        images = self._extract_images(result)
+        outputs_per_config = 1 if seeds is not None else n
+        images = []
+        for config in configs:
+            sampling_params_kwargs = self._build_sampling_params(
+                prompt, outputs_per_config, width, height, config
+            )
+            result = await asyncio.to_thread(
+                self._model.generate,
+                sampling_params_kwargs=sampling_params_kwargs,
+            )
+            images.extend(self._extract_images(result))
         return handle_image_result(response_format, images)

--- a/xinference/model/image/stable_diffusion/core.py
+++ b/xinference/model/image/stable_diffusion/core.py
@@ -39,7 +39,7 @@ from ....device_utils import (
 )
 from ....types import LoRA
 from ..sdapi import SDAPIDiffusionModelMixin
-from ..utils import handle_image_result
+from ..utils import handle_image_result, resolve_image_seed_list
 
 if TYPE_CHECKING:
     from ....core.progress_tracker import Progressor
@@ -783,10 +783,19 @@ class DiffusionModel(SDAPIDiffusionModelMixin):
         origin_size = kwargs.pop("origin_size", None)
         seed = kwargs.pop("seed", None)
         return_images = kwargs.pop("_return_images", None)
-        if seed is not None and seed != -1:
+        seeds = resolve_image_seed_list(
+            seed, int(kwargs.get("num_images_per_prompt", 1))
+        )
+        if seeds is not None:
+            kwargs["generator"] = [
+                torch.Generator(  # type: ignore
+                    device=get_available_device()
+                ).manual_seed(value)
+                for value in seeds
+            ]
+        elif seed is not None and seed != -1:
             kwargs["generator"] = generator = torch.Generator(device=get_available_device())  # type: ignore
-            if seed != -1:
-                kwargs["generator"] = generator.manual_seed(seed)
+            kwargs["generator"] = generator.manual_seed(seed)
         sampler_name = kwargs.pop("sampler_name", None)
         self._process_progressor(kwargs)
         if self._is_ideogram4_model() and kwargs.get("guidance_scale") is not None:

--- a/xinference/model/image/stable_diffusion/mlx.py
+++ b/xinference/model/image/stable_diffusion/mlx.py
@@ -158,8 +158,8 @@ class MLXDiffusionModel(SDAPIDiffusionModelMixin):
         if seeds is not None:
             data = []
             created = 0
-            for seed in seeds:
-                per_image_kwargs = {**kwargs, "seed": seed}
+            for image_seed in seeds:
+                per_image_kwargs = {**kwargs, "seed": image_seed}
                 result = self.text_to_image(
                     prompt,
                     n=1,

--- a/xinference/model/image/stable_diffusion/mlx.py
+++ b/xinference/model/image/stable_diffusion/mlx.py
@@ -23,7 +23,7 @@ from PIL import Image
 
 from ....types import LoRA
 from ..sdapi import SDAPIDiffusionModelMixin
-from ..utils import handle_image_result
+from ..utils import handle_image_result, resolve_image_seed_list
 
 if TYPE_CHECKING:
     from ....core.progress_tracker import Progressor
@@ -154,6 +154,22 @@ class MLXDiffusionModel(SDAPIDiffusionModelMixin):
 
         flux = self._model
         width, height = map(int, re.split(r"[^\d]+", size))
+        seeds = resolve_image_seed_list(kwargs.get("seed"), n)
+        if seeds is not None:
+            data = []
+            created = 0
+            for seed in seeds:
+                per_image_kwargs = {**kwargs, "seed": seed}
+                result = self.text_to_image(
+                    prompt,
+                    n=1,
+                    size=size,
+                    response_format=response_format,
+                    **per_image_kwargs,
+                )
+                created = max(created, result["created"])
+                data.extend(result["data"])
+            return {"created": created, "data": data}
 
         # Make the generator
         latent_size = to_latent_size((height, width))
@@ -163,7 +179,7 @@ class MLXDiffusionModel(SDAPIDiffusionModelMixin):
         gen_latent_kwargs["num_steps"] = num_steps
         if guidance := kwargs.get("guidance_scale"):
             gen_latent_kwargs["guidance"] = guidance
-        if seed := kwargs.get("seed"):
+        if (seed := kwargs.get("seed")) is not None and seed != -1:
             gen_latent_kwargs["seed"] = seed
 
         with self._release_after():

--- a/xinference/model/image/tests/test_image_seed_utils.py
+++ b/xinference/model/image/tests/test_image_seed_utils.py
@@ -1,0 +1,39 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from ..utils import MAX_IMAGE_SEED, resolve_image_seed_list
+
+
+def test_resolve_image_seed_list_preserves_and_pads_seeds():
+    seeds = resolve_image_seed_list([11, -1], 4)
+
+    assert seeds is not None
+    assert seeds[0] == 11
+    assert len(seeds) == 4
+    assert all(0 <= seed <= MAX_IMAGE_SEED for seed in seeds)
+
+
+def test_resolve_image_seed_list_keeps_scalar_seed_backward_compatible():
+    assert resolve_image_seed_list(11, 4) is None
+
+
+@pytest.mark.parametrize(
+    "seeds, n",
+    [([1, 2], 1), ([-2], 1), ([MAX_IMAGE_SEED + 1], 1), ([True], 1), ([1.5], 1)],
+)
+def test_resolve_image_seed_list_rejects_invalid_values(seeds, n):
+    with pytest.raises(ValueError):
+        resolve_image_seed_list(seeds, n)

--- a/xinference/model/image/utils.py
+++ b/xinference/model/image/utils.py
@@ -13,18 +13,49 @@
 # limitations under the License.
 import base64
 import os
+import random
 import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor
 from functools import partial
 from io import BytesIO
-from typing import TYPE_CHECKING, Optional
+from numbers import Integral
+from typing import TYPE_CHECKING, Any, List, Optional
 
 from ...constants import XINFERENCE_IMAGE_DIR
 from ...types import Image, ImageList
 
 if TYPE_CHECKING:
     from .core import ImageModelFamilyV2
+
+
+MAX_IMAGE_SEED = 2**31 - 1
+
+
+def resolve_image_seed_list(seed: Any, n: int) -> Optional[List[int]]:
+    """Resolve a per-image seed list, padding missing entries with random seeds."""
+    if not isinstance(seed, (list, tuple)):
+        return None
+    if n < 1:
+        raise ValueError("n must be greater than 0")
+    if len(seed) > n:
+        raise ValueError(f"Expected at most {n} image seeds, got {len(seed)}")
+
+    values = list(seed) + [-1] * (n - len(seed))
+    random_source = random.SystemRandom()
+    resolved: List[int] = []
+    for value in values:
+        if isinstance(value, bool) or not isinstance(value, Integral):
+            raise ValueError("Image seeds must be integers")
+        value = int(value)
+        if value == -1:
+            value = random_source.randrange(MAX_IMAGE_SEED + 1)
+        elif value < 0 or value > MAX_IMAGE_SEED:
+            raise ValueError(
+                f"Image seeds must be -1 or between 0 and {MAX_IMAGE_SEED}"
+            )
+        resolved.append(value)
+    return resolved
 
 
 def get_model_version(

--- a/xinference/model/image/vllm/core.py
+++ b/xinference/model/image/vllm/core.py
@@ -22,7 +22,7 @@ import uuid
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from ....types import LoRA
-from ..utils import handle_image_result
+from ..utils import handle_image_result, resolve_image_seed_list
 
 if TYPE_CHECKING:
     from ..core import ImageModelFamilyV2
@@ -508,13 +508,24 @@ class VLLMDiffusionModel:
             self._model_spec.default_generate_config or {}  # type: ignore
         ).copy()
         generate_config.update({k: v for k, v in kwargs.items() if v is not None})
-        sampling_params = self._build_sampling_params(n, width, height, generate_config)
+        seeds = resolve_image_seed_list(generate_config.get("seed"), n)
         prompt_payload = self._build_prompt(prompt, width, height)
-        if self._concurrency_available():
-            outputs = await self._submit_and_wait(prompt_payload, sampling_params)
-        else:
-            outputs = await asyncio.to_thread(
-                self._generate_serial, prompt_payload, sampling_params
+        images = []
+        configs = (
+            [{**generate_config, "seed": seed} for seed in seeds]
+            if seeds is not None
+            else [generate_config]
+        )
+        outputs_per_config = 1 if seeds is not None else n
+        for config in configs:
+            sampling_params = self._build_sampling_params(
+                outputs_per_config, width, height, config
             )
-        images = self._extract_images(outputs)
+            if self._concurrency_available():
+                outputs = await self._submit_and_wait(prompt_payload, sampling_params)
+            else:
+                outputs = await asyncio.to_thread(
+                    self._generate_serial, prompt_payload, sampling_params
+                )
+            images.extend(self._extract_images(outputs))
         return handle_image_result(response_format, images)

--- a/xinference/model/tests/test_utils.py
+++ b/xinference/model/tests/test_utils.py
@@ -32,7 +32,21 @@ from ..utils import (
     _force_virtualenv_engine_params,
     neutralize_broken_torchcodec,
     parse_uri,
+    resolve_media_seed,
 )
+
+
+def test_resolve_media_seed():
+    assert resolve_media_seed(0) == 0
+    assert resolve_media_seed(42) == 42
+    random_seed = resolve_media_seed(-1)
+    assert random_seed is not None
+    assert 0 <= random_seed <= 2**31 - 1
+
+    with pytest.raises(ValueError, match="Seed must be an integer"):
+        resolve_media_seed(True)
+    with pytest.raises(ValueError, match="Seed must be -1"):
+        resolve_media_seed(-2)
 
 
 def test_parse_uri():

--- a/xinference/model/utils.py
+++ b/xinference/model/utils.py
@@ -27,6 +27,7 @@ from abc import ABC, abstractmethod
 from contextvars import ContextVar
 from copy import deepcopy
 from json import JSONDecodeError
+from numbers import Integral
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
@@ -1029,6 +1030,24 @@ def set_all_random_seed(seed: int):
     np.random.seed(seed)
     torch.manual_seed(seed)
     torch.cuda.manual_seed_all(seed)
+
+
+MAX_MEDIA_SEED = 2**31 - 1
+
+
+def resolve_media_seed(seed: Any) -> Optional[int]:
+    """Validate a media seed and replace -1 with a fresh random value."""
+    if seed is None:
+        return None
+    if isinstance(seed, bool) or not isinstance(seed, Integral):
+        raise ValueError("Seed must be an integer")
+
+    value = int(seed)
+    if value == -1:
+        return random.SystemRandom().randrange(MAX_MEDIA_SEED + 1)
+    if value < 0 or value > MAX_MEDIA_SEED:
+        raise ValueError(f"Seed must be -1 or between 0 and {MAX_MEDIA_SEED}")
+    return value
 
 
 _cancellable_downloaders_var: ContextVar[Tuple["CancellableDownloader", ...]] = (

--- a/xinference/model/video/diffusers.py
+++ b/xinference/model/video/diffusers.py
@@ -15,6 +15,7 @@
 import base64
 import gc
 import importlib
+import inspect
 import json
 import logging
 import operator
@@ -32,8 +33,13 @@ import numpy as np
 import PIL.Image
 
 from ...constants import XINFERENCE_VIDEO_DIR
-from ...device_utils import gpu_count, move_model_to_available_device
+from ...device_utils import (
+    get_available_device,
+    gpu_count,
+    move_model_to_available_device,
+)
 from ...types import Video, VideoList
+from ..utils import resolve_media_seed
 
 if TYPE_CHECKING:
     from ...core.progress_tracker import Progressor
@@ -788,6 +794,33 @@ class DiffusersVideoModel:
         if progressor and progressor.request_id:
             kwargs["callback_on_step_end"] = report_status_callback
 
+    def _process_seed(self, kwargs: dict):
+        seed = resolve_media_seed(kwargs.pop("seed", None))
+        if seed is None:
+            return
+
+        assert self._model is not None
+        try:
+            parameters = inspect.signature(self._model.__call__).parameters
+        except (TypeError, ValueError):
+            logger.warning("Cannot inspect %s; ignoring `seed`", type(self._model))
+            return
+        accepts_generator = "generator" in parameters or any(
+            parameter.kind == inspect.Parameter.VAR_KEYWORD
+            for parameter in parameters.values()
+        )
+        if not accepts_generator:
+            logger.warning(
+                "%s does not accept `generator`; ignoring `seed`", type(self._model)
+            )
+            return
+
+        import torch
+
+        kwargs["generator"] = torch.Generator(
+            device=get_available_device()
+        ).manual_seed(seed)
+
     def text_to_video(
         self,
         prompt: str,
@@ -808,6 +841,7 @@ class DiffusersVideoModel:
             )
         generate_kwargs = self._model_spec.default_generate_config.copy()
         generate_kwargs.update(kwargs)
+        self._process_seed(generate_kwargs)
         generate_kwargs["num_videos_per_prompt"] = n
         fps = generate_kwargs.pop("fps", 10)
         if num_inference_steps is None:
@@ -846,6 +880,7 @@ class DiffusersVideoModel:
             )
         generate_kwargs = self._model_spec.default_generate_config.copy()
         generate_kwargs.update(kwargs)
+        self._process_seed(generate_kwargs)
         if num_inference_steps:
             generate_kwargs["num_inference_steps"] = num_inference_steps
 
@@ -932,6 +967,7 @@ class DiffusersVideoModel:
             )
         generate_kwargs = self._model_spec.default_generate_config.copy()
         generate_kwargs.update(kwargs)
+        self._process_seed(generate_kwargs)
         generate_kwargs["num_videos_per_prompt"] = n
         if num_inference_steps:
             generate_kwargs["num_inference_steps"] = num_inference_steps
@@ -983,6 +1019,7 @@ class DiffusersVideoModel:
 
         generate_kwargs = (self._model_spec.default_generate_config or {}).copy()
         generate_kwargs.update(kwargs)
+        self._process_seed(generate_kwargs)
         if num_inference_steps is None:
             num_inference_steps = generate_kwargs.pop(
                 "num_inference_steps", self._minimax_h3_lightning_steps or 50

--- a/xinference/model/video/tests/test_diffusers_video.py
+++ b/xinference/model/video/tests/test_diffusers_video.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
+from types import SimpleNamespace
 
 import pytest
 
@@ -20,6 +21,39 @@ from .. import BUILTIN_VIDEO_MODELS
 from ..diffusers import DiffusersVideoModel
 
 logger = logging.getLogger(__name__)
+
+
+def test_process_seed_builds_generator_or_ignores_it(monkeypatch):
+    import torch
+
+    from .. import diffusers as diffusers_module
+
+    model = DiffusersVideoModel(
+        "mock",
+        "/tmp/mock",
+        SimpleNamespace(model_ability=[], default_generate_config={}),  # type: ignore[arg-type]
+    )
+    monkeypatch.setattr(diffusers_module, "get_available_device", lambda: "cpu")
+
+    class AcceptsGenerator:
+        def __call__(self, prompt, generator=None):
+            return prompt, generator
+
+    model._model = AcceptsGenerator()
+    kwargs = {"seed": 42}
+    model._process_seed(kwargs)
+    assert "seed" not in kwargs
+    assert isinstance(kwargs["generator"], torch.Generator)
+    assert kwargs["generator"].initial_seed() == 42
+
+    class RejectsGenerator:
+        def __call__(self, prompt):
+            return prompt
+
+    model._model = RejectsGenerator()
+    kwargs = {"seed": 42}
+    model._process_seed(kwargs)
+    assert kwargs == {}
 
 
 @pytest.mark.skip(reason="Video model requires too many GRAM.")


### PR DESCRIPTION
## Summary

Add consistent seed controls to image, video, and audio generation WebUIs, and add a width/height swap button wherever both dimensions are configurable.

## Changes

- Add `Seed(s)` support for image generation.
  - Accept comma-separated seeds.
  - Default to `-1`.
  - Pad missing seeds to the requested image count on the backend.
  - Treat missing values and `-1` as random seeds.
  - Regenerate exactly one fresh seed per requested image whenever 🎲 is clicked.
- Add scalar seed controls to video and audio generation.
- Pass seeds through the existing `kwargs` API field.
- Normalize and forward seeds across supported image, video, and audio backends.
- Safely ignore seeds when the underlying model does not support them.
- Add width/height swap controls to image and video forms.
- Add frontend and backend seed utility tests.

## API Examples

Image generation:

```json
{
  "n": 4,
  "kwargs": "{\"seed\":[11,22]}"
}
```

This is handled as `[11, 22, -1, -1]`.

Video and audio generation:

```json
{
  "kwargs": "{\"seed\":11}"
}
```

## Compatibility

No top-level API schema changes. Seed values continue to use the existing `kwargs` passthrough mechanism.



<img width="1149" height="766" alt="d65cbed45276fd63f20e5afd71c322d9" src="https://github.com/user-attachments/assets/7462204a-9b8a-47d4-91cc-3746c9c509bd" />
