### PR TITLE
feat: Add Gemma-4 Transformers backend with batching support

### DIFF
--- a/xinference/model/llm/llm_family.json
+++ b/xinference/model/llm/llm_family.json
@@ -30264,7 +30264,8 @@
     "version": 2,
     "virtualenv": {
       "packages": [
-        "#transformers_dependencies# ; #engine# == \"Transformers\"",
+        "transformers>=5.10.0 ; #engine# == \"Transformers\"",
+        "accelerate>=0.28.0 ; #engine# == \"Transformers\"",
         "#mlx_dependencies# ; #engine# == \"MLX\"",
         "mlx-vlm>=0.6.1 ; #engine# == \"MLX\"",
         "vllm>=0.22.0 ; #engine# == \"vllm\"",

--- a/xinference/model/llm/transformers/core.py
+++ b/xinference/model/llm/transformers/core.py
@@ -51,8 +51,12 @@ from .utils import (
     _get_pad_param,
     convert_to_cache_cls,
     get_context_length,
+    get_first_populated_kv_cache_layer,
+    get_kv_cache_layer,
+    get_kv_cache_seq_length,
     get_max_src_len,
     pad_prefill_tokens,
+    set_kv_cache_layer,
 )
 
 logger = logging.getLogger(__name__)
@@ -793,7 +797,7 @@ class PytorchModel(LLM):
         if not isinstance(new_cache, DynamicCache):
             new_cache = convert_to_cache_cls(new_cache)
 
-        _, seq_len_idx = self.get_batch_size_and_seq_len_indexes_from_kv()
+        bs_idx, seq_len_idx = self.get_batch_size_and_seq_len_indexes_from_kv()
 
         # Handle empty caches
         if len(past_cache) == 0:
@@ -801,86 +805,91 @@ class PytorchModel(LLM):
         if len(new_cache) == 0:
             return past_cache
 
-        # Get first layer seq_len safely
-        past_first = past_cache[0] if len(past_cache) > 0 else (None, None)
-        new_first = new_cache[0] if len(new_cache) > 0 else (None, None)
+        def _merge_layer_tensors(layer_idx, past_k, past_v, new_k, new_v):
+            if past_k is None and past_v is None and new_k is None and new_v is None:
+                return None, None
+            if any(x is None for x in (past_k, past_v, new_k, new_v)):
+                raise ValueError(
+                    f"Incomplete KV cache data at layer {layer_idx}; refusing to "
+                    "drop requests while merging batches"
+                )
+            if past_k.dim() != new_k.dim() or past_v.dim() != new_v.dim():
+                raise ValueError(
+                    f"KV cache tensor dimension mismatch at layer {layer_idx}: "
+                    f"past={past_k.shape}/{past_v.shape}, "
+                    f"new={new_k.shape}/{new_v.shape}"
+                )
 
-        if past_first[0] is None or past_first[1] is None:
-            return new_cache
-        if new_first[0] is None or new_first[1] is None:
-            return past_cache
+            target_seq_len = max(past_k.shape[seq_len_idx], new_k.shape[seq_len_idx])
 
-        past_seq_len = past_first[0].shape[seq_len_idx]
-        new_seq_len = new_first[0].shape[seq_len_idx]
+            def _pad_to_target(tensor):
+                padding_len = target_seq_len - tensor.shape[seq_len_idx]
+                return (
+                    pad(tensor, _get_pad_param(seq_len_idx, padding_len))
+                    if padding_len
+                    else tensor
+                )
 
-        # Pad the shorter cache
-        if past_seq_len != new_seq_len:
-            if past_seq_len > new_seq_len:
-                padding_target = new_cache
-                padding_len = past_seq_len - new_seq_len
-            else:
-                padding_target = past_cache
-                padding_len = new_seq_len - past_seq_len
+            past_k, past_v = _pad_to_target(past_k), _pad_to_target(past_v)
+            new_k, new_v = _pad_to_target(new_k), _pad_to_target(new_v)
 
-            pad_param = _get_pad_param(seq_len_idx, padding_len)
-            for idx in range(len(padding_target)):
-                k = padding_target.key_cache[idx]
-                v = padding_target.value_cache[idx]
-                if k is not None and v is not None:
-                    padding_target.key_cache[idx] = pad(k, pad_param)
-                    padding_target.value_cache[idx] = pad(v, pad_param)
+            def _shape_without_batch(tensor):
+                return tuple(
+                    size for idx, size in enumerate(tensor.shape) if idx != bs_idx
+                )
 
-        # Merge caches
-        ret_kv = DynamicCache()
+            if _shape_without_batch(past_k) != _shape_without_batch(new_k) or (
+                _shape_without_batch(past_v) != _shape_without_batch(new_v)
+            ):
+                raise ValueError(
+                    f"KV cache shape mismatch at layer {layer_idx}: "
+                    f"past={past_k.shape}/{past_v.shape}, "
+                    f"new={new_k.shape}/{new_v.shape}"
+                )
+
+            return (
+                torch.cat((new_k, past_k), bs_idx).contiguous(),
+                torch.cat((new_v, past_v), bs_idx).contiguous(),
+            )
+
+        model_config = getattr(getattr(self, "_model", None), "config", None)
+        try:
+            ret_kv = DynamicCache(config=model_config)
+        except TypeError:
+            # Transformers before the layer-based cache API did not accept config.
+            ret_kv = DynamicCache()
         max_layers = max(len(past_cache), len(new_cache))
 
         for idx in range(max_layers):
-            past_k = past_cache.key_cache[idx] if idx < len(past_cache) else None
-            past_v = past_cache.value_cache[idx] if idx < len(past_cache) else None
-            new_k = new_cache.key_cache[idx] if idx < len(new_cache) else None
-            new_v = new_cache.value_cache[idx] if idx < len(new_cache) else None
+            past_k, past_v = get_kv_cache_layer(past_cache, idx)
+            new_k, new_v = get_kv_cache_layer(new_cache, idx)
+            merged_k, merged_v = _merge_layer_tensors(idx, past_k, past_v, new_k, new_v)
+            if merged_k is None:
+                continue
+            ret_kv.update(merged_k, merged_v, idx)
 
-            if past_k is not None and new_k is not None:
-                # Both layers exist - validate tensor dimensions before concatenation
-                if past_k.dim() != new_k.dim():
-                    logger.error(
-                        f"KV cache tensor dimension mismatch at layer {idx}: "
-                        f"past_k.dim()={past_k.dim()}, new_k.dim()={new_k.dim()}"
-                    )
-                    # Use the cache with higher batch size
-                    if past_k.shape[0] >= new_k.shape[0]:
-                        ret_kv.update(past_k, past_v, idx)
-                    else:
-                        ret_kv.update(new_k, new_v, idx)
-                    continue
-
-                if past_k.shape[1:] == new_k.shape[1:]:
-                    # Shapes are compatible, concatenate along batch dimension
-                    ret_kv.update(
-                        torch.cat((new_k, past_k), 0).contiguous(),
-                        torch.cat((new_v, past_v), 0).contiguous(),
-                        idx,
-                    )
-                else:
-                    # Detailed logging for shape mismatch
-                    logger.warning(
-                        f"KV cache shape mismatch at layer {idx}: "
-                        f"past_k.shape={past_k.shape}, new_k.shape={new_k.shape}. "
-                        f"This may be due to inconsistent batch sizes in continuous batching."
+            layers = getattr(ret_kv, "layers", None)
+            if layers is not None and idx < len(layers):
+                layer = layers[idx]
+                if hasattr(layer, "cumulative_length"):
+                    layer.cumulative_length = max(
+                        get_kv_cache_seq_length(past_cache, idx),
+                        get_kv_cache_seq_length(new_cache, idx),
                     )
 
-                    # Choose the cache with larger batch size to preserve more data
-                    if past_k.shape[0] >= new_k.shape[0]:
-                        ret_kv.update(past_k, past_v, idx)
-                    else:
-                        ret_kv.update(new_k, new_v, idx)
-            elif past_k is not None:
-                ret_kv.update(past_k, past_v, idx)
-            elif new_k is not None:
-                ret_kv.update(new_k, new_v, idx)
-            else:
-                # both None, fill with None
-                ret_kv.update(None, None, idx)
+        past_shared = getattr(past_cache, "shared_layers", {})
+        new_shared = getattr(new_cache, "shared_layers", {})
+        shared_layers = {}
+        for idx in set(past_shared) | set(new_shared):
+            past_k, past_v = past_shared.get(idx, (None, None))
+            new_k, new_v = new_shared.get(idx, (None, None))
+            merged_k, merged_v = _merge_layer_tensors(
+                f"shared: {idx}", past_k, past_v, new_k, new_v
+            )
+            if merged_k is not None:
+                shared_layers[idx] = merged_k, merged_v
+        if shared_layers:
+            ret_kv.shared_layers = shared_layers
 
         return ret_kv
 
@@ -980,13 +989,47 @@ class PytorchModel(LLM):
         self.handle_batch_inference_results(req_list)
 
     def build_reduced_kv_cache(self, cache, skipped_indexes: Set[int]):
-        batch_size = cache.key_cache[0].shape[0]
+        bs_idx, _ = self.get_batch_size_and_seq_len_indexes_from_kv()
+        _, first_key, _ = get_first_populated_kv_cache_layer(cache)
+        if first_key is None:
+            return cache
+        batch_size = first_key.shape[bs_idx]
         batch_slices = [num for num in range(batch_size) if num not in skipped_indexes]
-        for idx in range(len(cache)):
-            cache.key_cache[idx] = cache.key_cache[idx][batch_slices, ::].contiguous()
-            cache.value_cache[idx] = cache.value_cache[idx][
-                batch_slices, ::
-            ].contiguous()
+
+        batch_select_indices = getattr(cache, "batch_select_indices", None)
+        if batch_select_indices is not None:
+            batch_select_indices(torch.tensor(batch_slices, dtype=torch.long))
+        else:
+            for idx in range(len(cache)):
+                key, value = get_kv_cache_layer(cache, idx)
+                if key is None:
+                    continue
+                set_kv_cache_layer(
+                    cache,
+                    idx,
+                    key.index_select(
+                        bs_idx,
+                        torch.tensor(batch_slices, device=key.device),
+                    ).contiguous(),
+                    value.index_select(
+                        bs_idx,
+                        torch.tensor(batch_slices, device=value.device),
+                    ).contiguous(),
+                )
+
+        shared_layers = getattr(cache, "shared_layers", None)
+        if shared_layers:
+            for idx, (key, value) in shared_layers.items():
+                shared_layers[idx] = (
+                    key.index_select(
+                        bs_idx,
+                        torch.tensor(batch_slices, device=key.device),
+                    ).contiguous(),
+                    value.index_select(
+                        bs_idx,
+                        torch.tensor(batch_slices, device=value.device),
+                    ).contiguous(),
+                )
         return cache
 
 

--- a/xinference/model/llm/transformers/direct_chat.py
+++ b/xinference/model/llm/transformers/direct_chat.py
@@ -83,9 +83,9 @@ class PytorchDirectChatMixin(ChatModelMixin):
         messages: List[Dict],
         generate_config: Optional[PytorchGenerateConfig] = None,
     ) -> ChatCompletion:
-        generate_config = dict(generate_config or {})
-        tools = generate_config.get("tools")
-        streamer, prompt_tokens = self.build_streaming_iter(messages, generate_config)
+        config: Dict[str, Any] = dict(generate_config or {})
+        tools = config.get("tools")
+        streamer, prompt_tokens = self.build_streaming_iter(messages, config)
         completion_tokens, total_tokens = 0, prompt_tokens
         response = ""
         for chunk_count, new_text in enumerate(streamer, start=1):
@@ -115,11 +115,11 @@ class PytorchDirectChatMixin(ChatModelMixin):
         messages: List[Dict],
         generate_config: Optional[PytorchGenerateConfig] = None,
     ) -> Iterator[CompletionChunk]:
-        generate_config = dict(generate_config or {})
-        tools = generate_config.get("tools")
+        config: Dict[str, Any] = dict(generate_config or {})
+        tools = config.get("tools")
         use_tool_calls = bool(tools and self.tool_parser)
-        streamer, prompt_tokens = self.build_streaming_iter(messages, generate_config)
-        stream_options = generate_config.get("stream_options")
+        streamer, prompt_tokens = self.build_streaming_iter(messages, config)
+        stream_options = config.get("stream_options")
         include_usage = (
             stream_options.get("include_usage", False)
             if isinstance(stream_options, dict)

--- a/xinference/model/llm/transformers/direct_chat.py
+++ b/xinference/model/llm/transformers/direct_chat.py
@@ -1,0 +1,249 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import uuid
+from abc import abstractmethod
+from typing import Any, Dict, Iterator, List, Optional, Tuple, Union, cast
+
+from ....types import (
+    ChatCompletion,
+    ChatCompletionChunk,
+    CompletionChunk,
+    PytorchGenerateConfig,
+)
+from ..utils import ChatModelMixin, generate_completion, generate_completion_chunk
+
+
+class PytorchDirectChatMixin(ChatModelMixin):
+    """Shared direct-chat generation for processor-based Transformers models."""
+
+    model_uid: str
+    model_family: Any
+    _tokenizer: Any
+    tool_parser: Any
+    reasoning_parser: Any
+
+    @abstractmethod
+    def build_inputs_from_messages(
+        self,
+        messages: List[Dict],
+        generate_config: Dict,
+    ):
+        """Build the model inputs for one OpenAI-formatted chat request."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def build_generate_kwargs(
+        self,
+        generate_config: Dict,
+    ) -> Dict[str, Any]:
+        """Build the keyword arguments passed to ``model.generate``."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def build_streaming_iter(
+        self,
+        messages: List[Dict],
+        generate_config: Dict,
+    ) -> Tuple[Iterator, int]:
+        """Return a text iterator and the number of prompt tokens."""
+        raise NotImplementedError
+
+    def get_stop_strs(self) -> List[str]:
+        return []
+
+    def check_conditions(self, new_text: str) -> Tuple[str, bool]:
+        for stop_str in self.get_stop_strs():
+            if new_text.endswith(stop_str):
+                new_text = new_text[: -len(stop_str)]
+                break
+        return new_text, False
+
+    def count_completion_tokens(self, text: str, fallback: int) -> int:
+        encode = getattr(self._tokenizer, "encode", None)
+        if encode is None:
+            return fallback
+        try:
+            return len(encode(text, add_special_tokens=False))
+        except (TypeError, ValueError):
+            return fallback
+
+    def generate_non_streaming(
+        self,
+        messages: List[Dict],
+        generate_config: Optional[PytorchGenerateConfig] = None,
+    ) -> ChatCompletion:
+        generate_config = dict(generate_config or {})
+        tools = generate_config.get("tools")
+        streamer, prompt_tokens = self.build_streaming_iter(messages, generate_config)
+        completion_tokens, total_tokens = 0, prompt_tokens
+        response = ""
+        for chunk_count, new_text in enumerate(streamer, start=1):
+            new_text, should_stop = self.check_conditions(new_text)
+            if should_stop:
+                break
+            response += new_text
+            completion_tokens = self.count_completion_tokens(response, chunk_count)
+            total_tokens = prompt_tokens + completion_tokens
+        completion = generate_completion(
+            self.model_uid,
+            response,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens if prompt_tokens != -1 else -1,
+            total_tokens=total_tokens if prompt_tokens != -1 else -1,
+        )
+        if tools and self.tool_parser:
+            return self._post_process_completion(
+                self.model_family,
+                self.model_uid,
+                completion,
+            )
+        return self._to_chat_completion(completion, self.reasoning_parser)
+
+    def generate_streaming(
+        self,
+        messages: List[Dict],
+        generate_config: Optional[PytorchGenerateConfig] = None,
+    ) -> Iterator[CompletionChunk]:
+        generate_config = dict(generate_config or {})
+        tools = generate_config.get("tools")
+        use_tool_calls = bool(tools and self.tool_parser)
+        streamer, prompt_tokens = self.build_streaming_iter(messages, generate_config)
+        stream_options = generate_config.get("stream_options")
+        include_usage = (
+            stream_options.get("include_usage", False)
+            if isinstance(stream_options, dict)
+            else False
+        )
+
+        completion_id = str(uuid.uuid4())
+        completion_tokens, total_tokens = 0, prompt_tokens
+        previous_texts = [""]
+        previous_tools_texts = [""]
+        tool_call_state = {"seen": False}
+        is_first_chunk = True
+        response = ""
+        for chunk_count, new_text in enumerate(streamer, start=1):
+            new_text, should_stop = self.check_conditions(new_text)
+            if should_stop:
+                break
+            response += new_text
+            completion_tokens = self.count_completion_tokens(response, chunk_count)
+            total_tokens = prompt_tokens + completion_tokens
+            completion_chunk = generate_completion_chunk(
+                chunk_text=new_text,
+                finish_reason=None,
+                chunk_id=completion_id,
+                model_uid=self.model_uid,
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens if prompt_tokens != -1 else -1,
+                total_tokens=total_tokens if prompt_tokens != -1 else -1,
+                has_choice=True,
+                has_content=True,
+            )
+            if use_tool_calls:
+                chat_chunk = self._to_chat_completion_chunk(
+                    completion_chunk,
+                    self.reasoning_parser,
+                    previous_texts,
+                    ensure_role=is_first_chunk,
+                )
+                delta = chat_chunk["choices"][0]["delta"]
+                if delta.get("reasoning_content") is not None:
+                    yield cast(CompletionChunk, chat_chunk)
+                else:
+                    processed_chunk = self._post_process_completion_chunk(
+                        self.model_family,
+                        self.model_uid,
+                        chat_chunk,
+                        previous_texts=previous_tools_texts,
+                        tool_call_state=tool_call_state,
+                    )
+                    if processed_chunk:
+                        yield cast(CompletionChunk, processed_chunk)
+            else:
+                yield completion_chunk
+            is_first_chunk = False
+
+        completion_chunk = generate_completion_chunk(
+            chunk_text=None,
+            finish_reason="stop",
+            chunk_id=completion_id,
+            model_uid=self.model_uid,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens if prompt_tokens != -1 else -1,
+            total_tokens=total_tokens if prompt_tokens != -1 else -1,
+            has_choice=True,
+            has_content=False,
+        )
+        if use_tool_calls:
+            chat_chunk = self._to_chat_completion_chunk(
+                completion_chunk,
+                self.reasoning_parser,
+                previous_texts,
+                ensure_role=is_first_chunk,
+            )
+            processed_chunk = self._post_process_completion_chunk(
+                self.model_family,
+                self.model_uid,
+                chat_chunk,
+                previous_texts=previous_tools_texts,
+                tool_call_state=tool_call_state,
+            )
+            if processed_chunk:
+                yield cast(CompletionChunk, processed_chunk)
+        else:
+            yield completion_chunk
+
+        if include_usage:
+            usage_chunk = generate_completion_chunk(
+                chunk_text=None,
+                finish_reason=None,
+                chunk_id=completion_id,
+                model_uid=self.model_uid,
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens if prompt_tokens != -1 else -1,
+                total_tokens=total_tokens if prompt_tokens != -1 else -1,
+                has_choice=False,
+                has_content=False,
+            )
+            if use_tool_calls:
+                chat_chunk = self._to_chat_completion_chunk(
+                    usage_chunk,
+                    self.reasoning_parser,
+                    previous_texts,
+                    ensure_role=is_first_chunk,
+                )
+                processed_chunk = self._post_process_completion_chunk(
+                    self.model_family,
+                    self.model_uid,
+                    chat_chunk,
+                    previous_texts=previous_tools_texts,
+                    tool_call_state=tool_call_state,
+                )
+                if processed_chunk:
+                    yield cast(CompletionChunk, processed_chunk)
+            else:
+                yield usage_chunk
+
+    def build_direct_chat_result(
+        self,
+        messages: List[Dict],
+        generate_config: Optional[PytorchGenerateConfig] = None,
+    ) -> Union[ChatCompletion, Iterator[ChatCompletionChunk]]:
+        stream = bool(generate_config and generate_config.get("stream"))
+        if stream:
+            return self._to_chat_completion_chunks(
+                self.generate_streaming(messages, generate_config)
+            )
+        return self.generate_non_streaming(messages, generate_config)

--- a/xinference/model/llm/transformers/gemma4.py
+++ b/xinference/model/llm/transformers/gemma4.py
@@ -1,0 +1,339 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import uuid
+from threading import Thread
+from typing import Any, Dict, Iterator, List, Optional, Tuple, Union, cast
+
+from ....core.model import register_batching_multimodal_models
+from ....types import ChatCompletion, ChatCompletionChunk, CompletionChunk
+from ...utils import cache_clean
+from ...scheduler.request import InferenceRequest
+from ..utils import generate_completion, generate_completion_chunk
+from ..llm_family import LLMFamilyV2, LLMSpecV1, register_transformer
+from .core import PytorchChatModel, register_non_default_model
+
+
+@register_batching_multimodal_models("gemma-4")
+@register_transformer
+@register_non_default_model(
+    "Gemma4ForConditionalGeneration", "Gemma4UnifiedForConditionalGeneration"
+)
+class Gemma4ChatModel(PytorchChatModel):
+    GEMMA4_ARCHITECTURES = {"Gemma4ForConditionalGeneration"}
+    GEMMA4_UNIFIED_ARCHITECTURES = {"Gemma4UnifiedForConditionalGeneration"}
+    GEMMA4_MIN_TRANSFORMERS_VERSION = "5.5.0"
+    GEMMA4_UNIFIED_MIN_TRANSFORMERS_VERSION = "5.10.0"
+
+    @classmethod
+    def check_lib(cls) -> Union[bool, Tuple[bool, str]]:
+        result = super().check_lib()
+        if result is not True:
+            return result
+
+        import transformers
+        from packaging.version import Version
+
+        if Version(transformers.__version__) < Version(
+            cls.GEMMA4_MIN_TRANSFORMERS_VERSION
+        ):
+            return (
+                False,
+                f"Gemma-4 requires transformers>={cls.GEMMA4_MIN_TRANSFORMERS_VERSION}",
+            )
+        return True
+
+    @classmethod
+    def match_json(
+        cls, model_family: "LLMFamilyV2", model_spec: "LLMSpecV1", quantization: str
+    ) -> Union[bool, Tuple[bool, str]]:
+        if model_spec.model_format not in ["pytorch", "gptq", "awq", "bnb", "fp4"]:
+            return (
+                False,
+                "Gemma4 transformer supports pytorch/gptq/awq/bnb/fp4 formats only",
+            )
+        if not model_family.has_architecture(
+            *cls.GEMMA4_ARCHITECTURES, *cls.GEMMA4_UNIFIED_ARCHITECTURES
+        ):
+            return (
+                False,
+                f"Model architectures {model_family.architectures} are not Gemma-4-it",
+            )
+        if cls._is_unified_model_spec(model_spec):
+            import transformers
+            from packaging.version import Version
+
+            if Version(transformers.__version__) < Version(
+                cls.GEMMA4_UNIFIED_MIN_TRANSFORMERS_VERSION
+            ):
+                return (
+                    False,
+                    "Gemma-4 unified Transformers backend requires "
+                    f"transformers>={cls.GEMMA4_UNIFIED_MIN_TRANSFORMERS_VERSION}",
+                )
+        return True
+
+    @classmethod
+    def _is_unified_model_spec(cls, model_spec: "LLMSpecV1") -> bool:
+        model_id = getattr(model_spec, "model_id", None) or ""
+        return "gemma-4-12b" in model_id.lower()
+
+    def _load_model(self, **kwargs):
+        from transformers import AutoModelForCausalLM, AutoProcessor
+
+        processor = AutoProcessor.from_pretrained(
+            self.model_path,
+            trust_remote_code=kwargs["trust_remote_code"],
+            revision=kwargs["revision"],
+            padding_side="left",
+        )
+        tokenizer = processor.tokenizer
+        if tokenizer.pad_token_id is None:
+            if tokenizer.eos_token_id is None:
+                raise ValueError(
+                    "Gemma-4 tokenizer requires either a pad token or an EOS token"
+                )
+            tokenizer.pad_token = tokenizer.eos_token
+        tokenizer.padding_side = "left"
+
+        if self._is_unified_model_spec(self.model_spec):
+            from transformers import AutoModelForMultimodalLM
+
+            model_cls = AutoModelForMultimodalLM
+        else:
+            model_cls = AutoModelForCausalLM
+        model = model_cls.from_pretrained(
+            self.model_path,
+            **kwargs,
+        )
+        self._processor = processor
+        self._device = model.device
+        return model, tokenizer
+
+    def _get_full_prompt(self, messages: List[Dict], tools, generate_config: dict):
+        return self._transform_messages(messages)
+
+    def build_inputs_from_messages(
+        self,
+        messages: List[Dict],
+        generate_config: Dict,
+    ):
+        messages = self._transform_messages(messages)
+        inputs = self._processor.apply_chat_template(
+            messages,
+            tokenize=True,
+            add_generation_prompt=True,
+            return_tensors="pt",
+            return_dict=True,
+        ).to(self._device)
+        return inputs
+
+    def build_generate_kwargs(
+        self,
+        generate_config: Dict,
+    ) -> Dict[str, Any]:
+        return dict(
+            max_new_tokens=generate_config.get("max_tokens") or 512,
+            temperature=generate_config.get("temperature", 1),
+        )
+
+    def build_streaming_iter(
+        self,
+        messages: List[Dict],
+        generate_config: Dict,
+    ) -> Tuple[Iterator, int]:
+        from transformers import TextIteratorStreamer
+
+        inputs = self.build_inputs_from_messages(messages, generate_config)
+        configs = self.build_generate_kwargs(generate_config)
+
+        streamer = TextIteratorStreamer(
+            self._tokenizer, timeout=60.0, skip_prompt=True, skip_special_tokens=True
+        )
+
+        gen_kwargs = {"streamer": streamer, **inputs, **configs}
+        t = Thread(target=self._model.generate, kwargs=gen_kwargs)
+        t.start()
+        return streamer, len(inputs.input_ids[0])
+
+    def generate_non_streaming(
+        self,
+        messages: List[Dict],
+        generate_config: Optional[Dict] = None,
+    ) -> ChatCompletion:
+        generate_config = generate_config if generate_config else {}
+        tools = generate_config.get("tools", None)
+        streamer, prompt_tokens = self.build_streaming_iter(messages, generate_config)
+        completion_tokens, total_tokens = 0, 0
+        res = ""
+        for i, new_text in enumerate(streamer):
+            completion_tokens = i
+            total_tokens = prompt_tokens + completion_tokens
+            res += new_text
+        completion = generate_completion(
+            self.model_uid,
+            res,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens if prompt_tokens != -1 else -1,
+            total_tokens=total_tokens if prompt_tokens != -1 else -1,
+        )
+        if tools and self.tool_parser:
+            return self._post_process_completion(
+                self.model_family,
+                self.model_uid,
+                completion,
+            )
+        return self._to_chat_completion(completion, self.reasoning_parser)
+
+    def generate_streaming(
+        self,
+        messages: List[Dict],
+        generate_config: Optional[Dict] = None,
+    ) -> Iterator[CompletionChunk]:
+        generate_config = generate_config if generate_config else {}
+        tools = generate_config.get("tools", None)
+        use_tool_calls = bool(tools and self.tool_parser)
+        streamer, prompt_tokens = self.build_streaming_iter(messages, generate_config)
+        stream_options = generate_config.pop("stream_options", None)
+        include_usage = (
+            stream_options["include_usage"]
+            if isinstance(stream_options, dict)
+            else False
+        )
+
+        completion_id = str(uuid.uuid1())
+        completion_tokens, total_tokens = 0, 0
+        previous_texts = [""]
+        previous_tools_texts = [""]
+        tool_call_state = {"seen": False}
+        i = 0
+        for i, new_text in enumerate(streamer):
+            completion_tokens = i
+            total_tokens = prompt_tokens + completion_tokens
+            completion_chunk = generate_completion_chunk(
+                chunk_text=new_text,
+                finish_reason=None,
+                chunk_id=completion_id,
+                model_uid=self.model_uid,
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens if prompt_tokens != -1 else -1,
+                total_tokens=total_tokens if prompt_tokens != -1 else -1,
+                has_choice=True,
+                has_content=True,
+            )
+            if use_tool_calls:
+                chat_chunk = self._to_chat_completion_chunk(
+                    completion_chunk,
+                    self.reasoning_parser,
+                    previous_texts,
+                    ensure_role=i == 0,
+                )
+                processed_chunk = self._post_process_completion_chunk(
+                    self.model_family,
+                    self.model_uid,
+                    chat_chunk,
+                    previous_texts=previous_tools_texts,
+                    tool_call_state=tool_call_state,
+                )
+                if processed_chunk:
+                    yield cast(CompletionChunk, processed_chunk)
+            else:
+                yield completion_chunk
+
+        completion_chunk = generate_completion_chunk(
+            chunk_text=None,
+            finish_reason="stop",
+            chunk_id=completion_id,
+            model_uid=self.model_uid,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens if prompt_tokens != -1 else -1,
+            total_tokens=total_tokens if prompt_tokens != -1 else -1,
+            has_choice=True,
+            has_content=False,
+        )
+        if use_tool_calls:
+            chat_chunk = self._to_chat_completion_chunk(
+                completion_chunk,
+                self.reasoning_parser,
+                previous_texts,
+                ensure_role=i == 0,
+            )
+            processed_chunk = self._post_process_completion_chunk(
+                self.model_family,
+                self.model_uid,
+                chat_chunk,
+                previous_texts=previous_tools_texts,
+                tool_call_state=tool_call_state,
+            )
+            if processed_chunk:
+                yield cast(CompletionChunk, processed_chunk)
+        else:
+            yield completion_chunk
+
+        if include_usage:
+            yield generate_completion_chunk(
+                chunk_text=None,
+                finish_reason=None,
+                chunk_id=completion_id,
+                model_uid=self.model_uid,
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens if prompt_tokens != -1 else -1,
+                total_tokens=total_tokens if prompt_tokens != -1 else -1,
+                has_choice=False,
+                has_content=False,
+            )
+
+    @cache_clean
+    async def _direct_chat(
+        self,
+        messages: List[Dict],
+        generate_config: Optional[Dict] = None,
+    ) -> Union[ChatCompletion, Iterator[ChatCompletionChunk]]:
+        stream = generate_config.get("stream", False) if generate_config else False
+        return (
+            self._to_chat_completion_chunks(
+                self.generate_streaming(messages, generate_config)
+            )
+            if stream
+            else self.generate_non_streaming(messages, generate_config)
+        )
+
+    def build_prefill_kwargs(
+        self, prompts: List, req_list: List[InferenceRequest]
+    ) -> Dict:
+        inputs = self._processor.apply_chat_template(
+            prompts,
+            tokenize=True,
+            add_generation_prompt=True,
+            return_tensors="pt",
+            return_dict=True,
+            padding=True,
+        ).to(self._device)
+
+        for i, r in enumerate(req_list):
+            input_ids = inputs["input_ids"][i]
+            if "attention_mask" in inputs:
+                attention_mask = inputs["attention_mask"][i].bool()
+                real_len = int(attention_mask.sum().item())
+                r.padding_len = attention_mask.numel() - real_len
+                r.extra_kwargs["attention_mask_seq_len"] = real_len
+                r.prompt_tokens = input_ids[attention_mask].tolist()
+            else:
+                r.prompt_tokens = input_ids.tolist()
+                r.padding_len = 0
+
+        input_ids = inputs["input_ids"]
+        batch_size, seq_len = input_ids.shape
+        position_ids = self.build_prefill_position_ids(batch_size, seq_len, req_list)
+
+        return {**inputs, "position_ids": position_ids}

--- a/xinference/model/llm/transformers/gemma4.py
+++ b/xinference/model/llm/transformers/gemma4.py
@@ -17,10 +17,10 @@ from typing import Any, Dict, Iterator, List, Optional, Tuple, Union, cast
 
 from ....core.model import register_batching_multimodal_models
 from ....types import ChatCompletion, ChatCompletionChunk, CompletionChunk
-from ...utils import cache_clean
 from ...scheduler.request import InferenceRequest
-from ..utils import generate_completion, generate_completion_chunk
+from ...utils import cache_clean
 from ..llm_family import LLMFamilyV2, LLMSpecV1, register_transformer
+from ..utils import generate_completion, generate_completion_chunk
 from .core import PytorchChatModel, register_non_default_model
 
 

--- a/xinference/model/llm/transformers/gemma4.py
+++ b/xinference/model/llm/transformers/gemma4.py
@@ -15,7 +15,7 @@ from threading import Thread
 from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
 from ....core.model import register_batching_multimodal_models
-from ....types import ChatCompletion, ChatCompletionChunk
+from ....types import ChatCompletion, ChatCompletionChunk, PytorchGenerateConfig
 from ...scheduler.request import InferenceRequest
 from ...utils import cache_clean
 from ..llm_family import LLMFamilyV2, LLMSpecV1, register_transformer
@@ -179,7 +179,7 @@ class Gemma4ChatModel(PytorchDirectChatMixin, PytorchChatModel):
     async def _direct_chat(
         self,
         messages: List[Dict],
-        generate_config: Optional[Dict] = None,
+        generate_config: Optional[PytorchGenerateConfig] = None,
     ) -> Union[ChatCompletion, Iterator[ChatCompletionChunk]]:
         return self.build_direct_chat_result(messages, generate_config)
 

--- a/xinference/model/llm/transformers/gemma4.py
+++ b/xinference/model/llm/transformers/gemma4.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import json
 from threading import Thread
 from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
@@ -68,18 +69,6 @@ class Gemma4ChatModel(PytorchDirectChatMixin, PytorchChatModel):
                 False,
                 f"Model architectures {model_family.architectures} are not Gemma-4-it",
             )
-        if cls._is_unified_model_spec(model_spec):
-            import transformers
-            from packaging.version import Version
-
-            if Version(transformers.__version__) < Version(
-                cls.GEMMA4_UNIFIED_MIN_TRANSFORMERS_VERSION
-            ):
-                return (
-                    False,
-                    "Gemma-4 unified Transformers backend requires "
-                    f"transformers>={cls.GEMMA4_UNIFIED_MIN_TRANSFORMERS_VERSION}",
-                )
         return True
 
     @classmethod
@@ -87,8 +76,26 @@ class Gemma4ChatModel(PytorchDirectChatMixin, PytorchChatModel):
         model_id = getattr(model_spec, "model_id", None) or ""
         return "gemma-4-12b" in model_id.lower()
 
+    @classmethod
+    def _ensure_model_spec_transformers_version(cls, model_spec: "LLMSpecV1") -> None:
+        if not cls._is_unified_model_spec(model_spec):
+            return
+
+        import transformers
+        from packaging.version import Version
+
+        if Version(transformers.__version__) < Version(
+            cls.GEMMA4_UNIFIED_MIN_TRANSFORMERS_VERSION
+        ):
+            raise ImportError(
+                "Gemma-4 unified Transformers backend requires "
+                f"transformers>={cls.GEMMA4_UNIFIED_MIN_TRANSFORMERS_VERSION}"
+            )
+
     def _load_model(self, **kwargs):
         from transformers import AutoModelForCausalLM, AutoProcessor
+
+        self._ensure_model_spec_transformers_version(self.model_spec)
 
         processor = AutoProcessor.from_pretrained(
             self.model_path,
@@ -122,21 +129,33 @@ class Gemma4ChatModel(PytorchDirectChatMixin, PytorchChatModel):
     def _get_full_prompt(self, messages: List[Dict], tools, generate_config: dict):
         return self._transform_messages(messages)
 
+    def _get_processor_chat_template_kwargs(self, generate_config: Optional[Dict]):
+        template_kwargs = (
+            self._get_chat_template_kwargs_from_generate_config(
+                generate_config, getattr(self, "reasoning_parser", None)
+            )
+            or {}
+        )
+        tools = (generate_config or {}).get("tools")
+        if tools:
+            template_kwargs["tools"] = tools
+        return template_kwargs
+
+    def get_batching_prefill_compatibility_key(self, req: InferenceRequest) -> str:
+        generate_config = req.generate_config or {}
+        template_inputs = {
+            "tools": generate_config.get("tools"),
+            "chat_template_kwargs": generate_config.get("chat_template_kwargs"),
+        }
+        return json.dumps(template_inputs, sort_keys=True, default=repr)
+
     def build_inputs_from_messages(
         self,
         messages: List[Dict],
         generate_config: Dict,
     ):
         messages = self._transform_messages(messages)
-        template_kwargs = (
-            self._get_chat_template_kwargs_from_generate_config(
-                generate_config, self.reasoning_parser
-            )
-            or {}
-        )
-        tools = generate_config.get("tools")
-        if tools:
-            template_kwargs["tools"] = tools
+        template_kwargs = self._get_processor_chat_template_kwargs(generate_config)
         inputs = self._processor.apply_chat_template(
             messages,
             tokenize=True,
@@ -186,6 +205,9 @@ class Gemma4ChatModel(PytorchDirectChatMixin, PytorchChatModel):
     def build_prefill_kwargs(
         self, prompts: List, req_list: List[InferenceRequest]
     ) -> Dict:
+        template_kwargs = self._get_processor_chat_template_kwargs(
+            req_list[0].generate_config
+        )
         inputs = self._processor.apply_chat_template(
             prompts,
             tokenize=True,
@@ -193,6 +215,7 @@ class Gemma4ChatModel(PytorchDirectChatMixin, PytorchChatModel):
             return_tensors="pt",
             return_dict=True,
             padding=True,
+            **template_kwargs,
         ).to(self._device)
 
         for i, r in enumerate(req_list):

--- a/xinference/model/llm/transformers/gemma4.py
+++ b/xinference/model/llm/transformers/gemma4.py
@@ -11,17 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import uuid
 from threading import Thread
-from typing import Any, Dict, Iterator, List, Optional, Tuple, Union, cast
+from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
 from ....core.model import register_batching_multimodal_models
-from ....types import ChatCompletion, ChatCompletionChunk, CompletionChunk
+from ....types import ChatCompletion, ChatCompletionChunk
 from ...scheduler.request import InferenceRequest
 from ...utils import cache_clean
 from ..llm_family import LLMFamilyV2, LLMSpecV1, register_transformer
-from ..utils import generate_completion, generate_completion_chunk
 from .core import PytorchChatModel, register_non_default_model
+from .direct_chat import PytorchDirectChatMixin
 
 
 @register_batching_multimodal_models("gemma-4")
@@ -29,7 +28,7 @@ from .core import PytorchChatModel, register_non_default_model
 @register_non_default_model(
     "Gemma4ForConditionalGeneration", "Gemma4UnifiedForConditionalGeneration"
 )
-class Gemma4ChatModel(PytorchChatModel):
+class Gemma4ChatModel(PytorchDirectChatMixin, PytorchChatModel):
     GEMMA4_ARCHITECTURES = {"Gemma4ForConditionalGeneration"}
     GEMMA4_UNIFIED_ARCHITECTURES = {"Gemma4UnifiedForConditionalGeneration"}
     GEMMA4_MIN_TRANSFORMERS_VERSION = "5.5.0"
@@ -129,12 +128,22 @@ class Gemma4ChatModel(PytorchChatModel):
         generate_config: Dict,
     ):
         messages = self._transform_messages(messages)
+        template_kwargs = (
+            self._get_chat_template_kwargs_from_generate_config(
+                generate_config, self.reasoning_parser
+            )
+            or {}
+        )
+        tools = generate_config.get("tools")
+        if tools:
+            template_kwargs["tools"] = tools
         inputs = self._processor.apply_chat_template(
             messages,
             tokenize=True,
             add_generation_prompt=True,
             return_tensors="pt",
             return_dict=True,
+            **template_kwargs,
         ).to(self._device)
         return inputs
 
@@ -166,147 +175,13 @@ class Gemma4ChatModel(PytorchChatModel):
         t.start()
         return streamer, len(inputs.input_ids[0])
 
-    def generate_non_streaming(
-        self,
-        messages: List[Dict],
-        generate_config: Optional[Dict] = None,
-    ) -> ChatCompletion:
-        generate_config = generate_config if generate_config else {}
-        tools = generate_config.get("tools", None)
-        streamer, prompt_tokens = self.build_streaming_iter(messages, generate_config)
-        completion_tokens, total_tokens = 0, 0
-        res = ""
-        for i, new_text in enumerate(streamer):
-            completion_tokens = i
-            total_tokens = prompt_tokens + completion_tokens
-            res += new_text
-        completion = generate_completion(
-            self.model_uid,
-            res,
-            prompt_tokens=prompt_tokens,
-            completion_tokens=completion_tokens if prompt_tokens != -1 else -1,
-            total_tokens=total_tokens if prompt_tokens != -1 else -1,
-        )
-        if tools and self.tool_parser:
-            return self._post_process_completion(
-                self.model_family,
-                self.model_uid,
-                completion,
-            )
-        return self._to_chat_completion(completion, self.reasoning_parser)
-
-    def generate_streaming(
-        self,
-        messages: List[Dict],
-        generate_config: Optional[Dict] = None,
-    ) -> Iterator[CompletionChunk]:
-        generate_config = generate_config if generate_config else {}
-        tools = generate_config.get("tools", None)
-        use_tool_calls = bool(tools and self.tool_parser)
-        streamer, prompt_tokens = self.build_streaming_iter(messages, generate_config)
-        stream_options = generate_config.pop("stream_options", None)
-        include_usage = (
-            stream_options["include_usage"]
-            if isinstance(stream_options, dict)
-            else False
-        )
-
-        completion_id = str(uuid.uuid1())
-        completion_tokens, total_tokens = 0, 0
-        previous_texts = [""]
-        previous_tools_texts = [""]
-        tool_call_state = {"seen": False}
-        i = 0
-        for i, new_text in enumerate(streamer):
-            completion_tokens = i
-            total_tokens = prompt_tokens + completion_tokens
-            completion_chunk = generate_completion_chunk(
-                chunk_text=new_text,
-                finish_reason=None,
-                chunk_id=completion_id,
-                model_uid=self.model_uid,
-                prompt_tokens=prompt_tokens,
-                completion_tokens=completion_tokens if prompt_tokens != -1 else -1,
-                total_tokens=total_tokens if prompt_tokens != -1 else -1,
-                has_choice=True,
-                has_content=True,
-            )
-            if use_tool_calls:
-                chat_chunk = self._to_chat_completion_chunk(
-                    completion_chunk,
-                    self.reasoning_parser,
-                    previous_texts,
-                    ensure_role=i == 0,
-                )
-                processed_chunk = self._post_process_completion_chunk(
-                    self.model_family,
-                    self.model_uid,
-                    chat_chunk,
-                    previous_texts=previous_tools_texts,
-                    tool_call_state=tool_call_state,
-                )
-                if processed_chunk:
-                    yield cast(CompletionChunk, processed_chunk)
-            else:
-                yield completion_chunk
-
-        completion_chunk = generate_completion_chunk(
-            chunk_text=None,
-            finish_reason="stop",
-            chunk_id=completion_id,
-            model_uid=self.model_uid,
-            prompt_tokens=prompt_tokens,
-            completion_tokens=completion_tokens if prompt_tokens != -1 else -1,
-            total_tokens=total_tokens if prompt_tokens != -1 else -1,
-            has_choice=True,
-            has_content=False,
-        )
-        if use_tool_calls:
-            chat_chunk = self._to_chat_completion_chunk(
-                completion_chunk,
-                self.reasoning_parser,
-                previous_texts,
-                ensure_role=i == 0,
-            )
-            processed_chunk = self._post_process_completion_chunk(
-                self.model_family,
-                self.model_uid,
-                chat_chunk,
-                previous_texts=previous_tools_texts,
-                tool_call_state=tool_call_state,
-            )
-            if processed_chunk:
-                yield cast(CompletionChunk, processed_chunk)
-        else:
-            yield completion_chunk
-
-        if include_usage:
-            yield generate_completion_chunk(
-                chunk_text=None,
-                finish_reason=None,
-                chunk_id=completion_id,
-                model_uid=self.model_uid,
-                prompt_tokens=prompt_tokens,
-                completion_tokens=completion_tokens if prompt_tokens != -1 else -1,
-                total_tokens=total_tokens if prompt_tokens != -1 else -1,
-                has_choice=False,
-                has_content=False,
-            )
-
     @cache_clean
     async def _direct_chat(
         self,
         messages: List[Dict],
         generate_config: Optional[Dict] = None,
     ) -> Union[ChatCompletion, Iterator[ChatCompletionChunk]]:
-        stream = generate_config.get("stream", False) if generate_config else False
-        return (
-            self._to_chat_completion_chunks(
-                self.generate_streaming(messages, generate_config)
-            )
-            if stream
-            else self.generate_non_streaming(messages, generate_config)
-        )
+        return self.build_direct_chat_result(messages, generate_config)
 
     def build_prefill_kwargs(
         self, prompts: List, req_list: List[InferenceRequest]

--- a/xinference/model/llm/transformers/multimodal/core.py
+++ b/xinference/model/llm/transformers/multimodal/core.py
@@ -11,22 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import uuid
 from abc import abstractmethod
-from typing import Any, Dict, Iterator, List, Optional, Tuple, Union, cast
+from typing import Dict, Iterator, List, Optional, Union
 
-from .....types import (
-    ChatCompletion,
-    ChatCompletionChunk,
-    CompletionChunk,
-    PytorchGenerateConfig,
-)
+from .....types import ChatCompletion, ChatCompletionChunk, PytorchGenerateConfig
 from ....utils import cache_clean
-from ...utils import generate_completion, generate_completion_chunk
 from ..core import PytorchChatModel
+from ..direct_chat import PytorchDirectChatMixin
 
 
-class PytorchMultiModalModel(PytorchChatModel):
+class PytorchMultiModalModel(PytorchDirectChatMixin, PytorchChatModel):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._tokenizer = None
@@ -66,222 +60,10 @@ class PytorchMultiModalModel(PytorchChatModel):
         self.load_processor()
         self.load_multimodal_model()
 
-    @abstractmethod
-    def build_inputs_from_messages(
-        self,
-        messages: List[Dict],
-        generate_config: Dict,
-    ):
-        """
-        Convert from input OpenAI-formatted messages to
-        actual parameters needed for inference,
-        e.g. input_ids, attention_masks, etc.
-        """
-        pass
-
-    @abstractmethod
-    def build_generate_kwargs(
-        self,
-        generate_config: Dict,
-    ) -> Dict[str, Any]:
-        """
-        Hyperparameters needed for generation,
-        e.g. temperature, max_new_tokens, etc.
-        """
-        pass
-
-    @abstractmethod
-    def build_streaming_iter(
-        self,
-        messages: List[Dict],
-        generate_config: Dict,
-    ) -> Tuple[Iterator, int]:
-        """
-        Return the iterator needed for streaming inference and the length of prompt token for statisticians.
-        The length of prompt token usually comes from the input_ids.
-        In this interface you need to call the `build_inputs_from_messages` and `build_generate_kwargs`.
-        """
-        pass
-
-    def get_stop_strs(self) -> List[str]:
-        return []
-
-    def check_conditions(self, new_text: str) -> Tuple[str, bool]:
-        stop_strs = self.get_stop_strs()
-        for ss in stop_strs:
-            if new_text.endswith(ss):
-                new_text = new_text[: -len(ss)]
-                break
-        return new_text, False
-
-    def generate_non_streaming(
-        self,
-        messages: List[Dict],
-        generate_config: Optional[PytorchGenerateConfig] = None,
-    ) -> ChatCompletion:
-        generate_config = generate_config if generate_config else {}  # type: ignore
-        tools = generate_config.get("tools", None)
-        streamer, prompt_tokens = self.build_streaming_iter(messages, generate_config)  # type: ignore
-        completion_tokens, total_tokens = 0, 0
-        res = ""
-        for i, new_text in enumerate(streamer):
-            new_text, should_stop = self.check_conditions(new_text)
-            if should_stop:
-                break
-            completion_tokens = i
-            total_tokens = prompt_tokens + completion_tokens
-            res += new_text
-        completion = generate_completion(
-            self.model_uid,
-            res,
-            prompt_tokens=prompt_tokens,
-            completion_tokens=completion_tokens if prompt_tokens != -1 else -1,
-            total_tokens=total_tokens if prompt_tokens != -1 else -1,
-        )
-        if tools and self.tool_parser:
-            return self._post_process_completion(
-                self.model_family,
-                self.model_uid,
-                completion,
-            )
-        return self._to_chat_completion(completion, self.reasoning_parser)
-
-    def generate_streaming(
-        self,
-        messages: List[Dict],
-        generate_config: Optional[PytorchGenerateConfig] = None,
-    ) -> Iterator[CompletionChunk]:
-        generate_config = generate_config if generate_config else {}  # type: ignore
-        tools = generate_config.get("tools", None)
-        use_tool_calls = bool(tools and self.tool_parser)
-        streamer, prompt_tokens = self.build_streaming_iter(messages, generate_config)  # type: ignore
-        stream_options = generate_config.pop("stream_options", None)
-        include_usage = (
-            stream_options["include_usage"]
-            if isinstance(stream_options, dict)
-            else False
-        )
-
-        completion_id = str(uuid.uuid1())
-        completion_tokens, total_tokens = 0, 0
-        previous_texts = [""]
-        previous_tools_texts = [""]
-        tool_call_state = {"seen": False}
-        i = 0
-        for i, new_text in enumerate(streamer):
-            new_text, should_stop = self.check_conditions(new_text)
-            if should_stop:
-                break
-            completion_tokens = i
-            total_tokens = prompt_tokens + completion_tokens
-            completion_chunk = generate_completion_chunk(
-                chunk_text=new_text,
-                finish_reason=None,
-                chunk_id=completion_id,
-                model_uid=self.model_uid,
-                prompt_tokens=prompt_tokens,
-                completion_tokens=completion_tokens if prompt_tokens != -1 else -1,
-                total_tokens=total_tokens if prompt_tokens != -1 else -1,
-                has_choice=True,
-                has_content=True,
-            )
-            if use_tool_calls:
-                chat_chunk = self._to_chat_completion_chunk(
-                    completion_chunk,
-                    self.reasoning_parser,
-                    previous_texts,
-                    ensure_role=i == 0,
-                )
-                if (
-                    chat_chunk["choices"]
-                    and "reasoning_content" in chat_chunk["choices"][0]["delta"]
-                    and chat_chunk["choices"][0]["delta"]["reasoning_content"]
-                    is not None
-                ):
-                    yield cast(CompletionChunk, chat_chunk)
-                else:
-                    processed_chunk = self._post_process_completion_chunk(
-                        self.model_family,
-                        self.model_uid,
-                        chat_chunk,
-                        previous_texts=previous_tools_texts,
-                        tool_call_state=tool_call_state,
-                    )
-                    if processed_chunk:
-                        yield cast(CompletionChunk, processed_chunk)
-            else:
-                yield completion_chunk
-        completion_chunk = generate_completion_chunk(
-            chunk_text=None,
-            finish_reason="stop",
-            chunk_id=completion_id,
-            model_uid=self.model_uid,
-            prompt_tokens=prompt_tokens,
-            completion_tokens=completion_tokens if prompt_tokens != -1 else -1,
-            total_tokens=total_tokens if prompt_tokens != -1 else -1,
-            has_choice=True,
-            has_content=False,
-        )
-        if use_tool_calls:
-            chat_chunk = self._to_chat_completion_chunk(
-                completion_chunk,
-                self.reasoning_parser,
-                previous_texts,
-                ensure_role=i == 0,
-            )
-            processed_chunk = self._post_process_completion_chunk(
-                self.model_family,
-                self.model_uid,
-                chat_chunk,
-                previous_texts=previous_tools_texts,
-                tool_call_state=tool_call_state,
-            )
-            if processed_chunk:
-                yield cast(CompletionChunk, processed_chunk)
-        else:
-            yield completion_chunk
-        if include_usage:
-            completion_chunk = generate_completion_chunk(
-                chunk_text=None,
-                finish_reason=None,
-                chunk_id=completion_id,
-                model_uid=self.model_uid,
-                prompt_tokens=prompt_tokens,
-                completion_tokens=completion_tokens if prompt_tokens != -1 else -1,
-                total_tokens=total_tokens if prompt_tokens != -1 else -1,
-                has_choice=False,
-                has_content=False,
-            )
-            if use_tool_calls:
-                chat_chunk = self._to_chat_completion_chunk(
-                    completion_chunk,
-                    self.reasoning_parser,
-                    previous_texts,
-                    ensure_role=i == 0,
-                )
-                processed_chunk = self._post_process_completion_chunk(
-                    self.model_family,
-                    self.model_uid,
-                    chat_chunk,
-                    previous_texts=previous_tools_texts,
-                    tool_call_state=tool_call_state,
-                )
-                if processed_chunk:
-                    yield cast(CompletionChunk, processed_chunk)
-            else:
-                yield completion_chunk
-
     @cache_clean
     def chat(
         self,
         messages: List[Dict],
         generate_config: Optional[PytorchGenerateConfig] = None,
     ) -> Union[ChatCompletion, Iterator[ChatCompletionChunk]]:
-        stream = generate_config.get("stream", False) if generate_config else False
-        return (
-            self._to_chat_completion_chunks(
-                self.generate_streaming(messages, generate_config)
-            )
-            if stream
-            else self.generate_non_streaming(messages, generate_config)
-        )
+        return self.build_direct_chat_result(messages, generate_config)

--- a/xinference/model/llm/transformers/tests/test_cache_compatibility.py
+++ b/xinference/model/llm/transformers/tests/test_cache_compatibility.py
@@ -1,0 +1,174 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from types import SimpleNamespace
+
+import pytest
+import torch
+from transformers import DynamicCache, LlamaConfig
+
+from ..core import PytorchModel
+from ..utils import get_batch_size_and_seq_len_from_kv_cache, get_kv_cache_layer
+
+_HAS_LAYER_BASED_CACHE = hasattr(DynamicCache(), "layers")
+
+
+class _LegacyDynamicCache:
+    """The DynamicCache layout used by Transformers 4.46 through 4.52."""
+
+    def __init__(self, key_cache, value_cache):
+        self.key_cache = key_cache
+        self.value_cache = value_cache
+
+    def __len__(self):
+        return len(self.key_cache)
+
+    def get_seq_length(self, layer_idx=0):
+        if layer_idx >= len(self.key_cache):
+            return 0
+        key = self.key_cache[layer_idx]
+        if key is None or (isinstance(key, (list, tuple)) and not key):
+            return 0
+        return key.shape[2]
+
+
+def _model_for_cache_tests(config=None):
+    model = object.__new__(PytorchModel)
+    model._model = SimpleNamespace(config=config)
+    return model
+
+
+def _cache_with_tensor(value, batch_size=1, seq_len=3, config=None):
+    cache = DynamicCache(config=config) if config is not None else DynamicCache()
+    key = torch.full((batch_size, 2, seq_len, 4), value, dtype=torch.float32)
+    cache.update(key, key.clone(), 0)
+    return cache
+
+
+def test_get_batch_size_supports_legacy_and_layer_cache_layouts():
+    key = torch.zeros((2, 3, 5, 7))
+    legacy_cache = _LegacyDynamicCache([key], [key.clone()])
+    model = _model_for_cache_tests()
+
+    assert get_batch_size_and_seq_len_from_kv_cache(legacy_cache, model) == (2, 5)
+
+    layer_cache = _cache_with_tensor(1, batch_size=3, seq_len=4)
+    assert get_batch_size_and_seq_len_from_kv_cache(layer_cache, model) == (3, 4)
+
+    skipped_key = torch.zeros((4, 3, 6, 7))
+    cache_with_skipped_layer = DynamicCache()
+    cache_with_skipped_layer.update(skipped_key, skipped_key.clone(), 1)
+    assert get_batch_size_and_seq_len_from_kv_cache(
+        cache_with_skipped_layer, model
+    ) == (4, 6)
+
+    legacy_cache_with_skipped_layer = _LegacyDynamicCache(
+        [[], skipped_key], [[], skipped_key.clone()]
+    )
+    assert get_batch_size_and_seq_len_from_kv_cache(
+        legacy_cache_with_skipped_layer, model
+    ) == (4, 6)
+
+
+def test_empty_cache_layers_are_reported_without_indexing_failures():
+    model = _model_for_cache_tests()
+    assert get_batch_size_and_seq_len_from_kv_cache(DynamicCache(), model) == (0, 0)
+    assert get_batch_size_and_seq_len_from_kv_cache(
+        _LegacyDynamicCache([[]], [[]]), model
+    ) == (0, 0)
+
+
+def test_merge_and_reduce_legacy_dynamic_cache_layout():
+    model = _model_for_cache_tests()
+    past_key = torch.ones((1, 2, 3, 4))
+    new_key = torch.full((1, 2, 2, 4), 2, dtype=torch.float32)
+    past_cache = _LegacyDynamicCache([past_key], [past_key.clone()])
+    new_cache = _LegacyDynamicCache([new_key], [new_key.clone()])
+
+    merged = model.merge_kv_cache(past_cache, new_cache)
+    merged_key, _ = get_kv_cache_layer(merged, 0)
+    assert merged_key.shape == (2, 2, 3, 4)
+
+    model.build_reduced_kv_cache(merged, {0})
+    reduced_key, _ = get_kv_cache_layer(merged, 0)
+    torch.testing.assert_close(reduced_key, torch.ones((1, 2, 3, 4)))
+
+
+def test_merge_and_reduce_layer_based_dynamic_cache():
+    model = _model_for_cache_tests()
+    past_cache = _cache_with_tensor(1, seq_len=3)
+    new_cache = _cache_with_tensor(2, seq_len=2)
+
+    merged = model.merge_kv_cache(past_cache, new_cache)
+    key, value = get_kv_cache_layer(merged, 0)
+
+    assert key.shape == value.shape == (2, 2, 3, 4)
+    torch.testing.assert_close(key[0, :, 0], torch.zeros((2, 4)))
+    torch.testing.assert_close(
+        key[0, :, 1:], torch.full((2, 2, 4), 2, dtype=torch.float32)
+    )
+    torch.testing.assert_close(key[1], torch.ones((2, 3, 4)))
+
+    reduced = model.build_reduced_kv_cache(merged, {0})
+    reduced_key, _ = get_kv_cache_layer(reduced, 0)
+    torch.testing.assert_close(reduced_key, torch.ones((1, 2, 3, 4)))
+
+
+def test_merge_mixed_legacy_and_layer_cache_layouts():
+    model = _model_for_cache_tests()
+    past_key = torch.ones((1, 2, 3, 4))
+    past_cache = _LegacyDynamicCache([past_key], [past_key.clone()])
+    new_cache = _cache_with_tensor(2, seq_len=2)
+
+    merged = model.merge_kv_cache(past_cache, new_cache)
+    merged_key, _ = get_kv_cache_layer(merged, 0)
+
+    assert merged_key.shape == (2, 2, 3, 4)
+    torch.testing.assert_close(merged_key[0, :, 0], torch.zeros((2, 4)))
+    torch.testing.assert_close(
+        merged_key[0, :, 1:], torch.full((2, 2, 4), 2, dtype=torch.float32)
+    )
+    torch.testing.assert_close(merged_key[1], past_key[0])
+
+
+@pytest.mark.skipif(
+    not _HAS_LAYER_BASED_CACHE,
+    reason="Layer-based DynamicCache was introduced after Transformers 4.52",
+)
+def test_merge_preserves_sliding_cache_state_and_shared_layers():
+    config = LlamaConfig(num_hidden_layers=1, sliding_window=4)
+    model = _model_for_cache_tests(config)
+    past_cache = _cache_with_tensor(1, seq_len=3, config=config)
+    new_cache = _cache_with_tensor(2, seq_len=2, config=config)
+    past_cache.shared_layers = {1: (torch.ones((1, 2, 3, 4)), torch.ones((1, 2, 3, 4)))}
+    new_cache.shared_layers = {
+        1: (
+            torch.full((1, 2, 2, 4), 2, dtype=torch.float32),
+            torch.full((1, 2, 2, 4), 2, dtype=torch.float32),
+        )
+    }
+
+    merged = model.merge_kv_cache(past_cache, new_cache)
+
+    assert merged.layers[0].is_sliding
+    assert merged.layers[0].cumulative_length == 3
+    shared_key, _ = merged.shared_layers[1]
+    assert shared_key.shape == (2, 2, 3, 4)
+
+    model.build_reduced_kv_cache(merged, {1})
+    shared_key, _ = merged.shared_layers[1]
+    assert shared_key.shape == (1, 2, 3, 4)
+    torch.testing.assert_close(
+        shared_key[:, :, 1:],
+        torch.full((1, 2, 2, 4), 2, dtype=torch.float32),
+    )

--- a/xinference/model/llm/transformers/tests/test_gemma4.py
+++ b/xinference/model/llm/transformers/tests/test_gemma4.py
@@ -1,0 +1,222 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+from threading import Event
+
+import torch
+
+from .....core.model import XINFERENCE_BATCHING_ALLOWED_VISION_MODELS
+from ....scheduler.request import InferenceRequest
+from ...llm_family import LLMFamilyV2, PytorchLLMSpecV2
+from ..core import NON_DEFAULT_MODEL_LIST
+from ..gemma4 import Gemma4ChatModel
+
+
+class _Batch(dict):
+    def to(self, device):
+        return _Batch({k: v.to(device) for k, v in self.items()})
+
+    def __getattr__(self, item):
+        try:
+            return self[item]
+        except KeyError:
+            raise AttributeError(item)
+
+
+class _Processor:
+    def apply_chat_template(self, prompts, **kwargs):
+        assert kwargs["tokenize"] is True
+        assert kwargs["add_generation_prompt"] is True
+        assert kwargs["return_tensors"] == "pt"
+        assert kwargs["return_dict"] is True
+        assert kwargs["padding"] is True
+        assert prompts == [["longer"], ["shorter"]]
+        return _Batch(
+            {
+                "input_ids": torch.tensor([[1, 2, 3, 4], [0, 0, 5, 6]]),
+                "attention_mask": torch.tensor([[1, 1, 1, 1], [0, 0, 1, 1]]),
+            }
+        )
+
+
+class _DirectProcessor:
+    def apply_chat_template(self, messages, **kwargs):
+        assert kwargs["tokenize"] is True
+        assert kwargs["add_generation_prompt"] is True
+        assert kwargs["return_tensors"] == "pt"
+        assert kwargs["return_dict"] is True
+        assert messages == [
+            {"role": "user", "content": [{"type": "text", "text": "你好"}]}
+        ]
+        return _Batch(
+            {
+                "input_ids": torch.tensor([[1, 2, 3]]),
+                "attention_mask": torch.tensor([[1, 1, 1]]),
+            }
+        )
+
+
+class _Streamer:
+    def __init__(self, *args, **kwargs):
+        self.items = []
+        self.done = Event()
+
+    def __iter__(self):
+        self.done.wait(timeout=1)
+        return iter(self.items)
+
+
+class _Model:
+    def generate(self, **kwargs):
+        assert kwargs["max_new_tokens"] == 8
+        assert kwargs["temperature"] == 1
+        assert kwargs["input_ids"].tolist() == [[1, 2, 3]]
+        kwargs["streamer"].items.extend(["你", "好"])
+        kwargs["streamer"].done.set()
+
+
+def _request():
+    return InferenceRequest([], None, True, "chat", None)
+
+
+def _family(architectures, model_id="google/gemma-4-E4B-it"):
+    spec = PytorchLLMSpecV2(
+        model_format="pytorch",
+        model_size_in_billions=4,
+        quantization="none",
+        model_id=model_id,
+        model_revision=None,
+    )
+    return LLMFamilyV2(
+        version=2,
+        context_length=131072,
+        model_type="LLM",
+        model_name="gemma-4",
+        model_lang=["en"],
+        model_ability=["chat", "vision"],
+        model_specs=[spec],
+        chat_template=None,
+        stop_token_ids=None,
+        stop=None,
+        architectures=architectures,
+    )
+
+
+def test_gemma4_registers_transformers_and_batching_support():
+    assert "Gemma4ForConditionalGeneration" in NON_DEFAULT_MODEL_LIST
+    assert "Gemma4UnifiedForConditionalGeneration" in NON_DEFAULT_MODEL_LIST
+    assert "gemma-4" in XINFERENCE_BATCHING_ALLOWED_VISION_MODELS
+
+
+def test_gemma4_match_json_accepts_gemma4_conditional_generation():
+    family = _family(["Gemma4ForConditionalGeneration"])
+    spec = family.model_specs[0]
+
+    assert Gemma4ChatModel.match_json(family, spec, "none") is True
+
+
+def test_gemma4_match_json_rejects_unified_model_before_transformers_510(
+    monkeypatch,
+):
+    import transformers
+
+    family = _family(
+        ["Gemma4ForConditionalGeneration", "Gemma4UnifiedForConditionalGeneration"],
+        model_id="google/gemma-4-12B-it",
+    )
+    spec = family.model_specs[0]
+
+    monkeypatch.setattr(transformers, "__version__", "5.9.0")
+    result = Gemma4ChatModel.match_json(family, spec, "none")
+    assert result == (
+        False,
+        "Gemma-4 unified Transformers backend requires transformers>=5.10.0",
+    )
+
+    monkeypatch.setattr(transformers, "__version__", "5.10.0")
+    assert Gemma4ChatModel.match_json(family, spec, "none") is True
+
+
+def test_gemma4_prefill_uses_attention_mask_for_left_padding():
+    model = Gemma4ChatModel.__new__(Gemma4ChatModel)
+    model._processor = _Processor()
+    model._device = torch.device("cpu")
+
+    first = _request()
+    second = _request()
+
+    kwargs = model.build_prefill_kwargs([["longer"], ["shorter"]], [first, second])
+
+    assert kwargs["input_ids"].tolist() == [[1, 2, 3, 4], [0, 0, 5, 6]]
+    assert kwargs["attention_mask"].tolist() == [[1, 1, 1, 1], [0, 0, 1, 1]]
+    assert kwargs["position_ids"].tolist() == [[0, 1, 2, 3], [0, 0, 0, 1]]
+
+    assert first.prompt_tokens == [1, 2, 3, 4]
+    assert first.padding_len == 0
+    assert first.extra_kwargs["attention_mask_seq_len"] == 4
+    assert first.extra_kwargs["max_position_id"] == 3
+
+    assert second.prompt_tokens == [5, 6]
+    assert second.padding_len == 2
+    assert second.extra_kwargs["attention_mask_seq_len"] == 2
+    assert second.extra_kwargs["max_position_id"] == 1
+
+
+def _direct_model(monkeypatch):
+    import transformers
+
+    model = Gemma4ChatModel.__new__(Gemma4ChatModel)
+    model.model_uid = "gemma-4"
+    model.reasoning_parser = None
+    model.tool_parser = None
+    model.model_family = _family(["Gemma4ForConditionalGeneration"])
+    model._processor = _DirectProcessor()
+    model._tokenizer = object()
+    model._model = _Model()
+    model._device = torch.device("cpu")
+
+    monkeypatch.setattr(transformers, "TextIteratorStreamer", _Streamer)
+    return model
+
+
+def test_gemma4_direct_chat_streaming_returns_iterator(monkeypatch):
+    model = _direct_model(monkeypatch)
+    iterator = asyncio.run(
+        model._direct_chat(
+            [{"role": "user", "content": "你好"}],
+            {"stream": True, "max_tokens": 8},
+        )
+    )
+
+    assert iterator is not None
+    assert hasattr(iterator, "__iter__")
+    chunks = list(iterator)
+    assert chunks[0]["object"] == "chat.completion.chunk"
+    assert chunks[0]["choices"][0]["delta"]["content"] == "你"
+    assert chunks[1]["choices"][0]["delta"]["content"] == "好"
+    assert chunks[2]["choices"][0]["finish_reason"] == "stop"
+
+
+def test_gemma4_direct_chat_non_streaming_returns_completion(monkeypatch):
+    model = _direct_model(monkeypatch)
+    completion = asyncio.run(
+        model._direct_chat(
+            [{"role": "user", "content": "你好"}],
+            {"stream": False, "max_tokens": 8},
+        )
+    )
+
+    assert completion["object"] == "chat.completion"
+    assert completion["choices"][0]["message"]["content"] == "你好"

--- a/xinference/model/llm/transformers/tests/test_gemma4.py
+++ b/xinference/model/llm/transformers/tests/test_gemma4.py
@@ -13,11 +13,17 @@
 # limitations under the License.
 
 import asyncio
+import json
+from pathlib import Path
 from threading import Event
 
 import torch
+from packaging.requirements import Requirement
+from packaging.version import Version
 
 from .....core.model import XINFERENCE_BATCHING_ALLOWED_VISION_MODELS
+from .....core.utils import filter_virtualenv_packages_by_markers
+from .....core.virtual_env_manager import expand_engine_dependency_placeholders
 from ....scheduler.request import InferenceRequest
 from ...llm_family import LLMFamilyV2, PytorchLLMSpecV2
 from ..core import NON_DEFAULT_MODEL_LIST
@@ -120,6 +126,25 @@ def test_gemma4_registers_transformers_and_batching_support():
     assert "gemma-4" in XINFERENCE_BATCHING_ALLOWED_VISION_MODELS
 
 
+def test_gemma4_virtualenv_uses_supported_transformers():
+    family_path = Path(__file__).parents[2] / "llm_family.json"
+    families = json.loads(family_path.read_text())
+    gemma4 = next(x for x in families if x["model_name"] == "gemma-4")
+
+    packages = expand_engine_dependency_placeholders(
+        gemma4["virtualenv"]["packages"], "transformers"
+    )
+    packages = filter_virtualenv_packages_by_markers(packages, "transformers", "13.0")
+    requirements = {
+        Requirement(package).name: Requirement(package) for package in packages
+    }
+
+    transformers_requirement = requirements["transformers"]
+    assert Version("5.10.0") in transformers_requirement.specifier
+    assert Version("5.9.9") not in transformers_requirement.specifier
+    assert "accelerate" in requirements
+
+
 def test_gemma4_match_json_accepts_gemma4_conditional_generation():
     family = _family(["Gemma4ForConditionalGeneration"])
     spec = family.model_specs[0]
@@ -193,10 +218,15 @@ def _direct_model(monkeypatch):
 
 def test_gemma4_direct_chat_streaming_returns_iterator(monkeypatch):
     model = _direct_model(monkeypatch)
+    generate_config = {
+        "stream": True,
+        "max_tokens": 8,
+        "stream_options": {"include_usage": True},
+    }
     iterator = asyncio.run(
         model._direct_chat(
             [{"role": "user", "content": "你好"}],
-            {"stream": True, "max_tokens": 8},
+            generate_config,
         )
     )
 
@@ -207,6 +237,9 @@ def test_gemma4_direct_chat_streaming_returns_iterator(monkeypatch):
     assert chunks[0]["choices"][0]["delta"]["content"] == "你"
     assert chunks[1]["choices"][0]["delta"]["content"] == "好"
     assert chunks[2]["choices"][0]["finish_reason"] == "stop"
+    assert chunks[3]["choices"] == []
+    assert chunks[3]["usage"]["completion_tokens"] == 2
+    assert generate_config["stream_options"] == {"include_usage": True}
 
 
 def test_gemma4_direct_chat_non_streaming_returns_completion(monkeypatch):
@@ -220,3 +253,40 @@ def test_gemma4_direct_chat_non_streaming_returns_completion(monkeypatch):
 
     assert completion["object"] == "chat.completion"
     assert completion["choices"][0]["message"]["content"] == "你好"
+    assert completion["usage"]["prompt_tokens"] == 3
+    assert completion["usage"]["completion_tokens"] == 2
+    assert completion["usage"]["total_tokens"] == 5
+
+
+def test_gemma4_direct_inputs_forward_tools_to_chat_template():
+    captured = {}
+
+    class _ToolProcessor:
+        def apply_chat_template(self, messages, **kwargs):
+            captured.update(kwargs)
+            return _Batch(
+                {
+                    "input_ids": torch.tensor([[1, 2, 3]]),
+                    "attention_mask": torch.tensor([[1, 1, 1]]),
+                }
+            )
+
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "weather",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+    model = Gemma4ChatModel.__new__(Gemma4ChatModel)
+    model._processor = _ToolProcessor()
+    model._device = torch.device("cpu")
+    model.reasoning_parser = None
+
+    model.build_inputs_from_messages(
+        [{"role": "user", "content": "天气如何？"}], {"tools": tools}
+    )
+
+    assert captured["tools"] == tools

--- a/xinference/model/llm/transformers/tests/test_gemma4.py
+++ b/xinference/model/llm/transformers/tests/test_gemma4.py
@@ -17,6 +17,7 @@ import json
 from pathlib import Path
 from threading import Event
 
+import pytest
 import torch
 from packaging.requirements import Requirement
 from packaging.version import Version
@@ -24,8 +25,16 @@ from packaging.version import Version
 from .....core.model import XINFERENCE_BATCHING_ALLOWED_VISION_MODELS
 from .....core.utils import filter_virtualenv_packages_by_markers
 from .....core.virtual_env_manager import expand_engine_dependency_placeholders
+from ....scheduler.batch import BatchScheduler
 from ....scheduler.request import InferenceRequest
-from ...llm_family import LLMFamilyV2, PytorchLLMSpecV2
+from ... import generate_engine_config_by_model_family
+from ...llm_family import (
+    LLM_ENGINES,
+    SUPPORTED_ENGINES,
+    LLMFamilyV2,
+    PytorchLLMSpecV2,
+    check_engine_by_spec_parameters_with_virtual_env,
+)
 from ..core import NON_DEFAULT_MODEL_LIST
 from ..gemma4 import Gemma4ChatModel
 
@@ -42,7 +51,11 @@ class _Batch(dict):
 
 
 class _Processor:
+    def __init__(self):
+        self.captured_kwargs = {}
+
     def apply_chat_template(self, prompts, **kwargs):
+        self.captured_kwargs.update(kwargs)
         assert kwargs["tokenize"] is True
         assert kwargs["add_generation_prompt"] is True
         assert kwargs["return_tensors"] == "pt"
@@ -93,14 +106,14 @@ class _Model:
         kwargs["streamer"].done.set()
 
 
-def _request():
-    return InferenceRequest([], None, True, "chat", None)
+def _request(generate_config=None):
+    return InferenceRequest([], None, True, "chat", generate_config)
 
 
-def _family(architectures, model_id="google/gemma-4-E4B-it"):
+def _family(architectures, model_id="google/gemma-4-E4B-it", model_size_in_billions=4):
     spec = PytorchLLMSpecV2(
         model_format="pytorch",
-        model_size_in_billions=4,
+        model_size_in_billions=model_size_in_billions,
         quantization="none",
         model_id=model_id,
         model_revision=None,
@@ -117,6 +130,7 @@ def _family(architectures, model_id="google/gemma-4-E4B-it"):
         stop_token_ids=None,
         stop=None,
         architectures=architectures,
+        virtualenv={"packages": ['transformers>=5.10.0 ; #engine# == "Transformers"']},
     )
 
 
@@ -128,7 +142,7 @@ def test_gemma4_registers_transformers_and_batching_support():
 
 def test_gemma4_virtualenv_uses_supported_transformers():
     family_path = Path(__file__).parents[2] / "llm_family.json"
-    families = json.loads(family_path.read_text())
+    families = json.loads(family_path.read_text(encoding="utf-8"))
     gemma4 = next(x for x in families if x["model_name"] == "gemma-4")
 
     packages = expand_engine_dependency_placeholders(
@@ -152,7 +166,7 @@ def test_gemma4_match_json_accepts_gemma4_conditional_generation():
     assert Gemma4ChatModel.match_json(family, spec, "none") is True
 
 
-def test_gemma4_match_json_rejects_unified_model_before_transformers_510(
+def test_gemma4_unified_selection_does_not_depend_on_host_transformers(
     monkeypatch,
 ):
     import transformers
@@ -163,15 +177,45 @@ def test_gemma4_match_json_rejects_unified_model_before_transformers_510(
     )
     spec = family.model_specs[0]
 
-    monkeypatch.setattr(transformers, "__version__", "5.9.0")
-    result = Gemma4ChatModel.match_json(family, spec, "none")
-    assert result == (
-        False,
-        "Gemma-4 unified Transformers backend requires transformers>=5.10.0",
+    monkeypatch.setattr(transformers, "__version__", "5.5.0")
+    assert Gemma4ChatModel.match_json(family, spec, "none") is True
+
+    family.model_specs[0].model_size_in_billions = 12
+    monkeypatch.setitem(SUPPORTED_ENGINES, "Transformers", [Gemma4ChatModel])
+    monkeypatch.setitem(LLM_ENGINES, "gemma-4", {})
+    generate_engine_config_by_model_family(family)
+
+    assert (
+        check_engine_by_spec_parameters_with_virtual_env(
+            "Transformers",
+            "gemma-4",
+            "pytorch",
+            12,
+            "none",
+            llm_family=family,
+        )
+        is Gemma4ChatModel
     )
 
+
+def test_gemma4_unified_checks_transformers_version_before_loading(monkeypatch):
+    import transformers
+
+    family = _family(
+        ["Gemma4ForConditionalGeneration", "Gemma4UnifiedForConditionalGeneration"],
+        model_id="google/gemma-4-12B-it",
+        model_size_in_billions=12,
+    )
+
+    monkeypatch.setattr(transformers, "__version__", "5.9.0")
+    with pytest.raises(
+        ImportError,
+        match="Gemma-4 unified Transformers backend requires transformers>=5.10.0",
+    ):
+        Gemma4ChatModel._ensure_model_spec_transformers_version(family.model_specs[0])
+
     monkeypatch.setattr(transformers, "__version__", "5.10.0")
-    assert Gemma4ChatModel.match_json(family, spec, "none") is True
+    Gemma4ChatModel._ensure_model_spec_transformers_version(family.model_specs[0])
 
 
 def test_gemma4_prefill_uses_attention_mask_for_left_padding():
@@ -197,6 +241,47 @@ def test_gemma4_prefill_uses_attention_mask_for_left_padding():
     assert second.padding_len == 2
     assert second.extra_kwargs["attention_mask_seq_len"] == 2
     assert second.extra_kwargs["max_position_id"] == 1
+
+
+def test_gemma4_batching_forwards_tools_and_chat_template_kwargs():
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "weather",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+    generate_config = {
+        "tools": tools,
+        "chat_template_kwargs": {"enable_thinking": False},
+    }
+    model = Gemma4ChatModel.__new__(Gemma4ChatModel)
+    model._processor = _Processor()
+    model._device = torch.device("cpu")
+    model.reasoning_parser = None
+
+    model.build_prefill_kwargs(
+        [["longer"], ["shorter"]],
+        [_request(generate_config), _request(dict(generate_config))],
+    )
+
+    assert model._processor.captured_kwargs["tools"] == tools
+    assert model._processor.captured_kwargs["enable_thinking"] is False
+
+
+def test_gemma4_scheduler_separates_incompatible_template_kwargs():
+    model = Gemma4ChatModel.__new__(Gemma4ChatModel)
+    model._pytorch_model_config = {"max_num_seqs": 4}
+    scheduler = BatchScheduler(model)
+    first = _request({"chat_template_kwargs": {"enable_thinking": False}})
+    second = _request({"chat_template_kwargs": {"enable_thinking": False}})
+    third = _request({"chat_template_kwargs": {"enable_thinking": True}})
+    scheduler._waiting_queue.extend([first, second, third])
+
+    assert scheduler._handle_request() == [first, second]
+    assert list(scheduler._waiting_queue) == [third]
 
 
 def _direct_model(monkeypatch):

--- a/xinference/model/llm/transformers/utils.py
+++ b/xinference/model/llm/transformers/utils.py
@@ -174,48 +174,87 @@ def _get_pad_param(seq_len_idx: int, pad_len: int) -> Tuple:
     return tuple(dimensions)
 
 
+def get_kv_cache_layer(kv, layer_idx: int):
+    """Return one KV cache layer across Transformers cache layouts."""
+
+    def _none_if_empty(tensor):
+        if tensor is None:
+            return None
+        if isinstance(tensor, (list, tuple)) and not tensor:
+            return None
+        if hasattr(tensor, "numel") and tensor.numel() == 0:
+            return None
+        return tensor
+
+    layers = getattr(kv, "layers", None)
+    if layers is not None and layer_idx < len(layers):
+        layer = layers[layer_idx]
+        return _none_if_empty(getattr(layer, "keys", None)), _none_if_empty(
+            getattr(layer, "values", None)
+        )
+
+    key_cache = getattr(kv, "key_cache", None)
+    value_cache = getattr(kv, "value_cache", None)
+    if key_cache is not None and layer_idx < len(key_cache):
+        key = key_cache[layer_idx]
+        value = (
+            value_cache[layer_idx]
+            if value_cache is not None and layer_idx < len(value_cache)
+            else None
+        )
+        return _none_if_empty(key), _none_if_empty(value)
+
+    return None, None
+
+
+def set_kv_cache_layer(kv, layer_idx: int, key, value) -> None:
+    """Set one KV cache layer across Transformers cache layouts."""
+    layers = getattr(kv, "layers", None)
+    if layers is not None and layer_idx < len(layers):
+        layers[layer_idx].keys = key
+        layers[layer_idx].values = value
+        return
+
+    key_cache = getattr(kv, "key_cache", None)
+    value_cache = getattr(kv, "value_cache", None)
+    if key_cache is not None and value_cache is not None:
+        key_cache[layer_idx] = key
+        value_cache[layer_idx] = value
+        return
+
+    raise TypeError(f"Unsupported KV cache layout: {type(kv)!r}")
+
+
+def get_kv_cache_seq_length(kv, layer_idx: int = 0) -> int:
+    get_seq_length = getattr(kv, "get_seq_length", None)
+    if get_seq_length is None:
+        return 0
+    try:
+        return get_seq_length(layer_idx)
+    except TypeError:
+        # Some cache implementations only expose get_seq_length() without a layer index.
+        return get_seq_length()
+
+
+def get_first_populated_kv_cache_layer(kv):
+    for layer_idx in range(len(kv)):
+        key, value = get_kv_cache_layer(kv, layer_idx)
+        if key is not None:
+            return layer_idx, key, value
+    return None, None, None
+
+
 def get_batch_size_and_seq_len_from_kv_cache(kv, xinf_model_obj: "PytorchModel"):
     bs_idx, seq_len_idx = xinf_model_obj.get_batch_size_and_seq_len_indexes_from_kv()
-
-    try:
-        from transformers import HybridCache
-
-        if isinstance(kv, HybridCache):
-            if len(kv.key_cache) == 0 or kv.key_cache[0] is None:
-                return 0, 0
-            return kv.key_cache[0].shape[bs_idx], kv.get_seq_length()
-    except ImportError:
-        pass
 
     if kv is None:
         return 0, 0
 
-    if hasattr(kv, "key_cache"):
-        if len(kv.key_cache) == 0 or kv.key_cache[0] is None:
-            return 0, 0
-
-        key = kv.key_cache[0]
-        return (
-            key.shape[bs_idx],
-            (
-                kv.get_seq_length()
-                if hasattr(kv, "get_seq_length")
-                else key.shape[seq_len_idx]
-            ),
-        )
-
-    # New transformers Cache API (transformers >= 4.57 / 5.x): DynamicCache
-    # exposes `layers` (a list of CacheLayerMixin objects with `.keys` /
-    # `.values` tensors of shape [batch_size, num_heads, seq_len, head_dim])
-    # and `get_seq_length()`, but no longer exposes `key_cache` and (on 5.x)
-    # is not subscriptable. Without this branch the legacy `kv[0][0]` fallback
-    # below raises `TypeError: 'DynamicCache' object is not subscriptable`.
-    if hasattr(kv, "layers") and hasattr(kv, "get_seq_length"):
-        layers = kv.layers
-        first_keys = getattr(layers[0], "keys", None) if len(layers) > 0 else None
-        if first_keys is None or first_keys.numel() == 0:
-            return 0, kv.get_seq_length()
-        return first_keys.shape[bs_idx], kv.get_seq_length()
+    if hasattr(kv, "get_seq_length"):
+        layer_idx, key, _ = get_first_populated_kv_cache_layer(kv)
+        if key is None:
+            return 0, get_kv_cache_seq_length(kv)
+        return key.shape[bs_idx], get_kv_cache_seq_length(kv, layer_idx)
 
     return kv[0][0].shape[bs_idx], kv[0][0].shape[seq_len_idx] + 1
 

--- a/xinference/model/scheduler/batch.py
+++ b/xinference/model/scheduler/batch.py
@@ -80,10 +80,25 @@ class BatchScheduler:
             running_list.append(req)
 
         waiting_list: List[InferenceRequest] = []
+        waiting_batch_key = None
+        get_prefill_batch_key = getattr(
+            self._model, "get_batching_prefill_compatibility_key", None
+        )
         if len(running_list) < max_num_seqs:
             while len(self._waiting_queue) > 0:
                 req = self._waiting_queue.popleft()
                 self._check_request_aborted(req)
+                req_batch_key = (
+                    get_prefill_batch_key(req) if get_prefill_batch_key else None
+                )
+                if waiting_list and req_batch_key != waiting_batch_key:
+                    # A processor applies chat-template kwargs to the entire batch.
+                    # Keep requests with different template inputs for the next step
+                    # instead of leaking tools or reasoning settings across requests.
+                    self._waiting_queue.appendleft(req)
+                    break
+                if not waiting_list:
+                    waiting_batch_key = req_batch_key
                 waiting_list.append(req)
                 if len(running_list) + len(waiting_list) == max_num_seqs:
                     break


### PR DESCRIPTION
## Summary

- add the missing legacy and layer-based DynamicCache compatibility helpers used by continuous batching
- preserve sliding-cache state and shared layers while merging and reducing batches
- move processor-based direct chat generation into a shared mixin instead of duplicating it in `gemma4.py`
- support Gemma 4 Unified 12B with Transformers 5.10 and pass tools to the direct chat template
- add focused cache compatibility, direct chat, usage, tool-template, and virtualenv dependency tests

## Release note

- Add the Gemma 4 Transformers backend with complete continuous-batching support across legacy and layer-based DynamicCache layouts.

## Validation

- `pre-commit run --files <changed files>`
- `pytest -q xinference/model/llm/transformers/tests/test_gemma4.py xinference/model/llm/transformers/tests/test_cache_compatibility.py xinference/model/llm/tests/test_utils.py` (49 passed)
- OPT integration launch was attempted separately; its model setup could not complete locally because the host ran out of disk space, while the unrelated FP4 case is not present in the current catalog.