### PR TITLE
FEAT: support replica config in launch CLI and Web UI

### DIFF
--- a/doc/source/user_guide/launch.rst
+++ b/doc/source/user_guide/launch.rst
@@ -91,11 +91,30 @@ each entry currently supports exactly one worker.
         ],
     )
 
+The same placement can be supplied to ``xinference launch`` as a JSON array:
+
+.. code-block:: bash
+
+    xinference launch \
+      --model-name qwen2.5-instruct \
+      --model-engine vLLM \
+      --replica 2 \
+      --replica-config '[{"replica_uid":"primary","devices":[{"worker_ip":"192.168.1.10:9978","n_gpu":1,"gpu_idx":[0]}]},{"replica_uid":"secondary","devices":[{"worker_ip":"192.168.1.11:9978","n_gpu":1,"gpu_idx":[0]}]}]'
+
+``--replica_config`` remains available as a compatibility alias, but
+``--replica-config`` is recommended. If ``--replica`` is omitted, the CLI
+derives it from the number of array entries. If it is supplied explicitly, it
+must equal that number.
+
 ``replica_config`` is mutually exclusive with the model-level ``worker_ip``,
-``n_gpu``, and ``gpu_idx`` arguments. If ``replica_uid`` is omitted, Xinference
-assigns the stable default ``{model_uid}-{replica_index}`` (for example,
-``my-model-0``). Omit ``gpu_idx`` and use ``n_gpu="auto"`` to let the selected
-worker allocate GPUs automatically.
+``n_gpu``, and ``gpu_idx`` arguments, and with ``n_worker > 1``. The CLI
+therefore rejects ``--replica-config`` together with ``--worker-ip``,
+``--gpu-idx``, a non-``auto`` ``--n-gpu``, or ``--n-worker`` greater than 1.
+Each replica currently targets exactly one worker. If ``replica_uid`` is
+omitted, Xinference assigns the stable default
+``{model_uid}-{replica_index}`` (for example, ``my-model-0``). Omit ``gpu_idx``
+and use ``n_gpu="auto"`` to let the selected worker allocate GPUs
+automatically.
 
 Running models can be scaled one replica at a time. Placement is optional; if
 omitted, the supervisor selects a worker automatically.

--- a/frontend/src/components/pages/launch-model/launch-dialog/command-line.tsx
+++ b/frontend/src/components/pages/launch-model/launch-dialog/command-line.tsx
@@ -1,55 +1,98 @@
 'use client';
 
 import { FC, useState } from 'react';
-import { Terminal, Copy } from 'lucide-react';
-import { TooltipProvider, Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
+import { Copy, Terminal } from 'lucide-react';
+import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
-import { Textarea } from '@/components/ui/textarea';
 import {
   Dialog,
-  DialogHeader,
   DialogContent,
-  DialogTitle,
   DialogFooter,
+  DialogHeader,
+  DialogTitle,
 } from '@/components/ui/dialog';
+import { Textarea } from '@/components/ui/textarea';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { useI18n } from '@/contexts/i18n-context';
 import { copyToClipboard } from '@/lib/utils';
 import type { FormInstance } from '@/types/form';
-import { transformFormToFetch, generateCommandLineStatement, transformFetchToForm, parseXinferenceCommand } from '../utils';
+import {
+  generateCommandLineStatement,
+  parseXinferenceCommand,
+  transformFetchToForm,
+  transformFormToFetch,
+  validateReplicaPlacement,
+} from '../utils';
 
 interface CommandLineProps {
   canCopyCommandLine: boolean;
   form: FormInstance;
 }
+
 const CommandLine: FC<CommandLineProps> = ({ canCopyCommandLine, form }) => {
   const [commandLineParsingOpen, setCommandLineParsingOpen] = useState(false);
   const [commandLineParsingValue, setCommandLineParsingValue] = useState('');
   const { t } = useI18n();
+
+  const showCommandLineError = (error: unknown) => {
+    toast.error(
+      t('launchModel.commandLineParsingFailed', {
+        error: error instanceof Error ? error.message : String(error),
+      })
+    );
+  };
+
   const handleCopyCommandLine = () => {
     if (!canCopyCommandLine) return;
 
-    const params = transformFormToFetch(form.getFieldsValue());
+    try {
+      const values = form.getFieldsValue();
+      const placementError = validateReplicaPlacement(values);
+      if (placementError === 'incomplete') {
+        toast.error(t('launchModel.replicaPlacementIncomplete'));
+        return;
+      }
+      if (placementError === 'duplicate-alias') {
+        toast.error(t('launchModel.replicaAliasDuplicate'));
+        return;
+      }
 
-    copyToClipboard(generateCommandLineStatement(params));
+      const params = transformFormToFetch(values);
+
+      copyToClipboard(generateCommandLineStatement(params));
+    } catch (error) {
+      showCommandLineError(error);
+    }
   };
-  const onOpenChange = (open: boolean)=>{
-    if(!open) setCommandLineParsingValue('');
-    setCommandLineParsingOpen(open)
-  }
+
+  const onOpenChange = (open: boolean) => {
+    if (!open) setCommandLineParsingValue('');
+    setCommandLineParsingOpen(open);
+  };
+
   const handleClose = () => {
     setCommandLineParsingOpen(false);
     setCommandLineParsingValue('');
   };
+
   const handleCommandLineParsingConfirm = () => {
-    if(!commandLineParsingValue) {
-      setCommandLineParsingOpen(false);
-      return;
+    try {
+      if (!commandLineParsingValue.trim()) {
+        throw new Error('Command line cannot be empty.');
+      }
+
+      const params = parseXinferenceCommand(commandLineParsingValue);
+      const formData = transformFetchToForm(params);
+
+      // Parsing and conversion finish before this single merged write, so a
+      // malformed command never partially overwrites the current form.
+      form.setFieldsValue(formData);
+      handleClose();
+    } catch (error) {
+      showCommandLineError(error);
     }
-    const params = parseXinferenceCommand(commandLineParsingValue);
-    const formData = transformFetchToForm(params);
-    form.setFieldsValue(formData);
-    setCommandLineParsingOpen(false)
   };
+
   return (
     <>
       <TooltipProvider>
@@ -61,7 +104,7 @@ const CommandLine: FC<CommandLineProps> = ({ canCopyCommandLine, form }) => {
               size="icon"
               aria-label={t('launchModel.commandLineParsing')}
               onClick={() => setCommandLineParsingOpen(true)}
-              className='h-8'
+              className="h-8"
             >
               <Terminal />
             </Button>
@@ -77,7 +120,7 @@ const CommandLine: FC<CommandLineProps> = ({ canCopyCommandLine, form }) => {
                 size="icon"
                 aria-label={t('launchModel.copyToCommandLine')}
                 onClick={handleCopyCommandLine}
-                className='h-8'
+                className="h-8"
               >
                 <Copy />
               </Button>
@@ -101,13 +144,12 @@ const CommandLine: FC<CommandLineProps> = ({ canCopyCommandLine, form }) => {
             <Button variant="outline" onClick={handleClose}>
               {t('common.cancel')}
             </Button>
-            <Button  onClick={handleCommandLineParsingConfirm}>
-              {t('common.confirm')}
-            </Button>
+            <Button onClick={handleCommandLineParsingConfirm}>{t('common.confirm')}</Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>
     </>
   );
 };
+
 export default CommandLine;

--- a/frontend/src/components/pages/launch-model/launch-dialog/launch-dialog.tsx
+++ b/frontend/src/components/pages/launch-model/launch-dialog/launch-dialog.tsx
@@ -47,6 +47,7 @@ import {
   toOptionValue,
   transformFetchToForm,
   transformFormToFetch,
+  validateReplicaPlacement,
   normalizeProgress,
   normalizeReplicaStatuses,
   isEmptyLaunchValue,
@@ -112,7 +113,8 @@ export default function LaunchDialog({
   const modelEngineValue = toOptionValue(useWatch('model_engine', form));
   const modelFormatValue = toOptionValue(useWatch('model_format', form));
   const modelSizeInBillionsValue = useWatch('model_size_in_billions', form) as
-    ModelEngineItem['model_size_in_billions'] | undefined;
+    | ModelEngineItem['model_size_in_billions']
+    | undefined;
   const enableThinkingValue = useWatch('enable_thinking', form);
   const modelSizeInBillionsKey = toOptionValue(modelSizeInBillionsValue);
   const quantizationValue = toOptionValue(useWatch('quantization', form));
@@ -455,7 +457,8 @@ export default function LaunchDialog({
     if (!isCustomPlacement) return;
     const current =
       (form.getFieldValue('replica_config') as
-        Array<{ replica_uid?: string; worker_ip: string; gpu_idx: string }> | undefined) ?? [];
+        | Array<{ replica_uid?: string; worker_ip: string; gpu_idx: string }>
+        | undefined) ?? [];
     if (current.length === replicaValue) return;
     const next = Array.from(
       { length: replicaValue },
@@ -1454,11 +1457,11 @@ export default function LaunchDialog({
     ],
   };
 
-  // In custom placement mode (LLM only for now), hide the legacy global
-  // placement fields — they are mutually exclusive with replica_config and
-  // would only confuse the operator if shown alongside the per-replica editor.
+  // In custom placement mode, hide the legacy global placement fields. Each
+  // replica currently binds to exactly one worker, so n_worker is not editable.
   const currentLaunchFields = (modelTypeFields[modelType] || []).filter(
-    (field) => !isCustomPlacement || !['n_gpu', 'gpu_idx', 'worker_ip'].includes(field.name)
+    (field) =>
+      !isCustomPlacement || !['n_worker', 'n_gpu', 'gpu_idx', 'worker_ip'].includes(field.name)
   );
   // required fields is filled in
   const isReady = currentLaunchFields
@@ -1585,26 +1588,14 @@ export default function LaunchDialog({
   };
 
   const handleLaunch = async (values: FormValues) => {
-    if (values.replica_placement_mode === 'custom') {
-      const rows = Array.isArray(values.replica_config) ? values.replica_config : [];
-      const replicaCount = Number(values.replica) || 1;
-      const gpuIndexPattern = GPU_IDX_PATTERN;
-      const hasInvalidPlacement =
-        rows.length !== replicaCount ||
-        rows.some((row) => {
-          const gpuIndexes = String(row?.gpu_idx ?? '').trim();
-          return !row?.worker_ip || (gpuIndexes !== '' && !gpuIndexPattern.test(gpuIndexes));
-        });
-      if (hasInvalidPlacement) {
-        toast.error(t('launchModel.replicaPlacementIncomplete'));
-        return;
-      }
-
-      const aliases = rows.map((row) => String(row?.replica_uid ?? '').trim()).filter(Boolean);
-      if (new Set(aliases).size !== aliases.length) {
-        toast.error(t('launchModel.replicaAliasDuplicate'));
-        return;
-      }
+    const placementError = validateReplicaPlacement(values);
+    if (placementError === 'incomplete') {
+      toast.error(t('launchModel.replicaPlacementIncomplete'));
+      return;
+    }
+    if (placementError === 'duplicate-alias') {
+      toast.error(t('launchModel.replicaAliasDuplicate'));
+      return;
     }
 
     const newValues = transformFormToFetch(values);

--- a/frontend/src/components/pages/launch-model/launch-dialog/launch-dialog.tsx
+++ b/frontend/src/components/pages/launch-model/launch-dialog/launch-dialog.tsx
@@ -457,7 +457,12 @@ export default function LaunchDialog({
     if (!isCustomPlacement) return;
     const current =
       (form.getFieldValue('replica_config') as
-        | Array<{ replica_uid?: string; worker_ip: string; gpu_idx: string }>
+        | Array<{
+            replica_uid?: string;
+            worker_ip: string;
+            gpu_idx: string;
+            n_gpu?: number | 'auto';
+          }>
         | undefined) ?? [];
     if (current.length === replicaValue) return;
     const next = Array.from(

--- a/frontend/src/components/pages/launch-model/launch-dialog/replica-placement-config.tsx
+++ b/frontend/src/components/pages/launch-model/launch-dialog/replica-placement-config.tsx
@@ -13,6 +13,7 @@ interface ReplicaConfigRow {
   replica_uid?: string;
   worker_ip: string;
   gpu_idx: string;
+  n_gpu?: number | 'auto';
 }
 
 interface ReplicaPlacementConfigProps {
@@ -76,7 +77,14 @@ const ReplicaPlacementConfig: FC<ReplicaPlacementConfigProps> = ({ form, workerO
           <Input
             value={row?.gpu_idx ?? ''}
             placeholder={t('launchModel.GPUIdxPlaceholder')}
-            onChange={(e) => patchRow(index, { gpu_idx: e.target.value })}
+            onChange={(e) =>
+              patchRow(index, {
+                gpu_idx: e.target.value,
+                // Once the user edits GPU indexes, derive n_gpu from the new
+                // value instead of reusing metadata retained during import.
+                n_gpu: undefined,
+              })
+            }
           />
         </div>
       ))}

--- a/frontend/src/components/pages/launch-model/replica-config-utils.mjs
+++ b/frontend/src/components/pages/launch-model/replica-config-utils.mjs
@@ -1,0 +1,87 @@
+/**
+ * @param {unknown} value
+ * @returns {value is Record<string, unknown>}
+ */
+const isRecord = (value) => value !== null && typeof value === 'object' && !Array.isArray(value);
+
+/**
+ * @param {unknown} value
+ * @returns {number[] | undefined}
+ */
+export const parseReplicaGpuIndexes = (value) => {
+  if (typeof value !== 'string' || !value) return undefined;
+
+  const result = value
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean)
+    .map(Number)
+    .filter((num) => !Number.isNaN(num));
+
+  return result.length ? result : undefined;
+};
+
+/**
+ * Convert API/CLI replica placement entries into the UI's flat row format.
+ * `n_gpu` is retained as hidden row metadata so a numeric GPU count without
+ * explicit GPU indexes survives a command import and subsequent launch.
+ *
+ * @param {unknown[]} replicaConfig
+ * @returns {Array<{
+ *   replica_uid: unknown,
+ *   worker_ip: unknown,
+ *   gpu_idx: string,
+ *   n_gpu: unknown,
+ * }>}
+ */
+export const transformReplicaConfigToFormRows = (replicaConfig) =>
+  replicaConfig.map((entry) => {
+    const device = isRecord(entry) && Array.isArray(entry.devices) ? entry.devices[0] : {};
+    const deviceRecord = isRecord(device) ? device : {};
+
+    return {
+      replica_uid: (isRecord(entry) && entry.replica_uid) || '',
+      worker_ip: deviceRecord.worker_ip || '',
+      gpu_idx: Array.isArray(deviceRecord.gpu_idx) ? deviceRecord.gpu_idx.join(',') : '',
+      n_gpu: deviceRecord.n_gpu,
+    };
+  });
+
+/**
+ * Convert the UI's flat replica placement rows back into API/CLI entries.
+ * Explicit GPU indexes take precedence; otherwise the imported `n_gpu` value
+ * is preserved, falling back to automatic allocation for newly-created rows.
+ *
+ * @param {unknown[]} rows
+ * @returns {Array<{
+ *   replica_uid: string | undefined,
+ *   devices: Array<{
+ *     worker_ip: unknown,
+ *     n_gpu: number | 'auto',
+ *     gpu_idx: number[] | undefined,
+ *   }>,
+ * }>}
+ */
+export const transformReplicaFormRowsToConfig = (rows) =>
+  rows
+    .filter((row) => isRecord(row) && row.worker_ip)
+    .map((row) => {
+      const gpuIdx = parseReplicaGpuIndexes(row.gpu_idx);
+      const preservedNGPU =
+        row.n_gpu === 'auto' ||
+        (typeof row.n_gpu === 'number' && Number.isInteger(row.n_gpu) && row.n_gpu >= 0)
+          ? row.n_gpu
+          : 'auto';
+
+      return {
+        replica_uid:
+          typeof row.replica_uid === 'string' ? row.replica_uid.trim() || undefined : undefined,
+        devices: [
+          {
+            worker_ip: row.worker_ip,
+            n_gpu: gpuIdx ? gpuIdx.length : preservedNGPU,
+            gpu_idx: gpuIdx,
+          },
+        ],
+      };
+    });

--- a/frontend/src/components/pages/launch-model/replica-config-utils.test.mjs
+++ b/frontend/src/components/pages/launch-model/replica-config-utils.test.mjs
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  transformReplicaConfigToFormRows,
+  transformReplicaFormRowsToConfig,
+} from './replica-config-utils.mjs';
+
+const roundTrip = (replicaConfig) =>
+  transformReplicaFormRowsToConfig(transformReplicaConfigToFormRows(replicaConfig));
+
+test('preserves numeric n_gpu when gpu_idx is omitted', () => {
+  const replicaConfig = [
+    {
+      replica_uid: 'primary',
+      devices: [{ worker_ip: 'worker-0:9978', n_gpu: 1 }],
+    },
+  ];
+
+  const result = roundTrip(replicaConfig);
+
+  assert.equal(result[0].devices[0].n_gpu, 1);
+  assert.equal(result[0].devices[0].gpu_idx, undefined);
+});
+
+test('preserves auto n_gpu when gpu_idx is omitted', () => {
+  const replicaConfig = [
+    {
+      replica_uid: 'primary',
+      devices: [{ worker_ip: 'worker-0:9978', n_gpu: 'auto' }],
+    },
+  ];
+
+  const result = roundTrip(replicaConfig);
+
+  assert.equal(result[0].devices[0].n_gpu, 'auto');
+  assert.equal(result[0].devices[0].gpu_idx, undefined);
+});
+
+test('derives n_gpu from explicit gpu_idx instead of retained metadata', () => {
+  const result = transformReplicaFormRowsToConfig([
+    {
+      replica_uid: 'primary',
+      worker_ip: 'worker-0:9978',
+      gpu_idx: '0, 2',
+      n_gpu: 1,
+    },
+  ]);
+
+  assert.equal(result[0].devices[0].n_gpu, 2);
+  assert.deepEqual(result[0].devices[0].gpu_idx, [0, 2]);
+});

--- a/frontend/src/components/pages/launch-model/utils.tsx
+++ b/frontend/src/components/pages/launch-model/utils.tsx
@@ -30,6 +30,11 @@ import type {
   WorkerOption,
 } from './types';
 import type { TFunc } from '@/contexts/i18n-context';
+import {
+  parseReplicaGpuIndexes,
+  transformReplicaConfigToFormRows,
+  transformReplicaFormRowsToConfig,
+} from './replica-config-utils.mjs';
 
 export const MODEL_ENGINE_TYPES: RequestModelType[] = [
   ModelType.LLM,
@@ -418,18 +423,8 @@ function normalizeNGPU(value?: string | number) {
 }
 export const GPU_IDX_PATTERN = /^\d+(?:\s*,\s*\d+)*$/;
 
-export const parseGpuIndexes = (value?: string): number[] | undefined => {
-  if (!value) return undefined;
-
-  const result = value
-    .split(',')
-    .map((item) => item.trim())
-    .filter(Boolean)
-    .map(Number)
-    .filter((num) => !Number.isNaN(num));
-
-  return result.length ? result : undefined;
-};
+export const parseGpuIndexes = (value?: string): number[] | undefined =>
+  parseReplicaGpuIndexes(value);
 
 function transformWorkerIpToFetch(value: unknown) {
   if (!Array.isArray(value)) return value;
@@ -508,22 +503,7 @@ export function transformFormToFetch(values: FormValues) {
   delete nextValues.replica_placement_mode;
   if (placementMode === 'custom') {
     const rows = Array.isArray(nextValues.replica_config) ? nextValues.replica_config : [];
-    nextValues.replica_config = rows
-      .filter((row: unknown) => isRecord(row) && row.worker_ip)
-      .map((row: UnknownRecord) => {
-        const gpuIdx = parseGpuIndexes(row.gpu_idx as string);
-        return {
-          replica_uid:
-            typeof row.replica_uid === 'string' ? row.replica_uid.trim() || undefined : undefined,
-          devices: [
-            {
-              worker_ip: row.worker_ip,
-              n_gpu: gpuIdx ? gpuIdx.length : 'auto',
-              gpu_idx: gpuIdx,
-            },
-          ],
-        };
-      });
+    nextValues.replica_config = transformReplicaFormRowsToConfig(rows);
     // Mutual exclusion: the legacy global placement fields must not be sent
     // together with replica_config (the backend rejects this).
     delete nextValues.n_worker;
@@ -563,15 +543,7 @@ export function transformFetchToForm(values: FormValues) {
     nextValues.worker_ip = transformWorkerIpToForm(values.worker_ip);
   }
   if (Array.isArray(nextValues.replica_config) && nextValues.replica_config.length > 0) {
-    nextValues.replica_config = nextValues.replica_config.map((entry: unknown) => {
-      const device = isRecord(entry) && Array.isArray(entry.devices) ? entry.devices[0] : {};
-      const deviceRecord = isRecord(device) ? device : {};
-      return {
-        replica_uid: (isRecord(entry) && entry.replica_uid) || '',
-        worker_ip: deviceRecord.worker_ip || '',
-        gpu_idx: Array.isArray(deviceRecord.gpu_idx) ? deviceRecord.gpu_idx.join(',') : '',
-      };
-    });
+    nextValues.replica_config = transformReplicaConfigToFormRows(nextValues.replica_config);
     nextValues.replica_placement_mode = 'custom';
     nextValues.n_worker = undefined;
     nextValues.worker_ip = undefined;
@@ -755,9 +727,7 @@ function parseReplicaConfigCommandValue(value: string) {
       device.n_gpu !== undefined &&
       device.n_gpu !== null &&
       device.n_gpu !== 'auto' &&
-      (typeof device.n_gpu !== 'number' ||
-        !Number.isInteger(device.n_gpu) ||
-        device.n_gpu < 0)
+      (typeof device.n_gpu !== 'number' || !Number.isInteger(device.n_gpu) || device.n_gpu < 0)
     ) {
       throw new Error(
         `replica_config[${replicaIndex}].devices[0].n_gpu must be a non-negative integer or "auto".`

--- a/frontend/src/components/pages/launch-model/utils.tsx
+++ b/frontend/src/components/pages/launch-model/utils.tsx
@@ -751,9 +751,16 @@ function parseReplicaConfigCommandValue(value: string) {
         `replica_config[${replicaIndex}].devices[0].worker_ip must be a non-empty string.`
       );
     }
-    if (device.n_gpu !== undefined && device.n_gpu !== 'auto' && !Number.isInteger(device.n_gpu)) {
+    if (
+      device.n_gpu !== undefined &&
+      device.n_gpu !== null &&
+      device.n_gpu !== 'auto' &&
+      (typeof device.n_gpu !== 'number' ||
+        !Number.isInteger(device.n_gpu) ||
+        device.n_gpu < 0)
+    ) {
       throw new Error(
-        `replica_config[${replicaIndex}].devices[0].n_gpu must be an integer or "auto".`
+        `replica_config[${replicaIndex}].devices[0].n_gpu must be a non-negative integer or "auto".`
       );
     }
     if (

--- a/frontend/src/components/pages/launch-model/utils.tsx
+++ b/frontend/src/components/pages/launch-model/utils.tsx
@@ -526,6 +526,7 @@ export function transformFormToFetch(values: FormValues) {
       });
     // Mutual exclusion: the legacy global placement fields must not be sent
     // together with replica_config (the backend rejects this).
+    delete nextValues.n_worker;
     delete nextValues.worker_ip;
     delete nextValues.n_gpu;
     delete nextValues.gpu_idx;
@@ -561,7 +562,7 @@ export function transformFetchToForm(values: FormValues) {
   if ('worker_ip' in values) {
     nextValues.worker_ip = transformWorkerIpToForm(values.worker_ip);
   }
-  if (Array.isArray(nextValues.replica_config)) {
+  if (Array.isArray(nextValues.replica_config) && nextValues.replica_config.length > 0) {
     nextValues.replica_config = nextValues.replica_config.map((entry: unknown) => {
       const device = isRecord(entry) && Array.isArray(entry.devices) ? entry.devices[0] : {};
       const deviceRecord = isRecord(device) ? device : {};
@@ -572,8 +573,15 @@ export function transformFetchToForm(values: FormValues) {
       };
     });
     nextValues.replica_placement_mode = 'custom';
+    nextValues.n_worker = undefined;
+    nextValues.worker_ip = undefined;
+    nextValues.n_gpu = undefined;
+    nextValues.gpu_idx = undefined;
   } else if (nextValues.replica_placement_mode === undefined) {
+    nextValues.replica_config = undefined;
     nextValues.replica_placement_mode = 'auto';
+  } else {
+    nextValues.replica_config = undefined;
   }
   return nextValues;
 }
@@ -705,17 +713,95 @@ function setObjectPair(target: Record<string, unknown>, values: string[]) {
   }
 }
 
+function parseReplicaConfigCommandValue(value: string) {
+  if (!value) {
+    throw new Error('--replica-config requires a JSON value.');
+  }
+
+  let replicaConfig: unknown;
+
+  try {
+    replicaConfig = JSON.parse(value);
+  } catch {
+    throw new Error('--replica-config must contain valid JSON.');
+  }
+
+  if (!Array.isArray(replicaConfig)) {
+    throw new Error('--replica-config must be a JSON array.');
+  }
+  if (replicaConfig.length === 0) {
+    throw new Error('--replica-config must be a non-empty JSON array.');
+  }
+
+  replicaConfig.forEach((entry, replicaIndex) => {
+    if (!isRecord(entry)) {
+      throw new Error(`replica_config[${replicaIndex}] must be an object.`);
+    }
+    if (!Array.isArray(entry.devices) || entry.devices.length !== 1) {
+      throw new Error(`replica_config[${replicaIndex}].devices must contain exactly one device.`);
+    }
+
+    const device = entry.devices[0];
+
+    if (!isRecord(device)) {
+      throw new Error(`replica_config[${replicaIndex}].devices[0] must be an object.`);
+    }
+    if (typeof device.worker_ip !== 'string' || !device.worker_ip.trim()) {
+      throw new Error(
+        `replica_config[${replicaIndex}].devices[0].worker_ip must be a non-empty string.`
+      );
+    }
+    if (device.n_gpu !== undefined && device.n_gpu !== 'auto' && !Number.isInteger(device.n_gpu)) {
+      throw new Error(
+        `replica_config[${replicaIndex}].devices[0].n_gpu must be an integer or "auto".`
+      );
+    }
+    if (
+      device.gpu_idx !== undefined &&
+      device.gpu_idx !== null &&
+      (!Array.isArray(device.gpu_idx) ||
+        device.gpu_idx.some((gpuIndex) => !Number.isInteger(gpuIndex) || gpuIndex < 0))
+    ) {
+      throw new Error(
+        `replica_config[${replicaIndex}].devices[0].gpu_idx must contain non-negative integers.`
+      );
+    }
+    if (entry.replica_uid !== undefined && typeof entry.replica_uid !== 'string') {
+      throw new Error(`replica_config[${replicaIndex}].replica_uid must be a string.`);
+    }
+  });
+
+  return replicaConfig;
+}
+
 export function generateCommandLineStatement(params: FormValues) {
-  const entries = Object.entries(params).filter(([, value]) => !isEmptyCommandValue(value));
+  let commandParams = params;
+
+  if (Array.isArray(params.replica_config)) {
+    if (params.replica_config.length === 0) {
+      throw new Error('replica_config must contain at least one replica.');
+    }
+
+    const replica =
+      params.replica === undefined ? params.replica_config.length : Number(params.replica);
+
+    if (!Number.isInteger(replica) || replica !== params.replica_config.length) {
+      throw new Error('replica must match the number of entries in replica_config.');
+    }
+
+    commandParams = { ...params, replica };
+  }
+
+  const entries = Object.entries(commandParams).filter(([, value]) => !isEmptyCommandValue(value));
 
   const args = [
     ...commandLeadingKeys.flatMap((leadingKey) => entries.filter(([key]) => key === leadingKey)),
     ...entries.filter(([key]) => !commandLeadingKeys.includes(key)),
   ]
     .flatMap(([key, value]) => {
-      // CLI has no --replica-config flag, so per-replica placement is not
-      // expressible on the command line. Skip these UI-only / unsupported keys.
-      if (key === 'replica_config' || key === 'replica_placement_mode') {
+      // `replica_placement_mode` is UI-only. replica_config is serialized as
+      // compact JSON by the generic command-value path below.
+      if (key === 'replica_placement_mode') {
         return [];
       }
       if (key === 'gpu_idx' && Array.isArray(value)) {
@@ -854,6 +940,11 @@ export function parseXinferenceCommand(command: string) {
     const normalizedKey = normalizeCommandKey(key);
     const value = valueTokens.join(' ');
 
+    if (normalizedKey === 'replica_config') {
+      params.replica_config = parseReplicaConfigCommandValue(value);
+      continue;
+    }
+
     if (normalizedKey === 'gpu_idx') {
       params.gpu_idx = value
         .split(',')
@@ -953,6 +1044,22 @@ export function parseXinferenceCommand(command: string) {
     params.envs = envs;
   }
 
+  if (Array.isArray(params.replica_config)) {
+    if (params.replica === undefined) {
+      params.replica = params.replica_config.length;
+    } else {
+      const replica = Number(params.replica);
+
+      if (!Number.isInteger(replica) || replica < 1) {
+        throw new Error('--replica must be a positive integer when --replica-config is used.');
+      }
+      if (replica !== params.replica_config.length) {
+        throw new Error('--replica must match the number of entries in --replica-config.');
+      }
+      params.replica = replica;
+    }
+  }
+
   return params;
 }
 
@@ -975,6 +1082,33 @@ export function normalizeReplicaStatuses(value: unknown): ReplicaItem[] {
       : [];
 
   return statuses.filter(isRecord) as unknown as ReplicaItem[];
+}
+
+export type ReplicaPlacementValidationError = 'incomplete' | 'duplicate-alias';
+
+export function validateReplicaPlacement(
+  values: FormValues
+): ReplicaPlacementValidationError | undefined {
+  if (values.replica_placement_mode !== 'custom') return undefined;
+
+  const rows = Array.isArray(values.replica_config) ? values.replica_config : [];
+  const replicaCount = Number(values.replica) || 1;
+  const hasInvalidPlacement =
+    rows.length !== replicaCount ||
+    rows.some((row) => {
+      const gpuIndexes = String(row?.gpu_idx ?? '').trim();
+      return (
+        !String(row?.worker_ip ?? '').trim() ||
+        (gpuIndexes !== '' && !GPU_IDX_PATTERN.test(gpuIndexes))
+      );
+    });
+
+  if (hasInvalidPlacement) return 'incomplete';
+
+  const aliases = rows.map((row) => String(row?.replica_uid ?? '').trim()).filter(Boolean);
+  if (new Set(aliases).size !== aliases.length) return 'duplicate-alias';
+
+  return undefined;
 }
 
 export function isEmptyLaunchValue(value: unknown) {

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -503,6 +503,7 @@ const en = {
     confirmDeleteConfigCache: 'Delete this cached configuration? This action is irreversible.',
     invalidConfigCache: 'The model engine required by this cached configuration is unavailable.',
     commandLineParsing: 'Command Line Argument Parsing',
+    commandLineParsingFailed: 'Failed to process command line: {{error}}',
     copyToCommandLine: 'Copy as Command Line Command',
     modelEngine: 'Model Engine',
     modelFormat: 'Model Format',

--- a/frontend/src/i18n/locales/ja.ts
+++ b/frontend/src/i18n/locales/ja.ts
@@ -490,6 +490,7 @@ const ja = {
     confirmDeleteConfigCache: 'この設定キャッシュを削除しますか？この操作は元に戻せません。',
     invalidConfigCache: 'この設定キャッシュに必要なモデルエンジンは現在利用できません。',
     commandLineParsing: 'コマンドライン引数解析',
+    commandLineParsingFailed: 'コマンドラインの処理に失敗しました: {{error}}',
     copyToCommandLine: 'コマンドラインコマンドとしてコピー',
     modelEngine: 'モデルエンジン',
     modelFormat: 'モデルフォーマット',

--- a/frontend/src/i18n/locales/ko.ts
+++ b/frontend/src/i18n/locales/ko.ts
@@ -489,6 +489,7 @@ const ko = {
     confirmDeleteConfigCache: '이 구성 캐시를 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.',
     invalidConfigCache: '이 구성 캐시에 필요한 모델 엔진을 현재 사용할 수 없습니다.',
     commandLineParsing: '명령줄 인수 파싱',
+    commandLineParsingFailed: '명령줄 처리에 실패했습니다: {{error}}',
     copyToCommandLine: '명령줄 명령으로 복사',
     modelEngine: '모델 엔진',
     modelFormat: '모델 형식',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -481,6 +481,7 @@ const zh = {
     confirmDeleteConfigCache: '确认删除这条配置缓存吗？此操作无法恢复。',
     invalidConfigCache: '这条配置缓存对应的模型引擎当前不可用。',
     commandLineParsing: '解析命令行参数',
+    commandLineParsingFailed: '命令行参数处理失败：{{error}}',
     copyToCommandLine: '复制为命令行指令',
     modelEngine: '模型引擎',
     modelFormat: '模型格式',

--- a/xinference/core/replica_config.py
+++ b/xinference/core/replica_config.py
@@ -56,6 +56,8 @@ class DeviceConfig(_PlacementConfigBase):
     def _validate_n_gpu(cls, value):
         if value != "auto" and (isinstance(value, bool) or not isinstance(value, int)):
             raise TypeError("n_gpu must be an integer or 'auto'")
+        if value != "auto" and value < 0:
+            raise ValueError("n_gpu must be a non-negative integer or 'auto'")
         return value
 
     @validator("gpu_idx", pre=True)

--- a/xinference/core/tests/test_replica_config.py
+++ b/xinference/core/tests/test_replica_config.py
@@ -77,6 +77,7 @@ def test_from_dict_roundtrip():
         ("n_gpu", 1.5),
         ("n_gpu", True),
         ("n_gpu", "1"),
+        ("n_gpu", -1),
         ("gpu_idx", [0.9]),
         ("gpu_idx", [True]),
         ("gpu_idx", [0, 0]),

--- a/xinference/deploy/cmdline.py
+++ b/xinference/deploy/cmdline.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import asyncio
+import json
 import logging
 import os
 import sys
@@ -21,6 +22,7 @@ import warnings
 from typing import Dict, List, Optional, Sequence, Tuple, Union
 
 import click
+from click.core import ParameterSource
 from tqdm.auto import tqdm
 from xoscar.utils import get_next_port
 
@@ -801,6 +803,14 @@ def remove_cache(
     help="The replica count of the model, default is 1.",
 )
 @click.option(
+    "--replica-config",
+    "--replica_config",
+    "replica_config",
+    default=None,
+    type=str,
+    help="Per-replica worker and GPU placement as a non-empty JSON array.",
+)
+@click.option(
     "--n-worker",
     default=1,
     type=int,
@@ -920,6 +930,7 @@ def model_launch(
     model_format: str,
     quantization: str,
     replica: int,
+    replica_config: Optional[str],
     n_worker: int,
     n_gpu: str,
     lora_modules: Optional[Tuple],
@@ -959,6 +970,50 @@ def model_launch(
 
     if model_type == "LLM" and model_engine is None:
         raise ValueError("--model-engine is required for LLM models.")
+
+    _replica_config: Optional[List[Dict]] = None
+    if replica_config is not None:
+        try:
+            parsed_replica_config = json.loads(replica_config)
+        except json.JSONDecodeError as e:
+            raise click.BadParameter(
+                f"must be valid JSON: {e.msg}", param_hint="--replica-config"
+            ) from e
+
+        if not isinstance(parsed_replica_config, list):
+            raise click.BadParameter(
+                "must be a JSON array", param_hint="--replica-config"
+            )
+        if not parsed_replica_config:
+            raise click.BadParameter(
+                "must be a non-empty JSON array", param_hint="--replica-config"
+            )
+
+        _replica_config = parsed_replica_config
+        replica_source = ctx.get_parameter_source("replica")
+        if replica_source == ParameterSource.COMMANDLINE:
+            if replica != len(_replica_config):
+                raise click.BadParameter(
+                    "must match the number of entries in --replica-config",
+                    param_hint="--replica",
+                )
+        else:
+            replica = len(_replica_config)
+
+        conflicting_options = []
+        if worker_ip is not None:
+            conflicting_options.append("--worker-ip")
+        if gpu_idx is not None:
+            conflicting_options.append("--gpu-idx")
+        if n_gpu != "auto":
+            conflicting_options.append("--n-gpu")
+        if n_worker > 1:
+            conflicting_options.append("--n-worker")
+        if conflicting_options:
+            raise click.BadParameter(
+                "cannot be used together with " + ", ".join(conflicting_options),
+                param_hint="--replica-config",
+            )
 
     if n_gpu.lower() == "none":
         _n_gpu: Optional[Union[int, str]] = None
@@ -1030,6 +1085,7 @@ def model_launch(
         model_format=model_format,
         quantization=quantization,
         replica=replica,
+        replica_config=_replica_config,
         n_worker=n_worker,
         n_gpu=_n_gpu,
         peft_model_config=peft_model_config,

--- a/xinference/deploy/test/test_cmdline.py
+++ b/xinference/deploy/test/test_cmdline.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import json
 import os
 import tempfile
 
@@ -434,3 +435,136 @@ def test_launch_error_in_passing_parameters():
         "You must specify extra kwargs with `--` prefix. There is an error in parameter passing that is -l."
         in str(result)
     )
+
+
+def _invoke_launch_with_replica_config(monkeypatch, replica_config, *extra_args):
+    calls = {}
+
+    class DummyRESTfulClient:
+        def __init__(self, base_url, api_key=None):
+            calls["base_url"] = base_url
+            calls["api_key"] = api_key
+
+        def launch_model(self, **kwargs):
+            calls["launch_kwargs"] = kwargs
+            return "test-model-uid"
+
+        def get_instance_info(self, model_name, model_uid):
+            return [{"status": "READY"}]
+
+    monkeypatch.setattr(cmdline_module, "RESTfulClient", DummyRESTfulClient)
+    result = CliRunner().invoke(
+        model_launch,
+        [
+            "--endpoint",
+            "http://127.0.0.1:9997",
+            "--api-key",
+            "test-key",
+            "--model-name",
+            "test-model",
+            "--model-engine",
+            "transformers",
+            *extra_args,
+            replica_config,
+        ],
+    )
+    return result, calls
+
+
+@pytest.mark.parametrize("option", ["--replica-config", "--replica_config"])
+def test_launch_replica_config_is_passed_to_client(monkeypatch, option):
+    replica_config = [
+        {"devices": [{"worker_ip": "worker-0:9978", "n_gpu": 1, "gpu_idx": [0]}]},
+        {"devices": [{"worker_ip": "worker-1:9978", "n_gpu": 1, "gpu_idx": [1]}]},
+    ]
+
+    result, calls = _invoke_launch_with_replica_config(
+        monkeypatch, json.dumps(replica_config), option
+    )
+
+    assert result.exit_code == 0, result.output
+    assert calls["launch_kwargs"]["replica"] == 2
+    assert calls["launch_kwargs"]["replica_config"] == replica_config
+
+
+def test_launch_replica_config_accepts_matching_explicit_replica(monkeypatch):
+    replica_config = [
+        {"devices": [{"worker_ip": "worker-0:9978"}]},
+        {"devices": [{"worker_ip": "worker-1:9978"}]},
+    ]
+
+    result, calls = _invoke_launch_with_replica_config(
+        monkeypatch,
+        json.dumps(replica_config),
+        "--replica",
+        "2",
+        "--replica-config",
+    )
+
+    assert result.exit_code == 0, result.output
+    assert calls["launch_kwargs"]["replica"] == 2
+
+
+@pytest.mark.parametrize(
+    ("replica_config", "expected_message"),
+    [
+        ("not-json", "must be valid JSON"),
+        (json.dumps({"devices": []}), "must be a JSON array"),
+        (json.dumps([]), "must be a non-empty JSON array"),
+    ],
+)
+def test_launch_replica_config_rejects_invalid_json(
+    monkeypatch, replica_config, expected_message
+):
+    result, calls = _invoke_launch_with_replica_config(
+        monkeypatch, replica_config, "--replica-config"
+    )
+
+    assert result.exit_code == 2
+    assert expected_message in result.output
+    assert "launch_kwargs" not in calls
+
+
+def test_launch_replica_config_rejects_mismatched_explicit_replica(monkeypatch):
+    replica_config = [
+        {"devices": [{"worker_ip": "worker-0:9978"}]},
+        {"devices": [{"worker_ip": "worker-1:9978"}]},
+    ]
+
+    result, calls = _invoke_launch_with_replica_config(
+        monkeypatch,
+        json.dumps(replica_config),
+        "--replica",
+        "1",
+        "--replica-config",
+    )
+
+    assert result.exit_code == 2
+    assert "must match the number of entries in --replica-config" in result.output
+    assert "launch_kwargs" not in calls
+
+
+@pytest.mark.parametrize(
+    "conflicting_args",
+    [
+        ["--worker-ip", "worker-0:9978"],
+        ["--gpu-idx", "0"],
+        ["--n-gpu", "1"],
+        ["--n-worker", "2"],
+    ],
+)
+def test_launch_replica_config_rejects_global_placement_options(
+    monkeypatch, conflicting_args
+):
+    replica_config = [{"devices": [{"worker_ip": "worker-0:9978"}]}]
+
+    result, calls = _invoke_launch_with_replica_config(
+        monkeypatch,
+        json.dumps(replica_config),
+        *conflicting_args,
+        "--replica-config",
+    )
+
+    assert result.exit_code == 2
+    assert "cannot be used together with" in result.output
+    assert "launch_kwargs" not in calls


### PR DESCRIPTION
## Summary

- Add formal `--replica-config` support to `xinference launch`, including the compatible `--replica_config` alias.
- Validate JSON shape, replica count, and conflicts with global worker/GPU placement options before sending the launch request.
- Preserve per-replica Worker/GPU placement when copying a Web UI launch form to a command line and restore it when parsing the command.
- Hide and clean up `n_worker` and legacy global placement fields in per-replica placement mode.
- Share per-replica validation between model launch and command-line copy so incomplete configurations cannot produce invalid commands.
- Add CLI tests and update the launch documentation.

## Compatibility

- The existing REST API and Python Client `replica_config` structure is unchanged.
- Automatic scheduling and existing global Worker/GPU placement behavior are unchanged.
- Each replica remains restricted to one device, consistent with the existing backend validation.

## Tests

- `npm run lint` — passed, 0 errors (existing warnings remain).
- `npm run build` — passed.
- `python3 -m compileall -q xinference/deploy/cmdline.py xinference/deploy/test/test_cmdline.py` — passed.
- `pytest -q xinference/deploy/test/test_cmdline.py -k replica_config` — 11 passed.
- `git diff --check` — passed.