### PR TITLE
FIX: stabilize HY-WorldPlay runtime and progress reporting

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -210,6 +210,12 @@ Explore the API
 
 .. grid:: 2
 
+    .. grid-item-card::  World
+      :link: world
+      :link-type: ref
+
+      Learn how to generate environment videos with world models in Xinference.
+
     .. grid-item-card::  Flexible
       :link: flexible
       :link-type: ref

--- a/doc/source/locale/zh_CN/LC_MESSAGES/index.po
+++ b/doc/source/locale/zh_CN/LC_MESSAGES/index.po
@@ -143,6 +143,15 @@ msgstr "视频"
 msgid "Learn how to generate video with Xinference."
 msgstr "学习如何使用Xinference生成视频。"
 
+#: ../../source/index.rst:213
+msgid "World"
+msgstr "世界模型"
+
+#: ../../source/index.rst:217
+msgid ""
+"Learn how to generate environment videos with world models in Xinference."
+msgstr "学习如何在 Xinference 中使用世界模型生成环境视频。"
+
 #: ../../source/index.rst:214
 msgid "Flexible"
 msgstr "灵活模型"

--- a/doc/source/locale/zh_CN/LC_MESSAGES/models/builtin/world/astra.po
+++ b/doc/source/locale/zh_CN/LC_MESSAGES/models/builtin/world/astra.po
@@ -1,0 +1,71 @@
+# Chinese translations for Xinference package
+# Xinference 软件包的简体中文翻译.
+# Copyright (C) 2026, XINFERENCE HOLDINGS PTE. LTD.
+# This file is distributed under the same license as the Xinference package.
+# Automatically generated, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Xinference \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-08-28 21:37+0800\n"
+"PO-Revision-Date: 2026-08-28 21:37+0800\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: zh_CN\n"
+
+#: ../../source/models/builtin/world/astra.rst:5
+msgid "Astra"
+msgstr "Astra"
+
+#: ../../source/models/builtin/world/astra.rst:7
+msgid "**Model Name:** Astra"
+msgstr "**模型名称：** Astra"
+
+#: ../../source/models/builtin/world/astra.rst:8
+msgid "**Model Family:** Astra"
+msgstr "**模型家族：** Astra"
+
+#: ../../source/models/builtin/world/astra.rst:9
+msgid "**Abilities:** image2world"
+msgstr "**能力：** image2world"
+
+#: ../../source/models/builtin/world/astra.rst:10
+msgid "**Engine:** PyTorch"
+msgstr "**引擎：** PyTorch"
+
+#: ../../source/models/builtin/world/astra.rst:13
+msgid "Specifications"
+msgstr "规格"
+
+#: ../../source/models/builtin/world/astra.rst:15
+msgid "**Hugging Face Model ID:** EvanEternal/Astra"
+msgstr "**Hugging Face 模型 ID：** EvanEternal/Astra"
+
+#: ../../source/models/builtin/world/astra.rst:16
+msgid "**ModelScope Model ID:** Xorbits/Astra"
+msgstr "**ModelScope 模型 ID：** Xorbits/Astra"
+
+#: ../../source/models/builtin/world/astra.rst:17
+msgid "**Source:** https://github.com/EternalEvan/Astra"
+msgstr "**源代码：** https://github.com/EternalEvan/Astra"
+
+#: ../../source/models/builtin/world/astra.rst:18
+msgid "**Officially documented hardware:** one 24 GB GPU, such as an RTX 3090"
+msgstr "**官方说明的硬件要求：** 一张 24 GB GPU，例如 RTX 3090"
+
+#: ../../source/models/builtin/world/astra.rst:20
+msgid "Launch the model with::"
+msgstr "使用以下命令启动模型::"
+
+#: ../../source/models/builtin/world/astra.rst:24
+msgid ""
+"Camera trajectories are selected with ``cam_type`` values from 1 through 7 "
+"and are passed through ``extra_body`` in the REST API or ``model_kwargs`` in "
+"the Python client."
+msgstr ""
+"相机轨迹通过 1 到 7 的 ``cam_type`` 值选择，并通过 REST API 中的 "
+"``extra_body`` 或 Python 客户端中的 ``model_kwargs`` 传递。"

--- a/doc/source/locale/zh_CN/LC_MESSAGES/models/builtin/world/hy-worldplay-5b.po
+++ b/doc/source/locale/zh_CN/LC_MESSAGES/models/builtin/world/hy-worldplay-5b.po
@@ -1,0 +1,58 @@
+# Chinese translations for Xinference package
+# Xinference 软件包的简体中文翻译.
+# Copyright (C) 2026, XINFERENCE HOLDINGS PTE. LTD.
+# This file is distributed under the same license as the Xinference package.
+# Automatically generated, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Xinference \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-08-28 21:37+0800\n"
+"PO-Revision-Date: 2026-08-28 21:37+0800\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: zh_CN\n"
+
+#: ../../source/models/builtin/world/hy-worldplay-5b.rst:5
+msgid "HY-WorldPlay-5B"
+msgstr "HY-WorldPlay-5B"
+
+#: ../../source/models/builtin/world/hy-worldplay-5b.rst:7
+msgid "**Model Name:** HY-WorldPlay-5B"
+msgstr "**模型名称：** HY-WorldPlay-5B"
+
+#: ../../source/models/builtin/world/hy-worldplay-5b.rst:8
+msgid "**Model Family:** HY-WorldPlay"
+msgstr "**模型家族：** HY-WorldPlay"
+
+#: ../../source/models/builtin/world/hy-worldplay-5b.rst:9
+msgid "**Abilities:** text2world, image2world"
+msgstr "**能力：** text2world, image2world"
+
+#: ../../source/models/builtin/world/hy-worldplay-5b.rst:10
+msgid "**Engine:** PyTorch"
+msgstr "**引擎：** PyTorch"
+
+#: ../../source/models/builtin/world/hy-worldplay-5b.rst:13
+msgid "Specifications"
+msgstr "规格"
+
+#: ../../source/models/builtin/world/hy-worldplay-5b.rst:15
+msgid "**Hugging Face Model ID:** tencent/HY-WorldPlay"
+msgstr "**Hugging Face 模型 ID：** tencent/HY-WorldPlay"
+
+#: ../../source/models/builtin/world/hy-worldplay-5b.rst:16
+msgid "**ModelScope Model ID:** Tencent-Hunyuan/HY-WorldPlay"
+msgstr "**ModelScope 模型 ID：** Tencent-Hunyuan/HY-WorldPlay"
+
+#: ../../source/models/builtin/world/hy-worldplay-5b.rst:17
+msgid "**Source:** https://github.com/Tencent-Hunyuan/HY-WorldPlay"
+msgstr "**源代码：** https://github.com/Tencent-Hunyuan/HY-WorldPlay"
+
+#: ../../source/models/builtin/world/hy-worldplay-5b.rst:19
+msgid "Launch the model with::"
+msgstr "使用以下命令启动模型::"

--- a/doc/source/locale/zh_CN/LC_MESSAGES/models/builtin/world/index.po
+++ b/doc/source/locale/zh_CN/LC_MESSAGES/models/builtin/world/index.po
@@ -1,0 +1,26 @@
+# Chinese translations for Xinference package
+# Xinference 软件包的简体中文翻译.
+# Copyright (C) 2026, XINFERENCE HOLDINGS PTE. LTD.
+# This file is distributed under the same license as the Xinference package.
+# Automatically generated, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Xinference \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-08-28 21:37+0800\n"
+"PO-Revision-Date: 2026-08-28 21:37+0800\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: zh_CN\n"
+
+#: ../../source/models/builtin/world/index.rst:5
+msgid "World Models"
+msgstr "世界模型"
+
+#: ../../source/models/builtin/world/index.rst:7
+msgid "The following built-in world models are available in Xinference:"
+msgstr "Xinference 提供以下内置世界模型："

--- a/doc/source/locale/zh_CN/LC_MESSAGES/models/builtin/world/matrix-game-3.0-5b.po
+++ b/doc/source/locale/zh_CN/LC_MESSAGES/models/builtin/world/matrix-game-3.0-5b.po
@@ -1,0 +1,58 @@
+# Chinese translations for Xinference package
+# Xinference 软件包的简体中文翻译.
+# Copyright (C) 2026, XINFERENCE HOLDINGS PTE. LTD.
+# This file is distributed under the same license as the Xinference package.
+# Automatically generated, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Xinference \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-08-28 21:37+0800\n"
+"PO-Revision-Date: 2026-08-28 21:37+0800\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: zh_CN\n"
+
+#: ../../source/models/builtin/world/matrix-game-3.0-5b.rst:5
+msgid "Matrix-Game-3.0-5B"
+msgstr "Matrix-Game-3.0-5B"
+
+#: ../../source/models/builtin/world/matrix-game-3.0-5b.rst:7
+msgid "**Model Name:** Matrix-Game-3.0-5B"
+msgstr "**模型名称：** Matrix-Game-3.0-5B"
+
+#: ../../source/models/builtin/world/matrix-game-3.0-5b.rst:8
+msgid "**Model Family:** Matrix-Game-3.0"
+msgstr "**模型家族：** Matrix-Game-3.0"
+
+#: ../../source/models/builtin/world/matrix-game-3.0-5b.rst:9
+msgid "**Abilities:** image2world"
+msgstr "**能力：** image2world"
+
+#: ../../source/models/builtin/world/matrix-game-3.0-5b.rst:10
+msgid "**Engine:** PyTorch"
+msgstr "**引擎：** PyTorch"
+
+#: ../../source/models/builtin/world/matrix-game-3.0-5b.rst:13
+msgid "Specifications"
+msgstr "规格"
+
+#: ../../source/models/builtin/world/matrix-game-3.0-5b.rst:15
+msgid "**Hugging Face Model ID:** Skywork/Matrix-Game-3.0"
+msgstr "**Hugging Face 模型 ID：** Skywork/Matrix-Game-3.0"
+
+#: ../../source/models/builtin/world/matrix-game-3.0-5b.rst:16
+msgid "**ModelScope Model ID:** Skywork/Matrix-Game-3.0"
+msgstr "**ModelScope 模型 ID：** Skywork/Matrix-Game-3.0"
+
+#: ../../source/models/builtin/world/matrix-game-3.0-5b.rst:17
+msgid "**Source:** https://github.com/SkyworkAI/Matrix-Game"
+msgstr "**源代码：** https://github.com/SkyworkAI/Matrix-Game"
+
+#: ../../source/models/builtin/world/matrix-game-3.0-5b.rst:19
+msgid "Launch the model with::"
+msgstr "使用以下命令启动模型::"

--- a/doc/source/locale/zh_CN/LC_MESSAGES/models/index.po
+++ b/doc/source/locale/zh_CN/LC_MESSAGES/models/index.po
@@ -85,6 +85,14 @@ msgstr ""
 msgid "Video models"
 msgstr "视频模型"
 
+#: ../../source/models/index.rst:73
+msgid "world"
+msgstr "世界模型"
+
+#: ../../source/models/index.rst:77
+msgid "World generation models"
+msgstr "世界生成模型"
+
 #: ../../source/models/index.rst:75 ../../source/models/index.rst:240
 msgid "flexible"
 msgstr "灵活模型"
@@ -226,7 +234,15 @@ msgstr "视频"
 msgid "Learn how to generate video with Xinference."
 msgstr "学习如何使用Xinference生成视频。"
 
+#: ../../source/models/index.rst:246
+msgid "World"
+msgstr "世界模型"
+
+#: ../../source/models/index.rst:250
+msgid ""
+"Learn how to generate environment videos with world models in Xinference."
+msgstr "学习如何在 Xinference 中使用世界模型生成环境视频。"
+
 #: ../../source/models/index.rst:244
 msgid "Learn how to inference traditional ML models with Xinference."
 msgstr "了解如何使用 Xinference 推理传统机器学习模型。"
-

--- a/doc/source/locale/zh_CN/LC_MESSAGES/models/model_abilities/flexible.po
+++ b/doc/source/locale/zh_CN/LC_MESSAGES/models/model_abilities/flexible.po
@@ -20,8 +20,8 @@ msgstr ""
 "Generated-By: Babel 2.14.0\n"
 
 #: ../../source/models/model_abilities/flexible.rst:5
-msgid "Traditional ML models (Experimental)"
-msgstr "传统机器学习模型（实验性质）"
+msgid "Traditional ML models"
+msgstr "传统机器学习模型"
 
 #: ../../source/models/model_abilities/flexible.rst:7
 msgid ""
@@ -267,4 +267,3 @@ msgid ""
 msgstr "Xinference 内置的灵活模型 launcher 可以在  "
 "`Github <https://github.com/xorbitsai/inference/tree/main/xinference/model/flexible/launchers>`_ 找到，"
 "欢迎贡献更多传统机器学习模型的支持！"
-

--- a/doc/source/locale/zh_CN/LC_MESSAGES/models/model_abilities/flexible.po
+++ b/doc/source/locale/zh_CN/LC_MESSAGES/models/model_abilities/flexible.po
@@ -31,13 +31,6 @@ msgid ""
 msgstr ""
 "了解如何使用 Xinference 推理传统机器学习模型。在 Xinference 中，这些灵活可扩展的模型被称为 **灵活模型**。"
 
-#: ../../source/models/model_abilities/flexible.rst:10
-msgid ""
-"This ability is public since v1.7.1, now the API is not stable and may "
-"change during evolving."
-msgstr ""
-"该功能自 v1.7.1 版本起公开，目前 API 尚不稳定，可能会在后续迭代中发生变化。"
-
 #: ../../source/models/model_abilities/flexible.rst:15
 msgid "Introduction"
 msgstr "介绍"

--- a/doc/source/locale/zh_CN/LC_MESSAGES/models/model_abilities/video.po
+++ b/doc/source/locale/zh_CN/LC_MESSAGES/models/model_abilities/video.po
@@ -20,8 +20,8 @@ msgstr ""
 "Generated-By: Babel 2.17.0\n"
 
 #: ../../source/models/model_abilities/video.rst:5
-msgid "Video (Experimental)"
-msgstr "视频（实验性质）"
+msgid "Video"
+msgstr "视频"
 
 #: ../../source/models/model_abilities/video.rst:7
 msgid "Learn how to generate videos with Xinference."
@@ -285,4 +285,3 @@ msgstr "此示例将需要 20GB 的显存。"
 
 #~ msgid "/v1/video/generations/image"
 #~ msgstr ""
-

--- a/doc/source/locale/zh_CN/LC_MESSAGES/models/model_abilities/world.po
+++ b/doc/source/locale/zh_CN/LC_MESSAGES/models/model_abilities/world.po
@@ -1,0 +1,183 @@
+# Chinese translations for Xinference package
+# Xinference 软件包的简体中文翻译.
+# Copyright (C) 2026, XINFERENCE HOLDINGS PTE. LTD.
+# This file is distributed under the same license as the Xinference package.
+# Automatically generated, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Xinference \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-08-28 21:37+0800\n"
+"PO-Revision-Date: 2026-08-28 21:37+0800\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: zh_CN\n"
+
+#: ../../source/models/model_abilities/world.rst:5
+msgid "World (Experimental)"
+msgstr "世界模型（实验性）"
+
+#: ../../source/models/model_abilities/world.rst:7
+msgid ""
+"World models generate an environment video from a prompt and, when "
+"supported, an initial image. Xinference exposes one synchronous API for the "
+"first version:"
+msgstr ""
+"世界模型根据提示词生成环境视频，并在模型支持时接受初始图像。Xinference 的首个"
+"版本提供一个同步 API："
+
+#: ../../source/models/model_abilities/world.rst:10
+msgid "``POST /v1/worlds/generations``"
+msgstr "``POST /v1/worlds/generations``"
+
+#: ../../source/models/model_abilities/world.rst:12
+msgid ""
+"The common request fields are ``model``, ``prompt``, optional ``image`` or "
+"``video``, and ``generation_config``. Model-specific controls such as action "
+"or pose are passed through ``extra_body``. Continuous sessions and dedicated "
+"action or streaming APIs are not part of this first version."
+msgstr ""
+"通用请求字段包括 ``model``、``prompt``、可选的 ``image`` 或 ``video``，以及 "
+"``generation_config``。动作、位姿等模型特定的控制项通过 ``extra_body`` 传递。"
+"首个版本不包含连续会话，也不提供专用的动作或流式 API。"
+
+#: ../../source/models/model_abilities/world.rst:18
+msgid "Supported models"
+msgstr "支持的模型"
+
+#: ../../source/models/model_abilities/world.rst:20
+msgid ":ref:`Matrix-Game-3.0-5B <models_builtin_matrix-game-3.0-5b>`"
+msgstr ":ref:`Matrix-Game-3.0-5B <models_builtin_matrix-game-3.0-5b>`"
+
+#: ../../source/models/model_abilities/world.rst:21
+msgid ":ref:`HY-WorldPlay-5B <models_builtin_hy-worldplay-5b>`"
+msgstr ":ref:`HY-WorldPlay-5B <models_builtin_hy-worldplay-5b>`"
+
+#: ../../source/models/model_abilities/world.rst:22
+msgid ":ref:`Astra <models_builtin_astra>`"
+msgstr ":ref:`Astra <models_builtin_astra>`"
+
+#: ../../source/models/model_abilities/world.rst:24
+msgid ""
+"World models use the standard Xinference engine selection flow. Query ``GET /"
+"v1/engines/world/<MODEL_NAME>`` to list available engines and choose one "
+"with ``model_engine`` when launching the model. The initial built-in engine "
+"is ``PyTorch`` and requires an NVIDIA CUDA GPU."
+msgstr ""
+"世界模型使用 Xinference 标准的引擎选择流程。通过 ``GET /v1/engines/world/"
+"<MODEL_NAME>`` 查询可用引擎，并在启动模型时使用 ``model_engine`` 选择引擎。"
+"首个内置引擎为 ``PyTorch``，且需要 NVIDIA CUDA GPU。"
+
+#: ../../source/models/model_abilities/world.rst:30
+msgid "Quickstart"
+msgstr "快速开始"
+
+#: ../../source/models/model_abilities/world.rst:32
+msgid "Launch a model::"
+msgstr "启动模型::"
+
+#: ../../source/models/model_abilities/world.rst:39
+msgid "Generate with cURL:"
+msgstr "使用 cURL 生成："
+
+#: ../../source/models/model_abilities/world.rst:57
+msgid "Generate with the Xinference Python client:"
+msgstr "使用 Xinference Python 客户端生成："
+
+#: ../../source/models/model_abilities/world.rst:73
+msgid ""
+"The response follows the existing video result shape. The generated item is "
+"``result[\"data\"][0]`` and contains either a ``url`` or ``b64_json`` value. "
+"``b64_json`` is the raw base64 payload without a ``data:video/...`` prefix. "
+"The public REST endpoint accepts uploaded media as base64 data URLs; the "
+"Python client converts local file paths or bytes to that representation. "
+"Remote HTTP URLs and server-local paths are intentionally not accepted by "
+"the public endpoint. ``Matrix-Game-3.0-5B`` and ``Astra`` require an image; "
+"``HY-WorldPlay-5B`` accepts text-only or image-conditioned generation. None "
+"of the initial adapters accepts the reserved ``video`` input yet."
+msgstr ""
+"响应沿用现有的视频结果结构。生成项位于 ``result[\"data\"][0]``，其中包含 "
+"``url`` 或 ``b64_json``。``b64_json`` 是不带 ``data:video/...`` 前缀的原始 "
+"Base64 数据。公共 REST 端点接受以 Base64 data URL 形式上传的媒体；Python "
+"客户端会将本地文件路径或字节转换为该格式。公共端点有意不接受远程 HTTP URL "
+"或服务器本地路径。``Matrix-Game-3.0-5B`` 和 ``Astra`` 需要输入图像；``HY-"
+"WorldPlay-5B`` 支持纯文本生成或图像条件生成。首批适配器均不接受预留的 "
+"``video`` 输入。"
+
+#: ../../source/models/model_abilities/world.rst:85
+msgid "Progress and cancellation"
+msgstr "进度与取消"
+
+#: ../../source/models/model_abilities/world.rst:87
+msgid ""
+"Long-running requests can include a caller-generated ``request_id`` in "
+"``extra_body`` (or ``model_kwargs`` in the Python client). While that "
+"request is running, poll its progress::"
+msgstr ""
+"长时间运行的请求可以在 ``extra_body`` 中包含调用方生成的 ``request_id``"
+"（Python 客户端中为 ``model_kwargs``）。请求运行期间，可通过以下方式轮询进度::"
+
+#: ../../source/models/model_abilities/world.rst:93
+msgid "or use the REST endpoint::"
+msgstr "或者使用 REST 端点::"
+
+#: ../../source/models/model_abilities/world.rst:97
+msgid ""
+"The progress response is ``{\"progress\": <float>}``, where the value ranges "
+"from 0 to 1. Completed progress records are retained for five minutes by "
+"default (configurable with ``XINFERENCE_REMOVE_PROGRESS_INTERVAL``)."
+msgstr ""
+"进度响应为 ``{\"progress\": <float>}``，取值范围为 0 到 1。已完成的进度记录"
+"默认保留五分钟（可通过 ``XINFERENCE_REMOVE_PROGRESS_INTERVAL`` 配置）。"
+
+#: ../../source/models/model_abilities/world.rst:101
+msgid "Abort the same request with::"
+msgstr "使用以下方式中止同一请求::"
+
+#: ../../source/models/model_abilities/world.rst:105
+msgid "or::"
+msgstr "或者::"
+
+#: ../../source/models/model_abilities/world.rst:110
+msgid ""
+"For remote clients, ``b64_json`` is directly consumable but materializes the "
+"complete result in the response. ``url`` currently returns a path on the "
+"worker that ran the model and is intended for clients that share that "
+"filesystem. Xinference does not currently copy or clean up these files. "
+"Artifact storage, public download URLs, and continuous streaming are "
+"separate future capabilities rather than part of this synchronous first "
+"version."
+msgstr ""
+"对于远程客户端，``b64_json`` 可直接使用，但会在响应中物化完整结果。``url`` "
+"当前返回运行该模型的 worker 上的路径，适用于共享该文件系统的客户端。Xinference "
+"目前不会复制或清理这些文件。产物存储、公开下载 URL 和连续流式传输属于独立的未来"
+"能力，不在首个同步版本的范围内。"
+
+#: ../../source/models/model_abilities/world.rst:117
+msgid ""
+"The first launch downloads the pinned adapter source from its GitHub "
+"revision and any auxiliary base weights required by the selected model. "
+"Selecting ModelScope changes the model-weight source; it does not mirror the "
+"adapter source checkout. Launch therefore requires access to both configured "
+"sources. A fully managed air-gapped staging lifecycle for this complete "
+"dependency set is not part of the first version."
+msgstr ""
+"首次启动时会从固定的 GitHub 修订版本下载适配器源码，以及所选模型需要的辅助基础"
+"权重。选择 ModelScope 只会改变模型权重来源，不会镜像适配器源码。启动时因此需要"
+"同时访问这两个已配置的来源。首个版本不提供覆盖整套依赖的全托管隔离网络预部署"
+"流程。"
+
+#: ../../source/models/model_abilities/world.rst:124
+msgid ""
+"For Astra, camera control remains model-specific and is passed through "
+"``extra_body`` or ``model_kwargs``. For example, ``cam_type`` accepts values "
+"from 1 through 7 for the upstream preset trajectories. Astra's official "
+"inference path runs on a single 24 GB NVIDIA GPU."
+msgstr ""
+"Astra 的相机控制仍是模型特定参数，通过 ``extra_body`` 或 ``model_kwargs`` "
+"传递。例如，``cam_type`` 接受 1 到 7，分别对应上游预设的相机轨迹。Astra 的"
+"官方推理方式在单张 24 GB NVIDIA GPU 上运行。"

--- a/doc/source/models/index.rst
+++ b/doc/source/models/index.rst
@@ -243,6 +243,12 @@ Model Usage
 
 .. grid:: 2
 
+    .. grid-item-card::  World
+      :link: world
+      :link-type: ref
+
+      Learn how to generate environment videos with world models in Xinference.
+
     .. grid-item-card::  flexible
       :link: flexible
       :link-type: ref

--- a/doc/source/models/model_abilities/flexible.rst
+++ b/doc/source/models/model_abilities/flexible.rst
@@ -1,8 +1,8 @@
 .. _flexible:
 
-====================================
-Traditional ML models (Experimental)
-====================================
+=====================
+Traditional ML models
+=====================
 
 Learn how to inference traditional machine learning models with Xinference.
 These flexibly extensible models are referred to as **Flexible Models** within Xinference.

--- a/doc/source/models/model_abilities/flexible.rst
+++ b/doc/source/models/model_abilities/flexible.rst
@@ -8,7 +8,6 @@ Learn how to inference traditional machine learning models with Xinference.
 These flexibly extensible models are referred to as **Flexible Models** within Xinference.
 
 .. versionadded:: v1.7.1
-  This ability is public since v1.7.1, now the API is not stable and may change during evolving.
 
 
 Introduction

--- a/doc/source/models/model_abilities/video.rst
+++ b/doc/source/models/model_abilities/video.rst
@@ -1,8 +1,8 @@
 .. _video:
 
-====================
-Video (Experimental)
-====================
+=====
+Video
+=====
 
 Learn how to generate videos with Xinference.
 

--- a/frontend/src/components/pages/running-model-detail/panels/capability-task-panel.tsx
+++ b/frontend/src/components/pages/running-model-detail/panels/capability-task-panel.tsx
@@ -75,7 +75,9 @@ const CapabilityTaskPanel = forwardRef<CapabilityTaskPanelMethod, CapabilityTask
       config.showProgress &&
       (model.model_type !== ModelType.World ||
         model.model_family === 'Astra' ||
-        model.model_name === 'Astra')
+        model.model_name === 'Astra' ||
+        model.model_family === 'HY-WorldPlay' ||
+        model.model_name === 'HY-WorldPlay-5B')
     );
 
     const showCopyResult = useMemo(() => {

--- a/xinference/model/world/engine.py
+++ b/xinference/model/world/engine.py
@@ -12,7 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from importlib import metadata
 from typing import TYPE_CHECKING, Tuple, Union
+
+from packaging.requirements import Requirement
+from packaging.version import InvalidVersion, Version
 
 from ..utils import has_cuda_device
 from .engine_family import SUPPORTED_ENGINES, WorldEngineModel
@@ -39,6 +43,50 @@ class PyTorchMatrixGameModel(MatrixGameModel, PyTorchWorldEngineModel):
 
 
 class PyTorchHYWorldPlayModel(HYWorldPlayModel, PyTorchWorldEngineModel):
+    @classmethod
+    def check_host(cls) -> Union[bool, Tuple[bool, str]]:
+        host_result = super().check_host()
+        if host_result is not True:
+            return host_result
+
+        try:
+            torch_version = metadata.version("torch")
+        except metadata.PackageNotFoundError:
+            return False, "HY-WorldPlay requires host torch>=2.6.0"
+
+        try:
+            if Version(torch_version) < Version("2.6.0"):
+                return (
+                    False,
+                    "HY-WorldPlay requires host torch>=2.6.0; "
+                    f"found torch {torch_version}",
+                )
+        except InvalidVersion:
+            return False, f"HY-WorldPlay cannot validate host torch {torch_version!r}"
+
+        try:
+            torchvision_version = metadata.version("torchvision")
+            torchvision_requirements = metadata.requires("torchvision") or []
+        except metadata.PackageNotFoundError:
+            return False, "HY-WorldPlay requires host torchvision"
+
+        for requirement_text in torchvision_requirements:
+            requirement = Requirement(requirement_text)
+            if requirement.name.lower() != "torch":
+                continue
+            if requirement.marker is not None and not requirement.marker.evaluate():
+                continue
+            if not requirement.specifier.contains(torch_version, prereleases=True):
+                return (
+                    False,
+                    "HY-WorldPlay requires a compatible host torch/torchvision "
+                    f"pair; found torch {torch_version} and torchvision "
+                    f"{torchvision_version} (requires torch{requirement.specifier})",
+                )
+            break
+
+        return True
+
     @classmethod
     def match(cls, model_family: "WorldModelFamilyV1") -> bool:
         return model_family.model_family == "HY-WorldPlay"

--- a/xinference/model/world/hy_worldplay_runner.py
+++ b/xinference/model/world/hy_worldplay_runner.py
@@ -22,6 +22,11 @@ import argparse
 import os
 
 
+def _report_progress(progress: float, info: str) -> None:
+    if int(os.environ.get("RANK", "0")) == 0:
+        print(f"XINFERENCE_PROGRESS:{progress:.2f}:{info}", flush=True)
+
+
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--prompt", required=True)
@@ -50,11 +55,14 @@ def main() -> None:
     from wan.generate import WanRunner
 
     try:
+        _report_progress(0.05, "Loading HY-WorldPlay weights")
         runner = WanRunner(
             model_id=args.model_id,
             ckpt_path=args.ckpt_path,
             ar_model_path=args.ar_model_path,
         )
+        _report_progress(0.15, "HY-WorldPlay weights loaded")
+        _report_progress(0.18, f"Generating {args.num_chunk} chunk(s)")
         result = runner.predict(
             {
                 "prompt": args.prompt,
@@ -72,11 +80,13 @@ def main() -> None:
                 "num_chunk": args.num_chunk,
             }
         )
+        _report_progress(0.94, "Encoding HY-WorldPlay video")
         if int(os.environ.get("RANK", "0")) == 0:
             os.makedirs(args.out, exist_ok=True)
             export_to_video(
                 result["video"][0], os.path.join(args.out, "world.mp4"), fps=16
             )
+            _report_progress(0.98, "Saving HY-WorldPlay video")
     finally:
         if torch.distributed.is_initialized():
             torch.distributed.destroy_process_group()

--- a/xinference/model/world/model.py
+++ b/xinference/model/world/model.py
@@ -213,6 +213,24 @@ class WorldModel:
         self._running_processes: Dict[str, subprocess.Popen] = {}
         self._request_cancellations: Dict[str, threading.Event] = {}
 
+    def __getstate__(self):
+        # Model instances are serialized when handed to the actor subprocess.
+        # Synchronization primitives and live process state cannot cross that
+        # boundary; the instance has not started serving requests at this point.
+        state = self.__dict__.copy()
+        state["_process_lock"] = None
+        state["_runner_lock"] = None
+        state["_running_processes"] = {}
+        state["_request_cancellations"] = {}
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        self._process_lock = threading.Lock()
+        self._runner_lock = threading.Lock()
+        self._running_processes = {}
+        self._request_cancellations = {}
+
     @property
     def model_ability(self):
         return self._model_spec.model_ability

--- a/xinference/model/world/model.py
+++ b/xinference/model/world/model.py
@@ -823,22 +823,33 @@ class HYWorldPlayModel(WorldModel):
                     nonlocal current_chunk
                     if progressor is None:
                         return
-                    if match := re.search(r"XINFERENCE_PROGRESS:([0-9.]+):(.+)", line):
-                        progressor.set_progress(float(match.group(1)), match.group(2))
-                    elif match := re.search(
-                        r"Generate time for chunk\s+(\d+)\s+is", line
-                    ):
-                        current_chunk = int(match.group(1))
-                        completed = (current_chunk + 0.7) / num_chunks
-                        progressor.set_progress(
-                            0.18 + 0.72 * completed,
-                            f"Generated chunk {current_chunk + 1}/{num_chunks}",
-                        )
-                    elif "Decode latent 0:" in line and current_chunk >= 0:
-                        completed = (current_chunk + 1) / num_chunks
-                        progressor.set_progress(
-                            0.18 + 0.72 * completed,
-                            f"Decoded chunk {current_chunk + 1}/{num_chunks}",
+                    try:
+                        if match := re.search(
+                            r"XINFERENCE_PROGRESS:([0-9.]+):(.+)", line
+                        ):
+                            progressor.set_progress(
+                                float(match.group(1)), match.group(2)
+                            )
+                        elif match := re.search(
+                            r"Generate time for chunk\s+(\d+)\s+is", line
+                        ):
+                            current_chunk = int(match.group(1))
+                            completed = (current_chunk + 0.7) / num_chunks
+                            progressor.set_progress(
+                                0.18 + 0.72 * completed,
+                                f"Generated chunk {current_chunk + 1}/{num_chunks}",
+                            )
+                        elif "Decode latent 0:" in line and current_chunk >= 0:
+                            completed = (current_chunk + 1) / num_chunks
+                            progressor.set_progress(
+                                0.18 + 0.72 * completed,
+                                f"Decoded chunk {current_chunk + 1}/{num_chunks}",
+                            )
+                    except Exception:
+                        logger.warning(
+                            "Failed to parse HY-WorldPlay progress output: %r",
+                            line[:200],
+                            exc_info=True,
                         )
 
                 if progressor:

--- a/xinference/model/world/model.py
+++ b/xinference/model/world/model.py
@@ -815,6 +815,32 @@ class HYWorldPlayModel(WorldModel):
                         env.get("PYTHONPATH", ""),
                     ]
                 ).rstrip(os.pathsep)
+
+                num_chunks = int(config["num_chunk"])
+                current_chunk = -1
+
+                def update_progress(line: str) -> None:
+                    nonlocal current_chunk
+                    if progressor is None:
+                        return
+                    if match := re.search(r"XINFERENCE_PROGRESS:([0-9.]+):(.+)", line):
+                        progressor.set_progress(float(match.group(1)), match.group(2))
+                    elif match := re.search(
+                        r"Generate time for chunk\s+(\d+)\s+is", line
+                    ):
+                        current_chunk = int(match.group(1))
+                        completed = (current_chunk + 0.7) / num_chunks
+                        progressor.set_progress(
+                            0.18 + 0.72 * completed,
+                            f"Generated chunk {current_chunk + 1}/{num_chunks}",
+                        )
+                    elif "Decode latent 0:" in line and current_chunk >= 0:
+                        completed = (current_chunk + 1) / num_chunks
+                        progressor.set_progress(
+                            0.18 + 0.72 * completed,
+                            f"Decoded chunk {current_chunk + 1}/{num_chunks}",
+                        )
+
                 if progressor:
                     progressor.set_progress(0.02, "Starting HY-WorldPlay runner")
                 self._run_command(
@@ -822,6 +848,7 @@ class HYWorldPlayModel(WorldModel):
                     self._code_path,
                     env,
                     os.path.join(output_dir, "runner.log"),
+                    progress_callback=update_progress,
                     request_id=request_id,
                 )
                 videos = list(Path(output_dir).glob("*.mp4"))

--- a/xinference/model/world/model_spec.json
+++ b/xinference/model/world/model_spec.json
@@ -95,9 +95,8 @@
     },
     "virtualenv": {
       "packages": [
-        "torch>=2.6.0 ; #engine# == \"pytorch\"",
-        "torchvision==0.21.0",
-        "torchaudio==2.6.0",
+        "#system_torch# ; #engine# == \"pytorch\"",
+        "#system_torchvision#",
         "peft==0.17.0",
         "einops==0.8.0",
         "loguru==0.7.3",

--- a/xinference/model/world/tests/test_world_model.py
+++ b/xinference/model/world/tests/test_world_model.py
@@ -192,6 +192,67 @@ def test_worldplay_inherits_compatible_host_torch_stack(monkeypatch):
     assert not any(package.startswith("torchaudio") for package in processed)
 
 
+def test_worldplay_accepts_compatible_host_torch_stack(monkeypatch):
+    host_versions = {"torch": "2.9.0+cu130", "torchvision": "0.24.0+cu130"}
+    monkeypatch.setattr("xinference.model.world.engine.has_cuda_device", lambda: True)
+    monkeypatch.setattr(
+        "xinference.model.world.engine.metadata.version",
+        lambda package: host_versions[package],
+    )
+    monkeypatch.setattr(
+        "xinference.model.world.engine.metadata.requires",
+        lambda package: ["torch==2.9.0"] if package == "torchvision" else [],
+    )
+
+    assert PyTorchHYWorldPlayModel.check_host() is True
+
+
+@pytest.mark.parametrize(
+    ("host_versions", "torchvision_requirements", "expected_reason"),
+    [
+        (
+            {"torch": "2.5.1", "torchvision": "0.20.1"},
+            ["torch==2.5.1"],
+            "requires host torch>=2.6.0",
+        ),
+        (
+            {"torch": "2.9.0"},
+            ["torch==2.9.0"],
+            "requires host torchvision",
+        ),
+        (
+            {"torch": "2.9.0", "torchvision": "0.20.1"},
+            ["torch==2.5.1"],
+            "requires a compatible host torch/torchvision pair",
+        ),
+    ],
+)
+def test_worldplay_rejects_incompatible_host_torch_stack(
+    monkeypatch, host_versions, torchvision_requirements, expected_reason
+):
+    from importlib import metadata
+
+    def get_host_version(package):
+        try:
+            return host_versions[package]
+        except KeyError:
+            raise metadata.PackageNotFoundError(package)
+
+    monkeypatch.setattr("xinference.model.world.engine.has_cuda_device", lambda: True)
+    monkeypatch.setattr(
+        "xinference.model.world.engine.metadata.version", get_host_version
+    )
+    monkeypatch.setattr(
+        "xinference.model.world.engine.metadata.requires",
+        lambda package: torchvision_requirements,
+    )
+
+    compatible, reason = PyTorchHYWorldPlayModel.check_host()
+
+    assert compatible is False
+    assert expected_reason in reason
+
+
 def test_world_model_is_serializable_for_actor_subprocess():
     import cloudpickle
 

--- a/xinference/model/world/tests/test_world_model.py
+++ b/xinference/model/world/tests/test_world_model.py
@@ -375,8 +375,13 @@ def test_worldplay_generation_passes_model_specific_kwargs(tmp_path, monkeypatch
     output_root = tmp_path / "responses"
     monkeypatch.setattr(world_model_module, "XINFERENCE_WORLD_DIR", str(output_root))
     captured = {}
+    progress_updates = []
 
-    def fake_run(command, cwd, env, log_path, request_id=None):
+    class FakeProgressor:
+        def set_progress(self, progress, info=None):
+            progress_updates.append((progress, info))
+
+    def fake_run(command, cwd, env, log_path, progress_callback=None, request_id=None):
         captured.update(
             command=command,
             cwd=cwd,
@@ -384,6 +389,19 @@ def test_worldplay_generation_passes_model_specific_kwargs(tmp_path, monkeypatch
             log_path=log_path,
             request_id=request_id,
         )
+        assert progress_callback is not None
+        for line in (
+            "XINFERENCE_PROGRESS:0.05:Loading HY-WorldPlay weights\n",
+            "XINFERENCE_PROGRESS:0.15:HY-WorldPlay weights loaded\n",
+            "XINFERENCE_PROGRESS:0.18:Generating 2 chunk(s)\n",
+            "Generate time for chunk  0 is 10.0\n",
+            "Decode latent 0: 1.0 seconds\n",
+            "Generate time for chunk  1 is 9.0\n",
+            "Decode latent 0: 1.0 seconds\n",
+            "XINFERENCE_PROGRESS:0.94:Encoding HY-WorldPlay video\n",
+            "XINFERENCE_PROGRESS:0.98:Saving HY-WorldPlay video\n",
+        ):
+            progress_callback(line)
         output_dir = command[command.index("--out") + 1]
         Path(output_dir, "generated.mp4").write_bytes(b"worldplay")
 
@@ -392,6 +410,7 @@ def test_worldplay_generation_passes_model_specific_kwargs(tmp_path, monkeypatch
         "README.md@example.com",
         model_kwargs={"pose": "d-8", "num_chunk": 2},
         request_id="worldplay-request",
+        progressor=FakeProgressor(),
     )
 
     command = captured["command"]
@@ -404,6 +423,12 @@ def test_worldplay_generation_passes_model_specific_kwargs(tmp_path, monkeypatch
     assert captured["request_id"] == "worldplay-request"
     assert result["data"][0]["url"] is not None
     assert Path(result["data"][0]["url"]).read_bytes() == b"worldplay"
+    assert progress_updates[0] == (0.02, "Starting HY-WorldPlay runner")
+    assert (0.54, "Decoded chunk 1/2") in progress_updates
+    assert progress_updates[-1] == (0.98, "Saving HY-WorldPlay video")
+    assert [progress for progress, _ in progress_updates] == sorted(
+        progress for progress, _ in progress_updates
+    )
 
 
 @pytest.mark.parametrize("pose", ["forward", "x-4", "w-0", "w-four"])

--- a/xinference/model/world/tests/test_world_model.py
+++ b/xinference/model/world/tests/test_world_model.py
@@ -365,7 +365,9 @@ async def test_world_abort_marks_request_before_runner_registration(
     model.unregister_request("request-1")
 
 
-def test_worldplay_generation_passes_model_specific_kwargs(tmp_path, monkeypatch):
+def test_worldplay_generation_passes_model_specific_kwargs(
+    tmp_path, monkeypatch, caplog
+):
     from .. import model as world_model_module
 
     model_spec = BUILTIN_WORLD_MODELS["HY-WorldPlay-5B"][0]
@@ -391,6 +393,7 @@ def test_worldplay_generation_passes_model_specific_kwargs(tmp_path, monkeypatch
         )
         assert progress_callback is not None
         for line in (
+            "XINFERENCE_PROGRESS:1.2.3:malformed progress\n",
             "XINFERENCE_PROGRESS:0.05:Loading HY-WorldPlay weights\n",
             "XINFERENCE_PROGRESS:0.15:HY-WorldPlay weights loaded\n",
             "XINFERENCE_PROGRESS:0.18:Generating 2 chunk(s)\n",
@@ -424,6 +427,7 @@ def test_worldplay_generation_passes_model_specific_kwargs(tmp_path, monkeypatch
     assert result["data"][0]["url"] is not None
     assert Path(result["data"][0]["url"]).read_bytes() == b"worldplay"
     assert progress_updates[0] == (0.02, "Starting HY-WorldPlay runner")
+    assert "Failed to parse HY-WorldPlay progress output" in caplog.text
     assert (0.54, "Decoded chunk 1/2") in progress_updates
     assert progress_updates[-1] == (0.98, "Saving HY-WorldPlay video")
     assert [progress for progress, _ in progress_updates] == sorted(

--- a/xinference/model/world/tests/test_world_model.py
+++ b/xinference/model/world/tests/test_world_model.py
@@ -165,6 +165,33 @@ def test_astra_does_not_install_unused_controlnet_runtime():
     )
 
 
+def test_worldplay_inherits_compatible_host_torch_stack(monkeypatch):
+    from xoscar.virtualenv.core import VirtualEnvManager
+
+    model_spec = BUILTIN_WORLD_MODELS["HY-WorldPlay-5B"][0]
+
+    # Official WorldPlay requirements combine torch>=2.6 with companion
+    # packages pinned to torch 2.6.  Pinning those companions in the child
+    # environment conflicts with newer host builds required by platforms such
+    # as GB10/CUDA 13.  The inference path uses torchvision but never imports
+    # torchaudio, so inherit the host's matching torch/torchvision pair and do
+    # not resolve the unused audio companion.
+    assert model_spec.virtualenv is not None
+    packages = model_spec.virtualenv.packages
+    assert '#system_torch# ; #engine# == "pytorch"' in packages
+    assert "#system_torchvision#" in packages
+    assert not any(package.startswith("torchaudio") for package in packages)
+
+    host_versions = {"torch": "2.13.0", "torchvision": "0.28.0"}
+    monkeypatch.setattr(
+        "importlib.metadata.version", lambda package: host_versions[package]
+    )
+    processed = VirtualEnvManager.process_packages(packages, engine="pytorch")
+    assert "torch==2.13.0" in processed
+    assert "torchvision==0.28.0" in processed
+    assert not any(package.startswith("torchaudio") for package in processed)
+
+
 def test_generic_model_factory_preserves_world_engine_selection(monkeypatch):
     monkeypatch.setattr(
         PyTorchMatrixGameModel, "check_host", classmethod(lambda cls: True)

--- a/xinference/model/world/tests/test_world_model.py
+++ b/xinference/model/world/tests/test_world_model.py
@@ -192,6 +192,22 @@ def test_worldplay_inherits_compatible_host_torch_stack(monkeypatch):
     assert not any(package.startswith("torchaudio") for package in processed)
 
 
+def test_world_model_is_serializable_for_actor_subprocess():
+    import cloudpickle
+
+    model_spec = BUILTIN_WORLD_MODELS["HY-WorldPlay-5B"][0]
+    model = PyTorchHYWorldPlayModel("worldplay", "/weights/worldplay", model_spec)
+
+    restored = cloudpickle.loads(cloudpickle.dumps(model))
+
+    assert restored._process_lock.acquire(blocking=False)
+    restored._process_lock.release()
+    assert restored._runner_lock.acquire(blocking=False)
+    restored._runner_lock.release()
+    assert restored._running_processes == {}
+    assert restored._request_cancellations == {}
+
+
 def test_generic_model_factory_preserves_world_engine_selection(monkeypatch):
     monkeypatch.setattr(
         PyTorchMatrixGameModel, "check_host", classmethod(lambda cls: True)


### PR DESCRIPTION
## Summary

- reuse the host PyTorch and torchvision stack for HY-WorldPlay virtual environments, avoiding incompatible CUDA wheel resolution on GB10
- make World model instances serializable when they cross the actor-process boundary
- expose HY-WorldPlay progress in the Web UI and report weight loading, chunk generation, decoding, and video saving stages

## Validation

- pytest -q xinference/model/world/tests/test_world_model.py (39 passed)
- pre-commit run on all modified files
- ESLint on capability-task-panel.tsx