### PR TITLE
refactor(router): remove legacy Agent compatibility

### DIFF
--- a/frontend/src/types/services.ts
+++ b/frontend/src/types/services.ts
@@ -442,7 +442,7 @@ export interface TokenizerAssetBinding {
   observed_revision: string;
   observed_fingerprint: string;
   local_path: string;
-  binding_mode: 'manual' | 'on_demand' | 'legacy';
+  binding_mode: 'manual' | 'on_demand';
   owner_type: string;
   owner_id: string;
   generation: number;
@@ -462,7 +462,6 @@ export interface TokenRouterNode {
   managed_labels: Record<string, unknown>;
   tokenizer_asset_bindings: TokenizerAssetBinding[];
   capabilities: {
-    tokenizer_assets?: string[];
     [key: string]: unknown;
   };
   software_version: string;

--- a/xinference/api/schemas/router.py
+++ b/xinference/api/schemas/router.py
@@ -340,7 +340,6 @@ class RouterNodeRegister(BaseModel):
     port_range_start: int = Field(ge=1024, le=65535)
     port_range_end: int = Field(ge=1024, le=65535)
     max_instances: int = Field(ge=1)
-    labels: Dict[str, Any] = Field(default_factory=dict)
     reported_labels: Dict[str, Any] = Field(default_factory=dict)
     capabilities: Dict[str, Any] = Field(default_factory=dict)
     software_version: str = ""

--- a/xinference/api/tests/test_token_router_api.py
+++ b/xinference/api/tests/test_token_router_api.py
@@ -301,21 +301,23 @@ def create_app(
     return app
 
 
-def test_router_node_register_preserves_reported_labels_presence():
+def test_router_node_register_uses_only_reported_labels():
     base = {
         "node_id": "node-a",
         "advertise_host": "127.0.0.1",
         "port_range_start": 12080,
         "port_range_end": 12089,
         "max_instances": 5,
-        "labels": {"legacy": "value"},
     }
 
-    omitted = RouterNodeRegister(**base).dict(exclude_unset=True)
+    omitted = RouterNodeRegister(**base, labels={"legacy": "value"}).dict(
+        exclude_unset=True
+    )
     explicit_empty = RouterNodeRegister(**base, reported_labels={}).dict(
         exclude_unset=True
     )
 
+    assert "labels" not in omitted
     assert "reported_labels" not in omitted
     assert explicit_empty["reported_labels"] == {}
 

--- a/xinference/api/tests/test_token_router_orchestration_api.py
+++ b/xinference/api/tests/test_token_router_orchestration_api.py
@@ -29,7 +29,8 @@ async def test_managed_router_agent_runtime_lifecycle(tmp_path, monkeypatch) -> 
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
         created = await client.post("/v1/token_routers", json=router_payload())
         assert created.status_code == 201
-        revision = created.json()["revision"]
+        config = created.json()
+        revision = config["revision"]
 
         unauthorized = await client.post(
             "/v1/internal/token-router/nodes/register", json={}
@@ -45,13 +46,39 @@ async def test_managed_router_agent_runtime_lifecycle(tmp_path, monkeypatch) -> 
                 "port_range_start": 12080,
                 "port_range_end": 12089,
                 "max_instances": 5,
-                "labels": {"zone": "a"},
-                "capabilities": {"tokenizer_assets": [ASSET_ID]},
+                "reported_labels": {"zone": "a"},
+                "capabilities": {},
                 "software_version": "test",
             },
         )
         assert registered_node.status_code == 200
         assert registered_node.json()["online"] is True
+
+        created_bindings = await client.post(
+            f"/v1/tokenizer_assets/{ASSET_ID}/bindings",
+            json={
+                "node_ids": ["node-a"],
+                "desired_state": "present",
+                "binding_mode": "manual",
+            },
+        )
+        assert created_bindings.status_code == 201
+        binding = created_bindings.json()[0]
+        assert binding["binding_mode"] == "manual"
+
+        ready_binding = await client.post(
+            "/v1/internal/token-router/nodes/node-a/asset-bindings/status",
+            headers=headers,
+            json={
+                "asset_id": ASSET_ID,
+                "generation": binding["generation"],
+                "observed_state": "ready",
+                "observed_revision": config["tokenizer_asset_revision"],
+                "observed_fingerprint": config["tokenizer_asset_fingerprint"],
+                "local_path": f"/assets/{ASSET_ID}",
+            },
+        )
+        assert ready_binding.status_code == 200
 
         deployment = await client.put(
             "/v1/token_routers/router-a/deployment",
@@ -201,7 +228,7 @@ async def test_managed_router_enable_creates_binding_for_clean_agent(
                 "port_range_start": 12080,
                 "port_range_end": 12089,
                 "max_instances": 5,
-                "labels": {"zone": "a"},
+                "reported_labels": {"zone": "a"},
                 "capabilities": {},
                 "software_version": "test",
             },

--- a/xinference/core/router_node_store.py
+++ b/xinference/core/router_node_store.py
@@ -153,9 +153,7 @@ class RouterNodeStore:
             raise ValueError("max_instances must be greater than zero")
         if maximum > end - start + 1:
             raise ValueError("max_instances exceeds the Router node port range")
-        labels = data.get("reported_labels")
-        if labels is None:
-            labels = data.get("labels", {})
+        labels = data.get("reported_labels", {})
         if not isinstance(labels, dict):
             raise ValueError("reported_labels must be an object")
         if not isinstance(data.get("capabilities", {}), dict):
@@ -168,10 +166,7 @@ class RouterNodeStore:
         now = self._now()
         desired_state = current["desired_state"] if current else "active"
         created_at = current["created_at"] if current else now
-        reported_labels_value = data.get("reported_labels")
-        if reported_labels_value is None:
-            reported_labels_value = data.get("labels", {})
-        reported_labels = dict(reported_labels_value)
+        reported_labels = dict(data.get("reported_labels") or {})
         managed_labels = current.get("managed_labels", {}) if current else {}
         merged_labels = {**reported_labels, **managed_labels}
         with self._lock, self._connect() as conn:

--- a/xinference/core/router_orchestration.py
+++ b/xinference/core/router_orchestration.py
@@ -170,34 +170,6 @@ class RouterOrchestrationController:
 
     def register_node(self, data: Dict[str, Any]) -> Dict[str, Any]:
         node = self.nodes.register(data)
-        # Compatibility migration: turn the old static capability into persisted
-        # legacy Bindings when the Asset is already present in the Catalog.
-        for value in data.get("capabilities", {}).get("tokenizer_assets", []):
-            asset_id = value if isinstance(value, str) else value.get("asset_id", "")
-            asset = self.tokenizer_assets.get_asset(str(asset_id))
-            if asset is None:
-                continue
-            binding = self.tokenizer_assets.upsert_binding(
-                str(asset_id),
-                node["node_id"],
-                desired_state="present",
-                binding_mode="legacy",
-                username="legacy-capability-import",
-            )
-            try:
-                self.tokenizer_assets.report_binding_status(
-                    str(asset_id),
-                    node["node_id"],
-                    binding["generation"],
-                    "ready",
-                    observed_revision=asset["revision"],
-                    observed_fingerprint=asset["fingerprint"],
-                    local_path=str(asset.get("source", {}).get("path") or ""),
-                )
-            except ValueError:
-                # A structured legacy capability may advertise a different
-                # revision/fingerprint. It stays pending until Agent reconcile.
-                pass
         self.scheduler.reconcile_all()
         return self.render_node(node)
 

--- a/xinference/core/router_scheduler.py
+++ b/xinference/core/router_scheduler.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import logging
 from datetime import datetime, timezone
 from typing import Any, Dict, Iterable, List, Optional, Set
 
@@ -12,8 +11,6 @@ from .router_config_store import RouterConfigStore
 from .router_deployment_store import RouterDeploymentStore
 from .router_node_store import RouterNodeStore
 from .tokenizer_asset_store import TokenizerAssetStore
-
-logger = logging.getLogger(__name__)
 
 
 class RouterScheduler:
@@ -75,39 +72,16 @@ class RouterScheduler:
         if not asset_id:
             return True
         binding = self._asset_store.get_binding(asset_id, node["node_id"])
-        if binding is not None:
-            return (
-                binding["desired_state"] == "present"
-                and binding["observed_state"] == "ready"
-                and binding["observed_revision"]
-                == str(config.get("tokenizer_asset_revision") or "")
-                and binding["observed_fingerprint"].lower()
-                == str(config.get("tokenizer_asset_fingerprint") or "").lower()
-            )
-
-        # Compatibility window only: old Agents may still publish a static
-        # tokenizer_assets capability. Registration imports it into a legacy
-        # Binding whenever the Catalog contains the Asset.
-        capabilities = node.get("capabilities") or {}
-        assets = capabilities.get("tokenizer_assets") or []
-        if assets:
-            logger.warning(
-                "Using deprecated Router Agent tokenizer_assets capability for node %s",
-                node["node_id"],
-            )
-        for asset in assets:
-            if isinstance(asset, str) and asset == asset_id:
-                return True
-            if (
-                isinstance(asset, dict)
-                and asset.get("asset_id") == asset_id
-                and str(asset.get("revision") or "")
-                == str(config.get("tokenizer_asset_revision") or "")
-                and str(asset.get("fingerprint") or "").lower()
-                == str(config.get("tokenizer_asset_fingerprint") or "").lower()
-            ):
-                return True
-        return False
+        if binding is None:
+            return False
+        return (
+            binding["desired_state"] == "present"
+            and binding["observed_state"] == "ready"
+            and binding["observed_revision"]
+            == str(config.get("tokenizer_asset_revision") or "")
+            and binding["observed_fingerprint"].lower()
+            == str(config.get("tokenizer_asset_fingerprint") or "").lower()
+        )
 
     @staticmethod
     def _placement_matches(node: Dict[str, Any], placement: Dict[str, Any]) -> bool:

--- a/xinference/core/tests/test_router_node_store.py
+++ b/xinference/core/tests/test_router_node_store.py
@@ -10,18 +10,22 @@ def _node(node_id: str) -> dict:
         "port_range_start": 12080,
         "port_range_end": 12089,
         "max_instances": 5,
-        "labels": {"legacy": "value"},
+        "reported_labels": {"zone": "a"},
         "capabilities": {},
     }
 
 
-def test_register_uses_legacy_labels_only_when_reported_labels_is_omitted(tmp_path):
+def test_register_ignores_legacy_labels_when_reported_labels_is_omitted(tmp_path):
     store = RouterNodeStore(str(tmp_path / "nodes.db"))
+    legacy_only = _node("legacy-only")
+    legacy_only.pop("reported_labels")
+    legacy_only["labels"] = {"legacy": "value"}
 
-    legacy = store.register(_node("legacy"))
+    registered = store.register(legacy_only)
     explicit_empty = store.register({**_node("explicit-empty"), "reported_labels": {}})
 
-    assert legacy["reported_labels"] == {"legacy": "value"}
+    assert registered["reported_labels"] == {}
+    assert registered["labels"] == {}
     assert explicit_empty["reported_labels"] == {}
     assert explicit_empty["labels"] == {}
 

--- a/xinference/core/tests/test_router_orchestration.py
+++ b/xinference/core/tests/test_router_orchestration.py
@@ -19,7 +19,6 @@ def _config_store(tmp_path):
         "router-a",
         {
             "logical_model": "logical",
-            "tokenizer_asset_id": "asset-a",
         },
     )
     return store
@@ -39,8 +38,8 @@ def _node(
         "port_range_start": start,
         "port_range_end": start + port_count - 1,
         "max_instances": max_instances,
-        "labels": {"zone": "a"},
-        "capabilities": {"tokenizer_assets": ["asset-a"]},
+        "reported_labels": {"zone": "a"},
+        "capabilities": {},
         "software_version": "test",
     }
 
@@ -246,7 +245,7 @@ def test_stopping_assignment_keeps_capacity_and_port_reserved(tmp_path):
     store = _config_store(tmp_path)
     store.create(
         "router-b",
-        {"logical_model": "logical-b", "tokenizer_asset_id": "asset-a"},
+        {"logical_model": "logical-b"},
     )
     controller = RouterOrchestrationController(str(tmp_path / "routers.db"), store)
     controller.register_node(
@@ -417,6 +416,57 @@ def test_scheduler_tolerates_null_node_capabilities(tmp_path):
     )
 
 
+@pytest.mark.parametrize(
+    "legacy_capability",
+    [
+        pytest.param(["asset-a"], id="string"),
+        pytest.param(
+            [
+                {
+                    "asset_id": "asset-a",
+                    "revision": "v1",
+                    "fingerprint": "sha256:" + "a" * 64,
+                }
+            ],
+            id="structured",
+        ),
+    ],
+)
+def test_static_tokenizer_asset_capability_cannot_replace_binding(
+    tmp_path, legacy_capability
+):
+    store = _config_store(tmp_path)
+    store.update(
+        "router-a",
+        {
+            "logical_model": "logical",
+            "tokenizer_asset_id": "asset-a",
+            "tokenizer_asset_revision": "v1",
+            "tokenizer_asset_fingerprint": "sha256:" + "a" * 64,
+        },
+    )
+    controller = RouterOrchestrationController(str(tmp_path / "routers.db"), store)
+    controller.create_tokenizer_asset(
+        {
+            "asset_id": "asset-a",
+            "origin": "shared_fs",
+            "revision": "v1",
+            "fingerprint": "sha256:" + "a" * 64,
+            "source": {"type": "shared_fs", "path": "/assets/asset-a"},
+        },
+        "admin",
+    )
+    node = _node("node-a", "127.0.0.1", 12080)
+    node["capabilities"] = {"tokenizer_assets": legacy_capability}
+
+    registered = controller.register_node(node)
+
+    assert controller.list_tokenizer_asset_bindings(node_id="node-a") == []
+    assert (
+        controller.scheduler._node_has_asset(registered, store.get("router-a")) is False
+    )
+
+
 def test_asset_binding_readiness_gates_assignment_and_stale_preserves_runtime(tmp_path):
     store = _config_store(tmp_path)
     store.update(
@@ -438,9 +488,7 @@ def test_asset_binding_readiness_gates_assignment_and_stale_preserves_runtime(tm
             "source": {"type": "shared_fs", "path": "/assets/asset-a"},
         }
     )
-    node = _node("node-a", "127.0.0.1", 12080)
-    node["capabilities"] = {}
-    controller.register_node(node)
+    controller.register_node(_node("node-a", "127.0.0.1", 12080))
     controller.update_deployment(
         "router-a", {"management_mode": "managed", "desired_replicas": 1}
     )
@@ -488,7 +536,7 @@ def test_managed_labels_survive_agent_reregistration(tmp_path):
     controller.set_node_labels("node-a", {"environment": "test"})
 
     updated = _node("node-a", "127.0.0.1", 12080)
-    updated["labels"] = {"zone": "b"}
+    updated["reported_labels"] = {"zone": "b"}
     node = controller.register_node(updated)
 
     assert node["reported_labels"] == {"zone": "b"}

--- a/xinference/core/tests/test_tokenizer_asset_store.py
+++ b/xinference/core/tests/test_tokenizer_asset_store.py
@@ -64,6 +64,14 @@ def test_assets_and_many_to_many_bindings_are_persistent(tmp_path):
     }
 
 
+def test_legacy_binding_mode_is_rejected(tmp_path):
+    _, store = _stores(tmp_path)
+    store.create_asset(_asset())
+
+    with pytest.raises(ValueError, match="Invalid Tokenizer Asset Binding mode"):
+        store.upsert_binding("asset-a", "node-a", binding_mode="legacy")
+
+
 def test_binding_generation_fences_status_and_asset_updates(tmp_path):
     _, store = _stores(tmp_path)
     store.create_asset(_asset())

--- a/xinference/core/tokenizer_asset_store.py
+++ b/xinference/core/tokenizer_asset_store.py
@@ -31,7 +31,7 @@ class TokenizerAssetStore:
         "absent",
         "stale",
     }
-    _BINDING_MODES = {"manual", "on_demand", "legacy"}
+    _BINDING_MODES = {"manual", "on_demand"}
 
     def __init__(self, db_path: str) -> None:
         self._db_path = db_path
@@ -94,7 +94,7 @@ class TokenizerAssetStore:
                     FOREIGN KEY(asset_id) REFERENCES tokenizer_assets(asset_id),
                     FOREIGN KEY(node_id) REFERENCES token_router_nodes(node_id),
                     CHECK (desired_state IN ('present', 'absent')),
-                    CHECK (binding_mode IN ('manual', 'on_demand', 'legacy')),
+                    CHECK (binding_mode IN ('manual', 'on_demand')),
                     CHECK (generation >= 1)
                 )"""
             )

--- a/xinference/router/agent/service.py
+++ b/xinference/router/agent/service.py
@@ -175,33 +175,9 @@ class RouterAgent:
         self._stop_event.set()
 
     def _node_registration(self) -> Dict[str, Any]:
-        legacy_assets = [
-            value.strip()
-            for value in os.getenv(
-                "XINFERENCE_TOKEN_ROUTER_TOKENIZER_ASSETS", ""
-            ).split(",")
-            if value.strip()
-        ]
-        legacy_labels: Dict[str, str] = {}
-        for item in os.getenv("XINFERENCE_TOKEN_ROUTER_NODE_LABELS", "").split(","):
-            if "=" in item:
-                key, value = item.split("=", 1)
-                if key.strip():
-                    legacy_labels[key.strip()] = value.strip()
-        if legacy_assets:
-            logger.warning(
-                "XINFERENCE_TOKEN_ROUTER_TOKENIZER_ASSETS is deprecated; "
-                "migrate Assets to persistent Asset-Agent Bindings"
-            )
-        if legacy_labels:
-            logger.warning(
-                "XINFERENCE_TOKEN_ROUTER_NODE_LABELS is deprecated; "
-                "manage Router Agent labels through the control plane"
-            )
         reported_labels: Dict[str, str] = {
             "system.hostname": socket.gethostname(),
         }
-        reported_labels.update(legacy_labels)
         return {
             "node_id": self.config.node_id,
             "advertise_host": self.config.node_host,
@@ -210,11 +186,8 @@ class RouterAgent:
             "max_instances": self.config.max_instances,
             "software_version": __version__,
             "software_revision": _software_revision(),
-            "labels": reported_labels,
             "reported_labels": reported_labels,
             "capabilities": {
-                # Compatibility for one migration release only.
-                "tokenizer_assets": legacy_assets,
                 "hostname": socket.gethostname(),
             },
         }

--- a/xinference/router/tests/test_agent.py
+++ b/xinference/router/tests/test_agent.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import os
 from pathlib import Path
 from types import SimpleNamespace
@@ -197,6 +198,40 @@ def test_agent_config_reads_node_scope_environment(monkeypatch, tmp_path):
     assert config.port_range_start == 12080
     assert config.port_range_end == 12089
     assert not hasattr(config, "router_uid")
+
+
+def test_agent_registration_ignores_removed_legacy_environment(monkeypatch, caplog):
+    monkeypatch.setenv("XINFERENCE_TOKEN_ROUTER_NODE_LABELS", "zone=legacy")
+    monkeypatch.setenv("XINFERENCE_TOKEN_ROUTER_TOKENIZER_ASSETS", "asset-a")
+    monkeypatch.setattr(agent_service.socket, "gethostname", lambda: "router-host")
+    monkeypatch.setattr(agent_service, "_software_revision", lambda: "revision-a")
+    agent = object.__new__(RouterAgent)
+    agent.config = SimpleNamespace(
+        node_id="node-a",
+        node_host="127.0.0.1",
+        port_range_start=12080,
+        port_range_end=12089,
+        max_instances=5,
+    )
+
+    with caplog.at_level(logging.WARNING, logger=agent_service.__name__):
+        registration = agent._node_registration()
+
+    assert registration == {
+        "node_id": "node-a",
+        "advertise_host": "127.0.0.1",
+        "port_range_start": 12080,
+        "port_range_end": 12089,
+        "max_instances": 5,
+        "software_version": agent_service.__version__,
+        "software_revision": "revision-a",
+        "reported_labels": {"system.hostname": "router-host"},
+        "capabilities": {"hostname": "router-host"},
+    }
+    assert "labels" not in registration
+    assert "tokenizer_assets" not in registration["capabilities"]
+    assert "XINFERENCE_TOKEN_ROUTER_NODE_LABELS" not in caplog.text
+    assert "XINFERENCE_TOKEN_ROUTER_TOKENIZER_ASSETS" not in caplog.text
 
 
 def test_agent_gathers_host_cpu_and_memory_resources(monkeypatch):


### PR DESCRIPTION
## Summary

- stop reading the legacy Router Agent node-label and tokenizer-asset environment variables
- remove the legacy `labels` fallback from Router Agent registration
- stop importing `capabilities.tokenizer_assets` into persistent Bindings
- require a ready persistent Asset-Agent Binding for tokenizer asset scheduling
- remove the internal `legacy` Binding mode
- update frontend types and focused Agent, Store, orchestration, scheduler, and API tests

## Context

The removed compatibility paths were introduced with the Agent-based Router orchestration changes after the latest stable release and have not been part of a released Xinference version.

This removes the temporary migration shim before the new orchestration protocol is released. The supported paths are now:

- node labels: `reported_labels` plus Supervisor-managed `managed_labels`
- tokenizer assets: Asset Catalog plus persistent Asset-Agent Bindings

Unknown legacy registration fields continue to follow Pydantic's existing extra-field behavior, but they no longer affect node labels, Bindings, or scheduling.

## Validation

- `pytest -vv xinference/router/tests xinference/core/tests/test_router_node_store.py xinference/core/tests/test_router_orchestration.py xinference/core/tests/test_tokenizer_asset_store.py xinference/api/tests/test_token_router_orchestration_api.py xinference/api/tests/test_token_router_api.py` (`216 passed`)
- `pre-commit run --files <changed files>`
- `npx eslint src/types/services.ts`
- `git diff --check`
