### PR TITLE
fix: declare Token Router installation extra

### DIFF
--- a/doc/source/getting_started/installation.rst
+++ b/doc/source/getting_started/installation.rst
@@ -9,6 +9,29 @@ If you aim to serve all supported models, you can install all the necessary depe
 
    pip install "xinference[all]"
 
+Token Router
+~~~~~~~~~~~~
+The Token Router Runtime and Router Agent can be installed separately from
+the model-serving backends::
+
+   pip install "xinference[router]"
+
+When installing Xinference from a source checkout, use::
+
+   uv pip install -e ".[router]"
+
+The ``router`` extra provides the dependencies required by the Token Router
+Runtime and Router Agent. The ``all`` extra includes the ``router`` extra.
+
+The Supervisor can use the base installation::
+
+   pip install xinference
+
+Installing the package creates the ``xinference-router`` and
+``xinference-router-agent`` commands. The extra controls dependency
+installation; it does not start any Supervisor, Worker, Router, or Router
+Agent process.
+
 .. versionchanged:: v1.8.1
 
    Due to irreconcilable package dependency conflicts between vLLM and sglang, we have removed sglang from the all extra. If you want to use sglang, please install it separately via ``pip install 'xinference[sglang]'``.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,7 @@ dev = [
     "sphinx-tabs",
     "sphinx-design",
     "pypdfium2",  # For PDF OCR tests
+    "tomli; python_version < '3.11'",
 ]
 otel = [
     "opentelemetry-api>=1.20.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
     "xoscar>=0.9.7",
+    "psutil>=5.9.0",
     "torch",
     "pillow",
     "click<8.2.0",
@@ -115,6 +116,9 @@ otel = [
     "opentelemetry-instrumentation-fastapi>=0.41b0",
     "opentelemetry-instrumentation-httpx>=0.41b0",
 ]
+router = [
+    "tokenizers>=0.21.0,<0.23.0",
+]
 all = [
     "xinference[anthropic]",
     "xinference[llama_cpp]",
@@ -126,6 +130,7 @@ all = [
     "xinference[image]",
     "xinference[video]",
     "xinference[audio]",
+    "xinference[router]",
 ]
 intel = [
     "torch==2.1.0a0",

--- a/xinference/tests/test_build_backend.py
+++ b/xinference/tests/test_build_backend.py
@@ -19,6 +19,7 @@ import json
 import os
 import shutil
 import subprocess
+import tomllib
 
 import pytest
 
@@ -225,3 +226,20 @@ def test_reports_entry_index_for_unnamed_invalid_llm_families(backend, tmp_path)
 
     message = str(exc_info.value)
     assert all(f"'entry {index}'" in message for index in range(3))
+
+
+def test_project_declares_router_dependencies_and_all_includes_router():
+    with open(os.path.join(_REPO_ROOT, "pyproject.toml"), "rb") as f:
+        project = tomllib.load(f)
+
+    metadata = project["project"]
+    dependencies = metadata["dependencies"]
+    optional_dependencies = metadata["optional-dependencies"]
+    scripts = metadata["scripts"]
+
+    assert "psutil>=5.9.0" in dependencies
+    assert optional_dependencies["router"] == ["tokenizers>=0.21.0,<0.23.0"]
+    assert "xinference[router]" in optional_dependencies["all"]
+
+    assert scripts["xinference-router"] == "xinference.deploy.router:main"
+    assert scripts["xinference-router-agent"] == "xinference.deploy.router_agent:main"

--- a/xinference/tests/test_build_backend.py
+++ b/xinference/tests/test_build_backend.py
@@ -19,7 +19,11 @@ import json
 import os
 import shutil
 import subprocess
-import tomllib
+
+try:
+    import tomllib
+except ImportError:
+    import tomli as tomllib  # type: ignore[no-redef]
 
 import pytest
 


### PR DESCRIPTION
## Summary

- Declare `psutil` as a direct base dependency because it is used by Xinference core and Token Router resource reporting.
- Add a dedicated `router` extra for the Token Router Runtime and Router Agent.
- Include the `router` extra in `all`.
- Document base, Router, and full installation roles in the getting-started installation guide.
- Add structured metadata coverage for the Router extra, `all`, and Router console scripts.

The Router extra uses `tokenizers>=0.21.0,<0.23.0` so it remains compatible with the supported Transformers range, including `transformers==4.53.3` (which uses the 0.21.x tokenizers line) and newer Transformers releases using 0.22.x.

## Testing

- `pytest -q xinference/tests/test_build_backend.py xinference/router/tests` (152 passed)
- `uv pip install --dry-run -e '.[router]' 'transformers==4.53.3' 'tokenizers==0.21.4'`
- `pre-commit run --files pyproject.toml doc/source/getting_started/installation.rst xinference/tests/test_build_backend.py`
