### PR TITLE
fix(supervisor): reschedule autostart when the last replica dies

### DIFF
--- a/xinference/core/supervisor.py
+++ b/xinference/core/supervisor.py
@@ -4255,6 +4255,10 @@ class SupervisorActor(xo.StatelessActor):
         except Exception:
             logger.warning("Failed to mark %s TERMINATED in status guard", base_uid)
 
+        # Autostart owns relaunching a dead model; this is its 4th trigger,
+        # alongside startup, upsert_autostart_model and add_worker.
+        self._schedule_autostart()
+
     @log_async(logger=logger)
     async def get_model(self, model_uid: str) -> xo.ActorRefType["ModelActor"]:
         replica_info = self._model_uid_to_replica_info.get(model_uid, None)

--- a/xinference/core/tests/test_autostart.py
+++ b/xinference/core/tests/test_autostart.py
@@ -13,11 +13,11 @@
 # limitations under the License.
 
 import asyncio
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from xinference.core.supervisor import SupervisorActor
+from xinference.core.supervisor import ReplicaInfo, SupervisorActor
 
 
 class _DummySupervisor:
@@ -144,6 +144,63 @@ async def test_autostart_transitional_model_preserves_retry_attempts(model_statu
         "message": f"Model is {model_status.lower()}.",
         "last_error": "previous failure",
     }
+
+
+class _DummyReplicaDeathSupervisor:
+    mark_replica_dead = SupervisorActor.mark_replica_dead
+    _get_model_uid_and_replica_index = staticmethod(
+        SupervisorActor._get_model_uid_and_replica_index
+    )
+    _refresh_replica_scheduler = staticmethod(
+        SupervisorActor._refresh_replica_scheduler
+    )
+
+    def __init__(self, remaining_after_evict: int):
+        self._unexpected_down_replicas: dict = {}
+        self._replica_model_uid_to_worker: dict = {"uid-1-rep0": object()}
+        self._replica_model_uid_to_worker_shards: dict = {}
+        self._model_uid_to_replica_info = {
+            "uid-1": ReplicaInfo(replica=1, scheduler=iter([]), active_replica_ids=[0])
+        }
+        self._status_guard_ref = MagicMock()
+        self._status_guard_ref.get_instance_info = AsyncMock(return_value=[])
+        self._status_guard_ref.remove_replica_status = AsyncMock(
+            return_value=remaining_after_evict
+        )
+        self._status_guard_ref.update_instance_info = AsyncMock()
+        self.autostart_scheduled = False
+
+    def _schedule_autostart(self, delay: float = 0.0):
+        self.autostart_scheduled = True
+
+    async def _cleanup_distributed_actors(self, base_uid, terminate_rank0_on_worker):
+        return None
+
+
+@pytest.mark.asyncio
+async def test_mark_replica_dead_reschedules_autostart_on_last_replica():
+    # A dead last replica must be handed back to Autostart, not left
+    # TERMINATED forever.
+    supervisor = _DummyReplicaDeathSupervisor(remaining_after_evict=0)
+
+    await supervisor.mark_replica_dead("uid-1-rep0")
+
+    assert supervisor.autostart_scheduled is True
+    supervisor._status_guard_ref.update_instance_info.assert_called_once_with(
+        "uid-1", {"status": "TERMINATED"}
+    )
+
+
+@pytest.mark.asyncio
+async def test_mark_replica_dead_does_not_reschedule_autostart_when_degraded():
+    # A healthy replica remains after eviction: the model stays READY and
+    # Autostart, whose job is only to relaunch a fully-dead model, must not
+    # be woken.
+    supervisor = _DummyReplicaDeathSupervisor(remaining_after_evict=1)
+
+    await supervisor.mark_replica_dead("uid-1-rep0")
+
+    assert supervisor.autostart_scheduled is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
`SupervisorActor.mark_replica_dead()` advances a model to `TERMINATED` when
its last replica dies (worker exhausted
`XINFERENCE_MODEL_ACTOR_AUTO_RECOVER_LIMIT`), but never wakes Autostart.
Autostart's background task is only re-armed from three places: supervisor
startup, `upsert_autostart_model`, and worker `add_worker`
(`git log -G '_schedule_autostart' --follow` shows a single introducing
commit, #5076, and no other touches). `mark_replica_dead` is a fourth path
to `TERMINATED` and was never wired in when Autostart was added, so an
Autostart-launched model that exhausts local recovery is left dead until an
operator restarts the supervisor or relaunches it by hand.

Fix: call `self._schedule_autostart()` after the `TERMINATED` transition,
matching the existing three call sites. It is a no-op when there is nothing
to autostart, same as those.

Verification:
- New regression test in `test_autostart.py` drives the real
  `mark_replica_dead` through a minimal dummy supervisor (same pattern the
  file already uses for `_load_autostart_entries`/`_autostart_one_model`):
  it fails on main (Autostart never woken) and passes on this branch. A
  second test confirms a degraded-but-not-dead model (a healthy replica
  remains) correctly does not wake Autostart.
- `xinference/core/tests/test_autostart.py` and `test_worker.py` (which
  covers `mark_replica_dead`'s rank0/Xavier teardown path): 101 passed.
- `pre-commit run --files xinference/core/supervisor.py
  xinference/core/tests/test_autostart.py`: black, ruff, isort, mypy,
  codespell all clean.
- Not run: the full GPU-backed model test groups, and an end-to-end run
  through a real multi-actor supervisor/worker pair with a live crash-loop;
  this is a targeted unit-level regression test against the actual method,
  not a full cluster reproduction.

Fixes #5408
