### PR TITLE
feat(llm): support Ornith-1.5-397B

### DIFF
--- a/xinference/model/llm/llm_family.json
+++ b/xinference/model/llm/llm_family.json
@@ -35098,5 +35098,65 @@
     },
     "featured": false,
     "updated_at": 1787308415
+  },
+  {
+    "model_name": "Ornith-1.5-397B",
+    "model_description": "Ornith-1.5-397B is a 397B-total Mixture-of-Experts multimodal model built on the Qwen3.5 MoE architecture (Qwen3_5MoeForConditionalGeneration), supporting text, image, and video understanding with reasoning and tool-use capabilities.",
+    "context_length": 262144,
+    "model_lang": [
+      "en",
+      "zh"
+    ],
+    "model_ability": [
+      "chat",
+      "vision",
+      "tools",
+      "reasoning",
+      "hybrid"
+    ],
+    "model_specs": [
+      {
+        "model_size_in_billions": 397,
+        "model_format": "pytorch",
+        "model_src": {
+          "modelscope": {
+            "model_id": "ornith-ai/Ornith-1.5-397B",
+            "quantizations": [
+              "none"
+            ]
+          }
+        }
+      }
+    ],
+    "version": 2,
+    "virtualenv": {
+      "packages": [
+        "sglang>=0.5.9 ; #engine# == \"sglang\"",
+        "transformers>=5.8.1 ; #engine# == \"Transformers\"",
+        "qwen-vl-utils!=0.0.9 ; #engine# == \"Transformers\"",
+        "qwen_omni_utils ; #engine# == \"vllm\"",
+        "#system_numpy# ; #engine# == \"vllm\"",
+        "vllm==0.21.0 ; #engine# == \"vllm\"",
+        "ninja ; #engine# == \"vllm\"",
+        "#llama_cpp_dependencies# ; #engine# == \"llama.cpp\""
+      ]
+    },
+    "architectures": [
+      "Qwen3_5MoeForConditionalGeneration"
+    ],
+    "chat_template": "{%- set image_count = namespace(value=0) %}\n{%- set video_count = namespace(value=0) %}\n{%- macro render_content(content, do_vision_count, is_system_content=false) %}\n    {%- if content is string %}\n        {{- content }}\n    {%- elif content is iterable and content is not mapping %}\n        {%- for item in content %}\n            {%- if 'image' in item or 'image_url' in item or item.type == 'image' %}\n                {%- if is_system_content %}\n                    {{- raise_exception('System message cannot contain images.') }}\n                {%- endif %}\n                {%- if do_vision_count %}\n                    {%- set image_count.value = image_count.value + 1 %}\n                {%- endif %}\n                {%- if add_vision_id %}\n                    {{- 'Picture ' ~ image_count.value ~ ': ' }}\n                {%- endif %}\n                {{- '<|vision_start|><|image_pad|><|vision_end|>' }}\n            {%- elif 'video' in item or item.type == 'video' %}\n                {%- if is_system_content %}\n                    {{- raise_exception('System message cannot contain videos.') }}\n                {%- endif %}\n                {%- if do_vision_count %}\n                    {%- set video_count.value = video_count.value + 1 %}\n                {%- endif %}\n                {%- if add_vision_id %}\n                    {{- 'Video ' ~ video_count.value ~ ': ' }}\n                {%- endif %}\n                {{- '<|vision_start|><|video_pad|><|vision_end|>' }}\n            {%- elif 'text' in item %}\n                {{- item.text }}\n            {%- else %}\n                {{- raise_exception('Unexpected item type in content.') }}\n            {%- endif %}\n        {%- endfor %}\n    {%- elif content is none or content is undefined %}\n        {{- '' }}\n    {%- else %}\n        {{- raise_exception('Unexpected content type.') }}\n    {%- endif %}\n{%- endmacro %}\n{%- if not messages %}\n    {{- raise_exception('No messages provided.') }}\n{%- endif %}\n{%- if tools and tools is iterable and tools is not mapping %}\n    {{- '<|im_start|>system\\n' }}\n    {{- \"# Tools\\n\\nYou have access to the following functions:\\n\\n<tools>\" }}\n    {%- for tool in tools %}\n        {{- \"\\n\" }}\n        {{- tool | tojson }}\n    {%- endfor %}\n    {{- \"\\n</tools>\" }}\n    {{- '\\n\\nIf you choose to call a function ONLY reply in the following format with NO suffix:\\n\\n<tool_call>\\n<function=example_function_name>\\n<parameter=example_parameter_1>\\nvalue_1\\n</parameter>\\n<parameter=example_parameter_2>\\nThis is the value for the second parameter\\nthat can span\\nmultiple lines\\n</parameter>\\n</function>\\n</tool_call>\\n\\n<IMPORTANT>\\nReminder:\\n- Function calls MUST follow the specified format: an inner <function=...></function> block must be nested within <tool_call></tool_call> XML tags\\n- Required parameters MUST be specified\\n- You may provide optional reasoning for your function call in natural language BEFORE the function call, but NOT after\\n- If there is no function call available, answer the question like normal with your current knowledge and do not tell the user about function calls\\n</IMPORTANT>' }}\n    {%- if messages[0].role == 'system' %}\n        {%- set content = render_content(messages[0].content, false, true)|trim %}\n        {%- if content %}\n            {{- '\\n\\n' + content }}\n        {%- endif %}\n    {%- endif %}\n    {{- '<|im_end|>\\n' }}\n{%- else %}\n    {%- if messages[0].role == 'system' %}\n        {%- set content = render_content(messages[0].content, false, true)|trim %}\n        {{- '<|im_start|>system\\n' + content + '<|im_end|>\\n' }}\n    {%- endif %}\n{%- endif %}\n{%- set ns = namespace(multi_step_tool=true, last_query_index=messages|length - 1) %}\n{%- for message in messages[::-1] %}\n    {%- set index = (messages|length - 1) - loop.index0 %}\n    {%- if ns.multi_step_tool and message.role == \"user\" %}\n        {%- set content = render_content(message.content, false)|trim %}\n        {%- if not(content.startswith('<tool_response>') and content.endswith('</tool_response>')) %}\n            {%- set ns.multi_step_tool = false %}\n            {%- set ns.last_query_index = index %}\n        {%- endif %}\n    {%- endif %}\n{%- endfor %}\n{%- if ns.multi_step_tool %}\n    {{- raise_exception('No user query found in messages.') }}\n{%- endif %}\n{%- for message in messages %}\n    {%- set content = render_content(message.content, true)|trim %}\n    {%- if message.role == \"system\" %}\n        {%- if not loop.first %}\n            {{- raise_exception('System message must be at the beginning.') }}\n        {%- endif %}\n    {%- elif message.role == \"user\" %}\n        {{- '<|im_start|>' + message.role + '\\n' + content + '<|im_end|>' + '\\n' }}\n    {%- elif message.role == \"assistant\" %}\n        {%- set reasoning_content = '' %}\n        {%- if message.reasoning_content is string %}\n            {%- set reasoning_content = message.reasoning_content %}\n        {%- else %}\n            {%- if '</think>' in content %}\n                {%- set reasoning_content = content.split('</think>')[0].rstrip('\\n').split('<think>')[-1].lstrip('\\n') %}\n                {%- set content = content.split('</think>')[-1].lstrip('\\n') %}\n            {%- endif %}\n        {%- endif %}\n        {%- set reasoning_content = reasoning_content|trim %}\n        {%- if loop.index0 > ns.last_query_index %}\n            {{- '<|im_start|>' + message.role + '\\n<think>\\n' + reasoning_content + '\\n</think>\\n\\n' + content }}\n        {%- else %}\n            {{- '<|im_start|>' + message.role + '\\n' + content }}\n        {%- endif %}\n        {%- if message.tool_calls and message.tool_calls is iterable and message.tool_calls is not mapping %}\n            {%- for tool_call in message.tool_calls %}\n                {%- if tool_call.function is defined %}\n                    {%- set tool_call = tool_call.function %}\n                {%- endif %}\n                {%- if loop.first %}\n                    {%- if content|trim %}\n                        {{- '\\n\\n<tool_call>\\n<function=' + tool_call.name + '>\\n' }}\n                    {%- else %}\n                        {{- '<tool_call>\\n<function=' + tool_call.name + '>\\n' }}\n                    {%- endif %}\n                {%- else %}\n                    {{- '\\n<tool_call>\\n<function=' + tool_call.name + '>\\n' }}\n                {%- endif %}\n                {%- if tool_call.arguments is defined %}\n                    {%- for args_name, args_value in tool_call.arguments|items %}\n                        {{- '<parameter=' + args_name + '>\\n' }}\n                        {%- set args_value = args_value | tojson | safe if args_value is mapping or (args_value is sequence and args_value is not string) else args_value | string %}\n                        {{- args_value }}\n                        {{- '\\n</parameter>\\n' }}\n                    {%- endfor %}\n                {%- endif %}\n                {{- '</function>\\n</tool_call>' }}\n            {%- endfor %}\n        {%- endif %}\n        {{- '<|im_end|>\\n' }}\n    {%- elif message.role == \"tool\" %}\n        {%- if loop.previtem and loop.previtem.role != \"tool\" %}\n            {{- '<|im_start|>user' }}\n        {%- endif %}\n        {{- '\\n<tool_response>\\n' }}\n        {{- content }}\n        {{- '\\n</tool_response>' }}\n        {%- if not loop.last and loop.nextitem.role != \"tool\" %}\n            {{- '<|im_end|>\\n' }}\n        {%- elif loop.last %}\n            {{- '<|im_end|>\\n' }}\n        {%- endif %}\n    {%- else %}\n        {{- raise_exception('Unexpected message role.') }}\n    {%- endif %}\n{%- endfor %}\n{%- if add_generation_prompt %}\n    {{- '<|im_start|>assistant\\n' }}\n    {%- if enable_thinking is defined and enable_thinking is false %}\n        {{- '<think>\\n\\n</think>\\n\\n' }}\n    {%- else %}\n        {{- '<think>\\n' }}\n    {%- endif %}\n{%- endif %}",
+    "stop_token_ids": [
+      248044,
+      248046
+    ],
+    "reasoning_start_tag": "<think>",
+    "reasoning_end_tag": "</think>",
+    "stop": [
+      "<|endoftext|>",
+      "<|im_end|>"
+    ],
+    "tool_parser": "qwen",
+    "featured": false,
+    "updated_at": 1787303700
   }
 ]

--- a/xinference/model/llm/llm_family.json
+++ b/xinference/model/llm/llm_family.json
@@ -35132,6 +35132,7 @@
     "virtualenv": {
       "packages": [
         "sglang>=0.5.9 ; #engine# == \"sglang\"",
+        "qwen-vl-utils!=0.0.9 ; #engine# == \"sglang\"",
         "transformers>=5.8.1 ; #engine# == \"Transformers\"",
         "qwen-vl-utils!=0.0.9 ; #engine# == \"Transformers\"",
         "qwen_omni_utils ; #engine# == \"vllm\"",

--- a/xinference/model/llm/tests/test_llm_family.py
+++ b/xinference/model/llm/tests/test_llm_family.py
@@ -1651,3 +1651,84 @@ def test_ornith_15_builtin_family_matches_modelscope_qwen3_5_moe():
     )
     assert 'sglang>=0.5.9 ; #engine# == "sglang"' in family.virtualenv.packages
     assert 'vllm==0.21.0 ; #engine# == "vllm"' in family.virtualenv.packages
+
+
+def test_ornith_15_397b_builtin_family_matches_modelscope_qwen3_5_moe():
+    from ....core.model import XINFERENCE_BATCHING_ALLOWED_VISION_MODELS
+    from ..llm_family import BUILTIN_LLM_FAMILIES
+    from ..transformers.multimodal.qwen2_vl import Qwen2VLChatModel
+
+    families = {family.model_name: family for family in BUILTIN_LLM_FAMILIES}
+    family = families["Ornith-1.5-397B"]
+
+    assert family.context_length == 262144
+    assert family.architectures == ["Qwen3_5MoeForConditionalGeneration"]
+    assert family.model_ability == [
+        "chat",
+        "vision",
+        "tools",
+        "reasoning",
+        "hybrid",
+    ]
+
+    spec = family.model_specs[0]
+    assert spec.model_format == "pytorch"
+    assert spec.model_size_in_billions == 397
+    # The target model metadata does not provide a trustworthy activated
+    # parameter count; do not inherit qwen3.5's A17B value.
+    assert spec.activated_size_in_billions is None
+    assert spec.model_hub == "modelscope"
+    assert spec.model_id == "ornith-ai/Ornith-1.5-397B"
+    assert spec.quantization == "none"
+
+    modelscope_family = match_llm(
+        "Ornith-1.5-397B",
+        model_format="pytorch",
+        model_size_in_billions=397,
+        quantization="none",
+        download_hub="modelscope",
+    )
+    assert modelscope_family is not None
+    assert modelscope_family.model_specs[0].model_hub == "modelscope"
+    assert modelscope_family.model_specs[0].model_id == spec.model_id
+
+    assert Qwen2VLChatModel.match_json(family, spec, spec.quantization) is True
+    assert "Ornith-1.5-397B" in XINFERENCE_BATCHING_ALLOWED_VISION_MODELS
+    assert family.tool_parser == "qwen"
+    assert "<function=example_function_name>" in family.chat_template
+    assert (
+        'transformers>=5.8.1 ; #engine# == "Transformers"' in family.virtualenv.packages
+    )
+    assert (
+        'qwen-vl-utils!=0.0.9 ; #engine# == "Transformers"'
+        in family.virtualenv.packages
+    )
+    assert 'sglang>=0.5.9 ; #engine# == "sglang"' in family.virtualenv.packages
+    assert 'vllm==0.21.0 ; #engine# == "vllm"' in family.virtualenv.packages
+
+
+def test_ornith_15_397b_matches_vllm_021_multimodal(monkeypatch):
+    from ..llm_family import BUILTIN_LLM_FAMILIES
+    from ..vllm import core as vllm_core
+
+    family = next(
+        family
+        for family in BUILTIN_LLM_FAMILIES
+        if family.model_name == "Ornith-1.5-397B"
+    )
+    spec = family.model_specs[0]
+
+    monkeypatch.setattr(vllm_core, "VLLM_INSTALLED", True)
+    monkeypatch.setattr(vllm_core, "VLLM_VERSION", version.parse("0.21.0"))
+    monkeypatch.setattr(
+        vllm_core.VLLMMultiModel, "_has_cuda_device", classmethod(lambda cls: True)
+    )
+    monkeypatch.setattr(
+        vllm_core.VLLMMultiModel, "_is_linux", classmethod(lambda cls: True)
+    )
+    vllm_core._update_vllm_supported_lists()
+
+    assert "Qwen3_5MoeForConditionalGeneration" in (
+        vllm_core.VLLM_SUPPORTED_MULTI_MODEL_LIST
+    )
+    assert vllm_core.VLLMMultiModel.match_json(family, spec, spec.quantization) is True

--- a/xinference/model/llm/tests/test_llm_family.py
+++ b/xinference/model/llm/tests/test_llm_family.py
@@ -1704,6 +1704,7 @@ def test_ornith_15_397b_builtin_family_matches_modelscope_qwen3_5_moe():
         in family.virtualenv.packages
     )
     assert 'sglang>=0.5.9 ; #engine# == "sglang"' in family.virtualenv.packages
+    assert 'qwen-vl-utils!=0.0.9 ; #engine# == "sglang"' in family.virtualenv.packages
     assert 'vllm==0.21.0 ; #engine# == "vllm"' in family.virtualenv.packages
 
 

--- a/xinference/model/llm/transformers/multimodal/qwen2_vl.py
+++ b/xinference/model/llm/transformers/multimodal/qwen2_vl.py
@@ -37,6 +37,7 @@ logger = logging.getLogger(__name__)
     "qwen3.8",
     "Nex-N2",
     "Ornith-1.5-35B-A3B",
+    "Ornith-1.5-397B",
 )
 @register_transformer
 @register_non_default_model(


### PR DESCRIPTION
## Summary

- Add built-in ModelScope metadata for `Ornith-1.5-397B`.
- Reuse the existing Qwen3.5 MoE multimodal Transformers, vLLM, and SGLang architecture paths.
- Register the model for Transformers multimodal batching.
- Add family matching, dependency, batching, and vLLM 0.21 multimodal matching coverage.
- Keep `activated_size_in_billions` unset because the target model metadata does not provide a trustworthy activated-parameter count.

## vLLM version

The `vllm==0.21.0` dependency is intentional. This model uses the multimodal architecture:

```text
Qwen3_5MoeForConditionalGeneration
```

It does not use `Qwen3_5MoeForCausalLM`, for which Xinference has a separate `vLLM >= 0.27.0` requirement. A regression test now verifies that the Ornith family matches `VLLMMultiModel` with vLLM 0.21.0.

## Validation

Code-level validation:

- `pytest -q xinference/model/llm/tests/test_llm_family.py -k 'ornith_15'` — `3 passed`
- `pre-commit run --files xinference/model/llm/llm_family.json xinference/model/llm/tests/test_llm_family.py xinference/model/llm/transformers/multimodal/qwen2_vl.py`
- `git diff --check origin/main...HEAD`

Two-node deployment-path validation was also performed in the customized `feather-customized-3-1-0` environment using the actual ModelScope model cache:

- two nodes with 8 GPUs per node;
- one replica with `TP=8`, `PP=2`, and `max_model_len=4096`;
- vLLM 0.21.0, PyTorch 2.11.0+cu130, and CUDA 13.0;
- Supervisor scheduling and ModelActor creation completed on both nodes;
- all 16 vLLM GPU worker processes were created;
- the deployment entered vLLM EngineCore model loading and read the model, tokenizer, and processor configuration.

## Remaining validation boundary

The captured logs do not yet prove all of the following:

- final `wait_for_load` completion;
- complete BF16 weight loading;
- end-to-end text generation;
- image/video inference;
- reasoning and tool-call output verification;
- performance and stability results.

The PR therefore remains Draft until the desired end-to-end acceptance boundary is completed.
