### PR TITLE
feat(image): add Krea 2 models

### DIFF
--- a/doc/source/models/builtin/image/index.rst
+++ b/doc/source/models/builtin/image/index.rst
@@ -50,6 +50,10 @@ The following is a list of built-in image models in Xinference:
    ideogram4
   
    kolors
+
+   krea-2-raw
+
+   krea-2-turbo
   
    paddleocr-vl
   
@@ -96,4 +100,3 @@ The following is a list of built-in image models in Xinference:
    z-image
   
    z-image-turbo
-  

--- a/doc/source/models/builtin/image/krea-2-raw.rst
+++ b/doc/source/models/builtin/image/krea-2-raw.rst
@@ -1,0 +1,19 @@
+.. _models_builtin_krea-2-raw:
+
+==========
+Krea-2-Raw
+==========
+
+- **Model Name:** Krea-2-Raw
+- **Model Family:** stable_diffusion
+- **Abilities:** text2image
+- **Available ControlNet:** None
+
+Specifications
+^^^^^^^^^^^^^^
+
+- **Model ID:** krea/Krea-2-Raw
+
+Execute the following command to launch the model::
+
+   xinference launch --model-name Krea-2-Raw --model-type image

--- a/doc/source/models/builtin/image/krea-2-turbo.rst
+++ b/doc/source/models/builtin/image/krea-2-turbo.rst
@@ -1,0 +1,19 @@
+.. _models_builtin_krea-2-turbo:
+
+============
+Krea-2-Turbo
+============
+
+- **Model Name:** Krea-2-Turbo
+- **Model Family:** stable_diffusion
+- **Abilities:** text2image
+- **Available ControlNet:** None
+
+Specifications
+^^^^^^^^^^^^^^
+
+- **Model ID:** krea/Krea-2-Turbo
+
+Execute the following command to launch the model::
+
+   xinference launch --model-name Krea-2-Turbo --model-type image

--- a/doc/source/models/model_abilities/image.rst
+++ b/doc/source/models/model_abilities/image.rst
@@ -56,6 +56,8 @@ The Text-to-image API is supported with the following models in Xinference:
 * HiDream-O1-Image
 * HiDream-O1-Image-Dev
 * HiDream-O1-Image-Dev-2604
+* Krea-2-Raw
+* Krea-2-Turbo
 
 Image-to-image supported models:
 
@@ -108,6 +110,8 @@ for faster inference:
 
 * FLUX.1-dev
 * GLM-Image (SGLang only)
+* Krea-2-Raw (SGLang only)
+* Krea-2-Turbo (SGLang only)
 * Qwen-Image
 * Qwen-Image-2512
 * Z-Image

--- a/xinference/model/image/model_spec.json
+++ b/xinference/model/image/model_spec.json
@@ -2160,5 +2160,97 @@
     },
     "featured": true,
     "updated_at": 1787142695
+  },
+  {
+    "version": 2,
+    "model_name": "Krea-2-Raw",
+    "model_family": "stable_diffusion",
+    "model_description": "Krea 2 Raw is the undistilled base checkpoint for diverse text-to-image generation, fine-tuning, and post-training.",
+    "model_ability": [
+      "text2image"
+    ],
+    "model_src": {
+      "huggingface": {
+        "model_id": "krea/Krea-2-Raw",
+        "model_revision": "main"
+      },
+      "modelscope": {
+        "model_id": "krea/Krea-2-Raw",
+        "model_revision": "master"
+      }
+    },
+    "default_model_config": {
+      "torch_dtype": "bfloat16"
+    },
+    "default_generate_config": {
+      "num_inference_steps": 52,
+      "guidance_scale": 3.5
+    },
+    "virtualenv": {
+      "packages": [
+        "diffusers>=0.39.0 ; #engine# == \"diffusers\"",
+        "transformers>=5.2.0,<6 ; #engine# == \"diffusers\"",
+        "accelerate>=1.0.0 ; #engine# == \"diffusers\"",
+        "peft>=0.18.0 ; #engine# == \"diffusers\"",
+        "sentencepiece ; #engine# == \"diffusers\"",
+        "huggingface-hub>=1.23.0,<2.0 ; #engine# == \"diffusers\"",
+        "numpy<2.3 ; #engine# == \"SGLang\"",
+        "pandas<3 ; #engine# == \"SGLang\"",
+        "sglang[diffusion]>=0.5.15 ; #engine# == \"SGLang\"",
+        "#system_torch# ; #engine# == \"diffusers\"",
+        "#system_torchvision# ; #engine# == \"diffusers\"",
+        "#system_numpy# ; #engine# == \"diffusers\""
+      ],
+      "no_build_isolation": false,
+      "index_strategy": "unsafe-best-match"
+    },
+    "featured": false,
+    "updated_at": 1787576957
+  },
+  {
+    "version": 2,
+    "model_name": "Krea-2-Turbo",
+    "model_family": "stable_diffusion",
+    "model_description": "Krea 2 Turbo is the distilled 8-step Krea 2 checkpoint for fast, high-quality text-to-image generation.",
+    "model_ability": [
+      "text2image"
+    ],
+    "model_src": {
+      "huggingface": {
+        "model_id": "krea/Krea-2-Turbo",
+        "model_revision": "main"
+      },
+      "modelscope": {
+        "model_id": "krea/Krea-2-Turbo",
+        "model_revision": "master"
+      }
+    },
+    "default_model_config": {
+      "torch_dtype": "bfloat16"
+    },
+    "default_generate_config": {
+      "num_inference_steps": 8,
+      "guidance_scale": 0.0
+    },
+    "virtualenv": {
+      "packages": [
+        "diffusers>=0.39.0 ; #engine# == \"diffusers\"",
+        "transformers>=5.2.0,<6 ; #engine# == \"diffusers\"",
+        "accelerate>=1.0.0 ; #engine# == \"diffusers\"",
+        "peft>=0.18.0 ; #engine# == \"diffusers\"",
+        "sentencepiece ; #engine# == \"diffusers\"",
+        "huggingface-hub>=1.23.0,<2.0 ; #engine# == \"diffusers\"",
+        "numpy<2.3 ; #engine# == \"SGLang\"",
+        "pandas<3 ; #engine# == \"SGLang\"",
+        "sglang[diffusion]>=0.5.15 ; #engine# == \"SGLang\"",
+        "#system_torch# ; #engine# == \"diffusers\"",
+        "#system_torchvision# ; #engine# == \"diffusers\"",
+        "#system_numpy# ; #engine# == \"diffusers\""
+      ],
+      "no_build_isolation": false,
+      "index_strategy": "unsafe-best-match"
+    },
+    "featured": true,
+    "updated_at": 1787576958
   }
 ]

--- a/xinference/model/image/sglang/core.py
+++ b/xinference/model/image/sglang/core.py
@@ -33,6 +33,8 @@ logger = logging.getLogger(__name__)
 # https://docs.sglang.io/docs/sglang-diffusion/compatibility_matrix
 SGLANG_SUPPORTED_IMAGE_MODELS = (
     "GLM-Image",
+    "Krea-2-Raw",
+    "Krea-2-Turbo",
     "Qwen-Image",
     "Qwen-Image-2512",
     "Z-Image",
@@ -175,6 +177,14 @@ class SGLangDiffusionModel:
             # xinference behavior of generating a new image every call
             seed = random.randint(0, 2**31 - 1)
         params = dict(generate_config)
+        if (
+            self._model_spec
+            and self._model_spec.model_name in ("Krea-2-Raw", "Krea-2-Turbo")
+            and params.get("guidance_scale") is not None
+        ):
+            # Krea's reference CFG is cond + cfg * (cond - uncond), while
+            # SGLang uses uncond + scale * (cond - uncond).
+            params["guidance_scale"] += 1.0
         params.update(
             prompt=prompt,
             width=width,

--- a/xinference/model/image/tests/test_krea_2.py
+++ b/xinference/model/image/tests/test_krea_2.py
@@ -44,9 +44,7 @@ def test_krea_2_model_metadata(krea_families):
                 in spec.virtualenv.packages
             )
             assert all(
-                not package.startswith(
-                    "git+https://github.com/huggingface/diffusers"
-                )
+                not package.startswith("git+https://github.com/huggingface/diffusers")
                 for package in spec.virtualenv.packages
             )
             assert (

--- a/xinference/model/image/tests/test_krea_2.py
+++ b/xinference/model/image/tests/test_krea_2.py
@@ -1,0 +1,76 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+
+import pytest
+
+from .. import load_model_family_from_json
+
+
+@pytest.fixture
+def krea_families():
+    families = {}
+    spec_path = Path(__file__).parents[1] / "model_spec.json"
+    load_model_family_from_json(str(spec_path), families)
+    return families
+
+
+def test_krea_2_model_metadata(krea_families):
+    assert set(krea_families) >= {"Krea-2-Raw", "Krea-2-Turbo"}
+
+    for model_name in ("Krea-2-Raw", "Krea-2-Turbo"):
+        specs = {spec.model_hub: spec for spec in krea_families[model_name]}
+        assert specs["huggingface"].model_id == f"krea/{model_name}"
+        assert specs["huggingface"].model_revision == "main"
+        assert specs["modelscope"].model_id == f"krea/{model_name}"
+        assert specs["modelscope"].model_revision == "master"
+        for spec in specs.values():
+            assert getattr(spec, "lora_models", None) is None
+            assert spec.virtualenv.no_build_isolation is False
+            assert (
+                'diffusers>=0.39.0 ; #engine# == "diffusers"'
+                in spec.virtualenv.packages
+            )
+            assert all(
+                not package.startswith(
+                    "git+https://github.com/huggingface/diffusers"
+                )
+                for package in spec.virtualenv.packages
+            )
+            assert (
+                'huggingface-hub>=1.23.0,<2.0 ; #engine# == "diffusers"'
+                in spec.virtualenv.packages
+            )
+            assert (
+                '#system_torchvision# ; #engine# == "diffusers"'
+                in spec.virtualenv.packages
+            )
+            assert any(
+                "sglang[diffusion]>=0.5.15" in package
+                and '#engine# == "SGLang"' in package
+                for package in spec.virtualenv.packages
+            )
+
+    raw_spec = krea_families["Krea-2-Raw"][0]
+    assert raw_spec.default_generate_config == {
+        "num_inference_steps": 52,
+        "guidance_scale": 3.5,
+    }
+
+    turbo_spec = krea_families["Krea-2-Turbo"][0]
+    assert turbo_spec.default_generate_config == {
+        "num_inference_steps": 8,
+        "guidance_scale": 0.0,
+    }

--- a/xinference/model/image/tests/test_sglang_engine.py
+++ b/xinference/model/image/tests/test_sglang_engine.py
@@ -50,6 +50,10 @@ def test_match_on_linux_with_cuda():
         assert SGLangImageModel.match(_get_spec("sd3-medium")) is False
 
 
+def test_krea_2_models_are_registered():
+    assert {"Krea-2-Raw", "Krea-2-Turbo"} <= set(SGLANG_SUPPORTED_IMAGE_MODELS)
+
+
 def test_match_rejects_non_linux():
     with (
         patch.object(engine_platform, "system", return_value="Darwin"),
@@ -168,6 +172,20 @@ def test_build_sampling_params(fake_sglang_sampling_params):
     assert params["save_output"] is False
     assert params["return_frames"] is True
     assert "true_cfg_scale" not in params
+
+
+@pytest.mark.parametrize(
+    ("model_name", "xinference_scale", "sglang_scale"),
+    [("Krea-2-Turbo", 0.0, 1.0), ("Krea-2-Raw", 3.5, 4.5)],
+)
+def test_krea_2_guidance_scale_translation(
+    fake_sglang_sampling_params, model_name, xinference_scale, sglang_scale
+):
+    model = SGLangDiffusionModel("uid", "/path", model_spec=_get_spec(model_name))
+    params = model._build_sampling_params(
+        "a cat", 1, 1024, 1024, {"guidance_scale": xinference_scale}
+    )
+    assert params["guidance_scale"] == sglang_scale
 
 
 def test_build_sampling_params_stringifies_uuid(fake_sglang_sampling_params):


### PR DESCRIPTION
## Summary

Add built-in image model support for Krea 2 Raw and Krea 2 Turbo.

## Changes

- Register `Krea-2-Raw` and `Krea-2-Turbo` as built-in text-to-image models.
- Add Hugging Face and ModelScope sources:
  - Hugging Face revision: `main`
  - ModelScope revision: `master`
- Add Diffusers support using the released `diffusers>=0.39.0` package.
- Add SGLang inference support.
- Translate Krea CFG values to SGLang guidance scale semantics.
- Enable build isolation for Krea SGLang virtual environments so build dependencies are resolved automatically.
- Add minimal built-in model documentation and catalog entries.
- Add metadata, registration, and guidance-scale regression tests.

## Default Generation Settings

| Model | Inference Steps | Guidance Scale |
|---|---:|---:|
| `Krea-2-Raw` | 52 | 3.5 |
| `Krea-2-Turbo` | 8 | 0.0 |

## SGLang Guidance Scale

Krea uses:

```text
cond + cfg * (cond - uncond)
```

SGLang uses:

```text
uncond + scale * (cond - uncond)
```

Therefore, Xinference adds `1.0` to the configured Krea guidance scale before sending the request to SGLang.
