### PR TITLE
ENH: Add multi-engine video support with MLX

### DIFF
--- a/doc/source/gen_docs.py
+++ b/doc/source/gen_docs.py
@@ -573,19 +573,51 @@ def main():
     with open('../../xinference/model/video/model_spec.json', 'r') as file:
         models = json.load(file)
 
-        sorted_models = sorted(models, key=lambda x: x['model_name'].lower())
-        output_dir = './models/builtin/video'
-        os.makedirs(output_dir, exist_ok=True)
+        models_by_name = {}
+        for model in models:
+            model_name = model['model_name']
+            rendered_model = models_by_name.setdefault(
+                model_name, {**model, 'engine_specs': []}
+            )
 
-        for model in sorted_models:
-            # Process model_src for template compatibility
             model_src = _extract_primary_model_src(model)
+            model_id = None
             if model_src:
                 primary_src = model_src.get('huggingface') or model_src.get('modelscope')
                 if primary_src:
-                    model['model_id'] = primary_src['model_id']
+                    model_id = primary_src['model_id']
                     if primary_src.get('lightning_model_id'):
-                        model['lightning_model_id'] = primary_src['lightning_model_id']
+                        rendered_model['lightning_model_id'] = primary_src['lightning_model_id']
+            rendered_model['engine_specs'].append(
+                {'engine': model.get('engine'), 'model_id': model_id}
+            )
+
+        sorted_models = sorted(models_by_name.values(), key=lambda x: x['model_name'].lower())
+        output_dir = './models/builtin/video'
+        os.makedirs(output_dir, exist_ok=True)
+        generated_files = set()
+
+        for model in sorted_models:
+            engine_specs = model['engine_specs']
+            if len(engine_specs) > 1:
+                model['specifications'] = '\n'.join(
+                    f"- **{spec['engine']} model ID:** {spec['model_id']}"
+                    for spec in engine_specs
+                )
+                model['launch_engine'] = engine_specs[0]['engine']
+                model['available_engines_section'] = (
+                    '\n\nAvailable engines\n'
+                    '^^^^^^^^^^^^^^^^^\n\n'
+                    + '\n'.join(
+                        f"* ``{spec['engine']}``" for spec in engine_specs
+                    )
+                )
+            else:
+                model['specifications'] = (
+                    f"- **Model ID:** {engine_specs[0]['model_id']}"
+                )
+                model['launch_engine'] = None
+                model['available_engines_section'] = ''
 
             if model.get('lightning_versions'):
                 model['lightning_versions'] = ", ".join(model['lightning_versions'])
@@ -593,7 +625,12 @@ def main():
             rendered = env.get_template('video.rst.jinja').render(model)
             output_file_path = os.path.join(output_dir, f"{model['model_name'].lower()}.rst")
             with open(output_file_path, 'w') as output_file:
-                output_file.write(rendered)
+                output_file.write(rendered.rstrip('\n'))
+            generated_files.add(os.path.basename(output_file_path))
+
+        for filename in os.listdir(output_dir):
+            if filename.endswith('.rst') and filename not in generated_files and filename != 'index.rst':
+                os.remove(os.path.join(output_dir, filename))
 
         index_file_path = os.path.join(output_dir, "index.rst")
         with open(index_file_path, "w") as file:

--- a/doc/source/models/builtin/video/index.rst
+++ b/doc/source/models/builtin/video/index.rst
@@ -17,6 +17,14 @@ The following is a list of built-in video models in Xinference:
   
    hunyuanvideo
   
+   ltx-2-dev
+
+   ltx-2-distilled
+
+   ltx-2.3-dev
+
+   ltx-2.3-distilled
+
    minimax-h3
   
    wan2.1-1.3b
@@ -38,4 +46,3 @@ The following is a list of built-in video models in Xinference:
    wan2.2-i2v-a14b
   
    wan2.2-ti2v-5b
-  

--- a/doc/source/models/builtin/video/ltx-2-dev.rst
+++ b/doc/source/models/builtin/video/ltx-2-dev.rst
@@ -1,0 +1,18 @@
+.. _models_builtin_ltx-2-dev:
+
+=========
+LTX-2-dev
+=========
+
+- **Model Name:** LTX-2-dev
+- **Model Family:** LTX-2
+- **Abilities:** text2video, image2video, firstlastframe2video
+
+Specifications
+^^^^^^^^^^^^^^
+
+- **Model ID:** prince-canuma/LTX-2-dev
+
+Execute the following command to launch the model::
+
+   xinference launch --model-name LTX-2-dev --model-type video

--- a/doc/source/models/builtin/video/ltx-2-distilled.rst
+++ b/doc/source/models/builtin/video/ltx-2-distilled.rst
@@ -1,0 +1,18 @@
+.. _models_builtin_ltx-2-distilled:
+
+===============
+LTX-2-distilled
+===============
+
+- **Model Name:** LTX-2-distilled
+- **Model Family:** LTX-2
+- **Abilities:** text2video, image2video, firstlastframe2video
+
+Specifications
+^^^^^^^^^^^^^^
+
+- **Model ID:** prince-canuma/LTX-2-distilled
+
+Execute the following command to launch the model::
+
+   xinference launch --model-name LTX-2-distilled --model-type video

--- a/doc/source/models/builtin/video/ltx-2.3-dev.rst
+++ b/doc/source/models/builtin/video/ltx-2.3-dev.rst
@@ -1,0 +1,18 @@
+.. _models_builtin_ltx-2.3-dev:
+
+===========
+LTX-2.3-dev
+===========
+
+- **Model Name:** LTX-2.3-dev
+- **Model Family:** LTX-2.3
+- **Abilities:** text2video, image2video, firstlastframe2video
+
+Specifications
+^^^^^^^^^^^^^^
+
+- **Model ID:** prince-canuma/LTX-2.3-dev
+
+Execute the following command to launch the model::
+
+   xinference launch --model-name LTX-2.3-dev --model-type video

--- a/doc/source/models/builtin/video/ltx-2.3-distilled.rst
+++ b/doc/source/models/builtin/video/ltx-2.3-distilled.rst
@@ -1,0 +1,18 @@
+.. _models_builtin_ltx-2.3-distilled:
+
+=================
+LTX-2.3-distilled
+=================
+
+- **Model Name:** LTX-2.3-distilled
+- **Model Family:** LTX-2.3
+- **Abilities:** text2video, image2video, firstlastframe2video
+
+Specifications
+^^^^^^^^^^^^^^
+
+- **Model ID:** prince-canuma/LTX-2.3-distilled
+
+Execute the following command to launch the model::
+
+   xinference launch --model-name LTX-2.3-distilled --model-type video

--- a/doc/source/models/builtin/video/wan2.1-1.3b.rst
+++ b/doc/source/models/builtin/video/wan2.1-1.3b.rst
@@ -11,8 +11,15 @@ Wan2.1-1.3B
 Specifications
 ^^^^^^^^^^^^^^
 
-- **Model ID:** Wan-AI/Wan2.1-T2V-1.3B-Diffusers
+- **diffusers model ID:** Wan-AI/Wan2.1-T2V-1.3B-Diffusers
+- **MLX model ID:** Wan-AI/Wan2.1-T2V-1.3B
 
 Execute the following command to launch the model::
 
-   xinference launch --model-name Wan2.1-1.3B --model-type video
+   xinference launch --model-name Wan2.1-1.3B --model-type video --model-engine diffusers
+
+Available engines
+^^^^^^^^^^^^^^^^^
+
+* ``diffusers``
+* ``MLX``

--- a/doc/source/models/builtin/video/wan2.1-14b.rst
+++ b/doc/source/models/builtin/video/wan2.1-14b.rst
@@ -11,8 +11,15 @@ Wan2.1-14B
 Specifications
 ^^^^^^^^^^^^^^
 
-- **Model ID:** Wan-AI/Wan2.1-T2V-14B-Diffusers
+- **diffusers model ID:** Wan-AI/Wan2.1-T2V-14B-Diffusers
+- **MLX model ID:** Wan-AI/Wan2.1-T2V-14B
 
 Execute the following command to launch the model::
 
-   xinference launch --model-name Wan2.1-14B --model-type video
+   xinference launch --model-name Wan2.1-14B --model-type video --model-engine diffusers
+
+Available engines
+^^^^^^^^^^^^^^^^^
+
+* ``diffusers``
+* ``MLX``

--- a/doc/source/models/builtin/video/wan2.2-a14b.rst
+++ b/doc/source/models/builtin/video/wan2.2-a14b.rst
@@ -11,8 +11,15 @@ Wan2.2-A14B
 Specifications
 ^^^^^^^^^^^^^^
 
-- **Model ID:** Wan-AI/Wan2.2-T2V-A14B-Diffusers
+- **diffusers model ID:** Wan-AI/Wan2.2-T2V-A14B-Diffusers
+- **MLX model ID:** SceneWorks/wan2.2-t2v-a14b-mlx
 
 Execute the following command to launch the model::
 
-   xinference launch --model-name Wan2.2-A14B --model-type video
+   xinference launch --model-name Wan2.2-A14B --model-type video --model-engine diffusers
+
+Available engines
+^^^^^^^^^^^^^^^^^
+
+* ``diffusers``
+* ``MLX``

--- a/doc/source/models/builtin/video/wan2.2-i2v-a14b.rst
+++ b/doc/source/models/builtin/video/wan2.2-i2v-a14b.rst
@@ -11,8 +11,15 @@ Wan2.2-i2v-A14B
 Specifications
 ^^^^^^^^^^^^^^
 
-- **Model ID:** Wan-AI/Wan2.2-I2V-A14B-Diffusers
+- **diffusers model ID:** Wan-AI/Wan2.2-I2V-A14B-Diffusers
+- **MLX model ID:** SceneWorks/wan2.2-i2v-a14b-mlx
 
 Execute the following command to launch the model::
 
-   xinference launch --model-name Wan2.2-i2v-A14B --model-type video
+   xinference launch --model-name Wan2.2-i2v-A14B --model-type video --model-engine diffusers
+
+Available engines
+^^^^^^^^^^^^^^^^^
+
+* ``diffusers``
+* ``MLX``

--- a/doc/source/models/builtin/video/wan2.2-ti2v-5b.rst
+++ b/doc/source/models/builtin/video/wan2.2-ti2v-5b.rst
@@ -11,8 +11,15 @@ Wan2.2-ti2v-5B
 Specifications
 ^^^^^^^^^^^^^^
 
-- **Model ID:** Wan-AI/Wan2.2-TI2V-5B-Diffusers
+- **diffusers model ID:** Wan-AI/Wan2.2-TI2V-5B-Diffusers
+- **MLX model ID:** SceneWorks/wan2.2-ti2v-5b-mlx
 
 Execute the following command to launch the model::
 
-   xinference launch --model-name Wan2.2-ti2v-5B --model-type video
+   xinference launch --model-name Wan2.2-ti2v-5B --model-type video --model-engine diffusers
+
+Available engines
+^^^^^^^^^^^^^^^^^
+
+* ``diffusers``
+* ``MLX``

--- a/doc/source/models/model_abilities/video.rst
+++ b/doc/source/models/model_abilities/video.rst
@@ -46,28 +46,58 @@ The text-to-video API is supported with the following models in Xinference:
 * :ref:`HunyuanVideo <models_builtin_hunyuanvideo>`
 * :ref:`Wan2.1-1.3B <models_builtin_wan2.1-1.3b>`
 * :ref:`Wan2.1-14B <models_builtin_wan2.1-14b>`
+* :ref:`Wan2.2-A14B <models_builtin_wan2.2-a14b>`
+* :ref:`Wan2.2-ti2v-5B <models_builtin_wan2.2-ti2v-5b>`
+* :ref:`LTX-2-distilled <models_builtin_ltx-2-distilled>`
+* :ref:`LTX-2-dev <models_builtin_ltx-2-dev>`
+* :ref:`LTX-2.3-distilled <models_builtin_ltx-2.3-distilled>`
+* :ref:`LTX-2.3-dev <models_builtin_ltx-2.3-dev>`
 
 The image-to-video API is supported with the following models in Xinference:
 
 * :ref:`MiniMax-H3 <models_builtin_minimax-h3>`
 * :ref:`Wan2.1-i2v-14B-480p <models_builtin_wan2.1-i2v-14b-480p>`
 * :ref:`Wan2.1-i2v-14B-720p <models_builtin_wan2.1-i2v-14b-720p>`
+* :ref:`Wan2.2-i2v-A14B <models_builtin_wan2.2-i2v-a14b>`
+* :ref:`Wan2.2-ti2v-5B <models_builtin_wan2.2-ti2v-5b>`
+* :ref:`Wan2.2-Animate-2-14B <models_builtin_wan2.2-animate-2-14b>`
+* :ref:`Wan2.2-Animate-2-14B-Distilled <models_builtin_wan2.2-animate-2-14b-distilled>`
+* :ref:`LTX-2-distilled <models_builtin_ltx-2-distilled>`
+* :ref:`LTX-2-dev <models_builtin_ltx-2-dev>`
+* :ref:`LTX-2.3-distilled <models_builtin_ltx-2.3-distilled>`
+* :ref:`LTX-2.3-dev <models_builtin_ltx-2.3-dev>`
 
 The firstlastframe-to-video API is supported with the following models in Xinference:
 
 * :ref:`MiniMax-H3 <models_builtin_minimax-h3>`
 * :ref:`Wan2.1-flf2v-14B-720p <models_builtin_wan2.1-flf2v-14b-720p>`
+* :ref:`LTX-2-distilled <models_builtin_ltx-2-distilled>`
+* :ref:`LTX-2-dev <models_builtin_ltx-2-dev>`
+* :ref:`LTX-2.3-distilled <models_builtin_ltx-2.3-distilled>`
+* :ref:`LTX-2.3-dev <models_builtin_ltx-2.3-dev>`
 
 Video engines
 -------------
 
-Video runtimes are selected with ``--model-engine``. All currently built-in
-video models use the ``diffusers`` engine, which is also the default. For
-example, the explicit form is:
+Video runtimes are selected with ``--model-engine``. The ``diffusers`` engine
+remains the default for models that expose both runtimes. For example, launch
+Wan2.2-A14B with either engine explicitly:
 
 .. code-block:: bash
 
-    xinference launch --model-name MiniMax-H3 --model-type video --model-engine diffusers
+    xinference launch --model-name Wan2.2-A14B --model-type video --model-engine diffusers
+    xinference launch --model-name Wan2.2-A14B --model-type video --model-engine MLX
+
+The ``MLX`` engine uses `Blaizzy/mlx-video
+<https://github.com/Blaizzy/mlx-video>`_ and is available on Apple Silicon with
+Python 3.11 or newer. It supports Wan2.1 T2V, Wan2.2 T2V/I2V/TI2V, and the
+LTX-2/LTX-2.3 distilled and dev models listed above. The LTX models are MLX-only
+in Xinference.
+
+Wan2.1's official checkpoints are converted to the native MLX layout on first
+load and the converted copy is reused by later launches. This first launch
+therefore needs additional time and disk space. Wan2.2 and LTX use
+pre-converted checkpoints.
 
 The Web UI obtains the engines supported by each model from the engine query
 API and presents them in the launch dialog. Additional video runtimes can be

--- a/doc/source/models/model_abilities/video.rst
+++ b/doc/source/models/model_abilities/video.rst
@@ -58,6 +58,21 @@ The firstlastframe-to-video API is supported with the following models in Xinfer
 * :ref:`MiniMax-H3 <models_builtin_minimax-h3>`
 * :ref:`Wan2.1-flf2v-14B-720p <models_builtin_wan2.1-flf2v-14b-720p>`
 
+Video engines
+-------------
+
+Video runtimes are selected with ``--model-engine``. All currently built-in
+video models use the ``diffusers`` engine, which is also the default. For
+example, the explicit form is:
+
+.. code-block:: bash
+
+    xinference launch --model-name MiniMax-H3 --model-type video --model-engine diffusers
+
+The Web UI obtains the engines supported by each model from the engine query
+API and presents them in the launch dialog. Additional video runtimes can be
+registered independently without changing the Video API.
+
 Quickstart
 ===================
 

--- a/doc/templates/video.rst.jinja
+++ b/doc/templates/video.rst.jinja
@@ -11,14 +11,14 @@
 Specifications
 ^^^^^^^^^^^^^^
 
-- **Model ID:** {{ model_id }}{% if lightning_model_id %}
+{{ specifications }}{% if lightning_model_id %}
 - **Lightning Model ID:** {{ lightning_model_id }}
 - **Lightning Versions:** {{ lightning_versions }}{% endif %}
 
 Execute the following command to launch the model::
 
-   xinference launch --model-name {{ model_name }} --model-type video{% if lightning_versions %}
+   xinference launch --model-name {{ model_name }} --model-type video{% if launch_engine %} --model-engine {{ launch_engine }}{% endif %}{% if lightning_versions %}
 
 For Lightning LoRA acceleration, use::
 
-   xinference launch --model-name {{ model_name }} --model-type video --lightning_version ${{ '{' }}lightning_version{{ '}' }}{% endif %}
+   xinference launch --model-name {{ model_name }} --model-type video{% if launch_engine %} --model-engine {{ launch_engine }}{% endif %} --lightning_version ${{ '{' }}lightning_version{{ '}' }}{% endif %}{{ available_engines_section }}

--- a/frontend/src/components/pages/launch-model/launch-dialog/launch-dialog.tsx
+++ b/frontend/src/components/pages/launch-model/launch-dialog/launch-dialog.tsx
@@ -112,8 +112,7 @@ export default function LaunchDialog({
   const modelEngineValue = toOptionValue(useWatch('model_engine', form));
   const modelFormatValue = toOptionValue(useWatch('model_format', form));
   const modelSizeInBillionsValue = useWatch('model_size_in_billions', form) as
-    | ModelEngineItem['model_size_in_billions']
-    | undefined;
+    ModelEngineItem['model_size_in_billions'] | undefined;
   const enableThinkingValue = useWatch('enable_thinking', form);
   const modelSizeInBillionsKey = toOptionValue(modelSizeInBillionsValue);
   const quantizationValue = toOptionValue(useWatch('quantization', form));
@@ -342,14 +341,25 @@ export default function LaunchDialog({
     };
   }, [gpuAvailable, modelType, form]);
 
-  const downloadHubOptions = useMemo(
-    () =>
-      ['auto', 'none', ...(model?.download_hubs || [])].map((item) => ({
-        label: item,
-        value: item,
-      })),
-    [model?.download_hubs]
-  );
+  const downloadHubOptions = useMemo(() => {
+    const engineHubs = Array.from(
+      new Set(
+        (model?.modelSpecs || [])
+          .filter(
+            (spec) =>
+              !modelEngineValue ||
+              toOptionValue(spec.model_engine).toLowerCase() === modelEngineValue.toLowerCase()
+          )
+          .map((spec) => toOptionValue(spec.model_hub))
+          .filter(Boolean)
+      )
+    );
+    const availableHubs = engineHubs.length > 0 ? engineHubs : model?.download_hubs || [];
+    return ['auto', 'none', ...availableHubs].map((item) => ({
+      label: item,
+      value: item,
+    }));
+  }, [model?.download_hubs, model?.modelSpecs, modelEngineValue]);
 
   const workerIpFieldProps = useMemo(
     () => ({
@@ -445,8 +455,7 @@ export default function LaunchDialog({
     if (!isCustomPlacement) return;
     const current =
       (form.getFieldValue('replica_config') as
-        | Array<{ replica_uid?: string; worker_ip: string; gpu_idx: string }>
-        | undefined) ?? [];
+        Array<{ replica_uid?: string; worker_ip: string; gpu_idx: string }> | undefined) ?? [];
     if (current.length === replicaValue) return;
     const next = Array.from(
       { length: replicaValue },
@@ -1140,6 +1149,29 @@ export default function LaunchDialog({
         placeholder: t('launchModel.modelUidPlaceholder'),
       },
       {
+        name: 'model_engine',
+        type: 'select',
+        label: t('launchModel.modelEngine'),
+        fieldProps: { options: modelEngineOptions },
+        show: !!modelEngineOptions.length,
+      },
+      {
+        name: 'model_format',
+        type: 'select',
+        label: t('launchModel.modelFormat'),
+        disabled: !modelEngineValue,
+        fieldProps: { options: modelFormatOptions },
+        show: !!modelFormatOptions.length,
+      },
+      {
+        name: 'quantization',
+        type: 'select',
+        label: t('launchModel.quantization'),
+        disabled: !modelFormatValue,
+        fieldProps: { options: quantizationOptions },
+        show: !!quantizationOptions.length,
+      },
+      {
         name: 'replica',
         type: 'input',
         label: t('launchModel.replica'),
@@ -1245,6 +1277,7 @@ export default function LaunchDialog({
         type: 'switch',
         valuePropName: 'checked',
         tooltip: t('launchModel.CPUOffloadTip'),
+        show: !modelEngineValue || modelEngineValue.toLowerCase() === 'diffusers',
       },
       {
         name: 'collapsibleConfig',

--- a/frontend/src/components/pages/launch-model/utils.tsx
+++ b/frontend/src/components/pages/launch-model/utils.tsx
@@ -37,6 +37,7 @@ export const MODEL_ENGINE_TYPES: RequestModelType[] = [
   ModelType.Rerank,
   ModelType.Image,
   ModelType.Audio,
+  ModelType.Video,
 ];
 
 export function normalizeModelSize(value: unknown) {

--- a/xinference/client/restful/async_restful_client.py
+++ b/xinference/client/restful/async_restful_client.py
@@ -1357,7 +1357,7 @@ class AsyncClient:
         model_type: str
             type of model.
         model_engine: Optional[str]
-            Specify the inference engine of the model when launching LLM.
+            Specify the inference engine to use when launching the model.
         model_uid: str
             UID of model, auto generate a UUID if is None.
         model_size_in_billions: Optional[Union[int, str, float]]

--- a/xinference/client/restful/restful_client.py
+++ b/xinference/client/restful/restful_client.py
@@ -1244,7 +1244,7 @@ class Client:
         model_type: str
             type of model.
         model_engine: Optional[str]
-            Specify the inference engine of the model when launching LLM.
+            Specify the inference engine to use when launching the model.
         model_uid: str
             UID of model, auto generate a UUID if is None.
         model_size_in_billions: Optional[Union[int, str, float]]

--- a/xinference/core/model.py
+++ b/xinference/core/model.py
@@ -290,7 +290,7 @@ class ModelActor(xo.StatelessActor, CancelMixin):
         self._serve_count = 0
         model_type = self._model_description.get("model_type", "unknown")
         if model_type == "video":
-            engine_label = ""
+            engine_label = model_engine or ""
             format_label = ""
         elif model_type in ("audio", "image"):
             engine_label = model_engine or ""

--- a/xinference/core/tests/test_model.py
+++ b/xinference/core/tests/test_model.py
@@ -45,6 +45,31 @@ class MockModel:
         yield {"test2": prompt}
 
 
+class _DescribedModelFamily:
+    def __init__(self, model_type: str):
+        self._model_type = model_type
+
+    def to_description(self) -> dict:
+        return {"model_type": self._model_type, "model_name": "test-video"}
+
+
+class _DescribedModel:
+    def __init__(self, model_type: str):
+        self.model_family = _DescribedModelFamily(model_type)
+
+
+def test_video_metrics_keep_selected_engine_label():
+    actor = ModelActor(
+        supervisor_address="test:123",
+        worker_address="test:345",
+        model=_DescribedModel("video"),  # type: ignore
+        replica_model_uid="test-video-0",
+        model_engine="MLX",
+    )
+
+    assert actor._metrics_labels["engine"] == "MLX"
+
+
 class MockModelActor(ModelActor):
     def __init__(
         self,

--- a/xinference/core/tests/test_virtualenv_package_rewrite.py
+++ b/xinference/core/tests/test_virtualenv_package_rewrite.py
@@ -16,6 +16,7 @@ import platform
 from ..utils import (
     filter_virtualenv_packages_by_markers,
     find_direct_reference_packages,
+    find_remote_direct_reference_packages,
     rewrite_direct_url_packages_for_index,
 )
 from ..virtual_env_manager import ENGINE_VIRTUALENV_PACKAGES
@@ -87,6 +88,36 @@ def test_find_direct_references_after_wheel_rewrite():
     rewritten = rewrite_direct_url_packages_for_index(packages)
 
     assert find_direct_reference_packages(rewritten) == packages[1:4]
+
+
+def test_find_direct_references_supports_pep508_vcs_and_file_urls():
+    packages = [
+        "pkg-hg @ hg+https://example.invalid/repo",
+        "pkg-svn @ svn+ssh://example.invalid/repo",
+        "pkg-bzr @ bzr+https://example.invalid/repo",
+        'pkg-file @ file:///tmp/pkg ; python_version >= "3.10"',
+        "hg+https://example.invalid/bare-repo",
+        "transformers>=4.53.3",
+    ]
+
+    assert find_direct_reference_packages(packages) == packages[:-1]
+    assert find_remote_direct_reference_packages(packages) == [
+        packages[0],
+        packages[1],
+        packages[2],
+        packages[4],
+    ]
+
+
+def test_remote_direct_references_allow_bare_local_paths():
+    packages = [
+        "pkg-absolute @ /opt/local/pkg",
+        "pkg-relative @ ./local/pkg",
+        "pkg-parent @ ../local/pkg",
+        "pkg-remote @ https://example.invalid/pkg.tar.gz",
+    ]
+
+    assert find_remote_direct_reference_packages(packages) == [packages[-1]]
 
 
 def test_malformed_wheel_filename_unchanged():

--- a/xinference/core/tests/test_worker.py
+++ b/xinference/core/tests/test_worker.py
@@ -18,6 +18,7 @@ import json
 import os
 import shutil
 import threading
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, List, Optional, Tuple, Union
 
@@ -173,6 +174,76 @@ async def test_resolve_download_hub_uses_worker_local_model_src(monkeypatch):
     monkeypatch.setenv("XINFERENCE_MODEL_SRC", "modelscope")
 
     assert await WorkerActor.resolve_download_hub(None, None) == "modelscope"
+
+
+@pytest.mark.asyncio
+async def test_video_host_preflight_precedes_virtualenv_creation(monkeypatch):
+    from ...model.video.engine import MLXVideoEngineModel
+    from ...model.video.engine_family import VIDEO_ENGINES
+
+    class _Worker:
+        def __init__(self):
+            self.address = "127.0.0.1:0"
+            self._supervisor_address = "127.0.0.1:1"
+            self._event_collector_ref = None
+            self._model_uid_to_model = {}
+            self._model_uid_launching_guard = {}
+            self._launch_semaphore = asyncio.Semaphore(1)
+            self._launch_waiting = 0
+            self._launch_active = 0
+            self.venv_created = False
+
+        async def get_supervisor_ref(self, add_worker=False):
+            return object()
+
+        def _check_model_is_valid(self, model_name, model_format):
+            pass
+
+        def get_model_launch_status(self, model_uid):
+            return None
+
+        def _create_virtual_env_manager(self, *_args, **_kwargs):
+            self.venv_created = True
+            pytest.fail("virtualenv creation must not run before host preflight")
+
+    worker = _Worker()
+    monkeypatch.setattr(
+        MLXVideoEngineModel,
+        "check_host",
+        classmethod(lambda cls: (False, "requires Apple Silicon")),
+    )
+    # Linux and Windows intentionally omit MLX from their live engine matrix.
+    # Register the exact tuple under test so this ordering regression exercises
+    # the hard host preflight consistently on every CI platform.
+    monkeypatch.setitem(
+        VIDEO_ENGINES["Wan2.1-1.3B"],
+        "MLX",
+        [
+            {
+                "model_name": "Wan2.1-1.3B",
+                "model_format": "mlx",
+                "quantization": "none",
+                "video_class": MLXVideoEngineModel,
+            }
+        ],
+    )
+
+    with pytest.raises(ValueError, match="requires Apple Silicon"):
+        await WorkerActor.launch_builtin_model.__wrapped__(
+            worker,
+            model_uid="wan-mlx-0",
+            model_name="Wan2.1-1.3B",
+            model_size_in_billions=None,
+            model_format="mlx",
+            quantization="none",
+            model_engine="MLX",
+            model_type="video",
+            n_gpu=None,
+            enable_virtual_env=True,
+            download_hub="huggingface",
+        )
+
+    assert worker.venv_created is False
 
 
 class MockWorkerActorRealTerminate(MockWorkerActor):
@@ -1374,6 +1445,55 @@ def test_prepare_virtual_env_normal_pip_mirror_keeps_direct_wheel(monkeypatch):
     assert packages == [direct_wheel]
 
 
+def test_prepare_virtual_env_direct_reference_disables_skip_installed(monkeypatch):
+    manager = DummyVirtualEnvManager()
+    direct_reference = "mlx-video @ git+https://github.com/Blaizzy/mlx-video.git@abcdef"
+    settings = VirtualEnvSettings(
+        packages=[direct_reference],
+        inherit_pip_config=False,
+    )
+    monkeypatch.setattr(
+        "xinference.core.worker.XINFERENCE_VIRTUAL_ENV_OFFLINE_INSTALL", False
+    )
+    monkeypatch.setattr(
+        "xinference.core.worker.XINFERENCE_VIRTUAL_ENV_SKIP_INSTALLED", True
+    )
+
+    WorkerActor._prepare_virtual_env(manager, settings, None, model_engine="mlx")
+
+    packages, kwargs = manager.calls[0]
+    assert packages == [direct_reference]
+    assert kwargs["skip_installed"] is False
+
+
+@pytest.mark.parametrize(
+    "direct_reference",
+    [
+        "package @ hg+https://example.invalid/repo",
+        "package @ svn+ssh://example.invalid/repo",
+        "package @ bzr+https://example.invalid/repo",
+        'package @ file:///tmp/package ; python_version >= "3.10"',
+    ],
+)
+def test_prepare_virtual_env_all_direct_references_disable_skip_installed(
+    monkeypatch, direct_reference
+):
+    manager = DummyVirtualEnvManager()
+    settings = VirtualEnvSettings(packages=[direct_reference], inherit_pip_config=False)
+    monkeypatch.setattr(
+        "xinference.core.worker.XINFERENCE_VIRTUAL_ENV_OFFLINE_INSTALL", False
+    )
+    monkeypatch.setattr(
+        "xinference.core.worker.XINFERENCE_VIRTUAL_ENV_SKIP_INSTALLED", True
+    )
+
+    WorkerActor._prepare_virtual_env(manager, settings, None, model_engine="mlx")
+
+    packages, kwargs = manager.calls[0]
+    assert packages == [direct_reference]
+    assert kwargs["skip_installed"] is False
+
+
 def test_prepare_virtual_env_offline_mirror_rewrites_direct_wheel(monkeypatch):
     manager = DummyVirtualEnvManager()
     direct_wheel = "https://example.invalid/" "pkg-1.0.0-py3-none-any.whl"
@@ -1407,6 +1527,55 @@ def test_prepare_virtual_env_offline_mirror_rejects_git_source(monkeypatch):
         WorkerActor._prepare_virtual_env(manager, settings, None, model_engine=None)
 
     assert manager.calls == []
+
+
+@pytest.mark.parametrize(
+    "direct_reference",
+    [
+        "package @ hg+https://example.invalid/repo",
+        "package @ svn+ssh://example.invalid/repo",
+        "package @ bzr+https://example.invalid/repo",
+    ],
+)
+def test_prepare_virtual_env_offline_mirror_rejects_remote_vcs(
+    monkeypatch, direct_reference
+):
+    manager = DummyVirtualEnvManager()
+    settings = VirtualEnvSettings(
+        packages=[direct_reference],
+        inherit_pip_config=False,
+        index_url="http://xinference-pypiserver:8080/simple",
+    )
+    monkeypatch.setattr(
+        "xinference.core.worker.XINFERENCE_VIRTUAL_ENV_OFFLINE_INSTALL", True
+    )
+
+    with pytest.raises(ValueError, match="non-wheel direct references"):
+        WorkerActor._prepare_virtual_env(manager, settings, None, model_engine="mlx")
+
+    assert manager.calls == []
+
+
+def test_prepare_virtual_env_offline_allows_local_file_reference(monkeypatch):
+    manager = DummyVirtualEnvManager()
+    direct_reference = "package @ file:///tmp/package"
+    settings = VirtualEnvSettings(
+        packages=[direct_reference],
+        inherit_pip_config=False,
+        index_url="http://xinference-pypiserver:8080/simple",
+    )
+    monkeypatch.setattr(
+        "xinference.core.worker.XINFERENCE_VIRTUAL_ENV_OFFLINE_INSTALL", True
+    )
+    monkeypatch.setattr(
+        "xinference.core.worker.XINFERENCE_VIRTUAL_ENV_SKIP_INSTALLED", True
+    )
+
+    WorkerActor._prepare_virtual_env(manager, settings, None, model_engine="mlx")
+
+    packages, kwargs = manager.calls[0]
+    assert packages == [direct_reference]
+    assert kwargs["skip_installed"] is False
 
 
 def test_prepare_virtual_env_offline_sglang_engine_dispatch(monkeypatch):
@@ -2957,6 +3126,141 @@ async def test_try_recover_models_migrates_legacy_replica_uid(monkeypatch):
     ]
     assert worker.launch_model_uid == replica_model_uid
     assert worker.wait_for_load_called_with == replica_model_uid
+
+
+@pytest.mark.asyncio
+async def test_remove_model_cache_removes_mlx_video_derived_artifacts(
+    tmp_path, monkeypatch
+):
+    cache_root = tmp_path / "cache"
+    cache_dir = cache_root / "v2" / "wan-mlx"
+    cache_dir.mkdir(parents=True)
+    converted_dir = Path(f"{cache_dir}.mlx-video")
+    converted_dir.mkdir()
+    (converted_dir / "model.safetensors").write_bytes(b"converted")
+    conversion_lock = Path(f"{converted_dir}.lock")
+    conversion_lock.write_text("")
+    tensorizer_root = tmp_path / "tensorizer"
+    monkeypatch.setattr(worker_module, "XINFERENCE_CACHE_DIR", str(cache_root))
+    monkeypatch.setattr(
+        worker_module, "XINFERENCE_TENSORIZER_DIR", str(tensorizer_root)
+    )
+    from ...model.llm.transformers import tensorizer_utils
+
+    monkeypatch.setattr(
+        tensorizer_utils, "XINFERENCE_TENSORIZER_DIR", str(tensorizer_root)
+    )
+
+    class _Tracker:
+        async def list_deletable_models(self, model_version, address):
+            return str(cache_dir)
+
+        async def confirm_and_remove_model(self, model_version, address):
+            pass
+
+    class _Worker:
+        def __init__(self):
+            self._cache_tracker_ref = _Tracker()
+            self.address = "127.0.0.1:0"
+
+        async def list_deletable_models(self, model_version):
+            return await WorkerActor.list_deletable_models(self, model_version)
+
+    worker = _Worker()
+    paths = await WorkerActor.list_deletable_models(worker, "wan-mlx")
+    assert str(converted_dir) in paths
+    assert str(conversion_lock) in paths
+
+    assert await WorkerActor.confirm_and_remove_model(worker, "wan-mlx")
+    assert not cache_dir.exists()
+    assert not converted_dir.exists()
+    assert conversion_lock.exists()
+
+
+@pytest.mark.asyncio
+async def test_remove_model_cache_waits_for_active_mlx_conversion(
+    tmp_path, monkeypatch
+):
+    from filelock import FileLock
+
+    cache_root = tmp_path / "cache"
+    cache_dir = cache_root / "v2" / "wan-mlx"
+    cache_dir.mkdir(parents=True)
+    converted_dir = Path(f"{cache_dir}.mlx-video")
+    conversion_lock_path = Path(f"{converted_dir}.lock")
+    tensorizer_root = tmp_path / "tensorizer"
+    monkeypatch.setattr(worker_module, "XINFERENCE_CACHE_DIR", str(cache_root))
+    monkeypatch.setattr(
+        worker_module, "XINFERENCE_TENSORIZER_DIR", str(tensorizer_root)
+    )
+    from ...model.llm.transformers import tensorizer_utils
+
+    monkeypatch.setattr(
+        tensorizer_utils, "XINFERENCE_TENSORIZER_DIR", str(tensorizer_root)
+    )
+
+    conversion_started = threading.Event()
+    finish_conversion = threading.Event()
+
+    def convert():
+        with FileLock(str(conversion_lock_path)):
+            conversion_started.set()
+            assert finish_conversion.wait(timeout=5)
+            converted_dir.mkdir()
+            (converted_dir / "model.safetensors").write_bytes(b"converted")
+
+    conversion_thread = threading.Thread(target=convert)
+    conversion_thread.start()
+    assert conversion_started.wait(timeout=5)
+
+    class _Tracker:
+        async def list_deletable_models(self, model_version, address):
+            return str(cache_dir)
+
+        async def confirm_and_remove_model(self, model_version, address):
+            pass
+
+    class _Worker:
+        def __init__(self):
+            self._cache_tracker_ref = _Tracker()
+            self.address = "127.0.0.1:0"
+
+        async def list_deletable_models(self, model_version):
+            return await WorkerActor.list_deletable_models(self, model_version)
+
+    remove_task = asyncio.create_task(
+        WorkerActor.confirm_and_remove_model(_Worker(), "wan-mlx")
+    )
+    await asyncio.sleep(0.05)
+    assert not remove_task.done()
+    finish_conversion.set()
+
+    assert await remove_task
+    conversion_thread.join(timeout=5)
+    assert not conversion_thread.is_alive()
+    assert not cache_dir.exists()
+    assert not converted_dir.exists()
+    assert conversion_lock_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_wan_mlx_deletion_always_reserves_conversion_lock(tmp_path, monkeypatch):
+    cache_root = tmp_path / "cache"
+    cache_dir = cache_root / "v2" / "Wan2.1-1.3B-mlx"
+    cache_dir.mkdir(parents=True)
+    monkeypatch.setattr(worker_module, "XINFERENCE_CACHE_DIR", str(cache_root))
+
+    class _Tracker:
+        async def list_deletable_models(self, model_version, address):
+            return str(cache_dir)
+
+    class _Worker:
+        _cache_tracker_ref = _Tracker()
+        address = "127.0.0.1:0"
+
+    paths = await WorkerActor.list_deletable_models(_Worker(), "Wan2.1-1.3B-mlx")
+
+    assert f"{cache_dir}.mlx-video.lock" in paths
 
 
 @pytest.mark.asyncio

--- a/xinference/core/utils.py
+++ b/xinference/core/utils.py
@@ -671,22 +671,68 @@ def find_direct_reference_packages(packages: List[str]) -> List[str]:
     """Return requirements that still bypass package indexes.
 
     Wheel URLs supported by :func:`rewrite_direct_url_packages_for_index`
-    disappear before this helper is called. Remaining HTTP(S), ``git+`` and
-    PEP 508 direct references cannot be satisfied reliably by an offline
-    simple index, so callers can fail before an installer attempts egress.
+    disappear before this helper is called. Remaining HTTP(S), VCS, ``file://``
+    and PEP 508 direct references bypass the selected package index, so callers
+    must preserve their provenance instead of reconstructing name/version pins.
     """
 
     direct_references: List[str] = []
     for pkg in packages:
-        candidate = pkg.partition(";")[0].strip()
-        if candidate.startswith(("http://", "https://", "git+")):
+        if _direct_reference_target(pkg) is not None:
             direct_references.append(pkg)
-            continue
-        if "@" in candidate:
-            target = candidate.partition("@")[2].strip()
-            if target.startswith(("http://", "https://", "git+")):
-                direct_references.append(pkg)
     return direct_references
+
+
+def find_remote_direct_reference_packages(packages: List[str]) -> List[str]:
+    """Return direct references that require a non-index external source."""
+
+    remote_references: List[str] = []
+    for pkg in packages:
+        target = _direct_reference_target(pkg)
+        if target is None:
+            continue
+        if _is_local_direct_reference(target):
+            continue
+        remote_references.append(pkg)
+    return remote_references
+
+
+def _is_local_direct_reference(target: str) -> bool:
+    lowered = target.lower()
+    if lowered.startswith(
+        ("file://", "git+file://", "hg+file://", "svn+file://", "bzr+file://")
+    ):
+        return True
+    # PEP 508 also accepts absolute and relative path references without a
+    # file:// scheme. Remote direct references always carry a URL/VCS scheme.
+    return "://" not in target and not lowered.startswith(
+        ("git+", "hg+", "svn+", "bzr+")
+    )
+
+
+def _direct_reference_target(package: str) -> Optional[str]:
+    """Extract the URL/VCS target from a PEP 508 or bare direct reference."""
+
+    candidate = package.partition(";")[0].strip()
+    try:
+        requirement = Requirement(candidate)
+    except Exception:
+        requirement = None
+    if requirement is not None and requirement.url:
+        return requirement.url
+
+    direct_prefixes = (
+        "http://",
+        "https://",
+        "file://",
+        "git+",
+        "hg+",
+        "svn+",
+        "bzr+",
+    )
+    if candidate.lower().startswith(direct_prefixes):
+        return candidate
+    return None
 
 
 def assign_replica_gpu(

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -2614,20 +2614,26 @@ class WorkerActor(xo.StatelessActor):
             from ..model.cache_manager import CacheManager
             from ..model.video import BUILTIN_VIDEO_MODELS
 
-            # Add built-in video models (BUILTIN_VIDEO_MODELS contains model_name -> families list)
+            # Add one catalog entry per model and retain each engine/hub source
+            # as a launchable specification.
             for model_name, families in BUILTIN_VIDEO_MODELS.items():
+                if not families:
+                    continue
                 download_hubs = []
                 for family in families:
                     if family.model_hub not in download_hubs:
                         download_hubs.append(family.model_hub)
-                for family in families:
-                    if detailed:
+                if detailed:
+                    model_specs = []
+                    for family in families:
                         video_cache_manager = CacheManager(family)
-                        model_specs = [
+                        model_specs.append(
                             {
-                                "model_format": "pytorch",
+                                "model_format": family.model_format or "diffusers",
+                                "model_engine": family.engine or "diffusers",
                                 "model_hub": family.model_hub,
                                 "model_id": family.model_id,
+                                "cache_name": family.cache_name,
                                 "cache_status": video_cache_manager.get_cache_status(),
                                 "gguf_model_id": family.gguf_model_id,
                                 "gguf_quantizations": family.gguf_quantizations,
@@ -2635,17 +2641,26 @@ class WorkerActor(xo.StatelessActor):
                                     family.gguf_model_file_name_template
                                 ),
                             }
-                        ]
-                        ret.append(
-                            {
-                                **family.dict(),
-                                "model_specs": model_specs,
-                                "is_builtin": True,
-                                "download_hubs": download_hubs,
-                            }
                         )
-                    else:
-                        ret.append({"model_name": model_name, "is_builtin": True})
+                    representative = next(
+                        (
+                            family
+                            for family in families
+                            if family.model_hub == "huggingface"
+                            and (family.engine or "diffusers").lower() == "diffusers"
+                        ),
+                        families[0],
+                    )
+                    ret.append(
+                        {
+                            **representative.dict(),
+                            "model_specs": model_specs,
+                            "is_builtin": True,
+                            "download_hubs": download_hubs,
+                        }
+                    )
+                else:
+                    ret.append({"model_name": model_name, "is_builtin": True})
 
             ret.sort(key=sort_helper)
             return ret
@@ -3508,6 +3523,14 @@ class WorkerActor(xo.StatelessActor):
             from ..model.image.core import resolve_image_model_engine
 
             model_engine = resolve_image_model_engine(model_name, model_engine)
+            launch_args["model_engine"] = model_engine
+        elif model_type.lower() == "video":
+            from ..model.video.core import resolve_video_model_name_and_engine
+
+            model_name, model_engine = resolve_video_model_name_and_engine(
+                model_name, model_engine, use_default_engine=True
+            )
+            launch_args["model_name"] = model_name
             launch_args["model_engine"] = model_engine
         envs = _inject_jina_v3_allocator_env(model_type, model_name, envs, launch_args)
 

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -103,6 +103,7 @@ from .utils import (
     build_subpool_envs_for_virtual_env,
     filter_virtualenv_packages_by_markers,
     find_direct_reference_packages,
+    find_remote_direct_reference_packages,
     log_async,
     log_sync,
     merge_virtual_env_packages,
@@ -2613,10 +2614,16 @@ class WorkerActor(xo.StatelessActor):
         elif model_type == "video":
             from ..model.cache_manager import CacheManager
             from ..model.video import BUILTIN_VIDEO_MODELS
+            from ..model.video.core import VIDEO_REGISTRY_LOCK
 
             # Add one catalog entry per model and retain each engine/hub source
             # as a launchable specification.
-            for model_name, families in BUILTIN_VIDEO_MODELS.items():
+            with VIDEO_REGISTRY_LOCK:
+                video_models = [
+                    (model_name, list(families))
+                    for model_name, families in BUILTIN_VIDEO_MODELS.items()
+                ]
+            for model_name, families in video_models:
                 if not families:
                     continue
                 download_hubs = []
@@ -2793,13 +2800,14 @@ class WorkerActor(xo.StatelessActor):
                     return f
         elif model_type == "video":
             from ..model.video import BUILTIN_VIDEO_MODELS
+            from ..model.video.core import VIDEO_REGISTRY_LOCK
 
             # Check built-in video models
-            if model_name in BUILTIN_VIDEO_MODELS:
-                families = BUILTIN_VIDEO_MODELS[model_name]
-                for f in families:
-                    if f.model_hub == "huggingface":
-                        return f
+            with VIDEO_REGISTRY_LOCK:
+                families = list(BUILTIN_VIDEO_MODELS.get(model_name, []))
+            for f in families:
+                if f.model_hub == "huggingface":
+                    return f
             return None
         elif model_type == "rerank":
             from ..model.rerank import BUILTIN_RERANK_MODELS
@@ -3300,7 +3308,7 @@ class WorkerActor(xo.StatelessActor):
             # index_url is present breaks online users whose mirror does not
             # carry the direct wheel.
             packages = rewrite_direct_url_packages_for_index(packages)
-            direct_references = find_direct_reference_packages(packages)
+            direct_references = find_remote_direct_reference_packages(packages)
             if direct_references:
                 raise ValueError(
                     "Offline virtualenv installation does not support "
@@ -3321,6 +3329,20 @@ class WorkerActor(xo.StatelessActor):
         conf.pop("inherit_pip_config", None)
         if XINFERENCE_VIRTUAL_ENV_SKIP_INSTALLED:
             conf["skip_installed"] = XINFERENCE_VIRTUAL_ENV_SKIP_INSTALLED
+        direct_references = find_direct_reference_packages(packages)
+        if direct_references and conf.get("skip_installed"):
+            # xoscar's skip-installed optimization reconstructs an install list
+            # from ``uv pip install --dry-run`` output.  Direct references are
+            # reported as ``name @ URL`` rather than ``name==version`` and are
+            # therefore omitted from that reconstructed list, leaving only
+            # their dependencies installed.  Let uv handle the original
+            # requirements directly so the top-level package is installed too.
+            logger.info(
+                "Disabling skip-installed optimization for direct-reference "
+                "packages: %s",
+                direct_references,
+            )
+            conf["skip_installed"] = False
         if force_reinstall_xllamacpp:
             # Bypass the satisfied-package filter so uv is actually invoked with
             # the GPU index even when a same-version CPU wheel is already
@@ -3635,6 +3657,29 @@ class WorkerActor(xo.StatelessActor):
                             f"Launch cancelled while waiting in queue: {model_uid}"
                         )
 
+                    # Video engine host/tuple/hub checks are side-effect-free.
+                    # Run them before even creating a same-interpreter venv so
+                    # incompatible Apple-Silicon/Python/source requests leave no
+                    # cache or virtualenv artifacts behind.
+                    if model_type.lower() == "video" and model_engine:
+                        from ..model.video.core import match_diffusion
+                        from ..model.video.engine_family import (
+                            check_engine_by_model_name_and_engine_with_virtual_env,
+                        )
+
+                        video_model_spec = match_diffusion(
+                            model_name,
+                            download_hub,
+                            model_engine=model_engine,
+                        )
+                        check_engine_by_model_name_and_engine_with_virtual_env(
+                            model_engine,
+                            model_name,
+                            model_format,
+                            quantization,
+                            model_family=video_model_spec,
+                        )
+
                     # virtualenv
                     virtual_env_name = kwargs.pop("virtual_env_name", None)
                     # Use v4 structure: .xinference/virtualenv/v4/model_name/model_engine/python_version
@@ -3713,6 +3758,14 @@ class WorkerActor(xo.StatelessActor):
                         )
                         model_kwargs = kwargs.copy()
                         model_kwargs["enable_virtual_env"] = enable_virtual_env
+                        if (
+                            model_type.lower() == "video"
+                            and model_engine
+                            and model_engine.lower() == "mlx"
+                        ):
+                            model_kwargs["_xinference_virtual_env_packages"] = (
+                                virtual_env_packages
+                            )
                         if n_worker > 1:  # type: ignore
                             # for model across workers,
                             # add a few kwargs
@@ -4876,6 +4929,31 @@ class WorkerActor(xo.StatelessActor):
                 for root, _dirs, files in os.walk(draft_path):
                     paths.update(os.path.join(root, name) for name in files)
 
+        # MLX video converts official Wan checkpoints beside the registered
+        # cache entry. Keep this name-based and confined to the validated
+        # Xinference cache parent so a model_uri target is never traversed or
+        # removed. Known Wan MLX entries always include the lock path, even if
+        # it does not exist yet, closing the discovery-to-acquisition window.
+        converted_path = f"{path}.mlx-video"
+        conversion_lock_path = f"{converted_path}.lock"
+        is_wan_mlx_cache = model_version.lower().startswith(
+            "wan"
+        ) and model_version.lower().endswith("-mlx")
+        if (
+            WorkerActor._is_path_within(converted_path, cache_root)
+            and WorkerActor._is_path_within(conversion_lock_path, cache_root)
+            and (
+                is_wan_mlx_cache
+                or os.path.lexists(converted_path)
+                or os.path.lexists(conversion_lock_path)
+            )
+        ):
+            if os.path.lexists(converted_path):
+                paths.add(converted_path)
+            # Include the producer lock even if a concurrent conversion only
+            # created its output after the existence check above.
+            paths.add(conversion_lock_path)
+
         return list(paths)
 
     async def confirm_and_remove_model(self, model_version: str) -> bool:
@@ -4884,6 +4962,31 @@ class WorkerActor(xo.StatelessActor):
             logger.warning("cache_tracker_ref is None, cannot confirm and remove model")
             return False
         paths = await self.list_deletable_models(model_version)
+
+        # Coordinate with Wan conversion using the producer's exact FileLock.
+        # Lock paths are added even when absent so a conversion cannot start in
+        # the gap between discovery and deletion. The zero-byte lock inode is
+        # intentionally retained after release: unlinking it permits old and new
+        # acquirers to lock different inodes and defeats cross-process exclusion.
+        from filelock import FileLock
+
+        conversion_lock_paths = sorted(
+            path for path in paths if path.endswith(".mlx-video.lock")
+        )
+        conversion_locks = [FileLock(path) for path in conversion_lock_paths]
+        acquired_conversion_locks = []
+        try:
+            for conversion_lock in conversion_locks:
+                await asyncio.to_thread(conversion_lock.acquire)
+                acquired_conversion_locks.append(conversion_lock)
+        except BaseException:
+            for conversion_lock in reversed(acquired_conversion_locks):
+                await asyncio.to_thread(conversion_lock.release)
+            raise
+        for lock_path in conversion_lock_paths:
+            converted_path = lock_path[: -len(".lock")]
+            if os.path.lexists(converted_path):
+                paths.append(converted_path)
 
         # Remember managed download parents before deleting their files. They are
         # pruned with ``rmdir`` afterwards, so non-empty/shared directories stop
@@ -4904,33 +5007,42 @@ class WorkerActor(xo.StatelessActor):
             is_directory = not os.path.islink(path) and os.path.isdir(path)
             return is_directory, -path.count(os.sep)
 
-        for path in sorted(paths, key=_deletion_order):
-            try:
-                if os.path.islink(path):
-                    os.unlink(path)
-                elif os.path.isfile(path):
-                    os.remove(path)
-                elif os.path.isdir(path):
-                    path_abs = os.path.abspath(path)
-                    managed_roots = (
-                        os.path.abspath(XINFERENCE_CACHE_DIR),
-                        os.path.abspath(XINFERENCE_TENSORIZER_DIR),
-                    )
-                    if any(path_abs == root for root in managed_roots) or not any(
-                        WorkerActor._is_path_within(path_abs, root)
-                        for root in managed_roots
-                    ):
-                        logger.error(f"Refusing to delete unmanaged directory: {path}")
-                        return False
-                    shutil.rmtree(path)
-                else:
-                    logger.debug(f"{path} is not a valid path.")
-            except FileNotFoundError:
-                # A parent directory or a concurrent cleanup already removed it.
-                continue
-            except Exception as e:
-                logger.error(f"Fail to delete {path} with error:{e}.")  # noqa: E231
-                return False
+        try:
+            for path in sorted(
+                (path for path in paths if path not in conversion_lock_paths),
+                key=_deletion_order,
+            ):
+                try:
+                    if os.path.islink(path):
+                        os.unlink(path)
+                    elif os.path.isfile(path):
+                        os.remove(path)
+                    elif os.path.isdir(path):
+                        path_abs = os.path.abspath(path)
+                        managed_roots = (
+                            os.path.abspath(XINFERENCE_CACHE_DIR),
+                            os.path.abspath(XINFERENCE_TENSORIZER_DIR),
+                        )
+                        if any(path_abs == root for root in managed_roots) or not any(
+                            WorkerActor._is_path_within(path_abs, root)
+                            for root in managed_roots
+                        ):
+                            logger.error(
+                                f"Refusing to delete unmanaged directory: {path}"
+                            )
+                            return False
+                        shutil.rmtree(path)
+                    else:
+                        logger.debug(f"{path} is not a valid path.")
+                except FileNotFoundError:
+                    # A parent directory or a concurrent cleanup already removed it.
+                    continue
+                except Exception as e:
+                    logger.error(f"Fail to delete {path} with error:{e}.")  # noqa: E231
+                    return False
+        finally:
+            for conversion_lock in reversed(conversion_locks):
+                await asyncio.to_thread(conversion_lock.release)
 
         if not WorkerActor._prune_empty_download_dirs(download_parent_dirs):
             return False

--- a/xinference/deploy/cmdline.py
+++ b/xinference/deploy/cmdline.py
@@ -744,7 +744,7 @@ def remove_cache(
     "-en",
     type=str,
     default=None,
-    help="Specify the inference engine of the model when launching LLM.",
+    help="Specify the inference engine to use when launching the model.",
 )
 @click.option(
     "--model-uid",

--- a/xinference/model/core.py
+++ b/xinference/model/core.py
@@ -120,6 +120,9 @@ def create_model_instance(
             model_name,
             resolved_download_hub,
             model_path,
+            model_engine=model_engine,
+            model_format=model_format,
+            quantization=quantization,
             **kwargs,
         )
     elif model_type == "flexible":

--- a/xinference/model/utils.py
+++ b/xinference/model/utils.py
@@ -1809,6 +1809,31 @@ def _get_engine_params_by_name(
 
             for engine_class in supported_engines[engine_name]:
                 try:
+                    check_host = getattr(engine_class, "check_host", None)
+                    if callable(check_host):
+                        (
+                            host_ok,
+                            host_reason,
+                            host_error_type,
+                            host_details,
+                        ) = _normalize_match_result(
+                            check_host(),
+                            f"Engine {engine_name} is incompatible with the current host",
+                            "host_incompatible",
+                        )
+                        if not host_ok:
+                            _append_unavailable_engine(
+                                engine_name,
+                                host_reason,
+                                host_error_type,
+                                host_details,
+                            )
+                            # The engine was evaluated and rejected by a hard,
+                            # non-installable constraint. Do not let a
+                            # virtualenv marker turn it back into an option.
+                            matched = True
+                            break
+
                     match_func = getattr(engine_class, "match", None)
                     for family in families:
                         match_res = (
@@ -2028,15 +2053,16 @@ def _get_engine_params_by_name(
 
     if model_type == "video":
         from .video import BUILTIN_VIDEO_MODELS
+        from .video.core import VIDEO_REGISTRY_LOCK
         from .video.engine_family import VIDEO_ENGINES, get_supported_engines_for_model
 
-        if model_name not in VIDEO_ENGINES:
-            return None
-
-        available_engines = deepcopy(VIDEO_ENGINES[model_name])
+        with VIDEO_REGISTRY_LOCK:
+            if model_name not in VIDEO_ENGINES:
+                return None
+            available_engines = deepcopy(VIDEO_ENGINES[model_name])
+            video_families: List[Any] = list(BUILTIN_VIDEO_MODELS.get(model_name, []))
         for engine, params in available_engines.items():
             _append_available_engine(engine, params, "video_class")
-        video_families: List[Any] = list(BUILTIN_VIDEO_MODELS.get(model_name, []))
         supported_video_engines = get_supported_engines_for_model(video_families)
         _validate_available_image_engines(
             video_families,
@@ -2299,6 +2325,30 @@ def _get_engine_params_by_name_with_virtual_env(
 
             for engine_class in supported_engines[engine_name]:
                 try:
+                    check_host = getattr(engine_class, "check_host", None)
+                    if callable(check_host):
+                        (
+                            host_ok,
+                            host_reason,
+                            host_error_type,
+                            host_details,
+                        ) = _normalize_match_result(
+                            check_host(),
+                            f"Engine {engine_name} is incompatible with the current host",
+                            "host_incompatible",
+                        )
+                        if not host_ok:
+                            _append_unavailable_engine(
+                                engine_name,
+                                host_reason,
+                                host_error_type,
+                                host_details,
+                            )
+                            # Hard host constraints cannot be repaired by
+                            # installing dependencies in a virtualenv.
+                            matched = True
+                            break
+
                     match_func = getattr(engine_class, "match", None)
                     for family in families:
                         match_res = (
@@ -2596,15 +2646,16 @@ def _get_engine_params_by_name_with_virtual_env(
 
     elif model_type == "video":
         from .video import BUILTIN_VIDEO_MODELS
+        from .video.core import VIDEO_REGISTRY_LOCK
         from .video.engine_family import VIDEO_ENGINES, get_supported_engines_for_model
 
-        if model_name not in VIDEO_ENGINES:
-            return None
-
-        available_engines = deepcopy(VIDEO_ENGINES[model_name])
+        with VIDEO_REGISTRY_LOCK:
+            if model_name not in VIDEO_ENGINES:
+                return None
+            available_engines = deepcopy(VIDEO_ENGINES[model_name])
+            video_families: List[Any] = list(BUILTIN_VIDEO_MODELS.get(model_name, []))
         for engine, params in available_engines.items():
             _append_available_engine(engine, params, "video_class")
-        video_families: List[Any] = list(BUILTIN_VIDEO_MODELS.get(model_name, []))
         supported_video_engines = get_supported_engines_for_model(video_families)
         video_engine_markers: Set[str] = set()
         for family in video_families:

--- a/xinference/model/utils.py
+++ b/xinference/model/utils.py
@@ -2026,6 +2026,28 @@ def _get_engine_params_by_name(
         )
         return engine_params
 
+    if model_type == "video":
+        from .video import BUILTIN_VIDEO_MODELS
+        from .video.engine_family import VIDEO_ENGINES, get_supported_engines_for_model
+
+        if model_name not in VIDEO_ENGINES:
+            return None
+
+        available_engines = deepcopy(VIDEO_ENGINES[model_name])
+        for engine, params in available_engines.items():
+            _append_available_engine(engine, params, "video_class")
+        video_families: List[Any] = list(BUILTIN_VIDEO_MODELS.get(model_name, []))
+        supported_video_engines = get_supported_engines_for_model(video_families)
+        _validate_available_image_engines(
+            video_families,
+            supported_video_engines,
+            "video",
+        )
+        _collect_supported_image_engines(
+            video_families, supported_video_engines, "video"
+        )
+        return engine_params
+
     return None
 
 
@@ -2572,9 +2594,43 @@ def _get_engine_params_by_name_with_virtual_env(
 
         return engine_params
 
+    elif model_type == "video":
+        from .video import BUILTIN_VIDEO_MODELS
+        from .video.engine_family import VIDEO_ENGINES, get_supported_engines_for_model
+
+        if model_name not in VIDEO_ENGINES:
+            return None
+
+        available_engines = deepcopy(VIDEO_ENGINES[model_name])
+        for engine, params in available_engines.items():
+            _append_available_engine(engine, params, "video_class")
+        video_families: List[Any] = list(BUILTIN_VIDEO_MODELS.get(model_name, []))
+        supported_video_engines = get_supported_engines_for_model(video_families)
+        video_engine_markers: Set[str] = set()
+        for family in video_families:
+            video_engine_markers |= _collect_virtualenv_engine_markers(family)
+        _validate_available_image_engines(
+            video_families,
+            supported_video_engines,
+            "video",
+            video_engine_markers,
+            enable_virtual_env,
+        )
+        _collect_supported_image_engines(
+            video_families, supported_video_engines, "video"
+        )
+        _apply_virtualenv_engine_overrides(
+            engine_params,
+            supported_video_engines,
+            video_engine_markers,
+            enable_virtual_env,
+        )
+
+        return engine_params
+
     raise ValueError(
         "Cannot support model_engine for "
-        f"{model_type}, only available for LLM, embedding, rerank, image, audio"
+        f"{model_type}, only available for LLM, embedding, rerank, image, audio, video"
     )
 
 

--- a/xinference/model/video/__init__.py
+++ b/xinference/model/video/__init__.py
@@ -26,6 +26,8 @@ from .core import (
     generate_video_description,
     get_video_model_descriptions,
 )
+from .engine import register_builtin_video_engines
+from .engine_family import VIDEO_ENGINES, generate_engine_config_by_model_name
 
 
 def register_custom_model():
@@ -62,6 +64,12 @@ def _install():
     # Install models with intelligent merging based on timestamps
     from ..utils import install_models_with_merge
 
+    # Startup and tests may call the installer more than once in one process.
+    # Rebuild the derived registries to avoid duplicate model and engine specs.
+    BUILTIN_VIDEO_MODELS.clear()
+    VIDEO_MODEL_DESCRIPTIONS.clear()
+    VIDEO_ENGINES.clear()
+
     install_models_with_merge(
         BUILTIN_VIDEO_MODELS,
         "model_spec.json",
@@ -71,10 +79,23 @@ def _install():
         load_model_family_from_json,
     )
 
-    # register model description
+    # Register one cache/version entry per engine variant. Hugging Face is the
+    # preferred representative when the same variant has multiple hubs.
     for model_name, model_specs in BUILTIN_VIDEO_MODELS.items():
-        model_spec = [x for x in model_specs if x.model_hub == "huggingface"][0]
-        VIDEO_MODEL_DESCRIPTIONS.update(generate_video_description(model_spec))
+        variants = {}
+        for model_spec in model_specs:
+            version = model_spec.cache_name or model_spec.model_name
+            current = variants.get(version)
+            if current is None or model_spec.model_hub == "huggingface":
+                variants[version] = model_spec
+        VIDEO_MODEL_DESCRIPTIONS[model_name] = [
+            model_spec.to_version_info() for model_spec in variants.values()
+        ]
+
+    register_builtin_video_engines()
+    for model_specs in BUILTIN_VIDEO_MODELS.values():
+        for model_spec in model_specs:
+            generate_engine_config_by_model_name(model_spec)
 
     register_custom_model()
 

--- a/xinference/model/video/__init__.py
+++ b/xinference/model/video/__init__.py
@@ -22,6 +22,7 @@ from ..utils import flatten_model_src
 from .core import (
     BUILTIN_VIDEO_MODELS,
     VIDEO_MODEL_DESCRIPTIONS,
+    VIDEO_REGISTRY_LOCK,
     VideoModelFamilyV2,
     generate_video_description,
     get_video_model_descriptions,
@@ -64,40 +65,58 @@ def _install():
     # Install models with intelligent merging based on timestamps
     from ..utils import install_models_with_merge
 
-    # Startup and tests may call the installer more than once in one process.
-    # Rebuild the derived registries to avoid duplicate model and engine specs.
-    BUILTIN_VIDEO_MODELS.clear()
-    VIDEO_MODEL_DESCRIPTIONS.clear()
-    VIDEO_ENGINES.clear()
+    # Build a complete replacement away from the live registries. A reload can
+    # overlap model discovery/launch, and readers must never observe an empty or
+    # partially rebuilt set (nor lose the previous set if rebuilding fails).
+    new_builtin_video_models = {}
+    new_video_model_descriptions = {}
+    new_video_engines = {}
 
     install_models_with_merge(
-        BUILTIN_VIDEO_MODELS,
+        new_builtin_video_models,
         "model_spec.json",
         "video",
         "video_models.json",
         has_downloaded_models,
         load_model_family_from_json,
+        model_identity_func=lambda model: (
+            (model.engine or "diffusers").lower(),
+            model.model_hub,
+            model.cache_name or model.model_name,
+        ),
     )
 
     # Register one cache/version entry per engine variant. Hugging Face is the
     # preferred representative when the same variant has multiple hubs.
-    for model_name, model_specs in BUILTIN_VIDEO_MODELS.items():
+    for model_name, model_specs in new_builtin_video_models.items():
         variants = {}
         for model_spec in model_specs:
             version = model_spec.cache_name or model_spec.model_name
             current = variants.get(version)
             if current is None or model_spec.model_hub == "huggingface":
                 variants[version] = model_spec
-        VIDEO_MODEL_DESCRIPTIONS[model_name] = [
+        new_video_model_descriptions[model_name] = [
             model_spec.to_version_info() for model_spec in variants.values()
         ]
 
     register_builtin_video_engines()
-    for model_specs in BUILTIN_VIDEO_MODELS.values():
+    for model_specs in new_builtin_video_models.values():
         for model_spec in model_specs:
-            generate_engine_config_by_model_name(model_spec)
+            generate_engine_config_by_model_name(
+                model_spec, target_engines=new_video_engines
+            )
 
     register_custom_model()
+
+    # Keep the exported dictionaries stable for compatibility with existing
+    # imports, but serialize the in-place publication with all registry readers.
+    with VIDEO_REGISTRY_LOCK:
+        BUILTIN_VIDEO_MODELS.clear()
+        BUILTIN_VIDEO_MODELS.update(new_builtin_video_models)
+        VIDEO_MODEL_DESCRIPTIONS.clear()
+        VIDEO_MODEL_DESCRIPTIONS.update(new_video_model_descriptions)
+        VIDEO_ENGINES.clear()
+        VIDEO_ENGINES.update(new_video_engines)
 
 
 def has_downloaded_models():

--- a/xinference/model/video/core.py
+++ b/xinference/model/video/core.py
@@ -17,7 +17,7 @@ from typing import Any, Dict, List, Literal, Optional
 
 from ..core import CacheableModelSpec, VirtualEnvSettings
 from ..utils import ModelInstanceInfoMixin
-from .diffusers import DiffusersVideoModel
+from .engine_family import VideoEngineModel
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +41,9 @@ class VideoModelFamilyV2(CacheableModelSpec, ModelInstanceInfoMixin):
     model_ability: Optional[List[str]]
     default_model_config: Optional[Dict[str, Any]]
     default_generate_config: Optional[Dict[str, Any]]
+    engine: Optional[str]
+    model_format: Optional[str]
+    cache_name: Optional[str]
     gguf_model_id: Optional[str]
     gguf_quantizations: Optional[List[str]]
     gguf_model_file_name_template: Optional[str]
@@ -63,6 +66,7 @@ class VideoModelFamilyV2(CacheableModelSpec, ModelInstanceInfoMixin):
             "model_family": self.model_family,
             "model_revision": self.model_revision,
             "model_ability": self.model_ability,
+            "model_engine": getattr(self, "model_engine", None),
         }
 
     def to_version_info(self):
@@ -71,10 +75,33 @@ class VideoModelFamilyV2(CacheableModelSpec, ModelInstanceInfoMixin):
         cache_manager = CacheManager(self)
 
         return {
-            "model_version": self.model_name,
+            "model_version": self.cache_name or self.model_name,
             "model_file_location": cache_manager.get_cache_dir(),
             "cache_status": cache_manager.get_cache_status(),
         }
+
+
+def resolve_video_model_name_and_engine(
+    model_name: str,
+    model_engine: Optional[str] = None,
+    use_default_engine: bool = False,
+) -> tuple[str, Optional[str]]:
+    if use_default_engine or model_engine is not None:
+        from .engine_family import VIDEO_ENGINES
+
+        available_engines = VIDEO_ENGINES.get(model_name)
+        if available_engines and model_engine is None:
+            model_engine = next(iter(available_engines))
+        elif available_engines and model_engine is not None:
+            model_engine = next(
+                (
+                    engine
+                    for engine in available_engines
+                    if engine.lower() == model_engine.lower()
+                ),
+                model_engine,
+            )
+    return model_name, model_engine
 
 
 def generate_video_description(
@@ -90,12 +117,21 @@ def match_diffusion(
     download_hub: Optional[
         Literal["huggingface", "modelscope", "openmind_hub", "csghub"]
     ] = None,
+    model_engine: Optional[str] = None,
 ) -> VideoModelFamilyV2:
     from ..utils import download_from_modelscope
     from . import BUILTIN_VIDEO_MODELS
 
     if model_name in BUILTIN_VIDEO_MODELS:
         model_families = BUILTIN_VIDEO_MODELS[model_name]
+        if model_engine is not None:
+            engine_families = [
+                family
+                for family in model_families
+                if (family.engine or "").lower() == model_engine.lower()
+            ]
+            if engine_families:
+                model_families = engine_families
         if download_hub == "modelscope" or (
             download_hub is None and download_from_modelscope()
         ):
@@ -121,13 +157,50 @@ def create_video_model_instance(
     model_path: Optional[str] = None,
     gguf_quantization: Optional[str] = None,
     gguf_model_path: Optional[str] = None,
+    model_engine: Optional[str] = None,
+    model_format: Optional[str] = None,
+    quantization: Optional[str] = None,
     lightning_version: Optional[str] = None,
     lightning_model_path: Optional[str] = None,
     **kwargs,
-) -> DiffusersVideoModel:
+) -> VideoEngineModel:
     from .cache_manager import VideoCacheManager
+    from .engine_family import (
+        VIDEO_ENGINES,
+        check_engine_by_model_name_and_engine,
+        check_engine_by_model_name_and_engine_with_virtual_env,
+    )
 
-    model_spec = match_diffusion(model_name, download_hub)
+    enable_virtual_env = kwargs.pop("enable_virtual_env", None)
+    model_name, model_engine = resolve_video_model_name_and_engine(
+        model_name, model_engine, use_default_engine=True
+    )
+    model_spec = match_diffusion(model_name, download_hub, model_engine=model_engine)
+
+    if model_engine is None:
+        available_engines = VIDEO_ENGINES.get(model_name, {})
+        model_engine = next(iter(available_engines), "diffusers")
+
+    if enable_virtual_env is None:
+        from ...constants import XINFERENCE_ENABLE_VIRTUAL_ENV
+
+        enable_virtual_env = XINFERENCE_ENABLE_VIRTUAL_ENV
+
+    if enable_virtual_env:
+        model_cls = check_engine_by_model_name_and_engine_with_virtual_env(
+            model_engine,
+            model_spec.model_name,
+            model_format,
+            quantization,
+            model_family=model_spec,
+        )
+    else:
+        model_cls = check_engine_by_model_name_and_engine(
+            model_engine,
+            model_spec.model_name,
+            model_format,
+            quantization,
+        )
 
     if not model_path:
         cache_manager = VideoCacheManager(model_spec)
@@ -144,7 +217,9 @@ def create_video_model_instance(
         lightning_model_path = cache_manager.cache_lightning(lightning_version)
     assert model_path is not None
 
-    model = DiffusersVideoModel(
+    model_spec = model_spec.copy()
+    model_spec.model_engine = model_engine
+    model = model_cls(
         model_uid,
         model_path,
         model_spec,

--- a/xinference/model/video/core.py
+++ b/xinference/model/video/core.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
+import threading
 from collections import defaultdict
 from typing import Any, Dict, List, Literal, Optional
 
@@ -23,12 +24,14 @@ logger = logging.getLogger(__name__)
 
 VIDEO_MODEL_DESCRIPTIONS: Dict[str, List[Dict]] = defaultdict(list)
 BUILTIN_VIDEO_MODELS: Dict[str, List["VideoModelFamilyV2"]] = {}
+VIDEO_REGISTRY_LOCK = threading.RLock()
 
 
 def get_video_model_descriptions():
     import copy
 
-    return copy.deepcopy(VIDEO_MODEL_DESCRIPTIONS)
+    with VIDEO_REGISTRY_LOCK:
+        return copy.deepcopy(VIDEO_MODEL_DESCRIPTIONS)
 
 
 class VideoModelFamilyV2(CacheableModelSpec, ModelInstanceInfoMixin):
@@ -42,6 +45,7 @@ class VideoModelFamilyV2(CacheableModelSpec, ModelInstanceInfoMixin):
     default_model_config: Optional[Dict[str, Any]]
     default_generate_config: Optional[Dict[str, Any]]
     engine: Optional[str]
+    model_engine: Optional[str] = None
     model_format: Optional[str]
     cache_name: Optional[str]
     gguf_model_id: Optional[str]
@@ -52,6 +56,8 @@ class VideoModelFamilyV2(CacheableModelSpec, ModelInstanceInfoMixin):
     lightning_versions: Optional[List[str]]
     lightning_model_file_name_template: Optional[str]
     lightning_version_configs: Optional[Dict[str, Dict[str, Any]]]
+    text_encoder_model_id: Optional[str] = None
+    text_encoder_model_revision: Optional[str] = None
     virtualenv: Optional[VirtualEnvSettings]
 
     class Config:
@@ -89,7 +95,9 @@ def resolve_video_model_name_and_engine(
     if use_default_engine or model_engine is not None:
         from .engine_family import VIDEO_ENGINES
 
-        available_engines = VIDEO_ENGINES.get(model_name)
+        with VIDEO_REGISTRY_LOCK:
+            available_engines = VIDEO_ENGINES.get(model_name)
+            available_engines = dict(available_engines) if available_engines else None
         if available_engines and model_engine is None:
             model_engine = next(iter(available_engines))
         elif available_engines and model_engine is not None:
@@ -115,44 +123,57 @@ def generate_video_description(
 def match_diffusion(
     model_name: str,
     download_hub: Optional[
-        Literal["huggingface", "modelscope", "openmind_hub", "csghub"]
+        Literal["auto", "huggingface", "modelscope", "openmind_hub", "csghub"]
     ] = None,
     model_engine: Optional[str] = None,
 ) -> VideoModelFamilyV2:
     from ..utils import download_from_modelscope
     from . import BUILTIN_VIDEO_MODELS
 
-    if model_name in BUILTIN_VIDEO_MODELS:
-        model_families = BUILTIN_VIDEO_MODELS[model_name]
-        if model_engine is not None:
-            engine_families = [
-                family
-                for family in model_families
-                if (family.engine or "").lower() == model_engine.lower()
-            ]
-            if engine_families:
-                model_families = engine_families
-        if download_hub == "modelscope" or (
-            download_hub is None and download_from_modelscope()
-        ):
-            return (
-                [x for x in model_families if x.model_hub == "modelscope"]
-                + [x for x in model_families if x.model_hub == "huggingface"]
-            )[0]
-        else:
-            return [x for x in model_families if x.model_hub == "huggingface"][0]
-    else:
+    with VIDEO_REGISTRY_LOCK:
+        model_families = list(BUILTIN_VIDEO_MODELS.get(model_name, []))
+        available_model_names = list(BUILTIN_VIDEO_MODELS)
+
+    if not model_families:
         raise ValueError(
             f"Video model {model_name} not found, available"
-            f"model list: {BUILTIN_VIDEO_MODELS.keys()}"
+            f"model list: {available_model_names}"
         )
+
+    if model_engine is not None:
+        model_families = [
+            family
+            for family in model_families
+            if (family.engine or "").lower() == model_engine.lower()
+        ]
+        if not model_families:
+            raise ValueError(
+                f"Video model {model_name} cannot be run on engine {model_engine}."
+            )
+
+    preferred_hub = (
+        "modelscope"
+        if download_hub == "modelscope"
+        or (download_hub in (None, "auto") and download_from_modelscope())
+        else "huggingface"
+    )
+    hub_families = [
+        family for family in model_families if family.model_hub == preferred_hub
+    ]
+    if not hub_families:
+        engine_suffix = f" on engine {model_engine}" if model_engine else ""
+        raise ValueError(
+            f"Video model {model_name}{engine_suffix} does not provide a "
+            f"{preferred_hub} source. Choose a supported download hub explicitly."
+        )
+    return hub_families[0]
 
 
 def create_video_model_instance(
     model_uid: str,
     model_name: str,
     download_hub: Optional[
-        Literal["huggingface", "modelscope", "openmind_hub", "csghub"]
+        Literal["auto", "huggingface", "modelscope", "openmind_hub", "csghub"]
     ] = None,
     model_path: Optional[str] = None,
     gguf_quantization: Optional[str] = None,
@@ -219,6 +240,8 @@ def create_video_model_instance(
 
     model_spec = model_spec.copy()
     model_spec.model_engine = model_engine
+    if model_engine.lower() == "mlx":
+        kwargs["_xinference_enable_virtual_env"] = enable_virtual_env
     model = model_cls(
         model_uid,
         model_path,

--- a/xinference/model/video/engine.py
+++ b/xinference/model/video/engine.py
@@ -1,0 +1,40 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import TYPE_CHECKING
+
+from .diffusers import DiffusersVideoModel
+from .engine_family import SUPPORTED_ENGINES, VideoEngineModel
+
+if TYPE_CHECKING:
+    from .core import VideoModelFamilyV2
+
+
+class DiffusersVideoEngineModel(DiffusersVideoModel, VideoEngineModel):
+    engine_model_format = "diffusers"
+    engine_quantization = "none"
+    required_libs = ("diffusers",)
+
+    @classmethod
+    def match(cls, model_family: "VideoModelFamilyV2") -> bool:
+        engine = getattr(model_family, "engine", None)
+        return not engine or engine.lower() == "diffusers"
+
+    @classmethod
+    def is_model_family_supported(cls, model_family: "VideoModelFamilyV2") -> bool:
+        return cls.match(model_family)
+
+
+def register_builtin_video_engines() -> None:
+    SUPPORTED_ENGINES["diffusers"] = [DiffusersVideoEngineModel]

--- a/xinference/model/video/engine.py
+++ b/xinference/model/video/engine.py
@@ -12,10 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING
+import importlib.util
+import platform
+import sys
+from typing import TYPE_CHECKING, Tuple, Union
 
 from .diffusers import DiffusersVideoModel
 from .engine_family import SUPPORTED_ENGINES, VideoEngineModel
+from .mlx_video import MLXVideoModel
 
 if TYPE_CHECKING:
     from .core import VideoModelFamilyV2
@@ -36,5 +40,71 @@ class DiffusersVideoEngineModel(DiffusersVideoModel, VideoEngineModel):
         return cls.match(model_family)
 
 
+MLX_VIDEO_MODEL_NAMES = {
+    "LTX-2-distilled",
+    "LTX-2-dev",
+    "LTX-2.3-distilled",
+    "LTX-2.3-dev",
+    "Wan2.1-1.3B",
+    "Wan2.1-14B",
+    "Wan2.2-A14B",
+    "Wan2.2-i2v-A14B",
+    "Wan2.2-ti2v-5B",
+}
+
+
+class MLXVideoEngineModel(MLXVideoModel, VideoEngineModel):
+    engine_model_format = "mlx"
+    engine_quantization = "none"
+    required_libs = ("mlx", "mlx_video")
+
+    @classmethod
+    def check_host(cls) -> Union[bool, Tuple[bool, str]]:
+        if not cls._is_apple_silicon():
+            return False, "The MLX video engine requires Apple Silicon"
+        if sys.version_info < (3, 11):
+            return False, "Blaizzy/mlx-video requires Python 3.11 or newer"
+        return True
+
+    @classmethod
+    def check_lib(cls) -> Union[bool, Tuple[bool, str]]:
+        host_result = cls.check_host()
+        if host_result is not True:
+            return host_result
+        if importlib.util.find_spec("mlx") is None:
+            return False, "Library 'mlx' is not installed"
+        try:
+            wan_module = importlib.util.find_spec("mlx_video.models.wan_2.generate")
+            ltx_module = importlib.util.find_spec("mlx_video.models.ltx_2.generate")
+        except (ImportError, ModuleNotFoundError):
+            wan_module = ltx_module = None
+        if wan_module is None or ltx_module is None:
+            return (
+                False,
+                "Blaizzy/mlx-video is not installed; the unrelated PyPI package "
+                "with the same name is not compatible",
+            )
+        return True
+
+    @staticmethod
+    def _is_apple_silicon() -> bool:
+        return platform.system() == "Darwin" and platform.machine() == "arm64"
+
+    @classmethod
+    def match(cls, model_family: "VideoModelFamilyV2") -> bool:
+        return (
+            cls._is_apple_silicon()
+            and model_family.model_name in MLX_VIDEO_MODEL_NAMES
+            and (getattr(model_family, "engine", "") or "").lower() == "mlx"
+        )
+
+    @classmethod
+    def is_model_family_supported(cls, model_family: "VideoModelFamilyV2") -> bool:
+        return model_family.model_name in MLX_VIDEO_MODEL_NAMES
+
+
 def register_builtin_video_engines() -> None:
+    # The first registered engine remains the default for models with several
+    # runtimes, preserving the existing diffusers behavior for Wan models.
     SUPPORTED_ENGINES["diffusers"] = [DiffusersVideoEngineModel]
+    SUPPORTED_ENGINES["MLX"] = [MLXVideoEngineModel]

--- a/xinference/model/video/engine_family.py
+++ b/xinference/model/video/engine_family.py
@@ -39,6 +39,12 @@ class VideoEngineModel:
         return cls.match(model_family)
 
     @classmethod
+    def check_host(cls) -> Union[bool, Tuple[bool, str]]:
+        """Check non-installable host constraints before virtualenv fallback."""
+
+        return True
+
+    @classmethod
     def check_lib(cls) -> Union[bool, Tuple[bool, str]]:
         for lib in cls.required_libs:
             if importlib.util.find_spec(lib) is None:
@@ -49,6 +55,14 @@ class VideoEngineModel:
 # { video model name -> { engine name -> engine params } }
 VIDEO_ENGINES: Dict[str, Dict[str, List[Dict[str, Any]]]] = {}
 SUPPORTED_ENGINES: Dict[str, List[Type[VideoEngineModel]]] = {}
+
+
+class VideoEngineNotAvailableError(ValueError):
+    """The engine registry has no entry that a virtualenv may provide."""
+
+
+class VideoEngineConfigurationError(ValueError):
+    """The requested engine tuple or host is intrinsically incompatible."""
 
 
 def get_supported_engines_for_model(
@@ -70,7 +84,11 @@ def get_supported_engines_for_model(
 
 
 def _normalize_engine_name(model_name: str, model_engine: str) -> str:
-    for engine in VIDEO_ENGINES.get(model_name, {}):
+    from .core import VIDEO_REGISTRY_LOCK
+
+    with VIDEO_REGISTRY_LOCK:
+        engines = list(VIDEO_ENGINES.get(model_name, {}))
+    for engine in engines:
         if engine.lower() == model_engine.lower():
             return engine
     return model_engine
@@ -82,22 +100,35 @@ def check_engine_by_model_name_and_engine(
     model_format: Optional[str] = None,
     quantization: Optional[str] = None,
 ) -> Type[VideoEngineModel]:
-    if model_name not in VIDEO_ENGINES:
-        raise ValueError(f"Video model {model_name} not found.")
+    from .core import VIDEO_REGISTRY_LOCK
+
+    with VIDEO_REGISTRY_LOCK:
+        model_engines = VIDEO_ENGINES.get(model_name)
+        model_engines = dict(model_engines) if model_engines is not None else None
+    if model_engines is None:
+        raise VideoEngineNotAvailableError(f"Video model {model_name} not found.")
     model_engine = _normalize_engine_name(model_name, model_engine)
-    if model_engine not in VIDEO_ENGINES[model_name]:
-        raise ValueError(
+    if model_engine not in model_engines:
+        raise VideoEngineNotAvailableError(
             f"Video model {model_name} cannot be run on engine {model_engine}."
         )
-    for param in VIDEO_ENGINES[model_name][model_engine]:
+    for param in model_engines[model_engine]:
         if model_name != param["model_name"]:
             continue
         if (model_format and model_format != param["model_format"]) or (
             quantization and quantization != param["quantization"]
         ):
             continue
-        return param["video_class"]
-    raise ValueError(
+        engine_class = param["video_class"]
+        host_result = engine_class.check_host()
+        if host_result is not True:
+            if isinstance(host_result, tuple) and len(host_result) >= 2:
+                raise VideoEngineConfigurationError(str(host_result[1]))
+            raise VideoEngineConfigurationError(
+                f"Engine {model_engine} is incompatible with the current host"
+            )
+        return engine_class
+    raise VideoEngineConfigurationError(
         f"Video model {model_name} cannot be run on engine {model_engine}."
     )
 
@@ -114,7 +145,26 @@ def check_engine_by_model_name_and_engine_with_virtual_env(
     if model_family is None:
         raise ValueError(f"Video model {model_name} not found.")
 
+    expected_format = getattr(model_family, "model_format", None)
+    expected_quantization = getattr(model_family, "quantization", None) or "none"
+    if (model_format and model_format != expected_format) or (
+        quantization and quantization != expected_quantization
+    ):
+        raise VideoEngineConfigurationError(
+            f"Video model {model_name} cannot be run on engine {model_engine} "
+            f"with format {model_format or expected_format} and quantization "
+            f"{quantization or expected_quantization}."
+        )
+
     engine_markers = _collect_virtualenv_engine_markers(model_family)
+
+    def _host_error(engine_class: Type[VideoEngineModel]) -> Optional[str]:
+        result = engine_class.check_host()
+        if result is True:
+            return None
+        if isinstance(result, tuple) and len(result) >= 2:
+            return str(result[1])
+        return f"Engine {model_engine} is incompatible with the current host"
 
     def _engine_class_by_marker() -> Optional[Type[VideoEngineModel]]:
         if model_engine.lower() not in engine_markers:
@@ -133,21 +183,30 @@ def check_engine_by_model_name_and_engine_with_virtual_env(
         return None
 
     try:
-        return check_engine_by_model_name_and_engine(
+        engine_class = check_engine_by_model_name_and_engine(
             model_engine, model_name, model_format, quantization
         )
-    except ValueError:
-        engine_cls = _engine_class_by_marker()
-        if engine_cls is not None:
-            return engine_cls
-        raise
+    except VideoEngineNotAvailableError:
+        marker_engine_class = _engine_class_by_marker()
+        if marker_engine_class is None:
+            raise
+        engine_class = marker_engine_class
+
+    host_error = _host_error(engine_class)
+    if host_error is not None:
+        raise VideoEngineConfigurationError(host_error)
+    return engine_class
 
 
-def generate_engine_config_by_model_name(model_family: "VideoModelFamilyV2") -> None:
+def generate_engine_config_by_model_name(
+    model_family: "VideoModelFamilyV2",
+    target_engines: Optional[Dict[str, Dict[str, List[Dict[str, Any]]]]] = None,
+) -> None:
     model_name = model_family.model_name
     model_format = getattr(model_family, "model_format", None)
     quantization = getattr(model_family, "quantization", None)
-    engines: Dict[str, List[Dict[str, Any]]] = VIDEO_ENGINES.get(model_name, {})
+    registry = VIDEO_ENGINES if target_engines is None else target_engines
+    engines: Dict[str, List[Dict[str, Any]]] = registry.get(model_name, {})
     for engine, classes in SUPPORTED_ENGINES.items():
         for cls in classes:
             if not cls.match(model_family):
@@ -173,4 +232,10 @@ def generate_engine_config_by_model_name(model_family: "VideoModelFamilyV2") -> 
             engines[engine] = engine_params
             break
     if engines:
-        VIDEO_ENGINES[model_name] = engines
+        if target_engines is None:
+            from .core import VIDEO_REGISTRY_LOCK
+
+            with VIDEO_REGISTRY_LOCK:
+                VIDEO_ENGINES[model_name] = engines
+        else:
+            target_engines[model_name] = engines

--- a/xinference/model/video/engine_family.py
+++ b/xinference/model/video/engine_family.py
@@ -1,0 +1,176 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+import logging
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, Union
+
+if TYPE_CHECKING:
+    from .core import VideoModelFamilyV2
+
+logger = logging.getLogger(__name__)
+
+
+class VideoEngineModel:
+    required_libs: Tuple[str, ...] = ()
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+    @classmethod
+    def match(cls, model_family: "VideoModelFamilyV2") -> bool:
+        raise NotImplementedError
+
+    @classmethod
+    def is_model_family_supported(cls, model_family: "VideoModelFamilyV2") -> bool:
+        """Whether this engine implements the model, ignoring host constraints."""
+
+        return cls.match(model_family)
+
+    @classmethod
+    def check_lib(cls) -> Union[bool, Tuple[bool, str]]:
+        for lib in cls.required_libs:
+            if importlib.util.find_spec(lib) is None:
+                return False, f"Library '{lib}' is not installed"
+        return True
+
+
+# { video model name -> { engine name -> engine params } }
+VIDEO_ENGINES: Dict[str, Dict[str, List[Dict[str, Any]]]] = {}
+SUPPORTED_ENGINES: Dict[str, List[Type[VideoEngineModel]]] = {}
+
+
+def get_supported_engines_for_model(
+    model_families: List["VideoModelFamilyV2"],
+) -> Dict[str, List[Type[VideoEngineModel]]]:
+    return {
+        engine: [
+            cls
+            for cls in classes
+            if any(cls.is_model_family_supported(family) for family in model_families)
+        ]
+        for engine, classes in SUPPORTED_ENGINES.items()
+        if any(
+            cls.is_model_family_supported(family)
+            for cls in classes
+            for family in model_families
+        )
+    }
+
+
+def _normalize_engine_name(model_name: str, model_engine: str) -> str:
+    for engine in VIDEO_ENGINES.get(model_name, {}):
+        if engine.lower() == model_engine.lower():
+            return engine
+    return model_engine
+
+
+def check_engine_by_model_name_and_engine(
+    model_engine: str,
+    model_name: str,
+    model_format: Optional[str] = None,
+    quantization: Optional[str] = None,
+) -> Type[VideoEngineModel]:
+    if model_name not in VIDEO_ENGINES:
+        raise ValueError(f"Video model {model_name} not found.")
+    model_engine = _normalize_engine_name(model_name, model_engine)
+    if model_engine not in VIDEO_ENGINES[model_name]:
+        raise ValueError(
+            f"Video model {model_name} cannot be run on engine {model_engine}."
+        )
+    for param in VIDEO_ENGINES[model_name][model_engine]:
+        if model_name != param["model_name"]:
+            continue
+        if (model_format and model_format != param["model_format"]) or (
+            quantization and quantization != param["quantization"]
+        ):
+            continue
+        return param["video_class"]
+    raise ValueError(
+        f"Video model {model_name} cannot be run on engine {model_engine}."
+    )
+
+
+def check_engine_by_model_name_and_engine_with_virtual_env(
+    model_engine: str,
+    model_name: str,
+    model_format: Optional[str] = None,
+    quantization: Optional[str] = None,
+    model_family: Optional["VideoModelFamilyV2"] = None,
+) -> Type[VideoEngineModel]:
+    from ..utils import _collect_virtualenv_engine_markers
+
+    if model_family is None:
+        raise ValueError(f"Video model {model_name} not found.")
+
+    engine_markers = _collect_virtualenv_engine_markers(model_family)
+
+    def _engine_class_by_marker() -> Optional[Type[VideoEngineModel]]:
+        if model_engine.lower() not in engine_markers:
+            return None
+        for engine, engine_classes in SUPPORTED_ENGINES.items():
+            if engine.lower() != model_engine.lower():
+                continue
+            for engine_class in engine_classes:
+                if engine_class.is_model_family_supported(model_family):
+                    logger.warning(
+                        "Bypassing engine compatibility checks for %s due to "
+                        "virtualenv marker.",
+                        model_engine,
+                    )
+                    return engine_class
+        return None
+
+    try:
+        return check_engine_by_model_name_and_engine(
+            model_engine, model_name, model_format, quantization
+        )
+    except ValueError:
+        engine_cls = _engine_class_by_marker()
+        if engine_cls is not None:
+            return engine_cls
+        raise
+
+
+def generate_engine_config_by_model_name(model_family: "VideoModelFamilyV2") -> None:
+    model_name = model_family.model_name
+    model_format = getattr(model_family, "model_format", None)
+    quantization = getattr(model_family, "quantization", None)
+    engines: Dict[str, List[Dict[str, Any]]] = VIDEO_ENGINES.get(model_name, {})
+    for engine, classes in SUPPORTED_ENGINES.items():
+        for cls in classes:
+            if not cls.match(model_family):
+                continue
+            engine_params = engines.get(engine, [])
+            engine_model_format = getattr(cls, "engine_model_format", model_format)
+            engine_quantization = quantization
+            if engine_quantization is None:
+                engine_quantization = getattr(cls, "engine_quantization", None)
+            param = {
+                "model_name": model_name,
+                "model_format": engine_model_format,
+                "quantization": engine_quantization,
+                "video_class": cls,
+            }
+            if not any(
+                existing["model_name"] == model_name
+                and existing["model_format"] == engine_model_format
+                and existing["quantization"] == engine_quantization
+                for existing in engine_params
+            ):
+                engine_params.append(param)
+            engines[engine] = engine_params
+            break
+    if engines:
+        VIDEO_ENGINES[model_name] = engines

--- a/xinference/model/video/mlx_video.py
+++ b/xinference/model/video/mlx_video.py
@@ -1,0 +1,614 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import base64
+import importlib
+import importlib.metadata
+import json
+import logging
+import os
+import platform
+import shutil
+import sys
+import tempfile
+import time
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
+
+from packaging.requirements import Requirement
+
+from ...constants import XINFERENCE_VIDEO_DIR
+from ...types import Video, VideoList
+
+if TYPE_CHECKING:
+    import PIL.Image
+
+    from ...core.progress_tracker import Progressor
+    from .core import VideoModelFamilyV2
+
+logger = logging.getLogger(__name__)
+
+_WAN_CONVERSION_DTYPE = "bfloat16"
+_WAN_CONVERSION_MANIFEST = ".xinference-mlx-video-conversion.json"
+_WAN_CONVERSION_SCHEMA = 1
+
+
+class MLXVideoModel:
+    """Run ``Blaizzy/mlx-video`` models behind Xinference's Video API.
+
+    The upstream package exposes generation functions rather than persistent
+    pipeline objects. Model preparation therefore happens at ``load()``, while
+    each request delegates generation to the corresponding upstream function.
+    All MLX work is pinned to one thread because MLX GPU streams are
+    thread-local.
+    """
+
+    def __init__(
+        self,
+        model_uid: str,
+        model_path: str,
+        model_spec: "VideoModelFamilyV2",
+        **kwargs: Any,
+    ) -> None:
+        self.model_family = model_spec
+        self._model_uid = model_uid
+        self._model_path = model_path
+        self._model_spec = model_spec
+        self._abilities = model_spec.model_ability or []
+        self._enable_virtual_env = bool(
+            kwargs.pop("_xinference_enable_virtual_env", False)
+        )
+        self._virtual_env_packages: List[str] = list(
+            kwargs.pop("_xinference_virtual_env_packages", None) or []
+        )
+        self._kwargs = kwargs
+        self._runtime_model_path = model_path
+        self._text_encoder_path: Optional[str] = None
+        self._mlx_executor: Optional[ThreadPoolExecutor] = None
+
+    @property
+    def model_spec(self) -> "VideoModelFamilyV2":
+        return self._model_spec
+
+    @property
+    def model_ability(self) -> List[str]:
+        return self._abilities
+
+    def _run_on_mlx_thread(self, fn: Callable, *args: Any, **kwargs: Any) -> Any:
+        if self._mlx_executor is None:
+            self._mlx_executor = ThreadPoolExecutor(max_workers=1)
+        return self._mlx_executor.submit(fn, *args, **kwargs).result()
+
+    @staticmethod
+    def _is_wan_mlx_model_dir(path: Path) -> bool:
+        shared_files = (
+            path / "config.json",
+            path / "t5_encoder.safetensors",
+            path / "vae.safetensors",
+        )
+        if not all(file.is_file() for file in shared_files):
+            return False
+        return (path / "model.safetensors").is_file() or all(
+            (path / filename).is_file()
+            for filename in (
+                "high_noise_model.safetensors",
+                "low_noise_model.safetensors",
+            )
+        )
+
+    @classmethod
+    def _wan_source_fingerprint(cls, source_path: Path) -> Dict[str, Dict[str, int]]:
+        fingerprint: Dict[str, Dict[str, int]] = {}
+        for path in source_path.rglob("*"):
+            try:
+                if not path.is_file():
+                    continue
+                stat = path.stat()
+            except OSError:
+                continue
+            fingerprint[path.relative_to(source_path).as_posix()] = {
+                "size": stat.st_size,
+                "mtime_ns": stat.st_mtime_ns,
+            }
+        return fingerprint
+
+    @staticmethod
+    def _converter_requirement(packages: List[str]) -> Optional[str]:
+        for package in packages:
+            requirement_text = package.partition(";")[0].strip()
+            try:
+                if Requirement(requirement_text).name.lower() == "mlx-video":
+                    return requirement_text
+            except Exception:
+                if requirement_text.lower().startswith("mlx-video"):
+                    return requirement_text
+        return None
+
+    def _converter_runtime_identity(self) -> Dict[str, Any]:
+        """Describe the converter that is actually imported in this runtime."""
+
+        runtime: Dict[str, Any] = {
+            "environment": "virtualenv" if self._enable_virtual_env else "host"
+        }
+        try:
+            distribution = importlib.metadata.distribution("mlx-video")
+            runtime["distribution_version"] = distribution.version
+            direct_url = distribution.read_text("direct_url.json")
+            if direct_url:
+                runtime["direct_url"] = json.loads(direct_url)
+        except (importlib.metadata.PackageNotFoundError, OSError, ValueError):
+            module = importlib.import_module("mlx_video")
+            module_path = getattr(module, "__file__", None)
+            if module_path:
+                try:
+                    stat = Path(module_path).stat()
+                    runtime["module"] = {
+                        "path": str(Path(module_path).resolve()),
+                        "size": stat.st_size,
+                        "mtime_ns": stat.st_mtime_ns,
+                    }
+                except OSError:
+                    runtime["module"] = {"path": module_path}
+        return runtime
+
+    @classmethod
+    def _convert_wan_model(
+        cls,
+        source_path: Path,
+        conversion_identity: Optional[Dict[str, Any]] = None,
+    ) -> Path:
+        """Convert an official Wan checkpoint into mlx-video's native layout."""
+
+        from filelock import FileLock
+
+        converted_path = Path(f"{source_path}.mlx-video")
+        lock_path = Path(f"{converted_path}.lock")
+        with FileLock(str(lock_path)):
+            expected_manifest = {
+                "schema_version": _WAN_CONVERSION_SCHEMA,
+                "source": conversion_identity or {},
+                "source_files": cls._wan_source_fingerprint(source_path),
+                "dtype": _WAN_CONVERSION_DTYPE,
+                "output_schema": "mlx-video-wan-native-v1",
+            }
+            manifest_path = converted_path / _WAN_CONVERSION_MANIFEST
+            if cls._is_wan_mlx_model_dir(converted_path):
+                try:
+                    if json.loads(manifest_path.read_text()) == expected_manifest:
+                        return converted_path
+                except (OSError, ValueError, TypeError):
+                    pass
+
+            if converted_path.exists() and not manifest_path.is_file():
+                raise FileExistsError(
+                    f"Refusing to overwrite unmanaged Wan conversion target "
+                    f"{converted_path}. Move or remove it explicitly before retrying."
+                )
+            if converted_path.is_dir():
+                shutil.rmtree(converted_path)
+            elif converted_path.exists():
+                converted_path.unlink()
+
+            converted_path.parent.mkdir(parents=True, exist_ok=True)
+            temp_path = Path(
+                tempfile.mkdtemp(
+                    prefix=f".{converted_path.name}-",
+                    dir=str(converted_path.parent),
+                )
+            )
+            try:
+                convert_module = importlib.import_module(
+                    "mlx_video.models.wan_2.convert"
+                )
+                convert_module.convert_wan_checkpoint(
+                    str(source_path), str(temp_path), dtype=_WAN_CONVERSION_DTYPE
+                )
+                if not cls._is_wan_mlx_model_dir(temp_path):
+                    raise RuntimeError(
+                        f"mlx-video produced an incomplete Wan model in {temp_path}"
+                    )
+                (temp_path / _WAN_CONVERSION_MANIFEST).write_text(
+                    json.dumps(expected_manifest, sort_keys=True)
+                )
+                os.replace(temp_path, converted_path)
+            finally:
+                if temp_path.exists():
+                    shutil.rmtree(temp_path)
+        return converted_path
+
+    def _prepare_wan_model(self) -> None:
+        model_path = Path(self._model_path)
+        if self._is_wan_mlx_model_dir(model_path):
+            self._runtime_model_path = str(model_path)
+        else:
+            virtualenv = getattr(self._model_spec, "virtualenv", None)
+            spec_packages = getattr(virtualenv, "packages", None) or []
+            converter_requirement = self._converter_requirement(
+                self._virtual_env_packages
+            ) or self._converter_requirement(spec_packages)
+            converter_identity = {
+                "requirement": converter_requirement,
+                "runtime": self._converter_runtime_identity(),
+            }
+            self._runtime_model_path = str(
+                self._convert_wan_model(
+                    model_path,
+                    {
+                        "model_id": getattr(self._model_spec, "model_id", None),
+                        "model_revision": getattr(
+                            self._model_spec, "model_revision", None
+                        ),
+                        "converter": converter_identity,
+                    },
+                )
+            )
+
+    def _prepare_ltx_model(self) -> None:
+        """Prepare an LTX model and its optional external text encoder."""
+
+        model_path = Path(self._model_path)
+        text_encoder_model_id = getattr(self._model_spec, "text_encoder_model_id", None)
+        if text_encoder_model_id is None:
+            self._runtime_model_path = str(model_path)
+            self._text_encoder_path = None
+            return
+
+        if self._model_spec.model_hub == "modelscope":
+            from modelscope.hub.snapshot_download import snapshot_download
+        else:
+            from huggingface_hub import snapshot_download
+
+        text_encoder_path = Path(
+            snapshot_download(
+                text_encoder_model_id,
+                revision=getattr(self._model_spec, "text_encoder_model_revision", None),
+                allow_patterns=["text_encoder/**", "tokenizer/**"],
+            )
+        )
+        self._runtime_model_path = str(model_path)
+        self._text_encoder_path = str(text_encoder_path)
+
+    def load(self) -> None:
+        self._run_on_mlx_thread(self._load)
+
+    def stop(self) -> None:
+        if self._mlx_executor is not None:
+            self._mlx_executor.shutdown(wait=True)
+            self._mlx_executor = None
+
+    def _load(self) -> None:
+        if platform.system() != "Darwin" or platform.machine() != "arm64":
+            raise RuntimeError("The MLX video engine requires Apple Silicon")
+        if sys.version_info < (3, 11):
+            raise RuntimeError("Blaizzy/mlx-video requires Python 3.11 or newer")
+        importlib.import_module("mlx_video")
+        if self._model_spec.model_family == "Wan":
+            self._prepare_wan_model()
+        elif self._model_spec.model_family in ("LTX-2", "LTX-2.3"):
+            self._prepare_ltx_model()
+        else:
+            raise ValueError(
+                f"Unsupported mlx-video model family: {self._model_spec.model_family}"
+            )
+
+    @staticmethod
+    def _save_conditioning_image(image: "PIL.Image.Image") -> str:
+        fd, path = tempfile.mkstemp(suffix=".png")
+        os.close(fd)
+        try:
+            image.save(path, format="PNG")
+        except BaseException:
+            os.remove(path)
+            raise
+        return path
+
+    def _generation_kwargs(self, request_kwargs: Dict[str, Any]) -> Dict[str, Any]:
+        result = (self._model_spec.default_generate_config or {}).copy()
+        # ``self._kwargs`` contains model-launch options (for example the Web
+        # UI always sends ``cpu_offload``).  They are not generation options
+        # and must not leak into mlx-video's strict ``generate_video``
+        # signatures.
+        result.update(request_kwargs)
+        return {key: value for key, value in result.items() if value is not None}
+
+    @staticmethod
+    def _normalize_prompts(
+        prompt: Optional[Union[str, List[str]]], field_name: str
+    ) -> List[str]:
+        if prompt is None:
+            return [""]
+        if isinstance(prompt, str):
+            return [prompt]
+        if not isinstance(prompt, list):
+            raise TypeError(f"{field_name} must be a string or a list of strings")
+        if not prompt:
+            raise ValueError(f"{field_name} list must not be empty")
+        if not all(isinstance(value, str) for value in prompt):
+            raise TypeError(f"{field_name} must contain only strings")
+        return prompt
+
+    def _generate_wan(
+        self,
+        prompt: str,
+        output_path: str,
+        image_path: Optional[str],
+        num_inference_steps: Optional[int],
+        request_kwargs: Dict[str, Any],
+    ) -> None:
+        generate_kwargs = self._generation_kwargs(request_kwargs)
+        generate_kwargs.pop("output_path", None)
+        generate_kwargs.pop("model_dir", None)
+        generate_kwargs.pop("fps", None)
+        generate_kwargs.pop("pipeline", None)
+        if "guidance_scale" in generate_kwargs:
+            generate_kwargs["guide_scale"] = generate_kwargs.pop("guidance_scale")
+        if "cfg_scale" in generate_kwargs:
+            generate_kwargs["guide_scale"] = generate_kwargs.pop("cfg_scale")
+        if num_inference_steps is not None:
+            generate_kwargs["steps"] = num_inference_steps
+
+        generate_module = importlib.import_module("mlx_video.models.wan_2.generate")
+        generate_module.generate_video(
+            model_dir=self._runtime_model_path,
+            prompt=prompt,
+            image=image_path,
+            output_path=output_path,
+            **generate_kwargs,
+        )
+
+    def _generate_ltx(
+        self,
+        prompt: str,
+        output_path: str,
+        image_path: Optional[str],
+        last_image_path: Optional[str],
+        num_inference_steps: Optional[int],
+        request_kwargs: Dict[str, Any],
+    ) -> None:
+        generate_kwargs = self._generation_kwargs(request_kwargs)
+        generate_kwargs.pop("output_path", None)
+        generate_kwargs.pop("model_repo", None)
+        generate_kwargs.pop("text_encoder_repo", None)
+        generate_kwargs["save_frames"] = False
+        pipeline_name = generate_kwargs.pop("pipeline", "distilled")
+        if "guidance_scale" in generate_kwargs:
+            generate_kwargs["cfg_scale"] = generate_kwargs.pop("guidance_scale")
+        if "guide_scale" in generate_kwargs:
+            generate_kwargs["cfg_scale"] = generate_kwargs.pop("guide_scale")
+        if num_inference_steps is not None:
+            generate_kwargs["num_inference_steps"] = num_inference_steps
+
+        generate_module = importlib.import_module("mlx_video.models.ltx_2.generate")
+        pipeline = (
+            pipeline_name
+            if isinstance(pipeline_name, generate_module.PipelineType)
+            else generate_module.PipelineType(pipeline_name)
+        )
+        audio_path = str(Path(output_path).with_suffix(".wav"))
+        generate_kwargs["output_audio_path"] = audio_path
+        try:
+            generate_module.generate_video(
+                model_repo=self._runtime_model_path,
+                text_encoder_repo=self._text_encoder_path,
+                prompt=prompt,
+                pipeline=pipeline,
+                image=image_path,
+                end_image=last_image_path,
+                output_path=output_path,
+                **generate_kwargs,
+            )
+        finally:
+            if os.path.exists(audio_path):
+                try:
+                    os.remove(audio_path)
+                except OSError:
+                    pass
+
+    def _generate(
+        self,
+        prompt: Optional[Union[str, List[str]]],
+        n: int,
+        num_inference_steps: Optional[int],
+        response_format: str,
+        image: Optional["PIL.Image.Image"],
+        last_image: Optional["PIL.Image.Image"],
+        request_kwargs: Dict[str, Any],
+    ) -> VideoList:
+        if n < 1:
+            raise ValueError("n must be at least 1")
+        if response_format not in ("url", "b64_json"):
+            raise ValueError(f"Unsupported response format: {response_format}")
+        if last_image is not None:
+            if "firstlastframe2video" not in self._abilities:
+                raise ValueError(
+                    f"{self._model_spec.model_name} does not support "
+                    "firstlastframe2video"
+                )
+        elif image is not None and "image2video" not in self._abilities:
+            raise ValueError(
+                f"{self._model_spec.model_name} does not support image2video"
+            )
+        elif image is None and "text2video" not in self._abilities:
+            raise ValueError(
+                f"{self._model_spec.model_name} does not support text2video"
+            )
+        prompts = self._normalize_prompts(prompt, "prompt")
+        negative_prompt = request_kwargs.pop("negative_prompt", None)
+        negative_prompts: List[Optional[str]] = []
+        if isinstance(negative_prompt, list):
+            negative_prompts.extend(
+                self._normalize_prompts(negative_prompt, "negative_prompt")
+            )
+            if len(negative_prompts) != len(prompts):
+                raise ValueError(
+                    "negative_prompt list length must match prompt list length"
+                )
+        elif negative_prompt is None or isinstance(negative_prompt, str):
+            negative_prompts = [negative_prompt] * len(prompts)
+        else:
+            raise TypeError("negative_prompt must be a string or a list of strings")
+
+        progressor: Optional["Progressor"] = request_kwargs.pop("progressor", None)
+        request_kwargs.pop("request_id", None)
+        request_kwargs.pop("num_videos_per_prompt", None)
+
+        image_paths: List[str] = []
+        output_paths: List[str] = []
+        try:
+            image_path = None
+            last_image_path = None
+            if image is not None:
+                image_path = self._save_conditioning_image(image)
+                image_paths.append(image_path)
+            if last_image is not None:
+                last_image_path = self._save_conditioning_image(last_image)
+                image_paths.append(last_image_path)
+
+            os.makedirs(XINFERENCE_VIDEO_DIR, exist_ok=True)
+            total_outputs = len(prompts) * n
+            completed_outputs = 0
+            for prompt_index, prompt_text in enumerate(prompts):
+                prompt_kwargs = request_kwargs.copy()
+                if negative_prompts[prompt_index] is not None:
+                    prompt_kwargs["negative_prompt"] = negative_prompts[prompt_index]
+                for _ in range(n):
+                    output_path = os.path.join(
+                        XINFERENCE_VIDEO_DIR, f"{uuid.uuid4().hex}.mp4"
+                    )
+                    output_paths.append(output_path)
+                    if self._model_spec.model_family == "Wan":
+                        self._generate_wan(
+                            prompt_text,
+                            output_path,
+                            image_path,
+                            num_inference_steps,
+                            prompt_kwargs,
+                        )
+                    else:
+                        self._generate_ltx(
+                            prompt_text,
+                            output_path,
+                            image_path,
+                            last_image_path,
+                            num_inference_steps,
+                            prompt_kwargs,
+                        )
+                    if not os.path.isfile(output_path):
+                        raise RuntimeError(
+                            "mlx-video did not create the expected output "
+                            f"{output_path}"
+                        )
+                    completed_outputs += 1
+                    if progressor is not None and progressor.request_id:
+                        progressor.set_progress(completed_outputs / total_outputs)
+            return self._video_urls_to_response(output_paths, response_format)
+        except BaseException:
+            for output_path in output_paths:
+                try:
+                    os.remove(output_path)
+                except OSError:
+                    pass
+            raise
+        finally:
+            for image_path in image_paths:
+                try:
+                    os.remove(image_path)
+                except OSError:
+                    pass
+
+    def text_to_video(
+        self,
+        prompt: Union[str, List[str]],
+        n: int = 1,
+        num_inference_steps: Optional[int] = None,
+        response_format: str = "b64_json",
+        **kwargs: Any,
+    ) -> VideoList:
+        return self._run_on_mlx_thread(
+            self._generate,
+            prompt,
+            n,
+            num_inference_steps,
+            response_format,
+            None,
+            None,
+            kwargs,
+        )
+
+    def image_to_video(
+        self,
+        image: "PIL.Image.Image",
+        prompt: Optional[Union[str, List[str]]] = None,
+        n: int = 1,
+        num_inference_steps: Optional[int] = None,
+        response_format: str = "b64_json",
+        **kwargs: Any,
+    ) -> VideoList:
+        return self._run_on_mlx_thread(
+            self._generate,
+            prompt,
+            n,
+            num_inference_steps,
+            response_format,
+            image,
+            None,
+            kwargs,
+        )
+
+    def firstlastframe_to_video(
+        self,
+        first_frame: "PIL.Image.Image",
+        last_frame: "PIL.Image.Image",
+        prompt: Optional[Union[str, List[str]]] = None,
+        n: int = 1,
+        num_inference_steps: Optional[int] = None,
+        response_format: str = "b64_json",
+        **kwargs: Any,
+    ) -> VideoList:
+        return self._run_on_mlx_thread(
+            self._generate,
+            prompt,
+            n,
+            num_inference_steps,
+            response_format,
+            first_frame,
+            last_frame,
+            kwargs,
+        )
+
+    @staticmethod
+    def _video_urls_to_response(urls: List[str], response_format: str) -> VideoList:
+        if response_format == "url":
+            return VideoList(
+                created=int(time.time()),
+                data=[Video(url=url, b64_json=None) for url in urls],
+            )
+        if response_format != "b64_json":
+            raise ValueError(f"Unsupported response format: {response_format}")
+
+        data = []
+        try:
+            for url in urls:
+                with open(url, "rb") as video_file:
+                    encoded = base64.b64encode(video_file.read()).decode()
+                data.append(Video(url=None, b64_json=encoded))
+            return VideoList(created=int(time.time()), data=data)
+        finally:
+            for url in urls:
+                try:
+                    os.remove(url)
+                except OSError:
+                    pass

--- a/xinference/model/video/model_spec.json
+++ b/xinference/model/video/model_spec.json
@@ -618,5 +618,393 @@
     },
     "updated_at": 1786840547,
     "featured": true
+  },
+  {
+    "version": 2,
+    "model_name": "Wan2.1-1.3B",
+    "model_family": "Wan",
+    "engine": "MLX",
+    "model_format": "mlx",
+    "cache_name": "Wan2.1-1.3B-mlx",
+    "model_ability": [
+      "text2video"
+    ],
+    "default_model_config": {},
+    "default_generate_config": {
+      "width": 832,
+      "height": 480,
+      "num_frames": 81,
+      "scheduler": "unipc"
+    },
+    "cache_config": {
+      "allow_patterns": [
+        "config.json",
+        "diffusion_pytorch_model*.safetensors*",
+        "models_t5_umt5-xxl-enc-bf16.pth",
+        "Wan2.1_VAE.pth"
+      ]
+    },
+    "virtualenv": {
+      "packages": [
+        "mlx-video @ git+https://github.com/Blaizzy/mlx-video.git@87db56a51758fefb748a359b90a5283bb8ba4837 ; #engine# == \"MLX\"",
+        "#system_torch# ; #engine# == \"MLX\"",
+        "#system_numpy# ; #engine# == \"MLX\""
+      ]
+    },
+    "model_src": {
+      "huggingface": {
+        "model_id": "Wan-AI/Wan2.1-T2V-1.3B",
+        "model_revision": "37ec512624d61f7aa208f7ea8140a131f93afc9a"
+      }
+    },
+    "updated_at": 1787065586,
+    "featured": false
+  },
+  {
+    "version": 2,
+    "model_name": "Wan2.1-14B",
+    "model_family": "Wan",
+    "engine": "MLX",
+    "model_format": "mlx",
+    "cache_name": "Wan2.1-14B-mlx",
+    "model_ability": [
+      "text2video"
+    ],
+    "default_model_config": {},
+    "default_generate_config": {
+      "width": 1280,
+      "height": 704,
+      "num_frames": 81,
+      "scheduler": "unipc"
+    },
+    "cache_config": {
+      "allow_patterns": [
+        "config.json",
+        "diffusion_pytorch_model*.safetensors*",
+        "models_t5_umt5-xxl-enc-bf16.pth",
+        "Wan2.1_VAE.pth"
+      ]
+    },
+    "virtualenv": {
+      "packages": [
+        "mlx-video @ git+https://github.com/Blaizzy/mlx-video.git@87db56a51758fefb748a359b90a5283bb8ba4837 ; #engine# == \"MLX\"",
+        "#system_torch# ; #engine# == \"MLX\"",
+        "#system_numpy# ; #engine# == \"MLX\""
+      ]
+    },
+    "model_src": {
+      "huggingface": {
+        "model_id": "Wan-AI/Wan2.1-T2V-14B",
+        "model_revision": "a064a6c71f5be440641209c07bf2a5ce7a2ff5e4"
+      }
+    },
+    "updated_at": 1787065586,
+    "featured": false
+  },
+  {
+    "version": 2,
+    "model_name": "Wan2.2-A14B",
+    "model_family": "Wan",
+    "engine": "MLX",
+    "model_format": "mlx",
+    "cache_name": "Wan2.2-A14B-mlx",
+    "model_ability": [
+      "text2video"
+    ],
+    "default_model_config": {},
+    "default_generate_config": {
+      "width": 1280,
+      "height": 704,
+      "num_frames": 81,
+      "scheduler": "unipc"
+    },
+    "cache_config": {
+      "allow_patterns": [
+        "config.json",
+        "high_noise_model.safetensors",
+        "low_noise_model.safetensors",
+        "t5_encoder.safetensors",
+        "tokenizer.json",
+        "vae.safetensors"
+      ]
+    },
+    "virtualenv": {
+      "packages": [
+        "mlx-video @ git+https://github.com/Blaizzy/mlx-video.git@87db56a51758fefb748a359b90a5283bb8ba4837 ; #engine# == \"MLX\"",
+        "#system_numpy# ; #engine# == \"MLX\""
+      ]
+    },
+    "model_src": {
+      "huggingface": {
+        "model_id": "SceneWorks/wan2.2-t2v-a14b-mlx",
+        "model_revision": "991eb255c544bbb2e1f1e07da4355c2f0a5337b7"
+      },
+      "modelscope": {
+        "model_id": "Xorbits/wan2.2-t2v-a14b-mlx",
+        "model_revision": "master"
+      }
+    },
+    "updated_at": 1787065586,
+    "featured": false
+  },
+  {
+    "version": 2,
+    "model_name": "Wan2.2-i2v-A14B",
+    "model_family": "Wan",
+    "engine": "MLX",
+    "model_format": "mlx",
+    "cache_name": "Wan2.2-i2v-A14B-mlx",
+    "model_ability": [
+      "image2video"
+    ],
+    "default_model_config": {},
+    "default_generate_config": {
+      "width": 1280,
+      "height": 704,
+      "num_frames": 81,
+      "scheduler": "unipc"
+    },
+    "cache_config": {
+      "allow_patterns": [
+        "config.json",
+        "high_noise_model.safetensors",
+        "low_noise_model.safetensors",
+        "t5_encoder.safetensors",
+        "tokenizer.json",
+        "vae.safetensors"
+      ]
+    },
+    "virtualenv": {
+      "packages": [
+        "mlx-video @ git+https://github.com/Blaizzy/mlx-video.git@87db56a51758fefb748a359b90a5283bb8ba4837 ; #engine# == \"MLX\"",
+        "#system_numpy# ; #engine# == \"MLX\""
+      ]
+    },
+    "model_src": {
+      "huggingface": {
+        "model_id": "SceneWorks/wan2.2-i2v-a14b-mlx",
+        "model_revision": "c6c786170031eccc3a1fac0f98f1ad4ff988271e"
+      },
+      "modelscope": {
+        "model_id": "Xorbits/wan2.2-i2v-a14b-mlx",
+        "model_revision": "master"
+      }
+    },
+    "updated_at": 1787065586,
+    "featured": false
+  },
+  {
+    "version": 2,
+    "model_name": "Wan2.2-ti2v-5B",
+    "model_family": "Wan",
+    "engine": "MLX",
+    "model_format": "mlx",
+    "cache_name": "Wan2.2-ti2v-5B-mlx",
+    "model_ability": [
+      "text2video",
+      "image2video"
+    ],
+    "default_model_config": {},
+    "default_generate_config": {
+      "width": 1280,
+      "height": 704,
+      "num_frames": 81,
+      "scheduler": "unipc"
+    },
+    "cache_config": {
+      "allow_patterns": [
+        "config.json",
+        "model.safetensors",
+        "t5_encoder.safetensors",
+        "tokenizer.json",
+        "vae.safetensors"
+      ]
+    },
+    "virtualenv": {
+      "packages": [
+        "mlx-video @ git+https://github.com/Blaizzy/mlx-video.git@87db56a51758fefb748a359b90a5283bb8ba4837 ; #engine# == \"MLX\"",
+        "#system_numpy# ; #engine# == \"MLX\""
+      ]
+    },
+    "model_src": {
+      "huggingface": {
+        "model_id": "SceneWorks/wan2.2-ti2v-5b-mlx",
+        "model_revision": "bb1b055249614cf9d7cf4373fbdbc184b77dee88"
+      },
+      "modelscope": {
+        "model_id": "Xorbits/wan2.2-ti2v-5b-mlx",
+        "model_revision": "master"
+      }
+    },
+    "updated_at": 1787065586,
+    "featured": false
+  },
+  {
+    "version": 2,
+    "model_name": "LTX-2-distilled",
+    "model_family": "LTX-2",
+    "engine": "MLX",
+    "model_format": "mlx",
+    "cache_name": "LTX-2-distilled-mlx",
+    "model_ability": [
+      "text2video",
+      "image2video",
+      "firstlastframe2video"
+    ],
+    "default_model_config": {},
+    "default_generate_config": {
+      "width": 512,
+      "height": 512,
+      "num_frames": 33,
+      "fps": 24,
+      "pipeline": "distilled",
+      "verbose": false
+    },
+    "virtualenv": {
+      "packages": [
+        "mlx-video @ git+https://github.com/Blaizzy/mlx-video.git@87db56a51758fefb748a359b90a5283bb8ba4837 ; #engine# == \"MLX\"",
+        "#system_numpy# ; #engine# == \"MLX\""
+      ]
+    },
+    "model_src": {
+      "huggingface": {
+        "model_id": "prince-canuma/LTX-2-distilled",
+        "model_revision": "60135212a1e96122922a15bf249356a3ff38cde0"
+      },
+      "modelscope": {
+        "model_id": "Xorbits/LTX-2-distilled",
+        "model_revision": "master"
+      }
+    },
+    "updated_at": 1787065586,
+    "featured": false
+  },
+  {
+    "version": 2,
+    "model_name": "LTX-2-dev",
+    "model_family": "LTX-2",
+    "engine": "MLX",
+    "model_format": "mlx",
+    "cache_name": "LTX-2-dev-mlx",
+    "model_ability": [
+      "text2video",
+      "image2video",
+      "firstlastframe2video"
+    ],
+    "default_model_config": {},
+    "default_generate_config": {
+      "width": 512,
+      "height": 512,
+      "num_frames": 33,
+      "fps": 24,
+      "pipeline": "dev",
+      "verbose": false
+    },
+    "virtualenv": {
+      "packages": [
+        "mlx-video @ git+https://github.com/Blaizzy/mlx-video.git@87db56a51758fefb748a359b90a5283bb8ba4837 ; #engine# == \"MLX\"",
+        "#system_numpy# ; #engine# == \"MLX\""
+      ]
+    },
+    "model_src": {
+      "huggingface": {
+        "model_id": "prince-canuma/LTX-2-dev",
+        "model_revision": "98683cfe012c2f2a6343383674859de516f3d70b"
+      },
+      "modelscope": {
+        "model_id": "Xorbits/LTX-2-dev",
+        "model_revision": "master"
+      }
+    },
+    "updated_at": 1787065586,
+    "featured": false
+  },
+  {
+    "version": 2,
+    "model_name": "LTX-2.3-distilled",
+    "model_family": "LTX-2.3",
+    "engine": "MLX",
+    "model_format": "mlx",
+    "cache_name": "LTX-2.3-distilled-mlx",
+    "model_ability": [
+      "text2video",
+      "image2video",
+      "firstlastframe2video"
+    ],
+    "default_model_config": {},
+    "default_generate_config": {
+      "width": 512,
+      "height": 512,
+      "num_frames": 33,
+      "fps": 24,
+      "pipeline": "distilled",
+      "verbose": false
+    },
+    "text_encoder_model_id": "prince-canuma/LTX-2-distilled",
+    "text_encoder_model_revision": "60135212a1e96122922a15bf249356a3ff38cde0",
+    "virtualenv": {
+      "packages": [
+        "mlx-video @ git+https://github.com/Blaizzy/mlx-video.git@87db56a51758fefb748a359b90a5283bb8ba4837 ; #engine# == \"MLX\"",
+        "#system_numpy# ; #engine# == \"MLX\""
+      ]
+    },
+    "model_src": {
+      "huggingface": {
+        "model_id": "prince-canuma/LTX-2.3-distilled",
+        "model_revision": "65b104b9387fb173d8e4b92fc5effc47625baf2a"
+      },
+      "modelscope": {
+        "model_id": "Xorbits/LTX-2.3-distilled",
+        "model_revision": "master",
+        "text_encoder_model_id": "Xorbits/LTX-2-distilled",
+        "text_encoder_model_revision": "master"
+      }
+    },
+    "updated_at": 1787065586,
+    "featured": false
+  },
+  {
+    "version": 2,
+    "model_name": "LTX-2.3-dev",
+    "model_family": "LTX-2.3",
+    "engine": "MLX",
+    "model_format": "mlx",
+    "cache_name": "LTX-2.3-dev-mlx",
+    "model_ability": [
+      "text2video",
+      "image2video",
+      "firstlastframe2video"
+    ],
+    "default_model_config": {},
+    "default_generate_config": {
+      "width": 512,
+      "height": 512,
+      "num_frames": 33,
+      "fps": 24,
+      "pipeline": "dev",
+      "verbose": false
+    },
+    "text_encoder_model_id": "prince-canuma/LTX-2-distilled",
+    "text_encoder_model_revision": "60135212a1e96122922a15bf249356a3ff38cde0",
+    "virtualenv": {
+      "packages": [
+        "mlx-video @ git+https://github.com/Blaizzy/mlx-video.git@87db56a51758fefb748a359b90a5283bb8ba4837 ; #engine# == \"MLX\"",
+        "#system_numpy# ; #engine# == \"MLX\""
+      ]
+    },
+    "model_src": {
+      "huggingface": {
+        "model_id": "prince-canuma/LTX-2.3-dev",
+        "model_revision": "5da7eb70a6a8a2691f6810454a31f2790e65d8ee"
+      },
+      "modelscope": {
+        "model_id": "Xorbits/LTX-2.3-dev",
+        "model_revision": "master",
+        "text_encoder_model_id": "Xorbits/LTX-2-distilled",
+        "text_encoder_model_revision": "master"
+      }
+    },
+    "updated_at": 1787065586,
+    "featured": false
   }
 ]

--- a/xinference/model/video/model_spec.json
+++ b/xinference/model/video/model_spec.json
@@ -3,6 +3,8 @@
     "version": 2,
     "model_name": "CogVideoX-2b",
     "model_family": "CogVideoX",
+    "engine": "diffusers",
+    "model_format": "diffusers",
     "model_ability": [
       "text2video"
     ],
@@ -15,7 +17,7 @@
     },
     "virtualenv": {
       "packages": [
-        "diffusers>=0.33.0",
+        "diffusers>=0.33.0 ; #engine# == \"diffusers\"",
         "ftfy",
         "imageio-ffmpeg",
         "imageio",
@@ -39,6 +41,8 @@
     "version": 2,
     "model_name": "CogVideoX-5b",
     "model_family": "CogVideoX",
+    "engine": "diffusers",
+    "model_format": "diffusers",
     "model_ability": [
       "text2video"
     ],
@@ -51,7 +55,7 @@
     },
     "virtualenv": {
       "packages": [
-        "diffusers>=0.33.0",
+        "diffusers>=0.33.0 ; #engine# == \"diffusers\"",
         "ftfy",
         "imageio-ffmpeg",
         "imageio",
@@ -75,6 +79,8 @@
     "version": 2,
     "model_name": "HunyuanVideo",
     "model_family": "HunyuanVideo",
+    "engine": "diffusers",
+    "model_format": "diffusers",
     "model_ability": [
       "text2video"
     ],
@@ -85,7 +91,7 @@
     "default_generate_config": {},
     "virtualenv": {
       "packages": [
-        "diffusers>=0.33.0",
+        "diffusers>=0.33.0 ; #engine# == \"diffusers\"",
         "ftfy",
         "imageio-ffmpeg",
         "imageio",
@@ -143,6 +149,8 @@
     "version": 2,
     "model_name": "Wan2.1-1.3B",
     "model_family": "Wan",
+    "engine": "diffusers",
+    "model_format": "diffusers",
     "model_ability": [
       "text2video"
     ],
@@ -152,7 +160,7 @@
     "default_generate_config": {},
     "virtualenv": {
       "packages": [
-        "diffusers>=0.33.0",
+        "diffusers>=0.33.0 ; #engine# == \"diffusers\"",
         "ftfy",
         "imageio-ffmpeg",
         "imageio",
@@ -176,6 +184,8 @@
     "version": 2,
     "model_name": "Wan2.1-14B",
     "model_family": "Wan",
+    "engine": "diffusers",
+    "model_format": "diffusers",
     "model_ability": [
       "text2video"
     ],
@@ -185,7 +195,7 @@
     "default_generate_config": {},
     "virtualenv": {
       "packages": [
-        "diffusers>=0.33.0",
+        "diffusers>=0.33.0 ; #engine# == \"diffusers\"",
         "ftfy",
         "imageio-ffmpeg",
         "imageio",
@@ -209,6 +219,8 @@
     "version": 2,
     "model_name": "Wan2.1-i2v-14B-480p",
     "model_family": "Wan",
+    "engine": "diffusers",
+    "model_format": "diffusers",
     "model_ability": [
       "image2video"
     ],
@@ -223,7 +235,7 @@
     },
     "virtualenv": {
       "packages": [
-        "diffusers>=0.33.0",
+        "diffusers>=0.33.0 ; #engine# == \"diffusers\"",
         "ftfy",
         "imageio-ffmpeg",
         "imageio",
@@ -247,6 +259,8 @@
     "version": 2,
     "model_name": "Wan2.1-i2v-14B-720p",
     "model_family": "Wan",
+    "engine": "diffusers",
+    "model_format": "diffusers",
     "model_ability": [
       "image2video"
     ],
@@ -261,7 +275,7 @@
     },
     "virtualenv": {
       "packages": [
-        "diffusers>=0.33.0",
+        "diffusers>=0.33.0 ; #engine# == \"diffusers\"",
         "ftfy",
         "imageio-ffmpeg",
         "imageio",
@@ -285,6 +299,8 @@
     "version": 2,
     "model_name": "Wan2.1-flf2v-14B-720p",
     "model_family": "Wan",
+    "engine": "diffusers",
+    "model_format": "diffusers",
     "model_ability": [
       "firstlastframe2video"
     ],
@@ -299,7 +315,7 @@
     },
     "virtualenv": {
       "packages": [
-        "diffusers==0.35.1",
+        "diffusers==0.35.1 ; #engine# == \"diffusers\"",
         "ftfy",
         "imageio-ffmpeg",
         "imageio",
@@ -323,6 +339,8 @@
     "version": 2,
     "model_name": "Wan2.2-A14B",
     "model_family": "Wan",
+    "engine": "diffusers",
+    "model_format": "diffusers",
     "model_ability": [
       "text2video"
     ],
@@ -332,7 +350,7 @@
     "default_generate_config": {},
     "virtualenv": {
       "packages": [
-        "diffusers==0.35.1",
+        "diffusers==0.35.1 ; #engine# == \"diffusers\"",
         "ftfy",
         "imageio-ffmpeg",
         "imageio",
@@ -356,6 +374,8 @@
     "version": 2,
     "model_name": "Wan2.2-i2v-A14B",
     "model_family": "Wan",
+    "engine": "diffusers",
+    "model_format": "diffusers",
     "model_ability": [
       "image2video"
     ],
@@ -365,7 +385,7 @@
     "default_generate_config": {},
     "virtualenv": {
       "packages": [
-        "diffusers==0.35.1",
+        "diffusers==0.35.1 ; #engine# == \"diffusers\"",
         "ftfy",
         "imageio-ffmpeg",
         "imageio",
@@ -389,6 +409,8 @@
     "version": 2,
     "model_name": "Wan2.2-ti2v-5B",
     "model_family": "Wan",
+    "engine": "diffusers",
+    "model_format": "diffusers",
     "model_ability": [
       "text2video",
       "image2video"
@@ -399,7 +421,7 @@
     "default_generate_config": {},
     "virtualenv": {
       "packages": [
-        "diffusers==0.35.1",
+        "diffusers==0.35.1 ; #engine# == \"diffusers\"",
         "ftfy",
         "imageio-ffmpeg",
         "imageio",
@@ -423,6 +445,8 @@
     "version": 2,
     "model_name": "Wan2.2-Animate-2-14B",
     "model_family": "WanAnimate2",
+    "engine": "diffusers",
+    "model_format": "diffusers",
     "model_ability": [
       "image2video"
     ],
@@ -439,7 +463,7 @@
     },
     "virtualenv": {
       "packages": [
-        "diffusers @ git+https://github.com/huggingface/diffusers.git@refs/pull/14412/head",
+        "diffusers @ git+https://github.com/huggingface/diffusers.git@refs/pull/14412/head ; #engine# == \"diffusers\"",
         "transformers>=4.57.6",
         "accelerate>=1.13.0",
         "flash-attn",
@@ -470,6 +494,8 @@
     "version": 2,
     "model_name": "Wan2.2-Animate-2-14B-Distilled",
     "model_family": "WanAnimate2",
+    "engine": "diffusers",
+    "model_format": "diffusers",
     "model_ability": [
       "image2video"
     ],
@@ -486,7 +512,7 @@
     },
     "virtualenv": {
       "packages": [
-        "diffusers @ git+https://github.com/huggingface/diffusers.git@refs/pull/14412/head",
+        "diffusers @ git+https://github.com/huggingface/diffusers.git@refs/pull/14412/head ; #engine# == \"diffusers\"",
         "transformers>=4.57.6",
         "accelerate>=1.13.0",
         "flash-attn",
@@ -517,6 +543,8 @@
     "version": 2,
     "model_name": "MiniMax-H3",
     "model_family": "MiniMax-H3",
+    "engine": "diffusers",
+    "model_format": "diffusers",
     "model_ability": [
       "text2video",
       "image2video",
@@ -558,7 +586,7 @@
     },
     "virtualenv": {
       "packages": [
-        "git+https://github.com/huggingface/diffusers@2da7040be1a2e5f2fcbc8b985083342a308f5a86",
+        "git+https://github.com/huggingface/diffusers@2da7040be1a2e5f2fcbc8b985083342a308f5a86 ; #engine# == \"diffusers\"",
         "transformers>=5.15.0,<6.0",
         "peft==0.20.0",
         "huggingface-hub>=1.23.0,<2.0",

--- a/xinference/model/video/tests/test_minimax_h3_video.py
+++ b/xinference/model/video/tests/test_minimax_h3_video.py
@@ -198,7 +198,9 @@ def test_video_rejects_unsupported_lightning_before_cache(monkeypatch):
             cache_called = True
             return "/tmp/lightning.safetensors"
 
-    monkeypatch.setattr(core_module, "match_diffusion", lambda *args: _model_spec())
+    monkeypatch.setattr(
+        core_module, "match_diffusion", lambda *args, **kwargs: _model_spec()
+    )
     monkeypatch.setattr(cache_manager_module, "VideoCacheManager", FakeCacheManager)
 
     with pytest.raises(ValueError, match="does not support lightning acceleration"):

--- a/xinference/model/video/tests/test_mlx_video.py
+++ b/xinference/model/video/tests/test_mlx_video.py
@@ -1,0 +1,510 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import base64
+import importlib
+import os
+from enum import Enum
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from PIL import Image
+
+from .. import mlx_video as mlx_video_module
+from ..core import VideoModelFamilyV2
+from ..engine import MLXVideoEngineModel
+from ..mlx_video import MLXVideoModel
+
+
+def _model_spec(
+    model_name: str,
+    model_family: str,
+    abilities,
+    default_generate_config=None,
+    **kwargs,
+):
+    return VideoModelFamilyV2(
+        version=2,
+        model_name=model_name,
+        model_family=model_family,
+        model_id=f"test/{model_name}",
+        model_revision="test-revision",
+        model_ability=abilities,
+        default_model_config={},
+        default_generate_config=default_generate_config or {},
+        cache_config=None,
+        engine="MLX",
+        model_format="mlx",
+        cache_name=f"{model_name}-mlx",
+        virtualenv={"packages": []},
+        **kwargs,
+    )
+
+
+def _write_converted_wan_model(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    for filename in (
+        "config.json",
+        "model.safetensors",
+        "t5_encoder.safetensors",
+        "vae.safetensors",
+    ):
+        (path / filename).write_bytes(b"test")
+
+
+def test_convert_wan_model_is_atomic_and_reused(tmp_path, monkeypatch):
+    source_path = tmp_path / "raw-wan"
+    source_path.mkdir()
+    calls = []
+
+    def convert(source, output, dtype):
+        calls.append((source, dtype))
+        _write_converted_wan_model(Path(output))
+
+    real_import_module = mlx_video_module.importlib.import_module
+
+    def import_module(name):
+        if name == "mlx_video.models.wan_2.convert":
+            return SimpleNamespace(convert_wan_checkpoint=convert)
+        return real_import_module(name)
+
+    monkeypatch.setattr(mlx_video_module.importlib, "import_module", import_module)
+
+    converted_path = MLXVideoModel._convert_wan_model(source_path)
+    assert MLXVideoModel._is_wan_mlx_model_dir(converted_path)
+    assert calls == [(str(source_path), "bfloat16")]
+
+    assert MLXVideoModel._convert_wan_model(source_path) == converted_path
+    assert len(calls) == 1
+
+
+def test_convert_wan_model_rebuilds_when_source_changes(tmp_path, monkeypatch):
+    source_path = tmp_path / "raw-wan"
+    source_path.mkdir()
+    source_weight = source_path / "source.safetensors"
+    source_weight.write_bytes(b"first")
+    calls = []
+
+    def convert(source, output, dtype):
+        calls.append((source, dtype))
+        _write_converted_wan_model(Path(output))
+
+    real_import_module = mlx_video_module.importlib.import_module
+
+    def import_module(name):
+        if name == "mlx_video.models.wan_2.convert":
+            return SimpleNamespace(convert_wan_checkpoint=convert)
+        return real_import_module(name)
+
+    monkeypatch.setattr(mlx_video_module.importlib, "import_module", import_module)
+
+    converted_path = MLXVideoModel._convert_wan_model(source_path)
+    source_weight.write_bytes(b"changed-source")
+
+    assert MLXVideoModel._convert_wan_model(source_path) == converted_path
+    assert calls == [
+        (str(source_path), "bfloat16"),
+        (str(source_path), "bfloat16"),
+    ]
+
+
+def test_convert_wan_model_refuses_unmanaged_target(tmp_path):
+    source_path = tmp_path / "raw-wan"
+    source_path.mkdir()
+    converted_path = Path(f"{source_path}.mlx-video")
+    converted_path.mkdir()
+    marker = converted_path / "user-owned.txt"
+    marker.write_text("keep")
+
+    with pytest.raises(FileExistsError, match="Refusing to overwrite unmanaged"):
+        MLXVideoModel._convert_wan_model(source_path)
+
+    assert marker.read_text() == "keep"
+
+
+def test_prepare_wan_model_binds_effective_converter_override(tmp_path):
+    source_path = tmp_path / "raw-wan"
+    source_path.mkdir()
+    converted_path = tmp_path / "converted-wan"
+    spec = _model_spec("Wan2.1-1.3B", "Wan", ["text2video"])
+    spec.virtualenv.packages = [
+        "mlx-video @ git+https://example.invalid/mlx-video@default"
+    ]
+    override = "mlx-video @ git+https://example.invalid/mlx-video@override"
+    model = MLXVideoModel(
+        "uid",
+        str(source_path),
+        spec,
+        _xinference_enable_virtual_env=True,
+        _xinference_virtual_env_packages=[override],
+    )
+
+    with (
+        patch.object(
+            model,
+            "_converter_runtime_identity",
+            return_value={
+                "environment": "virtualenv",
+                "distribution_version": "0.1.dev0",
+                "direct_url": {"vcs_info": {"commit_id": "override"}},
+            },
+        ),
+        patch.object(
+            MLXVideoModel, "_convert_wan_model", return_value=converted_path
+        ) as convert,
+    ):
+        model._prepare_wan_model()
+
+    identity = convert.call_args.args[1]
+    assert identity["converter"] == {
+        "requirement": override,
+        "runtime": {
+            "environment": "virtualenv",
+            "distribution_version": "0.1.dev0",
+            "direct_url": {"vcs_info": {"commit_id": "override"}},
+        },
+    }
+    assert model._runtime_model_path == str(converted_path)
+
+
+def test_converter_runtime_identity_distinguishes_host_runtime():
+    spec = _model_spec("Wan2.1-1.3B", "Wan", ["text2video"])
+    model = MLXVideoModel(
+        "uid", "/downloaded", spec, _xinference_enable_virtual_env=False
+    )
+    distribution = SimpleNamespace(
+        version="0.2.0",
+        read_text=lambda name: (
+            '{"url":"file:///host/mlx-video"}' if name == "direct_url.json" else None
+        ),
+    )
+
+    with patch.object(
+        mlx_video_module.importlib.metadata,
+        "distribution",
+        return_value=distribution,
+    ):
+        identity = model._converter_runtime_identity()
+
+    assert identity == {
+        "environment": "host",
+        "distribution_version": "0.2.0",
+        "direct_url": {"url": "file:///host/mlx-video"},
+    }
+
+
+def test_wan_text_to_video_maps_request_and_returns_base64(tmp_path, monkeypatch):
+    spec = _model_spec(
+        "Wan2.1-1.3B",
+        "Wan",
+        ["text2video"],
+        {"width": 832, "height": 480, "num_frames": 81},
+    )
+    model = MLXVideoModel(
+        "uid", "/downloaded", spec, cpu_offload=False, unrelated_launch_option=True
+    )
+    model._runtime_model_path = "/converted"
+    calls = []
+
+    def generate_video(**kwargs):
+        calls.append(kwargs)
+        Path(kwargs["output_path"]).write_bytes(b"generated-video")
+
+    monkeypatch.setattr(
+        mlx_video_module.importlib,
+        "import_module",
+        lambda name: SimpleNamespace(generate_video=generate_video),
+    )
+    monkeypatch.setattr(mlx_video_module, "XINFERENCE_VIDEO_DIR", str(tmp_path))
+
+    response = model._generate(
+        "a test prompt",
+        n=2,
+        num_inference_steps=12,
+        response_format="b64_json",
+        image=None,
+        last_image=None,
+        request_kwargs={
+            "guidance_scale": 4.5,
+            "request_id": "request-id",
+            "num_videos_per_prompt": 2,
+        },
+    )
+
+    assert len(response["data"]) == 2
+    assert all(
+        base64.b64decode(video["b64_json"]) == b"generated-video"
+        for video in response["data"]
+    )
+    assert len(calls) == 2
+    for call in calls:
+        assert call["model_dir"] == "/converted"
+        assert call["prompt"] == "a test prompt"
+        assert call["steps"] == 12
+        assert call["guide_scale"] == 4.5
+        assert call["width"] == 832
+        assert call["height"] == 480
+        assert "cpu_offload" not in call
+        assert "unrelated_launch_option" not in call
+        assert "request_id" not in call
+        assert not os.path.exists(call["output_path"])
+
+
+def test_wan_prompt_lists_fan_out_and_pair_negative_prompts(tmp_path, monkeypatch):
+    spec = _model_spec(
+        "Wan2.1-1.3B",
+        "Wan",
+        ["text2video"],
+        {"width": 512, "height": 512, "num_frames": 17},
+    )
+    model = MLXVideoModel("uid", "/downloaded", spec)
+    model._runtime_model_path = "/converted"
+    calls = []
+
+    def generate_video(**kwargs):
+        calls.append(kwargs)
+        Path(kwargs["output_path"]).write_bytes(b"generated-video")
+
+    monkeypatch.setattr(
+        mlx_video_module.importlib,
+        "import_module",
+        lambda name: SimpleNamespace(generate_video=generate_video),
+    )
+    monkeypatch.setattr(mlx_video_module, "XINFERENCE_VIDEO_DIR", str(tmp_path))
+
+    response = model._generate(
+        ["first prompt", "second prompt"],
+        n=2,
+        num_inference_steps=4,
+        response_format="b64_json",
+        image=None,
+        last_image=None,
+        request_kwargs={"negative_prompt": ["first negative", "second negative"]},
+    )
+
+    assert len(response["data"]) == 4
+    assert [call["prompt"] for call in calls] == [
+        "first prompt",
+        "first prompt",
+        "second prompt",
+        "second prompt",
+    ]
+    assert [call["negative_prompt"] for call in calls] == [
+        "first negative",
+        "first negative",
+        "second negative",
+        "second negative",
+    ]
+
+
+def test_prompt_and_negative_prompt_lists_must_align(tmp_path, monkeypatch):
+    spec = _model_spec("Wan2.1-1.3B", "Wan", ["text2video"])
+    model = MLXVideoModel("uid", "/downloaded", spec)
+
+    with pytest.raises(
+        ValueError, match="negative_prompt list length must match prompt list length"
+    ):
+        model._generate(
+            ["first", "second"],
+            n=1,
+            num_inference_steps=4,
+            response_format="b64_json",
+            image=None,
+            last_image=None,
+            request_kwargs={"negative_prompt": ["only one"]},
+        )
+
+
+def test_ltx_first_last_frame_generation_cleans_temporary_inputs(tmp_path, monkeypatch):
+    class PipelineType(Enum):
+        DISTILLED = "distilled"
+        DEV = "dev"
+
+    spec = _model_spec(
+        "LTX-2.3-dev",
+        "LTX-2.3",
+        ["text2video", "image2video", "firstlastframe2video"],
+        {"pipeline": "dev", "width": 512, "height": 512, "num_frames": 33},
+    )
+    model = MLXVideoModel("uid", "/downloaded", spec)
+    model._runtime_model_path = "/ltx-model"
+    model._text_encoder_path = "/ltx-text-encoder"
+    calls = []
+
+    def generate_video(**kwargs):
+        assert Path(kwargs["image"]).is_file()
+        assert Path(kwargs["end_image"]).is_file()
+        calls.append(kwargs)
+        Path(kwargs["output_path"]).write_bytes(b"generated-video")
+        Path(kwargs["output_audio_path"]).write_bytes(b"generated-audio")
+
+    generate_module = SimpleNamespace(
+        PipelineType=PipelineType, generate_video=generate_video
+    )
+    monkeypatch.setattr(
+        mlx_video_module.importlib,
+        "import_module",
+        lambda name: generate_module,
+    )
+    monkeypatch.setattr(mlx_video_module, "XINFERENCE_VIDEO_DIR", str(tmp_path))
+
+    response = model._generate(
+        "a test prompt",
+        n=1,
+        num_inference_steps=20,
+        response_format="url",
+        image=Image.new("RGB", (8, 8), color="red"),
+        last_image=Image.new("RGB", (8, 8), color="blue"),
+        request_kwargs={"guidance_scale": 3.5},
+    )
+
+    assert len(calls) == 1
+    call = calls[0]
+    assert call["model_repo"] == "/ltx-model"
+    assert call["text_encoder_repo"] == "/ltx-text-encoder"
+    assert call["pipeline"] is PipelineType.DEV
+    assert call["num_inference_steps"] == 20
+    assert call["cfg_scale"] == 3.5
+    assert not Path(call["image"]).exists()
+    assert not Path(call["end_image"]).exists()
+    assert not Path(call["output_audio_path"]).exists()
+    assert response["data"][0]["url"] == call["output_path"]
+    Path(call["output_path"]).unlink()
+
+
+def test_ltx_audio_cleanup_error_does_not_mask_generation_error(tmp_path, monkeypatch):
+    class PipelineType(Enum):
+        DEV = "dev"
+
+    spec = _model_spec(
+        "LTX-2.3-dev",
+        "LTX-2.3",
+        ["text2video"],
+        {"pipeline": "dev"},
+    )
+    model = MLXVideoModel("uid", "/downloaded", spec)
+    output_path = str(tmp_path / "output.mp4")
+    audio_path = str(tmp_path / "output.wav")
+
+    def generate_video(**kwargs):
+        Path(kwargs["output_audio_path"]).write_bytes(b"generated-audio")
+        raise RuntimeError("generation failed")
+
+    monkeypatch.setattr(
+        mlx_video_module.importlib,
+        "import_module",
+        lambda name: SimpleNamespace(
+            PipelineType=PipelineType, generate_video=generate_video
+        ),
+    )
+
+    def fail_audio_cleanup(path):
+        assert path == audio_path
+        raise PermissionError("cleanup failed")
+
+    monkeypatch.setattr(mlx_video_module.os, "remove", fail_audio_cleanup)
+
+    with pytest.raises(RuntimeError, match="generation failed"):
+        model._generate_ltx(
+            "a test prompt",
+            output_path,
+            image_path=None,
+            last_image_path=None,
+            num_inference_steps=20,
+            request_kwargs={},
+        )
+
+
+def test_ltx_23_prepares_pinned_external_text_encoder(tmp_path):
+    model_path = tmp_path / "ltx-model"
+    model_path.mkdir()
+    text_encoder_path = tmp_path / "text-encoder"
+    text_encoder_path.mkdir()
+    spec = _model_spec(
+        "LTX-2.3-distilled",
+        "LTX-2.3",
+        ["text2video"],
+        text_encoder_model_id="prince-canuma/LTX-2-distilled",
+        text_encoder_model_revision="pinned-revision",
+    )
+    model = MLXVideoModel("uid", str(model_path), spec)
+
+    with patch(
+        "huggingface_hub.snapshot_download", return_value=str(text_encoder_path)
+    ) as snapshot_download:
+        model._prepare_ltx_model()
+
+    snapshot_download.assert_called_once_with(
+        "prince-canuma/LTX-2-distilled",
+        revision="pinned-revision",
+        allow_patterns=["text_encoder/**", "tokenizer/**"],
+    )
+    assert model._runtime_model_path == str(model_path)
+    assert model._text_encoder_path == str(text_encoder_path)
+
+
+def test_ltx_23_prepares_external_text_encoder_from_modelscope(tmp_path):
+    model_path = tmp_path / "ltx-model"
+    model_path.mkdir()
+    text_encoder_path = tmp_path / "text-encoder"
+    text_encoder_path.mkdir()
+    spec = _model_spec(
+        "LTX-2.3-distilled",
+        "LTX-2.3",
+        ["text2video"],
+        model_hub="modelscope",
+        text_encoder_model_id="Xorbits/LTX-2-distilled",
+        text_encoder_model_revision="master",
+    )
+    model = MLXVideoModel("uid", str(model_path), spec)
+    snapshot_download_module = importlib.import_module(
+        "modelscope.hub.snapshot_download"
+    )
+
+    with patch.object(
+        snapshot_download_module,
+        "snapshot_download",
+        return_value=str(text_encoder_path),
+    ) as snapshot_download:
+        model._prepare_ltx_model()
+
+    snapshot_download.assert_called_once_with(
+        "Xorbits/LTX-2-distilled",
+        revision="master",
+        allow_patterns=["text_encoder/**", "tokenizer/**"],
+    )
+    assert model._runtime_model_path == str(model_path)
+    assert model._text_encoder_path == str(text_encoder_path)
+
+
+def test_mlx_engine_rejects_unrelated_pypi_package_namespace():
+    def find_spec(name):
+        if name in ("mlx", "mlx_video"):
+            return object()
+        return None
+
+    with (
+        patch.object(MLXVideoEngineModel, "_is_apple_silicon", return_value=True),
+        patch("xinference.model.video.engine.sys.version_info", (3, 11)),
+        patch("importlib.util.find_spec", side_effect=find_spec),
+    ):
+        result = MLXVideoEngineModel.check_lib()
+
+    assert result == (
+        False,
+        "Blaizzy/mlx-video is not installed; the unrelated PyPI package "
+        "with the same name is not compatible",
+    )

--- a/xinference/model/video/tests/test_video_engine.py
+++ b/xinference/model/video/tests/test_video_engine.py
@@ -22,31 +22,66 @@ from ...utils import (
     get_engine_params_by_name,
     get_engine_params_by_name_with_virtual_env,
 )
-from .. import BUILTIN_VIDEO_MODELS, _install
+from .. import BUILTIN_VIDEO_MODELS, VIDEO_MODEL_DESCRIPTIONS, _install
 from ..cache_manager import VideoCacheManager
-from ..core import create_video_model_instance, resolve_video_model_name_and_engine
-from ..engine import DiffusersVideoEngineModel
-from ..engine_family import VIDEO_ENGINES, check_engine_by_model_name_and_engine
+from ..core import (
+    create_video_model_instance,
+    match_diffusion,
+    resolve_video_model_name_and_engine,
+)
+from ..engine import (
+    MLX_VIDEO_MODEL_NAMES,
+    DiffusersVideoEngineModel,
+    MLXVideoEngineModel,
+)
+from ..engine_family import (
+    VIDEO_ENGINES,
+    check_engine_by_model_name_and_engine,
+    check_engine_by_model_name_and_engine_with_virtual_env,
+)
 
 
 @pytest.fixture(scope="module", autouse=True)
 def setup_builtin_models():
+    with (
+        patch.object(MLXVideoEngineModel, "_is_apple_silicon", return_value=True),
+        patch("xinference.model.video.engine.sys.version_info", (3, 11)),
+    ):
+        _install()
+        yield
     _install()
 
 
-def test_builtin_video_models_register_diffusers_engine():
+def test_builtin_video_models_register_expected_engines():
     assert set(VIDEO_ENGINES) == set(BUILTIN_VIDEO_MODELS)
     for model_name, engines in VIDEO_ENGINES.items():
-        assert list(engines) == ["diffusers"]
-        params = engines["diffusers"]
-        assert params == [
-            {
-                "model_name": model_name,
-                "model_format": "diffusers",
-                "quantization": "none",
-                "video_class": DiffusersVideoEngineModel,
-            }
-        ]
+        expected_engines = []
+        if any(
+            family.engine == "diffusers" for family in BUILTIN_VIDEO_MODELS[model_name]
+        ):
+            expected_engines.append("diffusers")
+        if model_name in MLX_VIDEO_MODEL_NAMES:
+            expected_engines.append("MLX")
+        assert list(engines) == expected_engines
+
+        if "diffusers" in engines:
+            assert engines["diffusers"] == [
+                {
+                    "model_name": model_name,
+                    "model_format": "diffusers",
+                    "quantization": "none",
+                    "video_class": DiffusersVideoEngineModel,
+                }
+            ]
+        if "MLX" in engines:
+            assert engines["MLX"] == [
+                {
+                    "model_name": model_name,
+                    "model_format": "mlx",
+                    "quantization": "none",
+                    "video_class": MLXVideoEngineModel,
+                }
+            ]
 
 
 def test_video_engine_lookup_is_case_insensitive():
@@ -57,6 +92,13 @@ def test_video_engine_lookup_is_case_insensitive():
     assert resolve_video_model_name_and_engine(
         "MiniMax-H3", use_default_engine=True
     ) == ("MiniMax-H3", "diffusers")
+    assert (
+        check_engine_by_model_name_and_engine("mlx", "LTX-2-distilled")
+        is MLXVideoEngineModel
+    )
+    assert resolve_video_model_name_and_engine(
+        "Wan2.1-1.3B", "mlx", use_default_engine=True
+    ) == ("Wan2.1-1.3B", "MLX")
 
 
 def test_create_video_model_instance_records_default_engine():
@@ -72,6 +114,22 @@ def test_create_video_model_instance_records_default_engine():
     assert model.model_family.to_description()["model_engine"] == "diffusers"
 
 
+def test_create_mlx_video_model_instance():
+    model = create_video_model_instance(
+        "uid",
+        "LTX-2-distilled",
+        model_path="/fake/path",
+        model_engine="mlx",
+        model_format="mlx",
+        quantization="none",
+        enable_virtual_env=False,
+    )
+
+    assert isinstance(model, MLXVideoEngineModel)
+    assert model.model_family.model_engine == "MLX"
+    assert model.model_family.cache_name == "LTX-2-distilled-mlx"
+
+
 def test_invalid_video_engine_is_rejected_before_download():
     with patch.object(VideoCacheManager, "cache") as cache:
         with pytest.raises(ValueError, match="cannot be run on engine"):
@@ -82,6 +140,42 @@ def test_invalid_video_engine_is_rejected_before_download():
                 enable_virtual_env=False,
             )
     cache.assert_not_called()
+
+
+@pytest.mark.parametrize("download_hub", ["modelscope", "auto", None])
+def test_hf_only_mlx_video_rejects_modelscope_before_download(
+    monkeypatch, download_hub
+):
+    monkeypatch.setenv("XINFERENCE_MODEL_SRC", "modelscope")
+    with patch.object(VideoCacheManager, "cache") as cache:
+        with pytest.raises(ValueError, match="does not provide a modelscope source"):
+            create_video_model_instance(
+                "uid",
+                "Wan2.1-1.3B",
+                model_engine="MLX",
+                download_hub=download_hub,
+                enable_virtual_env=True,
+            )
+    cache.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("model_format", "quantization"),
+    [("diffusers", "none"), ("mlx", "q8_0")],
+)
+def test_virtualenv_fallback_preserves_explicit_video_tuple(model_format, quantization):
+    model_spec = match_diffusion(
+        "Wan2.1-1.3B", download_hub="huggingface", model_engine="MLX"
+    )
+
+    with pytest.raises(ValueError, match="with format"):
+        check_engine_by_model_name_and_engine_with_virtual_env(
+            "MLX",
+            model_spec.model_name,
+            model_format,
+            quantization,
+            model_family=model_spec,
+        )
 
 
 def test_generic_factory_forwards_video_engine():
@@ -139,9 +233,59 @@ def test_video_engine_uses_virtualenv_when_dependency_is_missing():
     assert params["diffusers"][0]["virtualenv_required"] is True
 
 
+def test_mlx_video_engine_uses_virtualenv_when_dependency_is_missing():
+    with (
+        patch("xinference.model.utils.sys.platform", "darwin"),
+        patch.object(
+            MLXVideoEngineModel,
+            "check_lib",
+            return_value=(False, "Blaizzy/mlx-video is not installed"),
+        ),
+    ):
+        params = get_engine_params_by_name_with_virtual_env(
+            "video", "LTX-2-distilled", enable_virtual_env=True
+        )
+
+    assert params["MLX"][0]["virtualenv_required"] is True
+
+
+def test_mlx_video_engine_old_python_is_not_virtualenv_repairable():
+    with (
+        patch("xinference.model.utils.sys.platform", "darwin"),
+        patch.object(MLXVideoEngineModel, "_is_apple_silicon", return_value=True),
+        patch("xinference.model.video.engine.sys.version_info", (3, 10)),
+    ):
+        params = get_engine_params_by_name_with_virtual_env(
+            "video", "LTX-2-distilled", enable_virtual_env=True
+        )
+
+    assert params["MLX"] == "Blaizzy/mlx-video requires Python 3.11 or newer"
+
+
+@pytest.mark.parametrize("enable_virtual_env", [False, True])
+def test_mlx_video_engine_incompatible_host_is_rejected_before_download(
+    enable_virtual_env,
+):
+    with (
+        patch.object(MLXVideoEngineModel, "_is_apple_silicon", return_value=False),
+        patch.object(VideoCacheManager, "cache") as cache,
+        pytest.raises(ValueError, match="requires Apple Silicon"),
+    ):
+        create_video_model_instance(
+            "uid",
+            "LTX-2-distilled",
+            model_engine="MLX",
+            enable_virtual_env=enable_virtual_env,
+        )
+
+    cache.assert_not_called()
+
+
 def test_video_specs_scope_diffusers_dependency_to_engine():
     for families in BUILTIN_VIDEO_MODELS.values():
         for family in families:
+            if family.engine != "diffusers":
+                continue
             assert family.engine == "diffusers"
             assert family.model_format == "diffusers"
             assert family.virtualenv is not None
@@ -163,6 +307,85 @@ def test_video_specs_scope_diffusers_dependency_to_engine():
             ]
 
 
+def test_mlx_video_specs_are_pinned_and_isolated():
+    mlx_specs = [
+        family
+        for families in BUILTIN_VIDEO_MODELS.values()
+        for family in families
+        if family.engine == "MLX"
+    ]
+
+    assert {family.model_name for family in mlx_specs} == MLX_VIDEO_MODEL_NAMES
+    assert len({family.cache_name for family in mlx_specs}) == len(
+        MLX_VIDEO_MODEL_NAMES
+    )
+    for family in mlx_specs:
+        assert family.model_format == "mlx"
+        if family.model_hub == "huggingface":
+            assert family.model_revision not in (None, "main")
+        else:
+            assert family.model_hub == "modelscope"
+            assert family.model_revision == "master"
+        assert family.cache_name.endswith("-mlx")
+        assert family.virtualenv is not None
+        mlx_packages = [
+            package
+            for package in family.virtualenv.packages
+            if package.startswith("mlx-video @")
+        ]
+        assert len(mlx_packages) == 1
+        assert "Blaizzy/mlx-video.git@87db56a" in mlx_packages[0]
+        assert '#engine# == "MLX"' in mlx_packages[0]
+
+    wan21_specs = [
+        family for family in mlx_specs if family.model_name.startswith("Wan2.1-")
+    ]
+    assert all(
+        '#system_torch# ; #engine# == "MLX"' in family.virtualenv.packages
+        for family in wan21_specs
+    )
+    ltx23_specs = [
+        family
+        for family in mlx_specs
+        if family.model_family == "LTX-2.3" and family.model_hub == "huggingface"
+    ]
+    assert all(
+        family.text_encoder_model_id == "prince-canuma/LTX-2-distilled"
+        for family in ltx23_specs
+    )
+    modelscope_ltx23_specs = [
+        family
+        for family in mlx_specs
+        if family.model_family == "LTX-2.3" and family.model_hub == "modelscope"
+    ]
+    assert all(
+        family.text_encoder_model_id == "Xorbits/LTX-2-distilled"
+        for family in modelscope_ltx23_specs
+    )
+
+
+@pytest.mark.parametrize(
+    ("model_name", "model_id"),
+    [
+        ("Wan2.2-A14B", "Xorbits/wan2.2-t2v-a14b-mlx"),
+        ("Wan2.2-i2v-A14B", "Xorbits/wan2.2-i2v-a14b-mlx"),
+        ("Wan2.2-ti2v-5B", "Xorbits/wan2.2-ti2v-5b-mlx"),
+        ("LTX-2-distilled", "Xorbits/LTX-2-distilled"),
+        ("LTX-2-dev", "Xorbits/LTX-2-dev"),
+        ("LTX-2.3-distilled", "Xorbits/LTX-2.3-distilled"),
+        ("LTX-2.3-dev", "Xorbits/LTX-2.3-dev"),
+    ],
+)
+def test_mirrored_mlx_models_default_to_modelscope(monkeypatch, model_name, model_id):
+    monkeypatch.setenv("XINFERENCE_MODEL_SRC", "modelscope")
+
+    model_spec = match_diffusion(model_name, model_engine="MLX")
+
+    assert model_spec.model_hub == "modelscope"
+    assert model_spec.model_id == model_id
+    assert model_spec.model_revision == "master"
+
+
 @pytest.mark.asyncio
 async def test_video_catalog_groups_hub_variants():
     from ....core.worker import WorkerActor
@@ -176,3 +399,41 @@ async def test_video_catalog_groups_hub_variants():
     assert {spec["model_engine"] for spec in specs} == {"diffusers"}
     assert {spec["model_format"] for spec in specs} == {"diffusers"}
     assert {spec["model_hub"] for spec in specs} == {"huggingface", "modelscope"}
+
+    wan_entries = [
+        item for item in registrations if item["model_name"] == "Wan2.2-A14B"
+    ]
+    assert len(wan_entries) == 1
+    wan_specs = wan_entries[0]["model_specs"]
+    assert {spec["model_engine"] for spec in wan_specs} == {"diffusers", "MLX"}
+    assert {spec["model_format"] for spec in wan_specs} == {"diffusers", "mlx"}
+    assert {spec["model_hub"] for spec in wan_specs} == {"huggingface", "modelscope"}
+
+
+def test_video_registry_reload_failure_preserves_live_registries(monkeypatch):
+    from ... import utils as model_utils
+
+    model_snapshot = {name: list(specs) for name, specs in BUILTIN_VIDEO_MODELS.items()}
+    description_snapshot = {
+        name: list(descriptions)
+        for name, descriptions in VIDEO_MODEL_DESCRIPTIONS.items()
+    }
+    engine_snapshot = {
+        name: {engine: list(params) for engine, params in engines.items()}
+        for name, engines in VIDEO_ENGINES.items()
+    }
+
+    def fail_after_partial_build(target, *_args, **_kwargs):
+        target["partial"] = []
+        raise RuntimeError("reload failed")
+
+    monkeypatch.setattr(
+        model_utils, "install_models_with_merge", fail_after_partial_build
+    )
+
+    with pytest.raises(RuntimeError, match="reload failed"):
+        _install()
+
+    assert BUILTIN_VIDEO_MODELS == model_snapshot
+    assert VIDEO_MODEL_DESCRIPTIONS == description_snapshot
+    assert VIDEO_ENGINES == engine_snapshot

--- a/xinference/model/video/tests/test_video_engine.py
+++ b/xinference/model/video/tests/test_video_engine.py
@@ -1,0 +1,178 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import patch
+
+import pytest
+
+from ....core.utils import filter_virtualenv_packages_by_markers
+from ...core import create_model_instance
+from ...utils import (
+    get_engine_params_by_name,
+    get_engine_params_by_name_with_virtual_env,
+)
+from .. import BUILTIN_VIDEO_MODELS, _install
+from ..cache_manager import VideoCacheManager
+from ..core import create_video_model_instance, resolve_video_model_name_and_engine
+from ..engine import DiffusersVideoEngineModel
+from ..engine_family import VIDEO_ENGINES, check_engine_by_model_name_and_engine
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_builtin_models():
+    _install()
+
+
+def test_builtin_video_models_register_diffusers_engine():
+    assert set(VIDEO_ENGINES) == set(BUILTIN_VIDEO_MODELS)
+    for model_name, engines in VIDEO_ENGINES.items():
+        assert list(engines) == ["diffusers"]
+        params = engines["diffusers"]
+        assert params == [
+            {
+                "model_name": model_name,
+                "model_format": "diffusers",
+                "quantization": "none",
+                "video_class": DiffusersVideoEngineModel,
+            }
+        ]
+
+
+def test_video_engine_lookup_is_case_insensitive():
+    assert (
+        check_engine_by_model_name_and_engine("DIFFUSERS", "MiniMax-H3")
+        is DiffusersVideoEngineModel
+    )
+    assert resolve_video_model_name_and_engine(
+        "MiniMax-H3", use_default_engine=True
+    ) == ("MiniMax-H3", "diffusers")
+
+
+def test_create_video_model_instance_records_default_engine():
+    model = create_video_model_instance(
+        "uid",
+        "MiniMax-H3",
+        model_path="/fake/path",
+        enable_virtual_env=False,
+    )
+
+    assert isinstance(model, DiffusersVideoEngineModel)
+    assert model.model_family.model_engine == "diffusers"
+    assert model.model_family.to_description()["model_engine"] == "diffusers"
+
+
+def test_invalid_video_engine_is_rejected_before_download():
+    with patch.object(VideoCacheManager, "cache") as cache:
+        with pytest.raises(ValueError, match="cannot be run on engine"):
+            create_video_model_instance(
+                "uid",
+                "MiniMax-H3",
+                model_engine="not-an-engine",
+                enable_virtual_env=False,
+            )
+    cache.assert_not_called()
+
+
+def test_generic_factory_forwards_video_engine():
+    with patch(
+        "xinference.model.video.core.create_video_model_instance"
+    ) as create_video:
+        create_model_instance(
+            "uid",
+            "video",
+            "MiniMax-H3",
+            "diffusers",
+            model_format="diffusers",
+            quantization="none",
+            download_hub="huggingface",
+        )
+
+    create_video.assert_called_once_with(
+        "uid",
+        "MiniMax-H3",
+        "huggingface",
+        None,
+        model_engine="diffusers",
+        model_format="diffusers",
+        quantization="none",
+    )
+
+
+def test_video_engine_api_returns_diffusers_format():
+    with patch.object(DiffusersVideoEngineModel, "check_lib", return_value=True):
+        params = get_engine_params_by_name(
+            "video", "MiniMax-H3", enable_virtual_env=False
+        )
+
+    assert params == {
+        "diffusers": [
+            {
+                "model_name": "MiniMax-H3",
+                "model_format": "diffusers",
+                "quantization": "none",
+            }
+        ]
+    }
+
+
+def test_video_engine_uses_virtualenv_when_dependency_is_missing():
+    with patch.object(
+        DiffusersVideoEngineModel,
+        "check_lib",
+        return_value=(False, "diffusers is not installed"),
+    ):
+        params = get_engine_params_by_name_with_virtual_env(
+            "video", "MiniMax-H3", enable_virtual_env=True
+        )
+
+    assert params["diffusers"][0]["virtualenv_required"] is True
+
+
+def test_video_specs_scope_diffusers_dependency_to_engine():
+    for families in BUILTIN_VIDEO_MODELS.values():
+        for family in families:
+            assert family.engine == "diffusers"
+            assert family.model_format == "diffusers"
+            assert family.virtualenv is not None
+            diffusers_packages = [
+                package
+                for package in family.virtualenv.packages
+                if "diffusers" in package.lower()
+            ]
+            assert diffusers_packages
+            assert all(
+                '#engine# == "diffusers"' in package for package in diffusers_packages
+            )
+            assert filter_virtualenv_packages_by_markers(
+                family.virtualenv.packages, "other", cuda_version=None
+            ) == [
+                package
+                for package in family.virtualenv.packages
+                if "diffusers" not in package.lower()
+            ]
+
+
+@pytest.mark.asyncio
+async def test_video_catalog_groups_hub_variants():
+    from ....core.worker import WorkerActor
+
+    worker = WorkerActor.__new__(WorkerActor)
+    registrations = await worker.list_model_registrations("video", detailed=True)
+    entries = [item for item in registrations if item["model_name"] == "MiniMax-H3"]
+
+    assert len(entries) == 1
+    specs = entries[0]["model_specs"]
+    assert {spec["model_engine"] for spec in specs} == {"diffusers"}
+    assert {spec["model_format"] for spec in specs} == {"diffusers"}
+    assert {spec["model_hub"] for spec in specs} == {"huggingface", "modelscope"}


### PR DESCRIPTION
## Summary

- add engine discovery and selection for video models in the runtime, API metadata, generated docs, and Web UI
- integrate the pinned `Blaizzy/mlx-video` runtime on Apple Silicon for Wan 2.1, Wan 2.2, LTX-2, and LTX-2.3 models
- register pinned Hugging Face sources and Xorbits ModelScope mirrors with engine-isolated caches and virtual environments
- prevent model-launch options from leaking into generation calls and ensure direct-reference virtualenv packages are installed

## Validation

- `pre-commit run --from-ref=upstream/main --to-ref=HEAD`
- `pytest -q xinference/model/video/tests xinference/core/tests/test_worker.py -k "video or prepare_virtual_env_direct_reference or prepare_virtual_env_normal_pip_mirror or prepare_virtual_env_offline_mirror"` (46 passed, 2 skipped)
- `npm run build`
- manually generated a Wan2.2-ti2v-5B video with the MLX engine from the Xorbits ModelScope mirror on Apple Silicon