### PR TITLE
fix(llm): support Hugging Face cache roots in auto-fill

### DIFF
--- a/xinference/model/llm/config_parser.py
+++ b/xinference/model/llm/config_parser.py
@@ -267,10 +267,15 @@ def _infer_model_size_from_path(model_path: str) -> Optional[Union[int, str]]:
             r"[0-9a-f]{40}|[0-9a-f]{64}", basename
         ):
             matches = re.findall(
-                r"(?<![a-z0-9])(\d+(?:[._]+\d+)?)b(?=$|[^a-z0-9])", basename
+                r"(?<![a-z0-9.])(a?)(\d+(?:[._]+\d+)?)b(?=$|[^a-z0-9.])",
+                basename,
             )
             if matches:
-                size_text = re.sub(r"[._]+", ".", matches[-1])
+                # Prefer a total-size token over an activated-size token like
+                # A3B, but accept the latter when it is the only size present.
+                total_sizes = [size for prefix, size in matches if not prefix]
+                size_text = total_sizes[-1] if total_sizes else matches[-1][1]
+                size_text = re.sub(r"[._]+", ".", size_text)
                 size_in_billions = _extract_numeric_size(size_text)
                 if size_in_billions:
                     return _format_size_in_billions(size_in_billions)

--- a/xinference/model/llm/config_parser.py
+++ b/xinference/model/llm/config_parser.py
@@ -1,8 +1,39 @@
 import json
 import os
+import re
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 _BUILTIN_FAMILY_CACHE: Optional[List[Dict[str, Any]]] = None
+
+
+def _resolve_huggingface_snapshot(model_dir: str) -> Optional[str]:
+    """Resolve a Hugging Face repository cache root to one snapshot."""
+    snapshots_dir = os.path.join(model_dir, "snapshots")
+    if not os.path.isdir(snapshots_dir):
+        return None
+
+    main_ref = os.path.join(model_dir, "refs", "main")
+    if os.path.isfile(main_ref):
+        with open(main_ref, "r") as file:
+            revision = file.read().strip()
+        if revision:
+            main_snapshot = os.path.join(snapshots_dir, revision)
+            if os.path.isfile(os.path.join(main_snapshot, "config.json")):
+                return main_snapshot
+
+    candidates = sorted(
+        os.path.join(snapshots_dir, revision)
+        for revision in os.listdir(snapshots_dir)
+        if os.path.isfile(os.path.join(snapshots_dir, revision, "config.json"))
+    )
+    if len(candidates) == 1:
+        return candidates[0]
+    if len(candidates) > 1:
+        raise ValueError(
+            f"Multiple Hugging Face snapshots found under {model_dir}; "
+            "specify one snapshots/<revision> directory explicitly."
+        )
+    return None
 
 
 def _resolve_config_and_dir(model_path: str) -> Tuple[str, str]:
@@ -14,6 +45,11 @@ def _resolve_config_and_dir(model_path: str) -> Tuple[str, str]:
         if os.path.basename(model_path) == "config.json":
             config_path = model_path
         else:
+            config_path = os.path.join(model_dir, "config.json")
+    if not os.path.exists(config_path) and os.path.isdir(model_dir):
+        snapshot_dir = _resolve_huggingface_snapshot(model_dir)
+        if snapshot_dir is not None:
+            model_dir = snapshot_dir
             config_path = os.path.join(model_dir, "config.json")
     if not os.path.exists(config_path):
         raise ValueError(f"config.json not found under {model_path}.")
@@ -47,6 +83,17 @@ def _get_first_value(config: Dict[str, Any], *keys: str) -> Optional[Any]:
         if value is not None:
             return value
     return None
+
+
+def _with_text_config_fallback(config: Dict[str, Any]) -> Dict[str, Any]:
+    """Expose nested text-model fields while preserving top-level values."""
+    text_config = config.get("text_config")
+    if not isinstance(text_config, dict):
+        return config
+
+    merged_config = dict(text_config)
+    merged_config.update(config)
+    return merged_config
 
 
 def _infer_context_length(config: Dict[str, Any]) -> int:
@@ -140,7 +187,9 @@ def _extract_numeric_size(value: Any) -> Optional[float]:
     return None
 
 
-def _infer_model_size_in_billions(config: Dict[str, Any]) -> Optional[Union[int, str]]:
+def _infer_model_size_in_billions(
+    config: Dict[str, Any], allow_architecture_estimate: bool = True
+) -> Optional[Union[int, str]]:
     size_value = _get_first_value(
         config,
         "model_size_in_billions",
@@ -166,6 +215,9 @@ def _infer_model_size_in_billions(config: Dict[str, Any]) -> Optional[Union[int,
             return _format_size_in_billions(param_value / 1e9)
         if param_value > 0:
             return _format_size_in_billions(param_value)
+
+    if not allow_architecture_estimate:
+        return None
 
     hidden_size = _get_first_value(config, "hidden_size", "d_model", "n_embd")
     num_layers = _get_first_value(config, "num_hidden_layers", "num_layers", "n_layer")
@@ -201,6 +253,20 @@ def _infer_model_size_in_billions(config: Dict[str, Any]) -> Optional[Union[int,
     if calculated_size_in_billions <= 0:
         return None
     return _format_size_in_billions(calculated_size_in_billions)
+
+
+def _infer_model_size_from_path(model_path: str) -> Optional[Union[int, str]]:
+    """Infer model size from names such as 0.8B, 0_8b, or 7B."""
+    basename = os.path.basename(os.path.normpath(model_path)).lower()
+    matches = re.findall(r"(?<![a-z0-9])(\d+(?:[._]+\d+)?)b(?=$|[^a-z0-9])", basename)
+    if not matches:
+        return None
+
+    size_text = re.sub(r"[._]+", ".", matches[-1])
+    size_in_billions = _extract_numeric_size(size_text)
+    if not size_in_billions:
+        return None
+    return _format_size_in_billions(size_in_billions)
 
 
 def _infer_quantization(config: Dict[str, Any], model_format: str) -> str:
@@ -255,9 +321,9 @@ def _infer_model_format(config: Dict[str, Any]) -> str:
 def build_llm_registration_from_local_config(
     model_path: str, model_family: str
 ) -> Dict[str, Any]:
-
     config_path, model_dir = _resolve_config_and_dir(model_path)
     config = _load_json_file(config_path)
+    inference_config = _with_text_config_fallback(config)
     tokenizer_config = _load_tokenizer_config(model_dir)
     chat_template_file = _load_chat_template_file(model_dir)
 
@@ -283,8 +349,16 @@ def build_llm_registration_from_local_config(
                 if "reasoning" not in model_ability:
                     model_ability.append("reasoning")
 
-    context_length = _infer_context_length(config)
-    model_size_in_billions = _infer_model_size_in_billions(config)
+    context_length = _infer_context_length(inference_config)
+    model_size_in_billions = _infer_model_size_in_billions(
+        inference_config, allow_architecture_estimate=False
+    )
+    if model_size_in_billions is None:
+        model_size_in_billions = _infer_model_size_from_path(model_path)
+    if model_size_in_billions is None:
+        model_size_in_billions = _infer_model_size_from_path(model_dir)
+    if model_size_in_billions is None:
+        model_size_in_billions = _infer_model_size_in_billions(inference_config)
     if model_size_in_billions is None:
         raise ValueError("Unable to infer model_size_in_billions from config.json.")
 
@@ -298,7 +372,7 @@ def build_llm_registration_from_local_config(
     model_spec = {
         "model_uri": model_dir,
         "model_format": model_format,
-        "model_size_in_billions": model_size_in_billions,
+        "model_size_in_billions": str(model_size_in_billions),
         "quantization": quantization,
     }
 

--- a/xinference/model/llm/config_parser.py
+++ b/xinference/model/llm/config_parser.py
@@ -12,14 +12,15 @@ def _resolve_huggingface_snapshot(model_dir: str) -> Optional[str]:
     if not os.path.isdir(snapshots_dir):
         return None
 
-    main_ref = os.path.join(model_dir, "refs", "main")
-    if os.path.isfile(main_ref):
-        with open(main_ref, "r") as file:
-            revision = file.read().strip()
-        if revision:
-            main_snapshot = os.path.join(snapshots_dir, revision)
-            if os.path.isfile(os.path.join(main_snapshot, "config.json")):
-                return main_snapshot
+    for ref_name in ("main", "master"):
+        ref_path = os.path.join(model_dir, "refs", ref_name)
+        if os.path.isfile(ref_path):
+            with open(ref_path, "r", encoding="utf-8") as file:
+                revision = file.read().strip()
+            if revision:
+                snapshot = os.path.join(snapshots_dir, revision)
+                if os.path.isfile(os.path.join(snapshot, "config.json")):
+                    return snapshot
 
     candidates = sorted(
         os.path.join(snapshots_dir, revision)
@@ -256,17 +257,25 @@ def _infer_model_size_in_billions(
 
 
 def _infer_model_size_from_path(model_path: str) -> Optional[Union[int, str]]:
-    """Infer model size from names such as 0.8B, 0_8b, or 7B."""
-    basename = os.path.basename(os.path.normpath(model_path)).lower()
-    matches = re.findall(r"(?<![a-z0-9])(\d+(?:[._]+\d+)?)b(?=$|[^a-z0-9])", basename)
-    if not matches:
-        return None
-
-    size_text = re.sub(r"[._]+", ".", matches[-1])
-    size_in_billions = _extract_numeric_size(size_text)
-    if not size_in_billions:
-        return None
-    return _format_size_in_billions(size_in_billions)
+    """Infer model size from nearby path components such as 0_8b or 7B."""
+    path = os.path.abspath(model_path)
+    for _ in range(4):
+        basename = os.path.basename(path).lower()
+        if not basename:
+            break
+        if basename not in {"snapshots", "refs"} and not re.fullmatch(
+            r"[0-9a-f]{40}|[0-9a-f]{64}", basename
+        ):
+            matches = re.findall(
+                r"(?<![a-z0-9])(\d+(?:[._]+\d+)?)b(?=$|[^a-z0-9])", basename
+            )
+            if matches:
+                size_text = re.sub(r"[._]+", ".", matches[-1])
+                size_in_billions = _extract_numeric_size(size_text)
+                if size_in_billions:
+                    return _format_size_in_billions(size_in_billions)
+        path = os.path.dirname(path)
+    return None
 
 
 def _infer_quantization(config: Dict[str, Any], model_format: str) -> str:

--- a/xinference/model/llm/config_parser.py
+++ b/xinference/model/llm/config_parser.py
@@ -1,6 +1,5 @@
 import json
 import os
-import re
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 _BUILTIN_FAMILY_CACHE: Optional[List[Dict[str, Any]]] = None
@@ -188,9 +187,7 @@ def _extract_numeric_size(value: Any) -> Optional[float]:
     return None
 
 
-def _infer_model_size_in_billions(
-    config: Dict[str, Any], allow_architecture_estimate: bool = True
-) -> Optional[Union[int, str]]:
+def _infer_model_size_in_billions(config: Dict[str, Any]) -> Optional[Union[int, str]]:
     size_value = _get_first_value(
         config,
         "model_size_in_billions",
@@ -216,9 +213,6 @@ def _infer_model_size_in_billions(
             return _format_size_in_billions(param_value / 1e9)
         if param_value > 0:
             return _format_size_in_billions(param_value)
-
-    if not allow_architecture_estimate:
-        return None
 
     hidden_size = _get_first_value(config, "hidden_size", "d_model", "n_embd")
     num_layers = _get_first_value(config, "num_hidden_layers", "num_layers", "n_layer")
@@ -254,33 +248,6 @@ def _infer_model_size_in_billions(
     if calculated_size_in_billions <= 0:
         return None
     return _format_size_in_billions(calculated_size_in_billions)
-
-
-def _infer_model_size_from_path(model_path: str) -> Optional[Union[int, str]]:
-    """Infer model size from nearby path components such as 0_8b or 7B."""
-    path = os.path.abspath(model_path)
-    for _ in range(4):
-        basename = os.path.basename(path).lower()
-        if not basename:
-            break
-        if basename not in {"snapshots", "refs"} and not re.fullmatch(
-            r"[0-9a-f]{40}|[0-9a-f]{64}", basename
-        ):
-            matches = re.findall(
-                r"(?<![a-z0-9.])(a?)(\d+(?:[._]+\d+)?)b(?=$|[^a-z0-9.])",
-                basename,
-            )
-            if matches:
-                # Prefer a total-size token over an activated-size token like
-                # A3B, but accept the latter when it is the only size present.
-                total_sizes = [size for prefix, size in matches if not prefix]
-                size_text = total_sizes[-1] if total_sizes else matches[-1][1]
-                size_text = re.sub(r"[._]+", ".", size_text)
-                size_in_billions = _extract_numeric_size(size_text)
-                if size_in_billions:
-                    return _format_size_in_billions(size_in_billions)
-        path = os.path.dirname(path)
-    return None
 
 
 def _infer_quantization(config: Dict[str, Any], model_format: str) -> str:
@@ -364,15 +331,7 @@ def build_llm_registration_from_local_config(
                     model_ability.append("reasoning")
 
     context_length = _infer_context_length(inference_config)
-    model_size_in_billions = _infer_model_size_in_billions(
-        inference_config, allow_architecture_estimate=False
-    )
-    if model_size_in_billions is None:
-        model_size_in_billions = _infer_model_size_from_path(model_path)
-    if model_size_in_billions is None:
-        model_size_in_billions = _infer_model_size_from_path(model_dir)
-    if model_size_in_billions is None:
-        model_size_in_billions = _infer_model_size_in_billions(inference_config)
+    model_size_in_billions = _infer_model_size_in_billions(inference_config)
     if model_size_in_billions is None:
         raise ValueError("Unable to infer model_size_in_billions from config.json.")
 

--- a/xinference/model/llm/tests/test_config_parser.py
+++ b/xinference/model/llm/tests/test_config_parser.py
@@ -3,7 +3,6 @@ import json
 import pytest
 
 from xinference.model.llm.config_parser import (
-    _infer_model_size_from_path,
     _resolve_config_and_dir,
     build_llm_registration_from_local_config,
 )
@@ -25,6 +24,7 @@ def test_auto_register_huggingface_cache_root(tmp_path, ref_name):
             "architectures": ["Qwen2ForCausalLM"],
             "text_config": {
                 "hidden_size": 3584,
+                "model_size_in_billions": 7,
                 "num_hidden_layers": 28,
                 "max_position_embeddings": 131072,
             },
@@ -48,14 +48,15 @@ def test_auto_register_huggingface_cache_root(tmp_path, ref_name):
     ]
 
 
-def test_auto_register_uses_cache_name_before_architecture_estimate(tmp_path):
-    model_dir = tmp_path / "qwen3_5-pytorch-0_8b-none"
+def test_auto_register_uses_config_before_architecture_estimate(tmp_path):
+    model_dir = tmp_path / "custom-qwen"
     _write_config(
         model_dir,
         {
             "max_position_embeddings": 4096,
             "text_config": {
                 "hidden_size": 2048,
+                "model_size_in_billions": 0.8,
                 "num_hidden_layers": 24,
                 "max_position_embeddings": 262144,
             },
@@ -68,40 +69,27 @@ def test_auto_register_uses_cache_name_before_architecture_estimate(tmp_path):
     assert result["model_specs"][0]["model_size_in_billions"] == "0_8"
 
 
-def test_auto_register_infers_size_from_snapshot_parent(tmp_path):
-    snapshot_dir = (
-        tmp_path
-        / "models--deepseek-ai--DeepSeek-R1-Distill-Qwen-7B"
-        / "snapshots"
-        / "916b56a44061fd5cd7d6a8fb632557ed4f724f60"
-    )
+@pytest.mark.parametrize(
+    "model_dir_name",
+    [
+        "ERNIE-4.5-300B-47B-PT-4bit",
+        "TinyLlama-1.1B-step-50K-105b-GGUF",
+    ],
+)
+def test_auto_register_does_not_infer_size_from_path(tmp_path, model_dir_name):
+    model_dir = tmp_path / model_dir_name
     _write_config(
-        snapshot_dir,
+        model_dir,
         {
-            "hidden_size": 3584,
-            "num_hidden_layers": 28,
-            "max_position_embeddings": 131072,
+            "hidden_size": 4096,
+            "num_hidden_layers": 32,
+            "num_parameters_in_billions": 6.6,
         },
     )
 
-    result = build_llm_registration_from_local_config(
-        str(snapshot_dir), "deepseek-r1-distill-qwen"
-    )
+    result = build_llm_registration_from_local_config(str(model_dir), "custom")
 
-    assert result["model_specs"][0]["model_size_in_billions"] == "7"
-
-
-@pytest.mark.parametrize(
-    ("model_path", "expected_size"),
-    [
-        ("Qwen1.5-MoE-A2.7B-Chat", "2_7"),
-        ("qwen1.5_7b_chat", 7),
-        ("Qwen3-30B-A3B", 30),
-        ("Qwen1.5-Chat", None),
-    ],
-)
-def test_infer_model_size_respects_token_boundaries(model_path, expected_size):
-    assert _infer_model_size_from_path(model_path) == expected_size
+    assert result["model_specs"][0]["model_size_in_billions"] == "6_6"
 
 
 def test_huggingface_cache_root_requires_unambiguous_snapshot(tmp_path):

--- a/xinference/model/llm/tests/test_config_parser.py
+++ b/xinference/model/llm/tests/test_config_parser.py
@@ -3,6 +3,7 @@ import json
 import pytest
 
 from xinference.model.llm.config_parser import (
+    _infer_model_size_from_path,
     _resolve_config_and_dir,
     build_llm_registration_from_local_config,
 )
@@ -88,6 +89,19 @@ def test_auto_register_infers_size_from_snapshot_parent(tmp_path):
     )
 
     assert result["model_specs"][0]["model_size_in_billions"] == "7"
+
+
+@pytest.mark.parametrize(
+    ("model_path", "expected_size"),
+    [
+        ("Qwen1.5-MoE-A2.7B-Chat", "2_7"),
+        ("qwen1.5_7b_chat", 7),
+        ("Qwen3-30B-A3B", 30),
+        ("Qwen1.5-Chat", None),
+    ],
+)
+def test_infer_model_size_respects_token_boundaries(model_path, expected_size):
+    assert _infer_model_size_from_path(model_path) == expected_size
 
 
 def test_huggingface_cache_root_requires_unambiguous_snapshot(tmp_path):

--- a/xinference/model/llm/tests/test_config_parser.py
+++ b/xinference/model/llm/tests/test_config_parser.py
@@ -1,0 +1,75 @@
+import json
+
+import pytest
+
+from xinference.model.llm.config_parser import (
+    _resolve_config_and_dir,
+    build_llm_registration_from_local_config,
+)
+
+
+def _write_config(model_dir, config):
+    model_dir.mkdir(parents=True, exist_ok=True)
+    (model_dir / "config.json").write_text(json.dumps(config))
+
+
+def test_auto_register_huggingface_cache_root(tmp_path):
+    cache_root = tmp_path / "models--deepseek-ai--DeepSeek-R1-Distill-Qwen-7B"
+    revision = "916b56a44061fd5cd7d6a8fb632557ed4f724f60"
+    snapshot_dir = cache_root / "snapshots" / revision
+    _write_config(
+        snapshot_dir,
+        {
+            "architectures": ["Qwen2ForCausalLM"],
+            "text_config": {
+                "hidden_size": 3584,
+                "num_hidden_layers": 28,
+                "max_position_embeddings": 131072,
+            },
+        },
+    )
+    (cache_root / "refs").mkdir()
+    (cache_root / "refs" / "main").write_text(revision)
+
+    result = build_llm_registration_from_local_config(
+        str(cache_root), "deepseek-r1-distill-qwen"
+    )
+
+    assert result["context_length"] == 131072
+    assert result["model_specs"] == [
+        {
+            "model_uri": str(snapshot_dir),
+            "model_format": "pytorch",
+            "model_size_in_billions": "7",
+            "quantization": "none",
+        }
+    ]
+
+
+def test_auto_register_uses_cache_name_before_architecture_estimate(tmp_path):
+    model_dir = tmp_path / "qwen3_5-pytorch-0_8b-none"
+    _write_config(
+        model_dir,
+        {
+            "max_position_embeddings": 4096,
+            "text_config": {
+                "hidden_size": 2048,
+                "num_hidden_layers": 24,
+                "max_position_embeddings": 262144,
+            },
+        },
+    )
+
+    result = build_llm_registration_from_local_config(str(model_dir), "qwen3.5")
+
+    assert result["context_length"] == 4096
+    assert result["model_specs"][0]["model_size_in_billions"] == "0_8"
+
+
+def test_huggingface_cache_root_requires_unambiguous_snapshot(tmp_path):
+    cache_root = tmp_path / "models--org--model-7B"
+    _write_config(cache_root / "snapshots" / "revision-a", {})
+    _write_config(cache_root / "snapshots" / "revision-b", {})
+
+    with pytest.raises(ValueError, match="Multiple Hugging Face snapshots"):
+        _resolve_config_and_dir(str(cache_root))

--- a/xinference/model/llm/tests/test_config_parser.py
+++ b/xinference/model/llm/tests/test_config_parser.py
@@ -13,7 +13,8 @@ def _write_config(model_dir, config):
     (model_dir / "config.json").write_text(json.dumps(config))
 
 
-def test_auto_register_huggingface_cache_root(tmp_path):
+@pytest.mark.parametrize("ref_name", ["main", "master"])
+def test_auto_register_huggingface_cache_root(tmp_path, ref_name):
     cache_root = tmp_path / "models--deepseek-ai--DeepSeek-R1-Distill-Qwen-7B"
     revision = "916b56a44061fd5cd7d6a8fb632557ed4f724f60"
     snapshot_dir = cache_root / "snapshots" / revision
@@ -29,7 +30,7 @@ def test_auto_register_huggingface_cache_root(tmp_path):
         },
     )
     (cache_root / "refs").mkdir()
-    (cache_root / "refs" / "main").write_text(revision)
+    (cache_root / "refs" / ref_name).write_text(revision)
 
     result = build_llm_registration_from_local_config(
         str(cache_root), "deepseek-r1-distill-qwen"
@@ -64,6 +65,29 @@ def test_auto_register_uses_cache_name_before_architecture_estimate(tmp_path):
 
     assert result["context_length"] == 4096
     assert result["model_specs"][0]["model_size_in_billions"] == "0_8"
+
+
+def test_auto_register_infers_size_from_snapshot_parent(tmp_path):
+    snapshot_dir = (
+        tmp_path
+        / "models--deepseek-ai--DeepSeek-R1-Distill-Qwen-7B"
+        / "snapshots"
+        / "916b56a44061fd5cd7d6a8fb632557ed4f724f60"
+    )
+    _write_config(
+        snapshot_dir,
+        {
+            "hidden_size": 3584,
+            "num_hidden_layers": 28,
+            "max_position_embeddings": 131072,
+        },
+    )
+
+    result = build_llm_registration_from_local_config(
+        str(snapshot_dir), "deepseek-r1-distill-qwen"
+    )
+
+    assert result["model_specs"][0]["model_size_in_billions"] == "7"
 
 
 def test_huggingface_cache_root_requires_unambiguous_snapshot(tmp_path):


### PR DESCRIPTION
## Summary

- resolve Hugging Face repository cache roots through `refs/main` or `refs/master`, with a unique-snapshot fallback and an explicit ambiguity error
- read context and architecture metadata from nested `text_config` while preserving top-level precedence
- derive model size only from configuration metadata, falling back to the existing architecture estimate instead of parsing ambiguous path names
- normalize auto-fill model-size output to a string so integral and fractional sizes have a consistent response type
- add focused regression coverage for Hugging Face cache layouts, nested configs, and ambiguous model directory names

## Release note

- LLM auto-fill now supports Hugging Face cache root directories and newer nested model configs, and returns consistent model-size values without guessing from directory names.

Closes #5402

## Validation

- `pytest -q xinference/model/llm/tests/test_config_parser.py` (6 passed)
- `pre-commit run --files xinference/model/llm/config_parser.py xinference/model/llm/tests/test_config_parser.py`
