### PR TITLE
FEAT: support NaviDC-OCR with Transformers and vLLM

### DIFF
--- a/doc/source/models/builtin/image/index.rst
+++ b/doc/source/models/builtin/image/index.rst
@@ -55,6 +55,8 @@ The following is a list of built-in image models in Xinference:
 
    krea-2-turbo
   
+   navidc-ocr
+  
    paddleocr-vl
   
    paddleocr-vl-1.6

--- a/doc/source/models/builtin/image/navidc-ocr.rst
+++ b/doc/source/models/builtin/image/navidc-ocr.rst
@@ -1,0 +1,22 @@
+.. _models_builtin_navidc-ocr:
+
+==========
+NaviDC-OCR
+==========
+
+- **Model Name:** NaviDC-OCR
+- **Model Family:** ocr
+- **Abilities:** ocr
+- **Available ControlNet:** None
+
+Specifications
+^^^^^^^^^^^^^^
+
+- **Model ID:** StarDoc-AI/NaviDC-OCR
+
+Execute the following command to launch the model::
+
+   xinference launch --model-name NaviDC-OCR --model-type image
+
+
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,9 @@ xinference-router-agent = "xinference.deploy.router_agent:main"
 xinference-migrate-auth = "xinference.api.oauth2.advanced.migrate:main"
 xinference-reset-auth-password = "xinference.api.oauth2.advanced.reset_password:main"
 
+[project.entry-points."vllm.general_plugins"]
+xinference_navidc_ocr = "xinference.thirdparty.navidc_ocr:register"
+
 [project.optional-dependencies]
 dev = [
     "cython>=0.29",

--- a/xinference/model/image/model_spec.json
+++ b/xinference/model/image/model_spec.json
@@ -2262,11 +2262,12 @@
     ],
     "virtualenv": {
       "packages": [
-        "transformers==4.57.1 ; #engine# == \"transformers\"",
+        "transformers==4.57.1",
+        "pillow>=11,<12",
         "accelerate==1.12.0 ; #engine# == \"transformers\"",
-        "pillow>=11,<12 ; #engine# == \"transformers\"",
         "#system_torch# ; #engine# == \"transformers\"",
         "#system_torchvision# ; #engine# == \"transformers\"",
+        "vllm==0.11.0 ; #engine# == \"vllm\"",
         "#system_numpy#"
       ]
     },

--- a/xinference/model/image/model_spec.json
+++ b/xinference/model/image/model_spec.json
@@ -2252,5 +2252,35 @@
     },
     "featured": true,
     "updated_at": 1787576958
+  },
+  {
+    "version": 2,
+    "model_name": "NaviDC-OCR",
+    "model_family": "ocr",
+    "model_ability": [
+      "ocr"
+    ],
+    "virtualenv": {
+      "packages": [
+        "transformers==4.57.1 ; #engine# == \"transformers\"",
+        "accelerate==1.12.0 ; #engine# == \"transformers\"",
+        "pillow>=11,<12 ; #engine# == \"transformers\"",
+        "#system_torch# ; #engine# == \"transformers\"",
+        "#system_torchvision# ; #engine# == \"transformers\"",
+        "#system_numpy#"
+      ]
+    },
+    "model_src": {
+      "huggingface": {
+        "model_id": "StarDoc-AI/NaviDC-OCR",
+        "model_revision": "main"
+      },
+      "modelscope": {
+        "model_id": "jackpi/NaviDC-OCR",
+        "model_revision": "master"
+      }
+    },
+    "featured": false,
+    "updated_at": 1787878771
   }
 ]

--- a/xinference/model/image/model_spec.json
+++ b/xinference/model/image/model_spec.json
@@ -2267,7 +2267,7 @@
         "accelerate==1.12.0 ; #engine# == \"transformers\"",
         "#system_torch# ; #engine# == \"transformers\"",
         "#system_torchvision# ; #engine# == \"transformers\"",
-        "vllm==0.11.0 ; #engine# == \"vllm\"",
+        "vllm>=0.23,<0.24 ; #engine# == \"vllm\"",
         "#system_numpy#"
       ]
     },

--- a/xinference/model/image/ocr/__init__.py
+++ b/xinference/model/image/ocr/__init__.py
@@ -17,6 +17,7 @@ from .deepseek_ocr import DeepSeekOCRModel
 from .got_ocr2 import GotOCR2Model
 from .hunyuan_ocr import HunyuanOCRModel
 from .mlx import MLXDeepSeekOCRModel
+from .navidc_ocr import NaviDCOCRModel
 from .ocr_family import SUPPORTED_ENGINES
 from .paddleocr_vl import PaddleOCRVLModel
 from .unlimited_ocr import UnlimitedOCRModel
@@ -32,6 +33,7 @@ __all__ = [
     "DeepSeekOCRModel",
     "GotOCR2Model",
     "HunyuanOCRModel",
+    "NaviDCOCRModel",
     "PaddleOCRVLModel",
     "UnlimitedOCRModel",
 ]
@@ -42,6 +44,7 @@ def register_builtin_ocr_engines() -> None:
         DeepSeekOCRModel,
         GotOCR2Model,
         HunyuanOCRModel,
+        NaviDCOCRModel,
         PaddleOCRVLModel,
         UnlimitedOCRModel,
     ]

--- a/xinference/model/image/ocr/__init__.py
+++ b/xinference/model/image/ocr/__init__.py
@@ -25,6 +25,7 @@ from .vllm import (
     VLLMDeepSeekOCRModel,
     VLLMGotOCR2Model,
     VLLMHunyuanOCRModel,
+    VLLMNaviDCOCRModel,
     VLLMPaddleOCRVLModel,
 )
 
@@ -51,6 +52,7 @@ def register_builtin_ocr_engines() -> None:
     SUPPORTED_ENGINES["vllm"] = [
         VLLMDeepSeekOCRModel,
         VLLMHunyuanOCRModel,
+        VLLMNaviDCOCRModel,
     ]
     SUPPORTED_ENGINES["mlx"] = [MLXDeepSeekOCRModel]
     # DeepDoc runs on onnxruntime via its own engine name

--- a/xinference/model/image/ocr/navidc_ocr.py
+++ b/xinference/model/image/ocr/navidc_ocr.py
@@ -77,7 +77,7 @@ class NaviDCOCRModel(OCRModel):
         self._device = device
         self._model = None
         self._processor = None
-        self._abilities = model_spec.model_ability or []  # type: ignore
+        self._abilities = model_spec.model_ability if model_spec is not None else []
         self._kwargs = kwargs
 
     @property

--- a/xinference/model/image/ocr/navidc_ocr.py
+++ b/xinference/model/image/ocr/navidc_ocr.py
@@ -1,0 +1,143 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from typing import TYPE_CHECKING, Optional
+
+import PIL.Image
+import torch
+
+if TYPE_CHECKING:
+    from ..core import ImageModelFamilyV2
+
+from ....device_utils import get_available_device
+from ...utils import allow_trust_remote_code
+from .ocr_family import OCRModel
+
+logger = logging.getLogger(__name__)
+
+
+class NaviDCOCRModel(OCRModel):
+    required_libs = ("transformers",)
+
+    DEFAULT_PROMPT = "Please output the text content from the image."
+    DEFAULT_SYSTEM_PROMPT = "You are a helpful assistant."
+
+    @classmethod
+    def match(cls, model_family: "ImageModelFamilyV2") -> bool:
+        return model_family.model_name == "NaviDC-OCR"
+
+    def __init__(
+        self,
+        model_uid: str,
+        model_path: Optional[str] = None,
+        device: Optional[str] = None,
+        model_spec: Optional["ImageModelFamilyV2"] = None,
+        **kwargs,
+    ):
+        self.model_family = model_spec
+        self._model_uid = model_uid
+        self._model_path = model_path
+        self._device = device
+        self._model = None
+        self._processor = None
+        self._abilities = model_spec.model_ability or []  # type: ignore
+        self._kwargs = kwargs
+
+    @property
+    def model_ability(self):
+        return self._abilities
+
+    def load(self):
+        from transformers import AutoModel, AutoProcessor
+
+        device = self._device or get_available_device()
+        model_kwargs = self._kwargs.copy()
+        use_fast = model_kwargs.pop("use_fast", True)
+        model_kwargs.setdefault(
+            "trust_remote_code", allow_trust_remote_code(self.model_family)
+        )
+        model_kwargs.setdefault(
+            "torch_dtype", torch.float32 if device == "cpu" else torch.bfloat16
+        )
+
+        self._processor = AutoProcessor.from_pretrained(
+            self._model_path,
+            trust_remote_code=allow_trust_remote_code(self.model_family),
+            use_fast=use_fast,
+        )
+        model = AutoModel.from_pretrained(self._model_path, **model_kwargs)
+        if "device_map" not in model_kwargs:
+            model = model.to(device)
+        self._model = model.eval()
+
+    def ocr(
+        self,
+        image: PIL.Image.Image,
+        prompt: Optional[str] = None,
+        **kwargs,
+    ) -> str:
+        if self._model is None or self._processor is None:
+            self.load()
+
+        if not isinstance(image, PIL.Image.Image):
+            raise ValueError("Input must be a PIL Image")
+        image = image.convert("RGB")
+
+        system_prompt = kwargs.pop("system_prompt", self.DEFAULT_SYSTEM_PROMPT)
+        messages = [
+            {"role": "system", "content": system_prompt},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image"},
+                    {"type": "text", "text": prompt or self.DEFAULT_PROMPT},
+                ],
+            },
+        ]
+
+        processor = self._processor
+        model = self._model
+        assert processor is not None
+        assert model is not None
+        chat_prompt = processor.apply_chat_template(
+            messages,
+            tokenize=False,
+            add_generation_prompt=True,
+        )
+        inputs = processor(
+            text=[chat_prompt],
+            images=[image],
+            padding=True,
+            return_tensors="pt",
+        ).to(device=model.device, dtype=model.dtype)
+
+        generation_kwargs = kwargs.copy()
+        generation_kwargs.setdefault("use_cache", True)
+        generation_kwargs.setdefault("max_new_tokens", 4096)
+        generation_kwargs.setdefault("do_sample", False)
+
+        with torch.inference_mode():
+            output_ids = model.generate(**inputs, **generation_kwargs)
+
+        generated_ids = output_ids[:, inputs["input_ids"].shape[-1] :]
+        output_texts = processor.batch_decode(
+            generated_ids,
+            skip_special_tokens=True,
+            clean_up_tokenization_spaces=False,
+        )
+        if not output_texts:
+            logger.warning("NaviDC-OCR returned empty decoded output.")
+            return ""
+        return output_texts[0].strip()

--- a/xinference/model/image/ocr/navidc_ocr.py
+++ b/xinference/model/image/ocr/navidc_ocr.py
@@ -32,7 +32,34 @@ class NaviDCOCRModel(OCRModel):
     required_libs = ("transformers",)
 
     DEFAULT_PROMPT = "Please output the text content from the image."
+    DEFAULT_LAYOUT_PROMPT = "Analyze the image layout."
     DEFAULT_SYSTEM_PROMPT = "You are a helpful assistant."
+    _IMAGE_PROMPT_PREFIX = "<image>\n"
+    _LEGACY_PROMPT_MAP = {
+        "OCR": DEFAULT_PROMPT,
+        "<image>\nFree OCR.": DEFAULT_PROMPT,
+        (
+            "<image>\nFree OCR. Extract all text content from the image."
+        ): DEFAULT_PROMPT,
+        (
+            "<image>\nConvert this document to clean markdown format. "
+            "Extract the text content and format it properly using markdown syntax. "
+            "Do not include any coordinate annotations or special formatting markers."
+        ): DEFAULT_PROMPT,
+        (
+            "<image>\n<|grounding|>Convert the document to markdown with "
+            "structure annotations. Include coordinate information for text regions "
+            "and maintain the document structure."
+        ): DEFAULT_LAYOUT_PROMPT,
+    }
+    NON_GENERATION_KWARGS = (
+        "model_size",
+        "test_compress",
+        "save_results",
+        "save_dir",
+        "eval_mode",
+        "request_id",
+    )
 
     @classmethod
     def match(cls, model_family: "ImageModelFamilyV2") -> bool:
@@ -59,11 +86,23 @@ class NaviDCOCRModel(OCRModel):
     def model_ability(self):
         return self._abilities
 
+    @classmethod
+    def _normalize_prompt(cls, prompt: Optional[str]) -> str:
+        if not prompt:
+            return cls.DEFAULT_PROMPT
+        mapped_prompt = cls._LEGACY_PROMPT_MAP.get(prompt)
+        if mapped_prompt is not None:
+            return mapped_prompt
+        if prompt.startswith(cls._IMAGE_PROMPT_PREFIX):
+            return prompt[len(cls._IMAGE_PROMPT_PREFIX) :]
+        return prompt
+
     def load(self):
         from transformers import AutoModel, AutoProcessor
 
         device = self._device or get_available_device()
         model_kwargs = self._kwargs.copy()
+        model_kwargs.pop("cpu_offload", None)
         use_fast = model_kwargs.pop("use_fast", True)
         model_kwargs.setdefault(
             "trust_remote_code", allow_trust_remote_code(self.model_family)
@@ -94,6 +133,7 @@ class NaviDCOCRModel(OCRModel):
         if not isinstance(image, PIL.Image.Image):
             raise ValueError("Input must be a PIL Image")
         image = image.convert("RGB")
+        prompt = self._normalize_prompt(prompt)
 
         system_prompt = kwargs.pop("system_prompt", self.DEFAULT_SYSTEM_PROMPT)
         messages = [
@@ -102,7 +142,7 @@ class NaviDCOCRModel(OCRModel):
                 "role": "user",
                 "content": [
                     {"type": "image"},
-                    {"type": "text", "text": prompt or self.DEFAULT_PROMPT},
+                    {"type": "text", "text": prompt},
                 ],
             },
         ]
@@ -124,6 +164,8 @@ class NaviDCOCRModel(OCRModel):
         ).to(device=model.device, dtype=model.dtype)
 
         generation_kwargs = kwargs.copy()
+        for key in self.NON_GENERATION_KWARGS:
+            generation_kwargs.pop(key, None)
         generation_kwargs.setdefault("use_cache", True)
         generation_kwargs.setdefault("max_new_tokens", 4096)
         generation_kwargs.setdefault("do_sample", False)

--- a/xinference/model/image/ocr/navidc_ocr.py
+++ b/xinference/model/image/ocr/navidc_ocr.py
@@ -38,9 +38,7 @@ class NaviDCOCRModel(OCRModel):
     _LEGACY_PROMPT_MAP = {
         "OCR": DEFAULT_PROMPT,
         "<image>\nFree OCR.": DEFAULT_PROMPT,
-        (
-            "<image>\nFree OCR. Extract all text content from the image."
-        ): DEFAULT_PROMPT,
+        ("<image>\nFree OCR. Extract all text content from the image."): DEFAULT_PROMPT,
         (
             "<image>\nConvert this document to clean markdown format. "
             "Extract the text content and format it properly using markdown syntax. "

--- a/xinference/model/image/ocr/tests/test_navidc_ocr.py
+++ b/xinference/model/image/ocr/tests/test_navidc_ocr.py
@@ -19,10 +19,13 @@ from types import ModuleType, SimpleNamespace
 import torch
 from PIL import Image
 
+from xinference.thirdparty.navidc_ocr import MODEL_ARCHITECTURE, MODEL_CLASS, register
+
 from ... import load_model_family_from_json
 from .. import register_builtin_ocr_engines
 from ..navidc_ocr import NaviDCOCRModel
 from ..ocr_family import OCR_ENGINES, generate_engine_config_by_model_name
+from ..vllm import VLLMNaviDCOCRModel
 
 
 def _load_navidc_families():
@@ -43,7 +46,15 @@ def test_navidc_ocr_metadata_and_engine_registration():
     assert all(spec.model_ability == ["ocr"] for spec in families)
     assert all(NaviDCOCRModel.match(spec) for spec in families)
     assert all(
+        "transformers==4.57.1" in spec.virtualenv.packages for spec in families
+    )
+    assert all("pillow>=11,<12" in spec.virtualenv.packages for spec in families)
+    assert all(
         'accelerate==1.12.0 ; #engine# == "transformers"' in spec.virtualenv.packages
+        for spec in families
+    )
+    assert all(
+        'vllm==0.11.0 ; #engine# == "vllm"' in spec.virtualenv.packages
         for spec in families
     )
 
@@ -53,6 +64,8 @@ def test_navidc_ocr_metadata_and_engine_registration():
         generate_engine_config_by_model_name(specs["huggingface"])
         engine_params = OCR_ENGINES["NaviDC-OCR"]["transformers"]
         assert engine_params[0]["ocr_class"] is NaviDCOCRModel
+        vllm_engine_params = OCR_ENGINES["NaviDC-OCR"]["vllm"]
+        assert vllm_engine_params[0]["ocr_class"] is VLLMNaviDCOCRModel
     finally:
         OCR_ENGINES.pop("NaviDC-OCR", None)
         if previous is not None:
@@ -174,3 +187,152 @@ def test_navidc_ocr_load_and_infer(monkeypatch):
     assert loaded_model.generate_kwargs["do_sample"] is False
     assert loaded_model.generate_kwargs["use_cache"] is True
     assert torch.equal(processor.decoded_ids, torch.tensor([[21, 22]]))
+
+
+def test_navidc_ocr_vllm_plugin_registration(monkeypatch):
+    class FakeModelRegistry:
+        registrations = []
+
+        @classmethod
+        def register_model(cls, architecture, model_class):
+            cls.registrations.append((architecture, model_class))
+
+    vllm_module = ModuleType("vllm")
+    vllm_module.ModelRegistry = FakeModelRegistry
+    monkeypatch.setitem(sys.modules, "vllm", vllm_module)
+
+    register()
+
+    assert FakeModelRegistry.registrations == [(MODEL_ARCHITECTURE, MODEL_CLASS)]
+    project_path = Path(__file__).parents[5] / "pyproject.toml"
+    assert (
+        'xinference_navidc_ocr = "xinference.thirdparty.navidc_ocr:register"'
+        in project_path.read_text()
+    )
+
+
+def test_navidc_ocr_vllm_install_dependencies():
+    from xinference.core.utils import filter_virtualenv_packages_by_markers
+    from xinference.core.virtual_env_manager import (
+        expand_engine_dependency_placeholders,
+    )
+
+    family = _load_navidc_families()[0]
+    expanded = expand_engine_dependency_placeholders(
+        family.virtualenv.packages,
+        "vllm",
+    )
+    prepared = filter_virtualenv_packages_by_markers(expanded, "vllm", None)
+
+    assert [package for package in prepared if package.startswith("vllm")] == [
+        "vllm==0.11.0"
+    ]
+    assert [package for package in prepared if package.startswith("transformers")] == [
+        "transformers==4.57.1"
+    ]
+    assert not any(package.startswith("accelerate") for package in prepared)
+
+
+def test_navidc_ocr_vllm_load_and_infer(monkeypatch):
+    from .. import vllm as vllm_ocr
+
+    class FakeProcessor:
+        def apply_chat_template(self, messages, **kwargs):
+            self.messages = messages
+            self.chat_template_kwargs = kwargs
+            return "rendered vllm prompt"
+
+    class FakeAutoProcessor:
+        @classmethod
+        def from_pretrained(cls, model_path, **kwargs):
+            cls.model_path = model_path
+            cls.kwargs = kwargs
+            return processor
+
+    class FakeSamplingParams:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    class FakeVLLMModel:
+        def generate(self, inputs, sampling_params):
+            self.inputs = inputs
+            self.sampling_params = sampling_params
+            return [SimpleNamespace(outputs=[SimpleNamespace(text="  vllm text  ")])]
+
+        def shutdown(self):
+            self.shutdown_called = True
+
+    processor = FakeProcessor()
+    loaded_model = FakeVLLMModel()
+    loaded = {}
+
+    def fake_load(model_path, model_kwargs):
+        loaded["model_path"] = model_path
+        loaded["model_kwargs"] = model_kwargs
+        return loaded_model
+
+    transformers_module = ModuleType("transformers")
+    transformers_module.AutoProcessor = FakeAutoProcessor
+    vllm_module = ModuleType("vllm")
+    vllm_module.SamplingParams = FakeSamplingParams
+    monkeypatch.setitem(sys.modules, "transformers", transformers_module)
+    monkeypatch.setitem(sys.modules, "vllm", vllm_module)
+    monkeypatch.setattr(vllm_ocr, "_load_vllm_model", fake_load)
+
+    model_spec = SimpleNamespace(
+        model_name="NaviDC-OCR",
+        model_ability=["ocr"],
+        is_builtin=True,
+    )
+    model = VLLMNaviDCOCRModel(
+        model_uid="navidc-vllm-test",
+        model_path="/models/navidc",
+        model_spec=model_spec,
+        torch_dtype=torch.bfloat16,
+        hf_overrides={"custom": "value"},
+    )
+    model.load()
+
+    assert loaded["model_path"] == "/models/navidc"
+    assert loaded["model_kwargs"]["hf_overrides"] == {
+        "custom": "value",
+        "architectures": [MODEL_ARCHITECTURE],
+    }
+    assert loaded["model_kwargs"]["trust_remote_code"] is True
+    assert "torch_dtype" not in loaded["model_kwargs"]
+    assert FakeAutoProcessor.model_path == "/models/navidc"
+    assert FakeAutoProcessor.kwargs == {
+        "trust_remote_code": True,
+        "use_fast": True,
+    }
+
+    result = model.ocr(
+        Image.new("RGBA", (8, 8)),
+        prompt="Read with vLLM.",
+        system_prompt="vLLM system",
+        max_new_tokens=123,
+        use_cache=True,
+    )
+
+    assert result == "vllm text"
+    assert processor.messages == [
+        {"role": "system", "content": "vLLM system"},
+        {
+            "role": "user",
+            "content": [
+                {"type": "image"},
+                {"type": "text", "text": "Read with vLLM."},
+            ],
+        },
+    ]
+    assert loaded_model.inputs[0]["prompt"] == "rendered vllm prompt"
+    assert loaded_model.inputs[0]["multi_modal_data"]["image"][0].mode == "RGB"
+    assert loaded_model.sampling_params.kwargs == {
+        "max_tokens": 123,
+        "temperature": 0.0,
+    }
+
+    model.stop()
+    assert loaded_model.shutdown_called is True
+    assert model._model is None
+    assert model._processor is None

--- a/xinference/model/image/ocr/tests/test_navidc_ocr.py
+++ b/xinference/model/image/ocr/tests/test_navidc_ocr.py
@@ -1,0 +1,176 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+import torch
+from PIL import Image
+
+from ... import load_model_family_from_json
+from .. import register_builtin_ocr_engines
+from ..navidc_ocr import NaviDCOCRModel
+from ..ocr_family import OCR_ENGINES, generate_engine_config_by_model_name
+
+
+def _load_navidc_families():
+    families = {}
+    spec_path = Path(__file__).parents[2] / "model_spec.json"
+    load_model_family_from_json(str(spec_path), families)
+    return families["NaviDC-OCR"]
+
+
+def test_navidc_ocr_metadata_and_engine_registration():
+    families = _load_navidc_families()
+    specs = {spec.model_hub: spec for spec in families}
+
+    assert specs["huggingface"].model_id == "StarDoc-AI/NaviDC-OCR"
+    assert specs["huggingface"].model_revision == "main"
+    assert specs["modelscope"].model_id == "jackpi/NaviDC-OCR"
+    assert specs["modelscope"].model_revision == "master"
+    assert all(spec.model_ability == ["ocr"] for spec in families)
+    assert all(NaviDCOCRModel.match(spec) for spec in families)
+    assert all(
+        'accelerate==1.12.0 ; #engine# == "transformers"' in spec.virtualenv.packages
+        for spec in families
+    )
+
+    previous = OCR_ENGINES.pop("NaviDC-OCR", None)
+    try:
+        register_builtin_ocr_engines()
+        generate_engine_config_by_model_name(specs["huggingface"])
+        engine_params = OCR_ENGINES["NaviDC-OCR"]["transformers"]
+        assert engine_params[0]["ocr_class"] is NaviDCOCRModel
+    finally:
+        OCR_ENGINES.pop("NaviDC-OCR", None)
+        if previous is not None:
+            OCR_ENGINES["NaviDC-OCR"] = previous
+
+
+def test_navidc_ocr_load_and_infer(monkeypatch):
+    class FakeInputs(dict):
+        def to(self, **kwargs):
+            self.to_kwargs = kwargs
+            return self
+
+    class FakeProcessor:
+        def __init__(self):
+            self.messages = None
+            self.process_kwargs = None
+            self.decoded_ids = None
+
+        def apply_chat_template(self, messages, **kwargs):
+            self.messages = messages
+            self.chat_template_kwargs = kwargs
+            return "rendered prompt"
+
+        def __call__(self, **kwargs):
+            self.process_kwargs = kwargs
+            self.inputs = FakeInputs(input_ids=torch.tensor([[11, 12]]))
+            return self.inputs
+
+        def batch_decode(self, generated_ids, **kwargs):
+            self.decoded_ids = generated_ids
+            self.decode_kwargs = kwargs
+            return ["  recognized text  "]
+
+    class FakeModel:
+        device = torch.device("cpu")
+        dtype = torch.float32
+
+        def to(self, device):
+            self.to_device = device
+            return self
+
+        def eval(self):
+            self.eval_called = True
+            return self
+
+        def generate(self, **kwargs):
+            self.generate_kwargs = kwargs
+            return torch.tensor([[11, 12, 21, 22]])
+
+    processor = FakeProcessor()
+    loaded_model = FakeModel()
+
+    class FakeAutoProcessor:
+        @classmethod
+        def from_pretrained(cls, model_path, **kwargs):
+            cls.model_path = model_path
+            cls.kwargs = kwargs
+            return processor
+
+    class FakeAutoModel:
+        @classmethod
+        def from_pretrained(cls, model_path, **kwargs):
+            cls.model_path = model_path
+            cls.kwargs = kwargs
+            return loaded_model
+
+    transformers_module = ModuleType("transformers")
+    transformers_module.AutoModel = FakeAutoModel
+    transformers_module.AutoProcessor = FakeAutoProcessor
+    monkeypatch.setitem(sys.modules, "transformers", transformers_module)
+
+    model_spec = SimpleNamespace(
+        model_name="NaviDC-OCR",
+        model_ability=["ocr"],
+        is_builtin=True,
+    )
+    model = NaviDCOCRModel(
+        model_uid="navidc-test",
+        model_path="/models/navidc",
+        device="cpu",
+        model_spec=model_spec,
+    )
+    model.load()
+
+    assert FakeAutoProcessor.model_path == "/models/navidc"
+    assert FakeAutoProcessor.kwargs == {
+        "trust_remote_code": True,
+        "use_fast": True,
+    }
+    assert FakeAutoModel.kwargs["trust_remote_code"] is True
+    assert FakeAutoModel.kwargs["torch_dtype"] is torch.float32
+    assert loaded_model.to_device == "cpu"
+    assert loaded_model.eval_called is True
+
+    result = model.ocr(
+        Image.new("RGBA", (8, 8)),
+        prompt="Read this document.",
+        system_prompt="System prompt",
+        max_new_tokens=123,
+    )
+
+    assert result == "recognized text"
+    assert processor.messages == [
+        {"role": "system", "content": "System prompt"},
+        {
+            "role": "user",
+            "content": [
+                {"type": "image"},
+                {"type": "text", "text": "Read this document."},
+            ],
+        },
+    ]
+    assert processor.process_kwargs["images"][0].mode == "RGB"
+    assert processor.inputs.to_kwargs == {
+        "device": loaded_model.device,
+        "dtype": loaded_model.dtype,
+    }
+    assert loaded_model.generate_kwargs["max_new_tokens"] == 123
+    assert loaded_model.generate_kwargs["do_sample"] is False
+    assert loaded_model.generate_kwargs["use_cache"] is True
+    assert torch.equal(processor.decoded_ids, torch.tensor([[21, 22]]))

--- a/xinference/model/image/ocr/tests/test_navidc_ocr.py
+++ b/xinference/model/image/ocr/tests/test_navidc_ocr.py
@@ -300,7 +300,7 @@ def test_navidc_ocr_vllm_install_dependencies():
     assert not any(package.startswith("accelerate") for package in prepared)
 
 
-def test_navidc_ocr_vllm_runs_on_actor_loop():
+def test_navidc_ocr_vllm_runs_on_dedicated_thread():
     model_spec = SimpleNamespace(
         model_name="NaviDC-OCR",
         model_ability=["ocr"],
@@ -311,37 +311,54 @@ def test_navidc_ocr_vllm_runs_on_actor_loop():
         model_path="/models/navidc",
         model_spec=model_spec,
     )
-    loop = asyncio.new_event_loop()
-
-    def _run_loop():
-        asyncio.set_event_loop(loop)
-        loop.run_forever()
-
-    async def _attach_loop():
-        model.set_loop(asyncio.get_running_loop())
-        return threading.get_ident()
-
-    loop_thread = threading.Thread(target=_run_loop)
-    loop_thread.start()
     try:
-        loop_thread_id = asyncio.run_coroutine_threadsafe(_attach_loop(), loop).result()
-        assert model._run_on_actor_loop(threading.get_ident) == loop_thread_id
-        assert loop_thread_id != threading.get_ident()
+        first_thread_id = model._run_on_vllm_thread(threading.get_ident)
+        second_thread_id = model._run_on_vllm_thread(threading.get_ident)
+
+        assert first_thread_id == second_thread_id
+        assert first_thread_id != threading.get_ident()
     finally:
-        loop.call_soon_threadsafe(loop.stop)
-        loop_thread.join()
-        loop.close()
+        model.stop()
 
 
-def test_navidc_ocr_vllm_stop_clears_state_on_actor_loop_failure(monkeypatch):
+def test_navidc_ocr_vllm_does_not_block_actor_loop():
+    model = VLLMNaviDCOCRModel(model_uid="navidc-vllm-loop-test")
+    started = threading.Event()
+    release = threading.Event()
+
+    def blocking_call():
+        started.set()
+        release.wait()
+
+    async def run_blocking_call():
+        task = asyncio.create_task(
+            asyncio.to_thread(model._run_on_vllm_thread, blocking_call)
+        )
+        fallback = threading.Timer(5, release.set)
+        fallback.start()
+        try:
+            assert await asyncio.to_thread(started.wait, 1)
+            assert not release.is_set()
+        finally:
+            release.set()
+            await task
+            fallback.cancel()
+
+    try:
+        asyncio.run(run_blocking_call())
+    finally:
+        model.stop()
+
+
+def test_navidc_ocr_vllm_stop_clears_state_on_owner_thread_failure(monkeypatch):
     model = VLLMNaviDCOCRModel(model_uid="navidc-vllm-stop-test")
     model._model = object()
     model._processor = object()
 
-    def fail_on_actor_loop(*args, **kwargs):
-        raise RuntimeError("actor loop is closed")
+    def fail_on_owner_thread(*args, **kwargs):
+        raise RuntimeError("owner thread is closed")
 
-    monkeypatch.setattr(model, "_run_on_actor_loop", fail_on_actor_loop)
+    monkeypatch.setattr(model, "_run_on_vllm_thread", fail_on_owner_thread)
 
     model.stop()
 

--- a/xinference/model/image/ocr/tests/test_navidc_ocr.py
+++ b/xinference/model/image/ocr/tests/test_navidc_ocr.py
@@ -53,9 +53,7 @@ def test_navidc_ocr_metadata_and_engine_registration():
     assert specs["modelscope"].model_revision == "master"
     assert all(spec.model_ability == ["ocr"] for spec in families)
     assert all(NaviDCOCRModel.match(spec) for spec in families)
-    assert all(
-        "transformers==4.57.1" in spec.virtualenv.packages for spec in families
-    )
+    assert all("transformers==4.57.1" in spec.virtualenv.packages for spec in families)
     assert all("pillow>=11,<12" in spec.virtualenv.packages for spec in families)
     assert all(
         'accelerate==1.12.0 ; #engine# == "transformers"' in spec.virtualenv.packages
@@ -307,9 +305,7 @@ def test_navidc_ocr_vllm_runs_on_actor_loop():
     loop_thread = threading.Thread(target=_run_loop)
     loop_thread.start()
     try:
-        loop_thread_id = asyncio.run_coroutine_threadsafe(
-            _attach_loop(), loop
-        ).result()
+        loop_thread_id = asyncio.run_coroutine_threadsafe(_attach_loop(), loop).result()
         assert model._run_on_actor_loop(threading.get_ident) == loop_thread_id
         assert loop_thread_id != threading.get_ident()
     finally:

--- a/xinference/model/image/ocr/tests/test_navidc_ocr.py
+++ b/xinference/model/image/ocr/tests/test_navidc_ocr.py
@@ -15,6 +15,7 @@
 import asyncio
 import sys
 import threading
+from importlib.metadata import PackageNotFoundError
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
 
@@ -97,6 +98,12 @@ def test_navidc_ocr_normalizes_legacy_prompts():
     )
     assert NaviDCOCRModel._normalize_prompt("<image>\nCustom task") == "Custom task"
     assert NaviDCOCRModel._normalize_prompt("Custom task") == "Custom task"
+
+
+def test_navidc_ocr_allows_missing_model_spec():
+    model = NaviDCOCRModel(model_uid="navidc-test")
+
+    assert model.model_ability == []
 
 
 def test_navidc_ocr_load_and_infer(monkeypatch):
@@ -259,6 +266,18 @@ def test_navidc_ocr_vllm_uses_compat_model_for_new_vllm(monkeypatch):
     assert _get_model_class() == COMPAT_MODEL_CLASS
 
 
+def test_navidc_ocr_vllm_falls_back_when_vllm_is_missing(monkeypatch):
+    def raise_package_not_found(_):
+        raise PackageNotFoundError
+
+    monkeypatch.setattr(
+        "xinference.thirdparty.navidc_ocr.package_version",
+        raise_package_not_found,
+    )
+
+    assert _get_model_class() == MODEL_CLASS
+
+
 def test_navidc_ocr_vllm_install_dependencies():
     from xinference.core.utils import filter_virtualenv_packages_by_markers
     from xinference.core.virtual_env_manager import (
@@ -312,6 +331,22 @@ def test_navidc_ocr_vllm_runs_on_actor_loop():
         loop.call_soon_threadsafe(loop.stop)
         loop_thread.join()
         loop.close()
+
+
+def test_navidc_ocr_vllm_stop_clears_state_on_actor_loop_failure(monkeypatch):
+    model = VLLMNaviDCOCRModel(model_uid="navidc-vllm-stop-test")
+    model._model = object()
+    model._processor = object()
+
+    def fail_on_actor_loop(*args, **kwargs):
+        raise RuntimeError("actor loop is closed")
+
+    monkeypatch.setattr(model, "_run_on_actor_loop", fail_on_actor_loop)
+
+    model.stop()
+
+    assert model._model is None
+    assert model._processor is None
 
 
 def test_navidc_ocr_vllm_load_and_infer(monkeypatch):

--- a/xinference/model/image/ocr/tests/test_navidc_ocr.py
+++ b/xinference/model/image/ocr/tests/test_navidc_ocr.py
@@ -12,14 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
 import sys
+import threading
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
 
 import torch
 from PIL import Image
 
-from xinference.thirdparty.navidc_ocr import MODEL_ARCHITECTURE, MODEL_CLASS, register
+from xinference.thirdparty.navidc_ocr import (
+    COMPAT_MODEL_CLASS,
+    MODEL_ARCHITECTURE,
+    MODEL_CLASS,
+    _get_model_class,
+    register,
+)
 
 from ... import load_model_family_from_json
 from .. import register_builtin_ocr_engines
@@ -54,7 +62,7 @@ def test_navidc_ocr_metadata_and_engine_registration():
         for spec in families
     )
     assert all(
-        'vllm==0.11.0 ; #engine# == "vllm"' in spec.virtualenv.packages
+        'vllm>=0.23,<0.24 ; #engine# == "vllm"' in spec.virtualenv.packages
         for spec in families
     )
 
@@ -70,6 +78,27 @@ def test_navidc_ocr_metadata_and_engine_registration():
         OCR_ENGINES.pop("NaviDC-OCR", None)
         if previous is not None:
             OCR_ENGINES["NaviDC-OCR"] = previous
+
+
+def test_navidc_ocr_normalizes_legacy_prompts():
+    assert NaviDCOCRModel._normalize_prompt(None) == NaviDCOCRModel.DEFAULT_PROMPT
+    assert NaviDCOCRModel._normalize_prompt("OCR") == NaviDCOCRModel.DEFAULT_PROMPT
+    assert (
+        NaviDCOCRModel._normalize_prompt(
+            "<image>\nFree OCR. Extract all text content from the image."
+        )
+        == NaviDCOCRModel.DEFAULT_PROMPT
+    )
+    assert (
+        NaviDCOCRModel._normalize_prompt(
+            "<image>\n<|grounding|>Convert the document to markdown with "
+            "structure annotations. Include coordinate information for text regions "
+            "and maintain the document structure."
+        )
+        == NaviDCOCRModel.DEFAULT_LAYOUT_PROMPT
+    )
+    assert NaviDCOCRModel._normalize_prompt("<image>\nCustom task") == "Custom task"
+    assert NaviDCOCRModel._normalize_prompt("Custom task") == "Custom task"
 
 
 def test_navidc_ocr_load_and_infer(monkeypatch):
@@ -147,6 +176,7 @@ def test_navidc_ocr_load_and_infer(monkeypatch):
         model_path="/models/navidc",
         device="cpu",
         model_spec=model_spec,
+        cpu_offload=False,
     )
     model.load()
 
@@ -157,14 +187,21 @@ def test_navidc_ocr_load_and_infer(monkeypatch):
     }
     assert FakeAutoModel.kwargs["trust_remote_code"] is True
     assert FakeAutoModel.kwargs["torch_dtype"] is torch.float32
+    assert "cpu_offload" not in FakeAutoModel.kwargs
     assert loaded_model.to_device == "cpu"
     assert loaded_model.eval_called is True
 
     result = model.ocr(
         Image.new("RGBA", (8, 8)),
-        prompt="Read this document.",
+        prompt="<image>\nFree OCR. Extract all text content from the image.",
         system_prompt="System prompt",
         max_new_tokens=123,
+        model_size="gundam",
+        test_compress=False,
+        save_results=False,
+        save_dir=None,
+        eval_mode=True,
+        request_id="request-1",
     )
 
     assert result == "recognized text"
@@ -174,7 +211,7 @@ def test_navidc_ocr_load_and_infer(monkeypatch):
             "role": "user",
             "content": [
                 {"type": "image"},
-                {"type": "text", "text": "Read this document."},
+                {"type": "text", "text": NaviDCOCRModel.DEFAULT_PROMPT},
             ],
         },
     ]
@@ -186,6 +223,9 @@ def test_navidc_ocr_load_and_infer(monkeypatch):
     assert loaded_model.generate_kwargs["max_new_tokens"] == 123
     assert loaded_model.generate_kwargs["do_sample"] is False
     assert loaded_model.generate_kwargs["use_cache"] is True
+    assert not (
+        set(NaviDCOCRModel.NON_GENERATION_KWARGS) & loaded_model.generate_kwargs.keys()
+    )
     assert torch.equal(processor.decoded_ids, torch.tensor([[21, 22]]))
 
 
@@ -200,6 +240,9 @@ def test_navidc_ocr_vllm_plugin_registration(monkeypatch):
     vllm_module = ModuleType("vllm")
     vllm_module.ModelRegistry = FakeModelRegistry
     monkeypatch.setitem(sys.modules, "vllm", vllm_module)
+    monkeypatch.setattr(
+        "xinference.thirdparty.navidc_ocr.package_version", lambda _: "0.11.2"
+    )
 
     register()
 
@@ -209,6 +252,13 @@ def test_navidc_ocr_vllm_plugin_registration(monkeypatch):
         'xinference_navidc_ocr = "xinference.thirdparty.navidc_ocr:register"'
         in project_path.read_text()
     )
+
+
+def test_navidc_ocr_vllm_uses_compat_model_for_new_vllm(monkeypatch):
+    monkeypatch.setattr(
+        "xinference.thirdparty.navidc_ocr.package_version", lambda _: "0.23.0+cu130"
+    )
+    assert _get_model_class() == COMPAT_MODEL_CLASS
 
 
 def test_navidc_ocr_vllm_install_dependencies():
@@ -225,12 +275,47 @@ def test_navidc_ocr_vllm_install_dependencies():
     prepared = filter_virtualenv_packages_by_markers(expanded, "vllm", None)
 
     assert [package for package in prepared if package.startswith("vllm")] == [
-        "vllm==0.11.0"
+        "vllm>=0.23,<0.24"
     ]
     assert [package for package in prepared if package.startswith("transformers")] == [
         "transformers==4.57.1"
     ]
     assert not any(package.startswith("accelerate") for package in prepared)
+
+
+def test_navidc_ocr_vllm_runs_on_actor_loop():
+    model_spec = SimpleNamespace(
+        model_name="NaviDC-OCR",
+        model_ability=["ocr"],
+        is_builtin=True,
+    )
+    model = VLLMNaviDCOCRModel(
+        model_uid="navidc-vllm-loop-test",
+        model_path="/models/navidc",
+        model_spec=model_spec,
+    )
+    loop = asyncio.new_event_loop()
+
+    def _run_loop():
+        asyncio.set_event_loop(loop)
+        loop.run_forever()
+
+    async def _attach_loop():
+        model.set_loop(asyncio.get_running_loop())
+        return threading.get_ident()
+
+    loop_thread = threading.Thread(target=_run_loop)
+    loop_thread.start()
+    try:
+        loop_thread_id = asyncio.run_coroutine_threadsafe(
+            _attach_loop(), loop
+        ).result()
+        assert model._run_on_actor_loop(threading.get_ident) == loop_thread_id
+        assert loop_thread_id != threading.get_ident()
+    finally:
+        loop.call_soon_threadsafe(loop.stop)
+        loop_thread.join()
+        loop.close()
 
 
 def test_navidc_ocr_vllm_load_and_infer(monkeypatch):
@@ -255,11 +340,13 @@ def test_navidc_ocr_vllm_load_and_infer(monkeypatch):
 
     class FakeVLLMModel:
         def generate(self, inputs, sampling_params):
+            self.generate_thread = threading.get_ident()
             self.inputs = inputs
             self.sampling_params = sampling_params
             return [SimpleNamespace(outputs=[SimpleNamespace(text="  vllm text  ")])]
 
         def shutdown(self):
+            self.shutdown_thread = threading.get_ident()
             self.shutdown_called = True
 
     processor = FakeProcessor()
@@ -267,6 +354,7 @@ def test_navidc_ocr_vllm_load_and_infer(monkeypatch):
     loaded = {}
 
     def fake_load(model_path, model_kwargs):
+        loaded["thread"] = threading.get_ident()
         loaded["model_path"] = model_path
         loaded["model_kwargs"] = model_kwargs
         return loaded_model
@@ -299,6 +387,8 @@ def test_navidc_ocr_vllm_load_and_infer(monkeypatch):
         "architectures": [MODEL_ARCHITECTURE],
     }
     assert loaded["model_kwargs"]["trust_remote_code"] is True
+    assert loaded["model_kwargs"]["gpu_memory_utilization"] == 0.7
+    assert loaded["model_kwargs"]["max_model_len"] == 16384
     assert "torch_dtype" not in loaded["model_kwargs"]
     assert FakeAutoProcessor.model_path == "/models/navidc"
     assert FakeAutoProcessor.kwargs == {
@@ -308,7 +398,7 @@ def test_navidc_ocr_vllm_load_and_infer(monkeypatch):
 
     result = model.ocr(
         Image.new("RGBA", (8, 8)),
-        prompt="Read with vLLM.",
+        prompt="OCR",
         system_prompt="vLLM system",
         max_new_tokens=123,
         use_cache=True,
@@ -321,7 +411,7 @@ def test_navidc_ocr_vllm_load_and_infer(monkeypatch):
             "role": "user",
             "content": [
                 {"type": "image"},
-                {"type": "text", "text": "Read with vLLM."},
+                {"type": "text", "text": NaviDCOCRModel.DEFAULT_PROMPT},
             ],
         },
     ]
@@ -331,8 +421,10 @@ def test_navidc_ocr_vllm_load_and_infer(monkeypatch):
         "max_tokens": 123,
         "temperature": 0.0,
     }
+    assert loaded_model.generate_thread == loaded["thread"]
 
     model.stop()
     assert loaded_model.shutdown_called is True
+    assert loaded_model.shutdown_thread == loaded["thread"]
     assert model._model is None
     assert model._processor is None

--- a/xinference/model/image/ocr/vllm.py
+++ b/xinference/model/image/ocr/vllm.py
@@ -18,10 +18,12 @@ from typing import Any, Dict, List, Optional, Union
 import PIL.Image
 
 from ....device_utils import is_vacc_available
+from ....thirdparty.navidc_ocr import MODEL_ARCHITECTURE as NAVIDC_MODEL_ARCHITECTURE
 from ...utils import allow_trust_remote_code
 from .deepseek_ocr import DeepSeekOCRModel
 from .got_ocr2 import GotOCR2Model
 from .hunyuan_ocr import HunyuanOCRModel
+from .navidc_ocr import NaviDCOCRModel
 from .paddleocr_vl import PaddleOCRVLModel
 
 logger = logging.getLogger(__name__)
@@ -304,6 +306,88 @@ class VLLMHunyuanOCRModel(HunyuanOCRModel):
 
         if isinstance(image, list):
             return texts
+        return texts[0] if texts else ""
+
+
+class VLLMNaviDCOCRModel(NaviDCOCRModel):
+    required_libs = ("vllm",)
+
+    def load(self):
+        from transformers import AutoProcessor
+
+        vllm_kwargs = _sanitize_vllm_kwargs(self._kwargs)
+        hf_overrides = vllm_kwargs.pop("hf_overrides", None) or {}
+        if not isinstance(hf_overrides, dict):
+            raise TypeError("NaviDC-OCR requires hf_overrides to be a dictionary")
+        hf_overrides = dict(hf_overrides)
+        hf_overrides["architectures"] = [NAVIDC_MODEL_ARCHITECTURE]
+        vllm_kwargs["hf_overrides"] = hf_overrides
+        vllm_kwargs.setdefault(
+            "trust_remote_code", allow_trust_remote_code(self.model_family)
+        )
+
+        self._model = _load_vllm_model(self._model_path, vllm_kwargs)
+        self._processor = AutoProcessor.from_pretrained(
+            self._model_path,
+            trust_remote_code=allow_trust_remote_code(self.model_family),
+            use_fast=True,
+        )
+
+    def stop(self):
+        _shutdown_vllm_model(self._model)
+        self._model = None
+        self._processor = None
+
+    def _build_prompt(self, prompt: str, system_prompt: str) -> str:
+        processor = self._processor
+        assert processor is not None
+        messages = [
+            {"role": "system", "content": system_prompt},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image"},
+                    {"type": "text", "text": prompt},
+                ],
+            },
+        ]
+        return processor.apply_chat_template(
+            messages,
+            tokenize=False,
+            add_generation_prompt=True,
+        )
+
+    def ocr(
+        self,
+        image: PIL.Image.Image,
+        prompt: Optional[str] = None,
+        **kwargs,
+    ) -> str:
+        if self._model is None or self._processor is None:
+            self.load()
+        assert self._model is not None
+
+        if not isinstance(image, PIL.Image.Image):
+            raise ValueError("Input must be a PIL Image")
+        image = image.convert("RGB")
+
+        system_prompt = kwargs.pop("system_prompt", self.DEFAULT_SYSTEM_PROMPT)
+        chat_prompt = self._build_prompt(
+            prompt or self.DEFAULT_PROMPT,
+            system_prompt,
+        )
+        inputs = [
+            {
+                "prompt": chat_prompt,
+                "multi_modal_data": {"image": [image]},
+            }
+        ]
+
+        kwargs.pop("use_cache", None)
+        kwargs.setdefault("max_new_tokens", 4096)
+        sampling_params = _build_sampling_params(kwargs)
+        outputs = self._model.generate(inputs, sampling_params)
+        texts = _extract_text(outputs)
         return texts[0] if texts else ""
 
 

--- a/xinference/model/image/ocr/vllm.py
+++ b/xinference/model/image/ocr/vllm.py
@@ -420,9 +420,7 @@ class VLLMNaviDCOCRModel(NaviDCOCRModel):
         kwargs.pop("use_cache", None)
         kwargs.setdefault("max_new_tokens", 4096)
         sampling_params = _build_sampling_params(kwargs)
-        outputs = self._run_on_actor_loop(
-            self._model.generate, inputs, sampling_params
-        )
+        outputs = self._run_on_actor_loop(self._model.generate, inputs, sampling_params)
         texts = _extract_text(outputs)
         return texts[0] if texts else ""
 

--- a/xinference/model/image/ocr/vllm.py
+++ b/xinference/model/image/ocr/vllm.py
@@ -367,6 +367,8 @@ class VLLMNaviDCOCRModel(NaviDCOCRModel):
     def stop(self):
         try:
             self._run_on_actor_loop(_shutdown_vllm_model, self._model)
+        except Exception:
+            logger.exception("Failed to shut down NaviDC-OCR vLLM model")
         finally:
             self._model = None
             self._processor = None

--- a/xinference/model/image/ocr/vllm.py
+++ b/xinference/model/image/ocr/vllm.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
 import logging
+import threading
 from typing import Any, Dict, List, Optional, Union
 
 import PIL.Image
@@ -312,6 +314,27 @@ class VLLMHunyuanOCRModel(HunyuanOCRModel):
 class VLLMNaviDCOCRModel(NaviDCOCRModel):
     required_libs = ("vllm",)
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._actor_loop: Optional[asyncio.AbstractEventLoop] = None
+        self._actor_loop_thread_id: Optional[int] = None
+
+    def set_loop(self, loop: asyncio.AbstractEventLoop) -> None:
+        self._actor_loop = loop
+        self._actor_loop_thread_id = threading.get_ident()
+
+    def _run_on_actor_loop(self, fn, *args, **kwargs):
+        # vLLM's offline client must be created and called on the model actor's
+        # event-loop thread; moving either operation to asyncio.to_thread stalls.
+        loop = self._actor_loop
+        if loop is None or threading.get_ident() == self._actor_loop_thread_id:
+            return fn(*args, **kwargs)
+
+        async def _invoke():
+            return fn(*args, **kwargs)
+
+        return asyncio.run_coroutine_threadsafe(_invoke(), loop).result()
+
     def load(self):
         from transformers import AutoProcessor
 
@@ -325,18 +348,28 @@ class VLLMNaviDCOCRModel(NaviDCOCRModel):
         vllm_kwargs.setdefault(
             "trust_remote_code", allow_trust_remote_code(self.model_family)
         )
+        vllm_kwargs.setdefault("gpu_memory_utilization", 0.7)
+        vllm_kwargs.setdefault("max_model_len", 16384)
 
-        self._model = _load_vllm_model(self._model_path, vllm_kwargs)
-        self._processor = AutoProcessor.from_pretrained(
-            self._model_path,
-            trust_remote_code=allow_trust_remote_code(self.model_family),
-            use_fast=True,
-        )
+        try:
+            self._model = self._run_on_actor_loop(
+                _load_vllm_model, self._model_path, vllm_kwargs
+            )
+            self._processor = AutoProcessor.from_pretrained(
+                self._model_path,
+                trust_remote_code=allow_trust_remote_code(self.model_family),
+                use_fast=True,
+            )
+        except Exception:
+            self.stop()
+            raise
 
     def stop(self):
-        _shutdown_vllm_model(self._model)
-        self._model = None
-        self._processor = None
+        try:
+            self._run_on_actor_loop(_shutdown_vllm_model, self._model)
+        finally:
+            self._model = None
+            self._processor = None
 
     def _build_prompt(self, prompt: str, system_prompt: str) -> str:
         processor = self._processor
@@ -370,10 +403,11 @@ class VLLMNaviDCOCRModel(NaviDCOCRModel):
         if not isinstance(image, PIL.Image.Image):
             raise ValueError("Input must be a PIL Image")
         image = image.convert("RGB")
+        prompt = self._normalize_prompt(prompt)
 
         system_prompt = kwargs.pop("system_prompt", self.DEFAULT_SYSTEM_PROMPT)
         chat_prompt = self._build_prompt(
-            prompt or self.DEFAULT_PROMPT,
+            prompt,
             system_prompt,
         )
         inputs = [
@@ -386,7 +420,9 @@ class VLLMNaviDCOCRModel(NaviDCOCRModel):
         kwargs.pop("use_cache", None)
         kwargs.setdefault("max_new_tokens", 4096)
         sampling_params = _build_sampling_params(kwargs)
-        outputs = self._model.generate(inputs, sampling_params)
+        outputs = self._run_on_actor_loop(
+            self._model.generate, inputs, sampling_params
+        )
         texts = _extract_text(outputs)
         return texts[0] if texts else ""
 

--- a/xinference/model/image/ocr/vllm.py
+++ b/xinference/model/image/ocr/vllm.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import asyncio
+import concurrent.futures
 import logging
 import threading
 from typing import Any, Dict, List, Optional, Union
@@ -29,6 +29,7 @@ from .navidc_ocr import NaviDCOCRModel
 from .paddleocr_vl import PaddleOCRVLModel
 
 logger = logging.getLogger(__name__)
+_navidc_vllm_executor_lock = threading.Lock()
 
 
 def _load_vllm_model(model_path: str, model_kwargs: Dict[str, Any]):
@@ -316,24 +317,21 @@ class VLLMNaviDCOCRModel(NaviDCOCRModel):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._actor_loop: Optional[asyncio.AbstractEventLoop] = None
-        self._actor_loop_thread_id: Optional[int] = None
+        self._vllm_executor: Optional[concurrent.futures.ThreadPoolExecutor] = None
 
-    def set_loop(self, loop: asyncio.AbstractEventLoop) -> None:
-        self._actor_loop = loop
-        self._actor_loop_thread_id = threading.get_ident()
-
-    def _run_on_actor_loop(self, fn, *args, **kwargs):
-        # vLLM's offline client must be created and called on the model actor's
-        # event-loop thread; moving either operation to asyncio.to_thread stalls.
-        loop = self._actor_loop
-        if loop is None or threading.get_ident() == self._actor_loop_thread_id:
-            return fn(*args, **kwargs)
-
-        async def _invoke():
-            return fn(*args, **kwargs)
-
-        return asyncio.run_coroutine_threadsafe(_invoke(), loop).result()
+    def _run_on_vllm_thread(self, fn, *args, **kwargs):
+        # The offline client requires creation and inference on the same thread.
+        # A dedicated worker preserves that affinity without blocking the actor loop.
+        executor = self._vllm_executor
+        if executor is None:
+            with _navidc_vllm_executor_lock:
+                if self._vllm_executor is None:
+                    self._vllm_executor = concurrent.futures.ThreadPoolExecutor(
+                        max_workers=1,
+                        thread_name_prefix=f"navidc-vllm-{self._model_uid}",
+                    )
+                executor = self._vllm_executor
+        return executor.submit(fn, *args, **kwargs).result()
 
     def load(self):
         from transformers import AutoProcessor
@@ -352,7 +350,7 @@ class VLLMNaviDCOCRModel(NaviDCOCRModel):
         vllm_kwargs.setdefault("max_model_len", 16384)
 
         try:
-            self._model = self._run_on_actor_loop(
+            self._model = self._run_on_vllm_thread(
                 _load_vllm_model, self._model_path, vllm_kwargs
             )
             self._processor = AutoProcessor.from_pretrained(
@@ -366,12 +364,17 @@ class VLLMNaviDCOCRModel(NaviDCOCRModel):
 
     def stop(self):
         try:
-            self._run_on_actor_loop(_shutdown_vllm_model, self._model)
+            self._run_on_vllm_thread(_shutdown_vllm_model, self._model)
         except Exception:
             logger.exception("Failed to shut down NaviDC-OCR vLLM model")
         finally:
             self._model = None
             self._processor = None
+            with _navidc_vllm_executor_lock:
+                executor = self._vllm_executor
+                self._vllm_executor = None
+            if executor is not None:
+                executor.shutdown(wait=False)
 
     def _build_prompt(self, prompt: str, system_prompt: str) -> str:
         processor = self._processor
@@ -405,11 +408,11 @@ class VLLMNaviDCOCRModel(NaviDCOCRModel):
         if not isinstance(image, PIL.Image.Image):
             raise ValueError("Input must be a PIL Image")
         image = image.convert("RGB")
-        prompt = self._normalize_prompt(prompt)
+        normalized_prompt = self._normalize_prompt(prompt)
 
         system_prompt = kwargs.pop("system_prompt", self.DEFAULT_SYSTEM_PROMPT)
         chat_prompt = self._build_prompt(
-            prompt,
+            normalized_prompt,
             system_prompt,
         )
         inputs = [
@@ -422,7 +425,9 @@ class VLLMNaviDCOCRModel(NaviDCOCRModel):
         kwargs.pop("use_cache", None)
         kwargs.setdefault("max_new_tokens", 4096)
         sampling_params = _build_sampling_params(kwargs)
-        outputs = self._run_on_actor_loop(self._model.generate, inputs, sampling_params)
+        outputs = self._run_on_vllm_thread(
+            self._model.generate, inputs, sampling_params
+        )
         texts = _extract_text(outputs)
         return texts[0] if texts else ""
 

--- a/xinference/thirdparty/navidc_ocr/README.xinference.md
+++ b/xinference/thirdparty/navidc_ocr/README.xinference.md
@@ -1,0 +1,16 @@
+# NaviDC-OCR vendored vLLM runtime
+
+This directory vendors `NaviOCR-vllm/NaviOCR_vllm/qwen2_5_vl.py` from:
+
+- Repository: https://github.com/caipeng328/NaviDC-OCR
+- Commit: `2e79d29bf32d4e8997b7cbd2ee619a12bfc8d616`
+- Source SHA-256: `f0f12a0c8809777c440b8cfc9fb67ee4c0e900919c63a54481dd68fdf797eba3`
+- License: Apache License 2.0, as declared by the vendored source header
+
+The model source is unchanged. Xinference provides its own registration module
+so the implementation uses the explicit `NaviOCRForConditionalGeneration`
+architecture without replacing vLLM's global
+`Qwen2_5_VLForConditionalGeneration` registration.
+
+The upstream implementation targets `vllm==0.11.0` and
+`transformers==4.57.1`.

--- a/xinference/thirdparty/navidc_ocr/__init__.py
+++ b/xinference/thirdparty/navidc_ocr/__init__.py
@@ -1,0 +1,28 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Register the vendored NaviDC-OCR model implementation with vLLM."""
+
+MODEL_ARCHITECTURE = "NaviOCRForConditionalGeneration"
+MODEL_CLASS = (
+    "xinference.thirdparty.navidc_ocr.qwen2_5_vl:"
+    "Qwen2_5_VLForConditionalGeneration"
+)
+UPSTREAM_COMMIT = "2e79d29bf32d4e8997b7cbd2ee619a12bfc8d616"
+
+
+def register() -> None:
+    from vllm import ModelRegistry
+
+    ModelRegistry.register_model(MODEL_ARCHITECTURE, MODEL_CLASS)

--- a/xinference/thirdparty/navidc_ocr/__init__.py
+++ b/xinference/thirdparty/navidc_ocr/__init__.py
@@ -14,7 +14,7 @@
 
 """Register the vendored NaviDC-OCR model implementation with vLLM."""
 
-from importlib.metadata import version as package_version
+from importlib.metadata import PackageNotFoundError, version as package_version
 
 from packaging.version import InvalidVersion, Version
 
@@ -34,7 +34,7 @@ def _get_model_class() -> str:
     try:
         if Version(package_version("vllm")) >= Version("0.23.0"):
             return COMPAT_MODEL_CLASS
-    except (ImportError, InvalidVersion):
+    except (PackageNotFoundError, InvalidVersion):
         pass
     return MODEL_CLASS
 

--- a/xinference/thirdparty/navidc_ocr/__init__.py
+++ b/xinference/thirdparty/navidc_ocr/__init__.py
@@ -14,15 +14,32 @@
 
 """Register the vendored NaviDC-OCR model implementation with vLLM."""
 
+from importlib.metadata import version as package_version
+
+from packaging.version import InvalidVersion, Version
+
 MODEL_ARCHITECTURE = "NaviOCRForConditionalGeneration"
 MODEL_CLASS = (
     "xinference.thirdparty.navidc_ocr.qwen2_5_vl:"
     "Qwen2_5_VLForConditionalGeneration"
 )
+COMPAT_MODEL_CLASS = (
+    "xinference.thirdparty.navidc_ocr.vllm_compat:"
+    "NaviOCRForConditionalGeneration"
+)
 UPSTREAM_COMMIT = "2e79d29bf32d4e8997b7cbd2ee619a12bfc8d616"
+
+
+def _get_model_class() -> str:
+    try:
+        if Version(package_version("vllm")) >= Version("0.23.0"):
+            return COMPAT_MODEL_CLASS
+    except (ImportError, InvalidVersion):
+        pass
+    return MODEL_CLASS
 
 
 def register() -> None:
     from vllm import ModelRegistry
 
-    ModelRegistry.register_model(MODEL_ARCHITECTURE, MODEL_CLASS)
+    ModelRegistry.register_model(MODEL_ARCHITECTURE, _get_model_class())

--- a/xinference/thirdparty/navidc_ocr/qwen2_5_vl.py
+++ b/xinference/thirdparty/navidc_ocr/qwen2_5_vl.py
@@ -1,0 +1,1485 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+# Adapted from
+# https://github.com/huggingface/transformers/blob/main/src/transformers/models/qwen2_5_vl/modeling_qwen2_5_vl.py
+# Copyright 2025 The vLLM team.
+# Copyright 2025 The Qwen Team.
+# Copyright 2025 The HuggingFace Inc. team.
+# All rights reserved.
+#
+# This code is based on EleutherAI's GPT-NeoX library and the GPT-NeoX
+# and OPT implementations in this library. It has been modified from its
+# original forms to accommodate minor architectural differences compared
+# to GPT-NeoX and OPT used by the Meta AI team that trained the model.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Inference-only Qwen2.5-VL model compatible with HuggingFace weights."""
+from collections.abc import Iterable, Mapping, Sequence
+from functools import lru_cache, partial
+from typing import Annotated, Any, Callable, Literal, Optional, Union
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from einops import rearrange
+from transformers import BatchFeature
+from transformers.models.qwen2_5_vl import Qwen2_5_VLProcessor
+from transformers.models.qwen2_5_vl.configuration_qwen2_5_vl import (
+    Qwen2_5_VLConfig, Qwen2_5_VLVisionConfig)
+
+from vllm.attention.layer import check_upstream_fa_availability
+from vllm.config import VllmConfig
+from vllm.distributed import parallel_state
+from vllm.distributed import utils as dist_utils
+from vllm.logger import init_logger
+from vllm.model_executor.layers.activation import get_act_and_mul_fn
+from vllm.model_executor.layers.layernorm import RMSNorm
+# yapf: disable
+from vllm.model_executor.layers.linear import (ColumnParallelLinear,
+                                               MergedColumnParallelLinear,
+                                               QKVParallelLinear,
+                                               RowParallelLinear)
+# yapf: enable
+from vllm.model_executor.layers.quantization import QuantizationConfig
+from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+from vllm.model_executor.models.module_mapping import MultiModelKeys
+from vllm.multimodal import MULTIMODAL_REGISTRY
+from vllm.multimodal.evs import (compute_mrope_for_media,
+                                 compute_retained_tokens_count,
+                                 compute_retention_mask,
+                                 recompute_mrope_positions)
+from vllm.multimodal.inputs import MultiModalFieldConfig, MultiModalKwargs
+from vllm.multimodal.parse import MultiModalDataItems
+from vllm.multimodal.processing import PromptReplacement, PromptUpdate
+from vllm.platforms import _Backend
+from vllm.sequence import IntermediateTensors
+from vllm.transformers_utils.config import uses_mrope
+from vllm.utils import is_pin_memory_available
+from vllm.utils.tensor_schema import TensorSchema, TensorShape
+
+from vllm.model_executor.models.interfaces import (MultiModalEmbeddings, SupportsLoRA,
+                         SupportsMultiModal, SupportsMultiModalPruning,
+                         SupportsPP, SupportsQuant)
+from vllm.model_executor.models.qwen2_vl import Qwen2VLDummyInputsBuilder as Qwen2_5_VLDummyInputsBuilder
+from vllm.model_executor.models.qwen2_vl import (Qwen2VLMultiModalProcessor, Qwen2VLProcessingInfo,
+                       apply_rotary_pos_emb_vision)
+from vllm.model_executor.models.utils import (AutoWeightsLoader, WeightsMapper, cast_overflow_tensors,
+                    init_vllm_registered_model, maybe_prefix,
+                    merge_multimodal_embeddings)
+from vllm.model_executor.models.vision import get_vit_attn_backend, run_dp_sharded_mrope_vision_model
+
+logger = init_logger(__name__)
+
+# === Vision Inputs === #
+
+
+class Qwen2_5_VLImagePixelInputs(TensorSchema):
+    """
+    Dimensions:
+        - np: Number of patches
+        - ni: Number of images
+        - cps: Number of channels * patch_size * patch_size
+
+    Historical context:
+        - pixel_values shape: (num_patches, num_channels * patch_size *
+          patch_size)
+        - image_grid_thw shape: (num_images, 3) in (grid_t, grid_h, grid_w)
+          formatnum_channels * patch_size * patch_size
+    """
+    type: Literal["pixel_values"]
+
+    pixel_values: Annotated[
+        torch.Tensor,
+        TensorShape("np", "cps"),
+    ]
+
+    image_grid_thw: Annotated[
+        torch.Tensor,
+        TensorShape("ni", 3),
+    ]
+
+
+class Qwen2_5_VLImageEmbeddingInputs(TensorSchema):
+    """
+    Dimensions:
+        - nf: Number of image features
+        - hs: Hidden size
+        - ni: Number of images
+
+    Historical context:
+        - image_embeds shape: (num_image_features, hidden_size)
+        - num_image_features varies based on the number and resolution of the
+          images.
+        - hidden_size must match the hidden size of language model backbone.
+        - image_grid_thw shape: (num_images, 3) in (grid_t, grid_h, grid_w)
+          format
+    """
+    type: Literal["image_embeds"]
+
+    image_embeds: Annotated[
+        torch.Tensor,
+        TensorShape("nf", "hs"),
+    ]
+
+    image_grid_thw: Annotated[
+        torch.Tensor,
+        TensorShape("ni", 3),
+    ]
+
+
+Qwen2_5_VLImageInputs = Union[Qwen2_5_VLImagePixelInputs,
+                              Qwen2_5_VLImageEmbeddingInputs]
+
+
+class Qwen2_5_VLVideoPixelInputs(TensorSchema):
+    """
+    Dimensions:
+        - np: Number of patches
+        - nv: Number of videos
+        - ctps: Number of channels * temporal_patch_size * patch_size *
+          patch_size
+
+    Historical context:
+        - pixel_values_videos shape: (num_patches, num_channels *
+          temporal_patch_size * patch_size * patch_size)
+        - video_grid_thw shape: (num_videos, 3) in (grid_t, grid_h, grid_w)
+          format
+        - second_per_grid_ts: The video time interval (in seconds) for each
+          grid along the temporal dimension in the 3D position IDs. Returned
+          when `videos` is not `None`.
+    """
+    type: Literal["pixel_values_videos"]
+
+    pixel_values_videos: Annotated[
+        torch.Tensor,
+        TensorShape("np", "ctps"),
+    ]
+
+    video_grid_thw: Annotated[
+        torch.Tensor,
+        TensorShape("nv", 3),
+    ]
+
+    second_per_grid_ts: Annotated[
+        Optional[torch.Tensor],
+        TensorShape("nv"),
+    ]
+
+
+class Qwen2_5_VLVideoEmbeddingInputs(TensorSchema):
+    """
+    Dimensions:
+        - nf: Number of video features
+        - hs: Hidden size
+        - nv: Number of videos
+
+    Historical context:
+        - video_embeds shape: (num_video_features, hidden_size)
+        - num_video_features varies based on the number and resolution of the
+          videos.
+        - hidden_size must match the hidden size of language model backbone.
+        - video_grid_thw shape: (num_videos, 3) in (grid_t, grid_h, grid_w)
+          format
+    """
+    type: Literal["video_embeds"]
+
+    video_embeds: Annotated[
+        torch.Tensor,
+        TensorShape("nf", "hs"),
+    ]
+
+    video_grid_thw: Annotated[
+        torch.Tensor,
+        TensorShape("nv", 3),
+    ]
+
+
+Qwen2_5_VLVideoInputs = Union[Qwen2_5_VLVideoPixelInputs,
+                              Qwen2_5_VLVideoEmbeddingInputs]
+
+# === Vision Encoder === #
+
+
+class Qwen2_5_VisionMLP(nn.Module):
+
+    def __init__(self,
+                 in_features: int,
+                 hidden_features: int,
+                 bias: bool = False,
+                 act_fn: Callable[[torch.Tensor], torch.Tensor] = F.silu,
+                 quant_config: Optional[QuantizationConfig] = None,
+                 prefix: str = "",
+                 use_data_parallel: bool = False):
+        super().__init__()
+        self.gate_up_proj = MergedColumnParallelLinear(
+            input_size=in_features,
+            output_sizes=[hidden_features] * 2,  # [gate_proj, up_proj]
+            bias=bias,
+            quant_config=quant_config,
+            prefix=f"{prefix}.gate_up_proj",
+            disable_tp=use_data_parallel)
+
+        self.down_proj = RowParallelLinear(hidden_features,
+                                           in_features,
+                                           bias=bias,
+                                           quant_config=quant_config,
+                                           prefix=f"{prefix}.down_proj",
+                                           disable_tp=use_data_parallel)
+        self.act_fn = act_fn
+
+    def forward(self, x: torch.Tensor):
+        gate_up, _ = self.gate_up_proj(x)
+        x = self.act_fn(gate_up)
+        x_down, _ = self.down_proj(x)
+        return x_down
+
+
+def all_gather_interleave(local_tensor, hidden_size: int, tp_size: int):
+    """All-gather the input tensor interleavely across model parallel group."""
+    import torch.distributed as dist
+    gathered_tensors = [torch.zeros_like(local_tensor) for _ in range(tp_size)]
+    dist.all_gather(gathered_tensors,
+                    local_tensor,
+                    group=parallel_state.get_tp_group().device_group)
+
+    gathered_tensors_split = [
+        torch.split(tensor, hidden_size // tp_size, -1)
+        for tensor in gathered_tensors
+    ]
+    ordered_tensors = [
+        tensor for pair in zip(*gathered_tensors_split) for tensor in pair
+    ]
+    result_tensor = torch.cat(ordered_tensors, dim=-1)
+    return result_tensor
+
+
+class Qwen2_5_VisionAttention(nn.Module):
+
+    def __init__(
+        self,
+        embed_dim: int,
+        num_heads: int,
+        projection_size: int,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+        use_data_parallel: bool = False,
+        attn_backend: _Backend = _Backend.TORCH_SDPA,
+        use_upstream_fa: bool = False,
+    ) -> None:
+        super().__init__()
+        # Per attention head and per partition values.
+        self.tp_size = (1 if use_data_parallel else
+                        parallel_state.get_tensor_model_parallel_world_size())
+        self.tp_rank = parallel_state.get_tensor_model_parallel_rank()
+        self.hidden_size_per_attention_head = dist_utils.divide(
+            projection_size, num_heads)
+        self.num_attention_heads_per_partition = dist_utils.divide(
+            num_heads, self.tp_size)
+
+        self.qkv = QKVParallelLinear(
+            hidden_size=embed_dim,
+            head_size=self.hidden_size_per_attention_head,
+            total_num_heads=num_heads,
+            total_num_kv_heads=num_heads,
+            bias=True,
+            quant_config=quant_config,
+            prefix=f"{prefix}.qkv",
+            disable_tp=use_data_parallel)
+
+        self.proj = RowParallelLinear(input_size=projection_size,
+                                      output_size=embed_dim,
+                                      quant_config=quant_config,
+                                      prefix=f"{prefix}.proj",
+                                      disable_tp=use_data_parallel)
+        self.attn_backend = attn_backend
+        self.use_upstream_fa = use_upstream_fa
+        self.is_flash_attn_backend = self.attn_backend in {
+            _Backend.FLASH_ATTN, _Backend.ROCM_AITER_FA
+        }
+
+    def split_qkv(self, qkv: torch.Tensor) -> tuple[torch.Tensor, ...]:
+        # [s, b, 3 * head * head_dim]
+        seq_len, bs, _ = qkv.shape
+        if self.tp_size > 1:
+            qkv = all_gather_interleave(qkv, self.qkv.hidden_size,
+                                        self.tp_size)
+
+        # [s, b, 3 * head * head_dim] -> 3 * [s, b, head * head_dim]
+        q, k, v = qkv.chunk(3, dim=2)
+
+        # 3 * [s, b, head * head_dim]
+        if self.tp_size > 1:
+            splitter = partial(dist_utils.split_tensor_along_last_dim,
+                               num_partitions=self.tp_size)
+            q = splitter(q)[self.tp_rank]
+            k = splitter(k)[self.tp_rank]
+            v = splitter(v)[self.tp_rank]
+
+        # 3 * [s, b, head * head_dim] -> 3 * [s, b, head, head_dim]
+        new_shape = (seq_len, bs, self.num_attention_heads_per_partition,
+                     self.hidden_size_per_attention_head)
+        q, k, v = (x.view(*new_shape) for x in (q, k, v))
+        return q, k, v
+
+    def forward(
+            self,
+            x: torch.Tensor,
+            cu_seqlens: torch.Tensor,
+            rotary_pos_emb: torch.Tensor,
+            max_seqlen: Optional[int] = None,  # Only used for Flash Attention
+            seqlens: Optional[list[int]] = None,  # Only used for xFormers
+    ) -> torch.Tensor:
+        # [s, b, c] --> [s, b, head * 3 * head_dim]
+        x, _ = self.qkv(x)
+
+        # [s, b, 3 * head * head_dim] -> 3 * [s, b, head, head_dim]
+        q, k, v = self.split_qkv(x)
+        batch_size = q.shape[1]
+
+        q, k, v = (rearrange(x, "s b ... -> b s ...").contiguous()
+                   for x in (q, k, v))
+        if rotary_pos_emb is not None:
+            # [2 * b, s, heads, head_dim]
+            qk_concat = torch.cat([q, k], dim=0)
+            qk_rotated = apply_rotary_pos_emb_vision(qk_concat, rotary_pos_emb)
+            q, k = torch.chunk(qk_rotated, 2, dim=0)
+
+        if self.is_flash_attn_backend:
+            if self.attn_backend == _Backend.ROCM_AITER_FA:
+                from aiter import flash_attn_varlen_func
+            else:
+                if self.use_upstream_fa:
+                    from flash_attn import flash_attn_varlen_func
+                else:
+                    from vllm.vllm_flash_attn import flash_attn_varlen_func
+
+            q, k, v = (rearrange(x, "b s ... -> (b s) ...") for x in [q, k, v])
+
+            output = flash_attn_varlen_func(q,
+                                            k,
+                                            v,
+                                            cu_seqlens_q=cu_seqlens,
+                                            cu_seqlens_k=cu_seqlens,
+                                            max_seqlen_q=max_seqlen,
+                                            max_seqlen_k=max_seqlen,
+                                            dropout_p=0.0,
+                                            causal=False)
+
+            context_layer = rearrange(output,
+                                      "(b s) h d -> s b (h d)",
+                                      b=batch_size).contiguous()
+        elif self.attn_backend == _Backend.TORCH_SDPA:
+            # Execute attention entry by entry for speed & less VRAM.
+            outputs = []
+            for i in range(1, len(cu_seqlens)):
+                start_idx = cu_seqlens[i - 1]
+                end_idx = cu_seqlens[i]
+                q_i = q[:, start_idx:end_idx]
+                k_i = k[:, start_idx:end_idx]
+                v_i = v[:, start_idx:end_idx]
+                q_i, k_i, v_i = (rearrange(x, "b s h d -> b h s d")
+                                 for x in [q_i, k_i, v_i])
+                output_i = F.scaled_dot_product_attention(q_i,
+                                                          k_i,
+                                                          v_i,
+                                                          dropout_p=0.0)
+                output_i = rearrange(output_i, "b h s d -> b s h d ")
+                outputs.append(output_i)
+            context_layer = torch.cat(outputs, dim=1)
+            context_layer = rearrange(context_layer,
+                                      "b s h d -> s b (h d)").contiguous()
+        elif self.attn_backend == _Backend.XFORMERS:
+            from xformers import ops as xops
+            from xformers.ops.fmha.attn_bias import BlockDiagonalMask
+
+            attn_bias = BlockDiagonalMask.from_seqlens(q_seqlen=seqlens,
+                                                       kv_seqlen=None,
+                                                       device=q.device)
+
+            context_layer = xops.memory_efficient_attention_forward(
+                q, k, v, attn_bias=attn_bias, p=0, scale=None)
+            context_layer = rearrange(context_layer,
+                                      "b s h d -> s b (h d)").contiguous()
+
+        output, _ = self.proj(context_layer)
+        return output
+
+
+class Qwen2_5_VisionBlock(nn.Module):
+
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        mlp_hidden_dim: int,
+        act_fn: Callable[[torch.Tensor], torch.Tensor] = F.silu,
+        norm_layer: Optional[Callable[[int], nn.Module]] = None,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+        use_data_parallel: bool = False,
+        attn_backend: _Backend = _Backend.TORCH_SDPA,
+        use_upstream_fa: bool = False,
+    ) -> None:
+        super().__init__()
+        if norm_layer is None:
+            norm_layer = partial(nn.LayerNorm, eps=1e-6)
+        self.norm1 = norm_layer(dim)
+        self.norm2 = norm_layer(dim)
+        self.attn = Qwen2_5_VisionAttention(
+            embed_dim=dim,
+            num_heads=num_heads,
+            projection_size=dim,
+            quant_config=quant_config,
+            prefix=f"{prefix}.attn",
+            use_data_parallel=use_data_parallel,
+            attn_backend=attn_backend,
+            use_upstream_fa=use_upstream_fa)
+        self.mlp = Qwen2_5_VisionMLP(dim,
+                                     mlp_hidden_dim,
+                                     act_fn=act_fn,
+                                     bias=True,
+                                     quant_config=quant_config,
+                                     prefix=f"{prefix}.mlp",
+                                     use_data_parallel=use_data_parallel)
+
+    def forward(
+            self,
+            x: torch.Tensor,
+            cu_seqlens: torch.Tensor,
+            rotary_pos_emb: torch.Tensor,
+            max_seqlen: Optional[int] = None,  # Only used for Flash Attention
+            seqlens: Optional[list[int]] = None,  # Only used for xFormers
+    ) -> torch.Tensor:
+        x_attn = self.attn(self.norm1(x),
+                           cu_seqlens=cu_seqlens,
+                           rotary_pos_emb=rotary_pos_emb,
+                           max_seqlen=max_seqlen,
+                           seqlens=seqlens)
+        x_fused_norm, residual = self.norm2(x, residual=x_attn)
+        x = residual + self.mlp(x_fused_norm)
+        return x
+
+
+class Qwen2_5_VisionPatchEmbed(nn.Module):
+
+    def __init__(
+        self,
+        patch_size: int = 14,
+        temporal_patch_size: int = 2,
+        in_channels: int = 3,
+        hidden_size: int = 1152,
+    ) -> None:
+        super().__init__()
+        self.patch_size = patch_size
+        self.temporal_patch_size = temporal_patch_size
+        self.hidden_size = hidden_size
+
+        kernel_size = (temporal_patch_size, patch_size, patch_size)
+        self.proj = nn.Conv3d(in_channels,
+                              hidden_size,
+                              kernel_size=kernel_size,
+                              stride=kernel_size,
+                              bias=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        L, C = x.shape
+        x = x.view(L, -1, self.temporal_patch_size, self.patch_size,
+                   self.patch_size)
+        x = self.proj(x).view(L, self.hidden_size)
+        return x
+
+
+class Qwen2_5_VisionPatchMerger(nn.Module):
+
+    def __init__(
+        self,
+        d_model: int,
+        context_dim: int,
+        norm_layer: Optional[Callable[[int], nn.Module]] = None,
+        spatial_merge_size: int = 2,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+        use_data_parallel: bool = False,
+    ) -> None:
+        super().__init__()
+        self.hidden_size = context_dim * (spatial_merge_size**2)
+        if norm_layer is None:
+            norm_layer = partial(nn.LayerNorm, eps=1e-6)
+        self.ln_q = norm_layer(context_dim)
+
+        self.mlp = nn.Sequential(
+            ColumnParallelLinear(
+                self.hidden_size,
+                self.hidden_size,
+                bias=True,
+                quant_config=quant_config,
+                prefix=f"{prefix}.mlp.0",
+                return_bias=False,
+                disable_tp=use_data_parallel,
+            ),
+            nn.GELU(),
+            RowParallelLinear(
+                self.hidden_size,
+                d_model,
+                bias=True,
+                quant_config=quant_config,
+                prefix=f"{prefix}.mlp.2",
+                return_bias=False,
+                disable_tp=use_data_parallel,
+            ),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.ln_q(x)
+        x = x.view(-1, self.hidden_size)
+        out = self.mlp(x)
+        return out
+
+
+class Qwen2_5_VisionRotaryEmbedding(nn.Module):
+
+    def __init__(self, dim: int, theta: float = 10000.0) -> None:
+        super().__init__()
+        self.dim = dim
+        self.theta = theta
+        inv_freq = 1.0 / (theta**(
+            torch.arange(0, dim, 2, dtype=torch.float, device='cpu') / dim))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._freqs_cached = None
+
+    def update_freqs_cache(self, seqlen: int) -> None:
+        if seqlen > self._seq_len_cached:
+            seqlen *= 2
+            self._seq_len_cached = seqlen
+            self.inv_freq = 1.0 / (self.theta**(torch.arange(
+                0, self.dim, 2, dtype=torch.float, device=self.inv_freq.device)
+                                                / self.dim))
+            seq = torch.arange(seqlen,
+                               device=self.inv_freq.device,
+                               dtype=self.inv_freq.dtype)
+            freqs = torch.outer(seq, self.inv_freq)
+            self._freqs_cached = freqs
+
+    def forward(self, seqlen: int) -> torch.Tensor:
+        self.update_freqs_cache(seqlen)
+        return self._freqs_cached[:seqlen]
+
+
+class Qwen2_5_VisionTransformer(nn.Module):
+
+    def __init__(
+        self,
+        vision_config: Qwen2_5_VLVisionConfig,
+        norm_eps: float = 1e-6,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+        use_data_parallel: bool = False,
+    ) -> None:
+        super().__init__()
+
+        patch_size = vision_config.patch_size
+        temporal_patch_size = vision_config.temporal_patch_size
+        in_channels = vision_config.in_channels
+        depth = vision_config.depth
+        self.hidden_size = vision_config.hidden_size
+        self.num_heads = vision_config.num_heads
+        self.use_data_parallel = use_data_parallel
+        self.out_hidden_size = vision_config.out_hidden_size
+
+        # args for get_window_index_thw
+        self.window_size = vision_config.window_size
+        self.patch_size = vision_config.patch_size
+        self.spatial_merge_size = vision_config.spatial_merge_size
+        self.fullatt_block_indexes = vision_config.fullatt_block_indexes
+        self.spatial_merge_unit = self.spatial_merge_size**2
+
+        self.patch_embed = Qwen2_5_VisionPatchEmbed(
+            patch_size=patch_size,
+            temporal_patch_size=temporal_patch_size,
+            in_channels=in_channels,
+            hidden_size=self.hidden_size,
+        )
+
+        norm_layer = partial(RMSNorm, eps=norm_eps)
+        head_dim = self.hidden_size // self.num_heads
+        self.rotary_pos_emb = Qwen2_5_VisionRotaryEmbedding(head_dim // 2)
+
+        use_upstream_fa = False
+        self.attn_backend = get_vit_attn_backend(
+            head_size=head_dim, dtype=torch.get_default_dtype())
+        if self.attn_backend != _Backend.FLASH_ATTN and \
+            check_upstream_fa_availability(
+                torch.get_default_dtype()):
+            self.attn_backend = _Backend.FLASH_ATTN
+            use_upstream_fa = True
+
+        if self.attn_backend not in {
+                _Backend.FLASH_ATTN, _Backend.TORCH_SDPA, _Backend.XFORMERS,
+                _Backend.ROCM_AITER_FA
+        }:
+            raise RuntimeError(
+                f"Qwen2.5-VL does not support {self.attn_backend} backend now."
+            )
+
+        self.blocks = nn.ModuleList([
+            Qwen2_5_VisionBlock(
+                dim=self.hidden_size,
+                num_heads=self.num_heads,
+                mlp_hidden_dim=vision_config.intermediate_size,
+                act_fn=get_act_and_mul_fn(vision_config.hidden_act),
+                norm_layer=norm_layer,
+                quant_config=quant_config,
+                prefix=f"{prefix}.blocks.{layer_idx}",
+                use_data_parallel=use_data_parallel,
+                attn_backend=self.attn_backend,
+                use_upstream_fa=use_upstream_fa) for layer_idx in range(depth)
+        ])
+        self.merger = Qwen2_5_VisionPatchMerger(
+            d_model=vision_config.out_hidden_size,
+            context_dim=self.hidden_size,
+            norm_layer=norm_layer,
+            spatial_merge_size=self.spatial_merge_size,
+            quant_config=quant_config,
+            prefix=f"{prefix}.merger",
+            use_data_parallel=use_data_parallel,
+        )
+
+    @property
+    def dtype(self) -> torch.dtype:
+        return self.patch_embed.proj.weight.dtype
+
+    @property
+    def device(self) -> torch.device:
+        return self.patch_embed.proj.weight.device
+
+    def rotary_pos_emb_thw(self, t, h, w):
+        hpos_ids = torch.arange(h).unsqueeze(1).expand(-1, w)
+        wpos_ids = torch.arange(w).unsqueeze(0).expand(h, -1)
+        hpos_ids = hpos_ids.reshape(
+            h // self.spatial_merge_size,
+            self.spatial_merge_size,
+            w // self.spatial_merge_size,
+            self.spatial_merge_size,
+        ).permute(0, 2, 1, 3).flatten()
+        wpos_ids = wpos_ids.reshape(
+            h // self.spatial_merge_size,
+            self.spatial_merge_size,
+            w // self.spatial_merge_size,
+            self.spatial_merge_size,
+        ).permute(0, 2, 1, 3).flatten()
+        pos_ids = torch.stack([hpos_ids, wpos_ids], dim=-1).repeat(t, 1)
+        max_size = max(h, w)
+        rotary_pos_emb_full = self.rotary_pos_emb(max_size)
+        rotary_pos_emb = rotary_pos_emb_full[pos_ids].flatten(1)
+        rotary_pos_emb = rotary_pos_emb.reshape(
+            rotary_pos_emb.shape[0] // self.spatial_merge_unit,
+            self.spatial_merge_unit, -1)
+
+        return rotary_pos_emb
+
+    def get_window_index_thw(self, grid_t, grid_h, grid_w):
+        vit_merger_window_size = (self.window_size //
+                                  self.spatial_merge_size // self.patch_size)
+
+        llm_grid_h = grid_h // self.spatial_merge_size
+        llm_grid_w = grid_w // self.spatial_merge_size
+        index = torch.arange(grid_t * llm_grid_h * llm_grid_w).reshape(
+            grid_t, llm_grid_h, llm_grid_w)
+        pad_h = vit_merger_window_size - llm_grid_h % vit_merger_window_size
+        pad_w = vit_merger_window_size - llm_grid_w % vit_merger_window_size
+        num_windows_h = (llm_grid_h + pad_h) // vit_merger_window_size
+        num_windows_w = (llm_grid_w + pad_w) // vit_merger_window_size
+        index_padded = F.pad(index, (0, pad_w, 0, pad_h), 'constant', -100)
+        index_padded = index_padded.reshape(grid_t, num_windows_h,
+                                            vit_merger_window_size,
+                                            num_windows_w,
+                                            vit_merger_window_size)
+        index_padded = index_padded.permute(0, 1, 3, 2, 4).reshape(
+            grid_t, num_windows_h * num_windows_w, vit_merger_window_size,
+            vit_merger_window_size)
+        seqlens = (index_padded != -100).sum([2, 3]).reshape(-1)
+        index_padded = index_padded.reshape(-1)
+        index_new = index_padded[index_padded != -100]
+        cu_seqlens_tmp = seqlens.cumsum(0) * self.spatial_merge_unit
+        cu_seqlens_tmp = cu_seqlens_tmp.to(dtype=torch.int32)
+        cu_seqlens_tmp = torch.unique_consecutive(cu_seqlens_tmp)
+
+        return index_new, cu_seqlens_tmp
+
+    @lru_cache(maxsize=1024)  # noqa: B019
+    def get_rope_by_thw(self, t, h, w):
+        window_index_thw, cu_seqlens_window_thw = self.get_window_index_thw(
+            t, h, w)
+        rotary_pos_emb_thw = self.rotary_pos_emb_thw(t, h, w)
+        rotary_pos_emb_thw = rotary_pos_emb_thw[window_index_thw, :, :]
+        rotary_pos_emb_thw = rotary_pos_emb_thw.flatten(start_dim=0, end_dim=1)
+        cu_seqlens_thw = torch.repeat_interleave(
+            torch.tensor([h * w], dtype=torch.int32), t)
+        return (rotary_pos_emb_thw, window_index_thw, cu_seqlens_window_thw,
+                cu_seqlens_thw)
+
+    def compute_attn_mask_seqlen(
+        self,
+        cu_seqlens: torch.Tensor,
+    ) -> tuple[Optional[int], Optional[list[int]]]:
+        max_seqlen, seqlens = None, None
+        if (self.attn_backend == _Backend.FLASH_ATTN
+                or self.attn_backend == _Backend.ROCM_AITER_FA):
+            max_seqlen = (cu_seqlens[1:] - cu_seqlens[:-1]).max().item()
+        elif self.attn_backend == _Backend.XFORMERS:
+            seqlens = (cu_seqlens[1:] - cu_seqlens[:-1]).tolist()
+        return max_seqlen, seqlens
+
+    @staticmethod
+    def invert_permutation(perm: torch.Tensor) -> torch.Tensor:
+        # building the inverse permutation in O(n) time
+        inv = torch.empty_like(perm, pin_memory=is_pin_memory_available())
+        inv[perm] = torch.arange(perm.numel(),
+                                 device=perm.device,
+                                 dtype=perm.dtype)
+        return inv
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        grid_thw: list[list[int]],
+    ) -> torch.Tensor:
+        # patchify
+        seq_len, _ = x.size()
+        rotary_pos_emb = []
+        window_index: list = []
+        cu_window_seqlens: list = [torch.tensor([0], dtype=torch.int32)]
+        cu_seqlens: list = []
+
+        hidden_states = x.to(device=self.device, dtype=self.dtype)
+        hidden_states = self.patch_embed(hidden_states)
+
+        window_index_id = 0
+        cu_window_seqlens_last = 0
+        for t, h, w in grid_thw:
+            t, h, w = int(t), int(h), int(w)
+            llm_h = h // self.spatial_merge_size
+            llm_w = w // self.spatial_merge_size
+
+            (
+                rotary_pos_emb_thw,
+                window_index_thw,
+                cu_seqlens_window_thw,
+                cu_seqlens_thw,
+            ) = self.get_rope_by_thw(t, h, w)
+
+            window_index.append(window_index_thw + window_index_id)
+            window_index_id += (t * llm_h * llm_w)
+
+            cu_seqlens_window_thw = (cu_seqlens_window_thw +
+                                     cu_window_seqlens_last)
+            cu_window_seqlens_last = cu_seqlens_window_thw[-1]
+            cu_window_seqlens.append(cu_seqlens_window_thw)
+
+            rotary_pos_emb.append(rotary_pos_emb_thw)
+
+            cu_seqlens.append(cu_seqlens_thw)
+
+        rotary_pos_emb = torch.cat(rotary_pos_emb)
+        window_index = torch.cat(window_index)
+        # compute reverse indices
+        reverse_indices = self.invert_permutation(window_index)
+        cu_window_seqlens = torch.cat(cu_window_seqlens)
+        cu_window_seqlens = torch.unique_consecutive(cu_window_seqlens)
+        cu_seqlens = torch.cat(cu_seqlens)
+        cu_seqlens = torch.cumsum(cu_seqlens, dim=0, dtype=torch.int32)
+        cu_seqlens = F.pad(cu_seqlens, (1, 0), "constant", 0)
+
+        # transformers
+        # pre-compute seqlens for window/full attn to reduce cuMemcpy operations
+        max_seqlen_full, seqlens_full = self.compute_attn_mask_seqlen(
+            cu_seqlens)
+        max_seqlen_window, seqlens_window = self.compute_attn_mask_seqlen(
+            cu_window_seqlens)
+
+        cu_seqlens = cu_seqlens.to(device=self.device, non_blocking=True)
+        cu_window_seqlens = cu_window_seqlens.to(device=self.device,
+                                                 non_blocking=True)
+        rotary_pos_emb = rotary_pos_emb.to(device=self.device,
+                                           non_blocking=True)
+        window_index = window_index.to(device=hidden_states.device,
+                                       non_blocking=True)
+        reverse_indices = reverse_indices.to(device=hidden_states.device,
+                                             non_blocking=True)
+
+        hidden_states = hidden_states.reshape(
+            seq_len // self.spatial_merge_unit, self.spatial_merge_unit, -1)
+        hidden_states = hidden_states[window_index, :, :]
+        hidden_states = hidden_states.reshape(seq_len, -1)
+
+        hidden_states = hidden_states.unsqueeze(1)
+
+        for layer_num, blk in enumerate(self.blocks):
+            if layer_num in self.fullatt_block_indexes:
+                cu_seqlens_now = cu_seqlens
+                max_seqlen_now = max_seqlen_full
+                seqlens_now = seqlens_full
+            else:
+                cu_seqlens_now = cu_window_seqlens
+                max_seqlen_now = max_seqlen_window
+                seqlens_now = seqlens_window
+
+            hidden_states = blk(
+                hidden_states,
+                cu_seqlens=cu_seqlens_now,
+                rotary_pos_emb=rotary_pos_emb,
+                max_seqlen=max_seqlen_now,
+                seqlens=seqlens_now,
+            )
+
+        # For Qwen2.5-VL-3B, float16 will overflow at last block
+        # for long visual tokens sequences.
+        if hidden_states.dtype == torch.float16:
+            hidden_states = cast_overflow_tensors(hidden_states)
+
+        # adapter
+        hidden_states = self.merger(hidden_states)
+        hidden_states = hidden_states[reverse_indices, :]
+        return hidden_states
+
+    def load_weights(self, weights: Iterable[tuple[str,
+                                                   torch.Tensor]]) -> set[str]:
+        stacked_params_mapping = [
+            # (param_name, shard_name, shard_id)
+            ("attn.qkv.", "attn.q.", "q"),
+            ("attn.qkv.", "attn.k.", "k"),
+            ("attn.qkv.", "attn.v.", "v"),
+            ("mlp.gate_up_proj.", "mlp.gate_proj.", 0),
+            ("mlp.gate_up_proj.", "mlp.up_proj.", 1),
+        ]
+        params_dict = dict(self.named_parameters(remove_duplicate=False))
+        loaded_params: set[str] = set()
+
+        for name, loaded_weight in weights:
+            for (param_name, weight_name, shard_id) in stacked_params_mapping:
+                if weight_name not in name:
+                    continue
+                name = name.replace(weight_name, param_name)
+                param = params_dict[name]
+                weight_loader = param.weight_loader
+                weight_loader(param, loaded_weight, shard_id)
+                break
+            else:
+                param = params_dict[name]
+                weight_loader = getattr(param, "weight_loader",
+                                        default_weight_loader)
+                weight_loader(param, loaded_weight)
+            loaded_params.add(name)
+        return loaded_params
+
+
+class Qwen2_5_VLProcessingInfo(Qwen2VLProcessingInfo):
+
+    def get_hf_config(self):
+        return self.ctx.get_hf_config(Qwen2_5_VLConfig)
+
+    def get_hf_processor(self, **kwargs: object) -> Qwen2_5_VLProcessor:
+        return self.ctx.get_hf_processor(
+            Qwen2_5_VLProcessor,
+            use_fast=kwargs.pop("use_fast", True),
+            **kwargs,
+        )
+
+
+class Qwen2_5_VLMultiModalProcessor(Qwen2VLMultiModalProcessor):
+
+    def _get_mm_fields_config(
+        self,
+        hf_inputs: BatchFeature,
+        hf_processor_mm_kwargs: Mapping[str, object],
+    ) -> Mapping[str, MultiModalFieldConfig]:
+        return dict(
+            **super()._get_mm_fields_config(hf_inputs, hf_processor_mm_kwargs),
+            second_per_grid_ts=MultiModalFieldConfig.batched("video"),
+        )
+
+    def _get_prompt_updates(
+        self,
+        mm_items: MultiModalDataItems,
+        hf_processor_mm_kwargs: Mapping[str, Any],
+        out_mm_kwargs: MultiModalKwargs,
+    ) -> Sequence[PromptUpdate]:
+        hf_processor = self.info.get_hf_processor(**hf_processor_mm_kwargs)
+        image_processor = self.info.get_image_processor(
+            **hf_processor_mm_kwargs)
+        tokenizer = self.info.get_tokenizer()
+        vocab = tokenizer.get_vocab()
+
+        placeholder = {
+            "image": vocab[hf_processor.image_token],
+            "video": vocab[hf_processor.video_token],
+        }
+
+        merge_length = image_processor.merge_size**2
+
+        def get_replacement_qwen2vl(item_idx: int, modality: str):
+            out_item = out_mm_kwargs[modality][item_idx]
+            grid_thw = out_item[f"{modality}_grid_thw"].data
+            assert isinstance(grid_thw, torch.Tensor)
+
+            num_tokens = int(grid_thw.prod()) // merge_length
+
+            # EVS-specific code
+            video_pruning_rate = self.info.ctx.get_mm_config(
+            ).video_pruning_rate
+            if (modality == "video" and video_pruning_rate is not None
+                    and video_pruning_rate > 0.0):
+                num_tokens = compute_retained_tokens_count(
+                    grid_thw,
+                    image_processor.merge_size,
+                    video_pruning_rate,
+                )
+            # End of EVS-specific code
+
+            return [placeholder[modality]] * num_tokens
+
+        return [
+            PromptReplacement(
+                modality=modality,
+                target=[placeholder[modality]],
+                replacement=partial(get_replacement_qwen2vl,
+                                    modality=modality),
+            ) for modality in ("image", "video")
+        ]
+
+
+@MULTIMODAL_REGISTRY.register_processor(
+    Qwen2_5_VLMultiModalProcessor,
+    info=Qwen2_5_VLProcessingInfo,
+    dummy_inputs=Qwen2_5_VLDummyInputsBuilder)
+class Qwen2_5_VLForConditionalGeneration(nn.Module, SupportsMultiModal,
+                                         SupportsLoRA, SupportsPP,
+                                         SupportsQuant,
+                                         SupportsMultiModalPruning):
+
+    packed_modules_mapping = {
+        "qkv_proj": ["q_proj", "k_proj", "v_proj"],
+        "gate_up_proj": ["gate_proj", "up_proj"],
+    }
+
+    # To ensure correct weight loading and mapping.
+    hf_to_vllm_mapper = WeightsMapper(
+        orig_to_new_prefix={
+            # mapping for new names in checkpoint saved after transformers v4.52
+            "model.language_model.": "language_model.model.",
+            "model.visual.": "visual.",
+            # mapping for original checkpoint
+            "lm_head.": "language_model.lm_head.",
+            "model.": "language_model.model.",
+        })
+
+    supports_encoder_tp_data = True
+
+    @classmethod
+    def get_placeholder_str(cls, modality: str, i: int) -> Optional[str]:
+        if modality.startswith("image"):
+            return "<|vision_start|><|image_pad|><|vision_end|>"
+        if modality.startswith("video"):
+            return "<|vision_start|><|video_pad|><|vision_end|>"
+
+        raise ValueError("Only image or video modality is supported")
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+        super().__init__()
+        config: Qwen2_5_VLConfig = vllm_config.model_config.hf_config
+        multimodal_config = vllm_config.model_config.multimodal_config
+
+        self.use_data_parallel = multimodal_config.mm_encoder_tp_mode == "data"
+        self.config = config
+        self.multimodal_config = multimodal_config
+        self.video_pruning_rate = multimodal_config.video_pruning_rate
+        self.is_multimodal_pruning_enabled = (
+            multimodal_config.is_multimodal_pruning_enabled())
+
+        if multimodal_config.get_limit_per_prompt("image") or \
+            multimodal_config.get_limit_per_prompt("video"):
+            self.visual = Qwen2_5_VisionTransformer(
+                config.vision_config,
+                norm_eps=getattr(config, "rms_norm_eps", 1e-6),
+                quant_config=self.quant_config,
+                prefix=maybe_prefix(prefix, "visual"),
+                use_data_parallel=self.use_data_parallel,
+            )
+        else:
+            self.visual = None
+
+        # self.language_model = init_vllm_registered_model(
+        #     vllm_config=vllm_config,
+        #     prefix=maybe_prefix(prefix, "language_model"),
+        #     architectures=["Qwen2ForCausalLM"],
+        # )
+        self.language_model = init_vllm_registered_model(
+            vllm_config=vllm_config,
+            prefix=maybe_prefix(prefix, "language_model"),
+            architectures=["Qwen3ForCausalLM"],
+        )
+        self.make_empty_intermediate_tensors = (
+            self.language_model.make_empty_intermediate_tensors)
+
+    def _validate_and_reshape_mm_tensor(self, mm_input: object,
+                                        name: str) -> torch.Tensor:
+        if not isinstance(mm_input, (torch.Tensor, list)):
+            raise ValueError(f"Incorrect type of {name}. "
+                             f"Got type: {type(mm_input)}")
+        if isinstance(mm_input, torch.Tensor):
+            if mm_input.ndim == 2:
+                return mm_input
+            if mm_input.ndim != 3:
+                raise ValueError(f"{name} should be 2D or batched 3D tensor. "
+                                 f"Got ndim: {mm_input.ndim} "
+                                 f"(shape={mm_input.shape})")
+            return mm_input.reshape(-1, mm_input.shape[-1])
+        else:
+            return torch.concat(mm_input)
+
+    def _parse_and_validate_image_input(
+            self, **kwargs: object) -> Optional[Qwen2_5_VLImageInputs]:
+        pixel_values = kwargs.pop("pixel_values", None)
+        image_embeds = kwargs.pop("image_embeds", None)
+        image_grid_thw = kwargs.pop("image_grid_thw", None)
+
+        if pixel_values is None and image_embeds is None:
+            return None
+
+        if pixel_values is not None:
+            pixel_values = self._validate_and_reshape_mm_tensor(
+                pixel_values, "image pixel values")
+            image_grid_thw = self._validate_and_reshape_mm_tensor(
+                image_grid_thw, "image grid_thw")
+
+            return Qwen2_5_VLImagePixelInputs(type="pixel_values",
+                                              pixel_values=pixel_values,
+                                              image_grid_thw=image_grid_thw)
+
+        if image_embeds is not None:
+            image_embeds = self._validate_and_reshape_mm_tensor(
+                image_embeds, "image embeds")
+            image_grid_thw = self._validate_and_reshape_mm_tensor(
+                image_grid_thw, "image grid_thw")
+
+            return Qwen2_5_VLImageEmbeddingInputs(
+                type="image_embeds",
+                image_embeds=image_embeds,
+                image_grid_thw=image_grid_thw)
+
+    def _parse_and_validate_video_input(
+            self, **kwargs: object) -> Optional[Qwen2_5_VLVideoInputs]:
+        pixel_values_videos = kwargs.pop("pixel_values_videos", None)
+        video_embeds = kwargs.pop("video_embeds", None)
+        video_grid_thw = kwargs.pop("video_grid_thw", None)
+        second_per_grid_ts = kwargs.pop("second_per_grid_ts", None)
+
+        if pixel_values_videos is None and video_embeds is None:
+            return None
+
+        if pixel_values_videos is not None:
+            pixel_values_videos = self._validate_and_reshape_mm_tensor(
+                pixel_values_videos, "video pixel values")
+            video_grid_thw = self._validate_and_reshape_mm_tensor(
+                video_grid_thw, "video grid_thw")
+            if second_per_grid_ts is not None and second_per_grid_ts.ndim == 2:
+                second_per_grid_ts = second_per_grid_ts.squeeze(-1)
+            return Qwen2_5_VLVideoPixelInputs(
+                type="pixel_values_videos",
+                pixel_values_videos=pixel_values_videos,
+                video_grid_thw=video_grid_thw,
+                second_per_grid_ts=second_per_grid_ts,
+            )
+
+        if video_embeds is not None:
+            video_embeds = self._validate_and_reshape_mm_tensor(
+                video_embeds, "video embeds")
+            video_grid_thw = self._validate_and_reshape_mm_tensor(
+                video_grid_thw, "video grid_thw")
+
+            return Qwen2_5_VLVideoEmbeddingInputs(
+                type="video_embeds",
+                video_embeds=video_embeds,
+                video_grid_thw=video_grid_thw)
+
+    def _process_image_input(
+            self,
+            image_input: Qwen2_5_VLImageInputs) -> tuple[torch.Tensor, ...]:
+
+        grid_thw = image_input["image_grid_thw"]
+        assert grid_thw.ndim == 2
+        grid_thw_list = grid_thw.tolist()
+
+        if image_input["type"] == "image_embeds":
+            image_embeds = image_input["image_embeds"].type(self.visual.dtype)
+        else:
+            pixel_values = image_input["pixel_values"]
+
+            if self.use_data_parallel:
+                return run_dp_sharded_mrope_vision_model(self.visual,
+                                                         pixel_values,
+                                                         grid_thw_list,
+                                                         rope_type="rope_3d")
+            else:
+                image_embeds = self.visual(pixel_values,
+                                           grid_thw=grid_thw_list)
+
+        # Split concatenated embeddings for each image item.
+        # Using prod on grid_thw_list instead of grid_thw.prod avoids CUDA sync
+        merge_size = self.visual.spatial_merge_size
+        sizes = (torch.tensor(grid_thw_list, dtype=torch.long).prod(-1) //
+                 (merge_size * merge_size)).tolist()
+
+        return image_embeds.split(sizes)
+
+    def _postprocess_image_embeds_evs(
+            self, image_embeds_split: tuple[torch.Tensor, ...],
+            image_input: Qwen2_5_VLImageInputs) -> tuple[torch.Tensor, ...]:
+        """
+        Append mrope positions for each for images.
+        This is necessary to recover correct mrope
+        positions after video pruning
+
+        Args:
+            image_embeds_split: Tuple of image embeddings for
+                each image item.
+            image_input: Image input data.
+
+        Returns:
+            Tuple of image embeddings for each image item.
+            Resulting embeddings will have extra 4 channels for
+            computed mrope positions.
+        """
+        merge_size = self.visual.spatial_merge_size
+        grid_thw = image_input["image_grid_thw"]
+        grid_thw_list = grid_thw.tolist()
+        image_embeds_out = []
+        for emb, size in zip(image_embeds_split, grid_thw_list):
+            positions = compute_mrope_for_media(size,
+                                                merge_size).to(emb.device)
+            emb = torch.cat([emb, positions], dim=1)
+            image_embeds_out.append(emb)
+        image_embeds_split = image_embeds_out
+        return tuple(image_embeds_split)
+
+    def _process_video_input(
+            self,
+            video_input: Qwen2_5_VLVideoInputs) -> tuple[torch.Tensor, ...]:
+
+        grid_thw = video_input["video_grid_thw"]
+        assert grid_thw.ndim == 2
+        grid_thw_list = grid_thw.tolist()
+
+        if video_input["type"] == "video_embeds":
+            video_embeds = video_input["video_embeds"].type(self.visual.dtype)
+        else:
+            pixel_values_videos = video_input["pixel_values_videos"]
+            if self.use_data_parallel:
+                return run_dp_sharded_mrope_vision_model(self.visual,
+                                                         pixel_values_videos,
+                                                         grid_thw_list,
+                                                         rope_type="rope_3d")
+            else:
+                video_embeds = self.visual(pixel_values_videos,
+                                           grid_thw=grid_thw_list)
+
+        # Split concatenated embeddings for each video item.
+        merge_size = self.visual.spatial_merge_size
+        # Using prod on grid_thw_list instead of grid_thw.prod avoids CUDA sync
+        sizes = (torch.tensor(grid_thw_list, dtype=torch.long).prod(-1) //
+                 (merge_size * merge_size)).tolist()
+
+        return video_embeds.split(sizes)
+
+    def _postprocess_video_embeds_evs(
+            self, video_embeds_split: tuple[torch.Tensor, ...],
+            video_input: Qwen2_5_VLVideoInputs) -> tuple[torch.Tensor, ...]:
+        """
+        Prunes video embeddings via Efficient Video Sampling (EVS)
+        and then appends mrope positions for each retained embeddings
+
+        Args:
+            video_embeds_split: Tuple of video embeddings for each video item.
+            video_input: Video input data.
+
+        Returns:
+            Tuple of video embeddings for each video item.
+            Resulting embeddings will have extra 4 channels for
+            computed mrope positions.
+        """
+        grid_thw = video_input["video_grid_thw"]
+        assert grid_thw.ndim == 2
+        grid_thw_list = grid_thw.tolist()
+        merge_size = self.visual.spatial_merge_size
+
+        # Cast to long to match the original code
+        # https://github.com/huggingface/transformers/blob/41980ce93e775f6c88500c51c8db7946fc6a2add/src/transformers/models/qwen2_5_vl/modular_qwen2_5_vl.py#L491 # noqa
+        second_per_grid_ts = video_input["second_per_grid_ts"].long()
+        tokens_per_second = self.config.vision_config.tokens_per_second
+
+        video_embeds_out = []
+        for emb, size, video_second_per_grid_t in zip(video_embeds_split,
+                                                      grid_thw_list,
+                                                      second_per_grid_ts):
+            # For each video, we compute retention mask using EVS
+            retention_mask = compute_retention_mask(
+                emb,
+                size,
+                spatial_merge_size=self.visual.spatial_merge_size,
+                q=self.video_pruning_rate,
+            )
+            positions = compute_mrope_for_media(
+                size,
+                merge_size,
+                tokens_per_second=tokens_per_second,
+                video_second_per_grid=video_second_per_grid_t.item(),
+            ).to(emb.device)
+
+            emb = emb[retention_mask]
+            positions = positions[retention_mask]
+            emb = torch.cat([emb, positions], dim=1)
+            video_embeds_out.append(emb)
+        return tuple(video_embeds_out)
+
+    def recompute_mrope_positions(
+        self,
+        input_ids: list[int],
+        multimodal_embeddings: tuple[torch.Tensor, ...],
+        mrope_positions: torch.LongTensor,
+        num_computed_tokens: int,
+    ) -> tuple[tuple[torch.Tensor, ...], torch.Tensor, int]:
+        """
+        Update part of input mrope positions (starting with
+        num_computed_tokens index). Original mrope_positions are computed
+        for unpruned sequence and becomes incorrect once pruning occurs,
+        so once we prune media tokens we should reflect this in the
+        mrope_positions before we feed it to LLM.
+
+        Args:
+            input_ids: (N,) All input tokens of the prompt (Containing
+                entire sequence).
+            multimodal_embeddings: Tuple of multimodal embeddings.
+            mrope_positions: Existing mrope positions (3, N) for entire
+                sequence
+            num_computed_tokens: A number of computed tokens so far.
+
+        Returns:
+            Tuple of (multimodal_embeddings, mrope_positions,
+                mrope_position_delta).
+        """
+        image_token_id = self.config.image_token_id
+        video_token_id = self.config.video_token_id
+        vision_start_token_id = self.config.vision_start_token_id
+
+        # Device
+        device = (multimodal_embeddings[0].device
+                  if len(multimodal_embeddings) else mrope_positions.device)
+
+        # Tensors
+        input_ids_t = torch.as_tensor(input_ids,
+                                      device=device,
+                                      dtype=torch.long)
+
+        # fmt: off
+        mm_embeddings_out = [mm[:, :-4] for mm in
+                             multimodal_embeddings]
+        mm_embeddings_pos = [mm[:, -4:].permute(1, 0).long() for mm in
+                             multimodal_embeddings]
+        # fmt: in
+
+        positions, mrope_positions_delta = recompute_mrope_positions(
+            input_ids_t,
+            mm_embeddings_pos,
+            mrope_positions,
+            num_computed_tokens,
+            vision_start_token_id,
+            image_token_id,
+            video_token_id,
+        )
+
+        return tuple(mm_embeddings_out), positions, mrope_positions_delta
+
+    def _parse_and_validate_multimodal_inputs(self, **kwargs: object) -> dict:
+        mm_input_by_modality = {}
+
+        # Preserve the order of modalities if there are multiple of them
+        # from the order of kwargs.
+        for input_key in kwargs:
+            if input_key in ("pixel_values", "image_embeds"
+                             ) and "image" not in mm_input_by_modality:
+                mm_input_by_modality[
+                    "image"] = self._parse_and_validate_image_input(**kwargs)
+            if input_key in ("pixel_values_videos", "video_embeds"
+                             ) and "video" not in mm_input_by_modality:
+                mm_input_by_modality[
+                    "video"] = self._parse_and_validate_video_input(**kwargs)
+        return mm_input_by_modality
+
+    def get_language_model(self) -> torch.nn.Module:
+        return self.language_model
+
+    def get_multimodal_embeddings(self,
+                                  **kwargs: object) -> MultiModalEmbeddings:
+
+        mm_input_by_modality = self._parse_and_validate_multimodal_inputs(
+            **kwargs)
+        if not mm_input_by_modality:
+            return []
+
+        # The result multimodal_embeddings is tuple of tensors, with each
+        # tensor correspoending to a multimodal data item (image or video).
+        multimodal_embeddings: tuple[torch.Tensor, ...] = ()
+
+        # NOTE: It is important to iterate over the keys in this dictionary
+        # to preserve the order of the modalities.
+        for modality in mm_input_by_modality:
+            multimodal_input = mm_input_by_modality[modality]
+            if modality == "image":
+                vision_embeddings = self._process_image_input(multimodal_input)
+                if self.is_multimodal_pruning_enabled:
+                    vision_embeddings = self._postprocess_image_embeds_evs(
+                        vision_embeddings, multimodal_input
+                    )
+                multimodal_embeddings += vision_embeddings
+            if modality == "video":
+                video_embeddings = self._process_video_input(multimodal_input)
+                if self.is_multimodal_pruning_enabled:
+                    video_embeddings = self._postprocess_video_embeds_evs(
+                        video_embeddings, multimodal_input
+                    )
+                multimodal_embeddings += video_embeddings
+        return multimodal_embeddings
+
+    def get_input_embeddings(
+        self,
+        input_ids: torch.Tensor,
+        multimodal_embeddings: Optional[MultiModalEmbeddings] = None,
+    ) -> torch.Tensor:
+        inputs_embeds = self.language_model.get_input_embeddings(input_ids)
+        if multimodal_embeddings is not None \
+            and len(multimodal_embeddings) != 0:
+            inputs_embeds = merge_multimodal_embeddings(
+                input_ids, inputs_embeds, multimodal_embeddings,
+                [self.config.image_token_id, self.config.video_token_id])
+        return inputs_embeds
+
+    def get_input_embeddings_v0(
+        self,
+        input_ids: torch.Tensor,
+        image_input: Optional[Qwen2_5_VLImageInputs] = None,
+        video_input: Optional[Qwen2_5_VLVideoInputs] = None,
+    ) -> torch.Tensor:
+        inputs_embeds = self.get_input_embeddings(input_ids)
+        if image_input is not None:
+            image_embeds = self._process_image_input(image_input)
+            if self.is_multimodal_pruning_enabled:
+                image_embeds = self._postprocess_image_embeds_evs(
+                    image_embeds, image_input
+                )
+            inputs_embeds = merge_multimodal_embeddings(
+                input_ids,
+                inputs_embeds,
+                image_embeds,
+                placeholder_token_id=self.config.image_token_id,
+            )
+
+        if video_input is not None:
+            video_embeds = self._process_video_input(video_input)
+            if self.is_multimodal_pruning_enabled:
+                video_embeds = self._postprocess_video_embeds_evs(
+                    video_embeds, video_input
+                )
+            inputs_embeds = merge_multimodal_embeddings(
+                input_ids,
+                inputs_embeds,
+                video_embeds,
+                placeholder_token_id=self.config.video_token_id,
+            )
+        return inputs_embeds
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        intermediate_tensors: Optional[IntermediateTensors] = None,
+        inputs_embeds: Optional[torch.Tensor] = None,
+        **kwargs: object,
+    ) -> Union[torch.Tensor, IntermediateTensors]:
+        """Run forward pass for Qwen2.5-VL.
+
+        Args:
+            input_ids: Flattened (concatenated) input_ids corresponding to a
+                batch.
+            positions: Flattened (concatenated) position ids corresponding to a
+                batch. **NOTE**: If mrope is enabled (default setting for
+                Qwen2.5-VL opensource models), the shape will be `(3, seq_len)`,
+                otherwise it will be `(seq_len,).
+        """
+
+        if intermediate_tensors is not None:
+            inputs_embeds = None
+
+        # NOTE: In v1, inputs_embeds is always generated at model runner from
+        # `get_multimodal_embeddings` and `get_input_embeddings`, this
+        # condition is only for v0 compatibility.
+        elif inputs_embeds is None:
+            image_input = self._parse_and_validate_image_input(**kwargs)
+            video_input = self._parse_and_validate_video_input(**kwargs)
+
+            if image_input is None and video_input is None:
+                inputs_embeds = None
+            else:
+                if uses_mrope(self.config):
+                    assert positions.ndim == 2 and positions.size(0) == 3, (
+                        "multimodal section rotary embedding requires "
+                        f"(3, seq_len) positions, but got {positions.size()}")
+                inputs_embeds = self.get_input_embeddings_v0(
+                    input_ids,
+                    image_input=image_input,
+                    video_input=video_input)
+                input_ids = None
+
+        hidden_states = self.language_model.model(
+            input_ids=input_ids,
+            positions=positions,
+            intermediate_tensors=intermediate_tensors,
+            inputs_embeds=inputs_embeds,
+        )
+        return hidden_states
+
+    def compute_logits(
+        self,
+        hidden_states: torch.Tensor,
+    ) -> Optional[torch.Tensor]:
+        return self.language_model.compute_logits(hidden_states)
+
+    def load_weights(self, weights: Iterable[tuple[str,
+                                                   torch.Tensor]]) -> set[str]:
+
+        skip_prefixes = []
+        if self.visual is None:
+            skip_prefixes.extend(["visual."])
+        loader = AutoWeightsLoader(self, skip_prefixes=skip_prefixes)
+        return loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
+
+    def get_mm_mapping(self) -> MultiModelKeys:
+        """
+        Get the module prefix in multimodal models
+        """
+        return MultiModelKeys.from_string_field(
+            language_model="language_model",
+            connector="visual.merger.",
+            tower_model="visual.",
+        )

--- a/xinference/thirdparty/navidc_ocr/vllm_compat.py
+++ b/xinference/thirdparty/navidc_ocr/vllm_compat.py
@@ -1,0 +1,67 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""NaviDC-OCR adapter for recent vLLM releases."""
+
+from torch import nn
+from vllm.config import VllmConfig
+from vllm.model_executor.models.qwen2_5_vl import (
+    Qwen2_5_VLForConditionalGeneration,
+    Qwen2_5_VisionTransformer,
+)
+from vllm.model_executor.models.utils import (
+    init_vllm_registered_model,
+    maybe_prefix,
+)
+
+
+class NaviOCRForConditionalGeneration(Qwen2_5_VLForConditionalGeneration):
+    """Use vLLM's current Qwen2.5-VL stack with NaviDC's Qwen3 text tower."""
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+        # Calling super() would construct Qwen2ForCausalLM, which ignores NaviDC's
+        # explicit head_dim=128.  The checkpoint has Qwen3 q/k norm weights and the
+        # upstream NaviDC implementation also uses Qwen3ForCausalLM.
+        nn.Module.__init__(self)
+        config = vllm_config.model_config.hf_config
+        multimodal_config = vllm_config.model_config.multimodal_config
+
+        self.use_data_parallel = multimodal_config.mm_encoder_tp_mode == "data"
+        self.config = config
+        self.model_config = vllm_config.model_config
+        self.vllm_config = vllm_config
+        self.multimodal_config = multimodal_config
+        self.video_pruning_rate = multimodal_config.video_pruning_rate
+        self.is_multimodal_pruning_enabled = (
+            multimodal_config.is_multimodal_pruning_enabled()
+        )
+
+        with self._mark_tower_model(vllm_config, {"image", "video"}):
+            self.visual = Qwen2_5_VisionTransformer(
+                vision_config=config.vision_config,
+                norm_eps=getattr(config, "rms_norm_eps", 1e-6),
+                quant_config=self.quant_config,
+                prefix=maybe_prefix(prefix, "visual"),
+            )
+
+        with self._mark_language_model(vllm_config):
+            self.language_model = init_vllm_registered_model(
+                vllm_config=vllm_config,
+                prefix=maybe_prefix(prefix, "language_model"),
+                architectures=["Qwen3ForCausalLM"],
+            )
+
+        self.make_empty_intermediate_tensors = (
+            self.language_model.make_empty_intermediate_tensors
+        )


### PR DESCRIPTION
## Summary

This PR adds built-in NaviDC-OCR support with both Transformers and vLLM engines.

## Changes

- Add NaviDC-OCR to the built-in image model registry.
- Support two model sources:
  - Hugging Face: `StarDoc-AI/NaviDC-OCR`, revision `main`
  - ModelScope: `jackpi/NaviDC-OCR`, revision `master`
- Add Transformers inference with:
  - backend-owned default OCR prompts
  - legacy prompt normalization
  - deterministic generation defaults
  - filtering of UI-only arguments before model generation
- Add vLLM inference with:
  - `vllm>=0.23,<0.24`
  - dedicated `NaviOCRForConditionalGeneration` registration
  - a compatibility adapter using vLLM's current Qwen2.5-VL vision
    stack and Qwen3 language tower
  - model creation, generation, and shutdown on the Xinference model
    actor event-loop thread
- Register the vLLM plugin through `vllm.general_plugins`, allowing
  spawned EngineCore processes to resolve the NaviDC architecture.
- Avoid replacing vLLM's global Qwen2.5-VL registration, preventing
  conflicts with existing Qwen2.5-VL models.
- Set overridable vLLM defaults:
  - `gpu_memory_utilization=0.7`
  - `max_model_len=16384`
- Vendor the upstream NaviDC vLLM implementation from commit
  `2e79d29bf32d4e8997b7cbd2ee619a12bfc8d616`.
- Add model registration, dependency, prompt, Transformers, vLLM,
  compatibility, and actor-loop tests.
- Add generated built-in model documentation.

## References

- https://github.com/caipeng328/NaviDC-OCR
- https://huggingface.co/StarDoc-AI/NaviDC-OCR