### PR TITLE
ENH: support Base64 video input in vLLM chat

### DIFF
--- a/xinference/model/llm/vllm/core.py
+++ b/xinference/model/llm/vllm/core.py
@@ -2247,6 +2247,8 @@ class VLLMMultiModel(VLLMModel, ChatModelMixin):
             metadata.setdefault("total_num_frames", total_num_frames)
             metadata.setdefault("frames_indices", list(range(total_num_frames)))
             if fps is not None:
+                if fps <= 0:
+                    raise ValueError("Video fps must be greater than 0")
                 metadata.setdefault("fps", fps)
                 metadata.setdefault("duration", total_num_frames / fps)
             if len(shape) >= 3:
@@ -2377,7 +2379,10 @@ class VLLMMultiModel(VLLMModel, ChatModelMixin):
 
                                 mime_type, b64_data = match.groups()
                                 try:
-                                    decoded = base64.b64decode(b64_data, validate=True)
+                                    normalized_b64_data = "".join(b64_data.split())
+                                    decoded = base64.b64decode(
+                                        normalized_b64_data, validate=True
+                                    )
                                 except (binascii.Error, ValueError) as exc:
                                     raise ValueError(
                                         f"Invalid base64 data URI for {media_key}"

--- a/xinference/model/llm/vllm/core.py
+++ b/xinference/model/llm/vllm/core.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import asyncio
+import copy
 import importlib
 import itertools
 import json
@@ -2223,12 +2224,9 @@ class VLLMMultiModel(VLLMModel, ChatModelMixin):
     def _attach_video_metadata(
         videos: List[Any], fps_list: Optional[List[Any]]
     ) -> List[Any]:
-        if not fps_list:
-            return videos
-
         attached: List[Any] = []
         for idx, video in enumerate(videos):
-            fps = fps_list[idx] if idx < len(fps_list) else None
+            fps = fps_list[idx] if fps_list and idx < len(fps_list) else None
             data = video
             metadata: Dict[str, Any] = {}
             if (
@@ -2238,10 +2236,23 @@ class VLLMMultiModel(VLLMModel, ChatModelMixin):
             ):
                 data = video[0]
                 metadata = dict(video[1])
+
+            shape = getattr(data, "shape", None)
+            if not shape:
+                raise ValueError("Decoded video does not expose a frame dimension")
+            total_num_frames = int(shape[0])
+            if total_num_frames <= 0:
+                raise ValueError("Decoded video contains no frames")
+
+            metadata.setdefault("total_num_frames", total_num_frames)
+            metadata.setdefault("frames_indices", list(range(total_num_frames)))
             if fps is not None:
                 metadata.setdefault("fps", fps)
-                metadata.setdefault("video_fps", fps)
-            attached.append((data, metadata) if metadata else data)
+                metadata.setdefault("duration", total_num_frames / fps)
+            if len(shape) >= 3:
+                metadata.setdefault("height", int(shape[-2]))
+                metadata.setdefault("width", int(shape[-1]))
+            attached.append((data, metadata))
         return attached
 
     def _sanitize_model_config(
@@ -2325,52 +2336,80 @@ class VLLMMultiModel(VLLMModel, ChatModelMixin):
             prompt_token_ids=token_ids, multi_modal_data=multi_modal_data
         )
 
-    def _handle_base64_images(self, messages, temp_files):
+    def _handle_base64_media(self, messages, temp_dir):
         import base64
+        import binascii
+        import mimetypes
         import re
         import tempfile
+        from pathlib import Path
 
-        # Regex to match data URI scheme
+        # OpenAI-compatible image_url/video_url content parts carry the URL in
+        # a nested ``{"url": ...}`` object.  qwen_omni_utils can consume
+        # image data URIs directly, but its video readers require a path/URL,
+        # so materialize both modalities consistently before transforming the
+        # messages into Qwen's schema.
         data_uri_pattern = re.compile(
-            r"data:([a-zA-Z0-9]+/[a-zA-Z0-9-.+]+);base64,(.*)"
+            r"data:([a-zA-Z0-9]+/[a-zA-Z0-9.+-]+);base64,(.*)",
+            re.IGNORECASE | re.DOTALL,
         )
 
         for msg in messages:
             if isinstance(msg, dict) and isinstance(msg.get("content"), list):
                 for content in msg["content"]:
                     if isinstance(content, dict):
-                        # check image_url
-                        if "image_url" in content and isinstance(
-                            content["image_url"], dict
-                        ):
-                            url = content["image_url"].get("url", "")
-                            if isinstance(url, str) and url.startswith("data:"):
-                                match = data_uri_pattern.match(url)
-                                if match:
-                                    mime_type, b64_data = match.groups()
-                                    try:
-                                        # Create temp file
-                                        suffix = ".bin"
-                                        if "pdf" in mime_type:
-                                            suffix = ".pdf"
-                                        elif "png" in mime_type:
-                                            suffix = ".png"
-                                        elif "jpeg" in mime_type or "jpg" in mime_type:
-                                            suffix = ".jpg"
+                        media_key = next(
+                            (
+                                key
+                                for key in ("image_url", "video_url")
+                                if key in content
+                            ),
+                            None,
+                        )
+                        if media_key and isinstance(content[media_key], dict):
+                            url = content[media_key].get("url", "")
+                            if isinstance(url, str) and url[:5].lower() == "data:":
+                                match = data_uri_pattern.fullmatch(url)
+                                if match is None:
+                                    raise ValueError(
+                                        f"Invalid base64 data URI for {media_key}"
+                                    )
 
-                                        with tempfile.NamedTemporaryFile(
-                                            delete=False, suffix=suffix
-                                        ) as tmp:
-                                            tmp.write(base64.b64decode(b64_data))
-                                            content["image_url"]["url"] = tmp.name
-                                            temp_files.append(tmp.name)
-                                            logger.debug(
-                                                f"Decoded base64 content to temp file: {tmp.name}"
-                                            )
-                                    except Exception as e:
-                                        logger.error(
-                                            f"Failed to decode base64 file: {e}"
-                                        )
+                                mime_type, b64_data = match.groups()
+                                try:
+                                    decoded = base64.b64decode(b64_data, validate=True)
+                                except (binascii.Error, ValueError) as exc:
+                                    raise ValueError(
+                                        f"Invalid base64 data URI for {media_key}"
+                                    ) from exc
+                                if not decoded:
+                                    raise ValueError(
+                                        f"Empty base64 data URI for {media_key}"
+                                    )
+
+                                clean_mime_type = mime_type.lower()
+                                suffix = mimetypes.guess_extension(
+                                    clean_mime_type, strict=False
+                                )
+                                if clean_mime_type in ("image/jpeg", "image/jpg"):
+                                    suffix = ".jpg"
+                                elif not suffix:
+                                    suffix = ".bin"
+
+                                with tempfile.NamedTemporaryFile(
+                                    dir=temp_dir, delete=False, suffix=suffix
+                                ) as tmp:
+                                    tmp.write(decoded)
+                                    content[media_key]["url"] = (
+                                        Path(tmp.name).as_uri()
+                                        if media_key == "video_url"
+                                        else tmp.name
+                                    )
+                                    logger.debug(
+                                        "Decoded base64 %s content to temporary file: %s",
+                                        media_key,
+                                        tmp.name,
+                                    )
 
     async def _get_chat_template_and_tokenizer(
         self, model_family: str
@@ -2404,62 +2443,76 @@ class VLLMMultiModel(VLLMModel, ChatModelMixin):
 
         model_family = self.model_family.model_family or self.model_family.model_name
         audios, images, videos, video_kwargs = None, None, None, None
-        if "internvl" not in model_family.lower():
-            from qwen_omni_utils import (
-                process_audio_info,
-                process_mm_info,
-                process_vision_info,
-            )
-
-            # Pre-process messages to handle base64 data URIs BEFORE transform
-            temp_files: List[str] = []
-            if (
-                "vision" in self.model_family.model_ability
-                or "omni" in self.model_family.model_ability
-            ):
-                self._handle_base64_images(messages, temp_files)
-
-            messages = self._transform_messages(messages)
-
-            chat_template_kwargs = (
-                self._get_chat_template_kwargs_from_generate_config(
-                    generate_config, self.reasoning_parser
-                )
-                or {}
-            )
-            chat_context_var.set(chat_template_kwargs)
-            full_context_kwargs = chat_template_kwargs.copy()
-            if tools and (
-                model_family in QWEN_TOOL_CALL_FAMILY
-                or model_family in GEMMA_TOOL_CALL_FAMILY
-                or model_family in GLM5_TOOL_CALL_FAMILY
-                or model_family in KIMI_K3_TOOL_CALL_FAMILY
-            ):
-                full_context_kwargs["tools"] = tools
-            assert self.model_family.chat_template is not None
-
-            # Kimi-K3 has no Jinja template and renders through its tokenizer's
-            # custom Python apply_chat_template implementation.
-            chat_template, tokenizer = await self._get_chat_template_and_tokenizer(
-                model_family
-            )
-
-            if "omni" in self.model_family.model_ability:
-                audios, images, videos, video_kwargs = process_mm_info(
-                    messages, use_audio_in_video=True, return_video_kwargs=True
-                )
-            elif "audio" in self.model_family.model_ability:
-                audios = process_audio_info(messages, use_audio_in_video=False)
-            elif "vision" in self.model_family.model_ability:
-                images, videos, video_kwargs = process_vision_info(  # type: ignore
-                    messages, return_video_kwargs=True
+        temp_dir = None
+        try:
+            if "internvl" not in model_family.lower():
+                from qwen_omni_utils import (
+                    process_audio_info,
+                    process_mm_info,
+                    process_vision_info,
                 )
 
-            prompt = self.get_full_context(
-                messages, chat_template, tokenizer=tokenizer, **full_context_kwargs
-            )
-        else:
-            prompt, images = self.get_specific_prompt(model_family, messages)
+                # Work on a copy so request messages never retain paths that are
+                # removed when the request-level temporary directory is cleaned.
+                messages = copy.deepcopy(messages)
+                if (
+                    "vision" in self.model_family.model_ability
+                    or "omni" in self.model_family.model_ability
+                ):
+                    import tempfile
+
+                    temp_dir = tempfile.TemporaryDirectory(prefix="xinference-vllm-")
+                    self._handle_base64_media(messages, temp_dir.name)
+
+                messages = self._transform_messages(messages)
+
+                chat_template_kwargs = (
+                    self._get_chat_template_kwargs_from_generate_config(
+                        generate_config, self.reasoning_parser
+                    )
+                    or {}
+                )
+                chat_context_var.set(chat_template_kwargs)
+                full_context_kwargs = chat_template_kwargs.copy()
+                if tools and (
+                    model_family in QWEN_TOOL_CALL_FAMILY
+                    or model_family in GEMMA_TOOL_CALL_FAMILY
+                    or model_family in GLM5_TOOL_CALL_FAMILY
+                    or model_family in KIMI_K3_TOOL_CALL_FAMILY
+                ):
+                    full_context_kwargs["tools"] = tools
+                assert self.model_family.chat_template is not None
+
+                # Kimi-K3 has no Jinja template and renders through its tokenizer's
+                # custom Python apply_chat_template implementation.
+                chat_template, tokenizer = await self._get_chat_template_and_tokenizer(
+                    model_family
+                )
+
+                if "omni" in self.model_family.model_ability:
+                    audios, images, videos, video_kwargs = process_mm_info(
+                        messages, use_audio_in_video=True, return_video_kwargs=True
+                    )
+                elif "audio" in self.model_family.model_ability:
+                    audios = process_audio_info(messages, use_audio_in_video=False)
+                elif "vision" in self.model_family.model_ability:
+                    images, videos, video_kwargs = process_vision_info(  # type: ignore
+                        messages, return_video_kwargs=True
+                    )
+
+                prompt = self.get_full_context(
+                    messages, chat_template, tokenizer=tokenizer, **full_context_kwargs
+                )
+            else:
+                prompt, images = self.get_specific_prompt(model_family, messages)
+        finally:
+            if temp_dir is not None:
+                try:
+                    temp_dir.cleanup()
+                except Exception:
+                    logger.warning(
+                        "Failed to clean up temporary media directory", exc_info=True
+                    )
         inputs = {"prompt": prompt, "multi_modal_data": {}, "mm_processor_kwargs": {}}
         if images:
             inputs["multi_modal_data"]["image"] = images

--- a/xinference/model/llm/vllm/tests/test_core_chat_model.py
+++ b/xinference/model/llm/vllm/tests/test_core_chat_model.py
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import base64
+import sys
+import tempfile
+import types
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -73,6 +78,187 @@ class TestVLLMMultiModelChatTemplate:
             )
             == "native-kimi-k3-prompt"
         )
+
+
+class TestVLLMBase64Media:
+    class FakeVideo:
+        shape = (4, 3, 336, 336)
+
+    @pytest.fixture
+    def model(self):
+        from ..core import VLLMMultiModel
+
+        return object.__new__(VLLMMultiModel)
+
+    @pytest.mark.parametrize(
+        ("media_key", "mime_type", "expected_suffix", "expects_file_uri"),
+        [
+            ("image_url", "image/png", ".png", False),
+            ("image_url", "image/jpeg", ".jpg", False),
+            ("video_url", "video/mp4", ".mp4", True),
+            ("video_url", "application/x-xinference-test", ".bin", True),
+        ],
+    )
+    def test_handle_base64_media_uses_mime_suffix(
+        self, model, media_key, mime_type, expected_suffix, expects_file_uri
+    ):
+        media_data = f"{media_key}-{mime_type}".encode()
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": media_key,
+                        media_key: {
+                            "url": f"data:{mime_type};base64,"
+                            + base64.b64encode(media_data).decode()
+                        },
+                    }
+                ],
+            }
+        ]
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            model._handle_base64_media(messages, temp_dir)
+
+            materialized_url = messages[0]["content"][0][media_key]["url"]
+            assert materialized_url.startswith("file://") is expects_file_uri
+            media_path = Path(materialized_url.removeprefix("file://"))
+            assert media_path.is_absolute()
+            assert media_path.suffix == expected_suffix
+            assert media_path.read_bytes() == media_data
+
+        assert not media_path.exists()
+
+    def test_handle_base64_media_preserves_non_data_urls(self, model):
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "https://example.com/image.png"},
+                    },
+                    {
+                        "type": "video_url",
+                        "video_url": {"url": "https://example.com/video.mp4"},
+                    },
+                    {
+                        "type": "audio_url",
+                        "audio_url": {"url": "data:audio/wav;base64,YXVkaW8="},
+                    },
+                ],
+            }
+        ]
+        expected = [dict(item) for item in messages[0]["content"]]
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            model._handle_base64_media(messages, temp_dir)
+            assert list(Path(temp_dir).iterdir()) == []
+
+        assert messages[0]["content"] == expected
+
+    @pytest.mark.parametrize(
+        "data_uri",
+        [
+            "data:video/mp4;base64,%%%not-base64%%%",
+            "data:video/mp4,dm lkZW8=",
+            "data:video/mp4;base64,",
+        ],
+    )
+    def test_handle_base64_media_rejects_invalid_data(self, model, data_uri):
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "video_url",
+                        "video_url": {"url": data_uri},
+                    }
+                ],
+            }
+        ]
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with pytest.raises(ValueError, match="base64 data URI for video_url"):
+                model._handle_base64_media(messages, temp_dir)
+            assert list(Path(temp_dir).iterdir()) == []
+
+    @pytest.mark.asyncio
+    async def test_async_chat_cleans_materialized_video_after_processing(
+        self, model, monkeypatch
+    ):
+        video_data = b"mp4-video-content"
+        data_uri = "data:video/mp4;base64," + base64.b64encode(video_data).decode()
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "video_url",
+                        "video_url": {"url": data_uri},
+                    }
+                ],
+            }
+        ]
+        captured = {}
+
+        qwen_omni_utils = types.ModuleType("qwen_omni_utils")
+
+        def process_vision_info(transformed_messages, *, return_video_kwargs):
+            assert return_video_kwargs is True
+            video_uri = transformed_messages[0]["content"][0]["video"]
+            video_path = Path(video_uri.removeprefix("file://"))
+            assert video_uri.startswith("file://")
+            assert video_path.read_bytes() == video_data
+            captured["video_path"] = video_path
+            return None, [self.FakeVideo()], {"fps": [2.0]}
+
+        qwen_omni_utils.process_vision_info = process_vision_info
+        qwen_omni_utils.process_audio_info = MagicMock()
+        qwen_omni_utils.process_mm_info = MagicMock()
+        monkeypatch.setitem(sys.modules, "qwen_omni_utils", qwen_omni_utils)
+
+        model.model_uid = "test-model"
+        model.model_family = MagicMock()
+        model.model_family.model_family = "qwen2-vl"
+        model.model_family.model_name = "qwen2-vl"
+        model.model_family.model_ability = ["chat", "vision"]
+        model.model_family.chat_template = "chat-template"
+        model.reasoning_parser = None
+        model._get_chat_template_kwargs_from_generate_config = MagicMock(
+            return_value={}
+        )
+
+        async def get_chat_template_and_tokenizer(_model_family):
+            return "chat-template", None
+
+        model._get_chat_template_and_tokenizer = get_chat_template_and_tokenizer
+        model.get_full_context = MagicMock(return_value="prompt")
+        model._sanitize_chat_config = MagicMock(return_value={"stream": False})
+
+        async def async_generate(inputs, *_args, **_kwargs):
+            assert not captured["video_path"].exists()
+            [(video, metadata)] = inputs["multi_modal_data"]["video"]
+            assert isinstance(video, self.FakeVideo)
+            assert metadata == {
+                "total_num_frames": 4,
+                "frames_indices": [0, 1, 2, 3],
+                "fps": 2.0,
+                "duration": 2.0,
+                "height": 336,
+                "width": 336,
+            }
+            return {"completion": "ok"}
+
+        model.async_generate = async_generate
+        model._to_chat_completion = MagicMock(return_value={"result": "ok"})
+
+        result = await model.async_chat(messages, {})
+
+        assert result == {"result": "ok"}
+        assert messages[0]["content"][0]["video_url"]["url"] == data_uri
+        assert not captured["video_path"].exists()
 
 
 class TestVLLMChatModel:

--- a/xinference/model/llm/vllm/tests/test_core_chat_model.py
+++ b/xinference/model/llm/vllm/tests/test_core_chat_model.py
@@ -158,6 +158,36 @@ class TestVLLMBase64Media:
 
         assert messages[0]["content"] == expected
 
+    def test_handle_base64_media_accepts_folded_base64(self, model):
+        media_data = b"folded-base64-video"
+        encoded = base64.b64encode(media_data).decode()
+        folded = "\r\n  ".join(
+            encoded[index : index + 4] for index in range(0, len(encoded), 4)
+        )
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "video_url",
+                        "video_url": {"url": f"data:video/mp4;base64,{folded}"},
+                    }
+                ],
+            }
+        ]
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            model._handle_base64_media(messages, temp_dir)
+
+            video_uri = messages[0]["content"][0]["video_url"]["url"]
+            video_path = Path(video_uri.removeprefix("file://"))
+            assert video_path.read_bytes() == media_data
+
+    @pytest.mark.parametrize("fps", [0, 0.0, -1.0])
+    def test_attach_video_metadata_rejects_non_positive_fps(self, model, fps):
+        with pytest.raises(ValueError, match="fps must be greater than 0"):
+            model._attach_video_metadata([self.FakeVideo()], [fps])
+
     @pytest.mark.parametrize(
         "data_uri",
         [


### PR DESCRIPTION
## Summary

- materialize Base64 `image_url` and `video_url` data URIs into request-scoped temporary files
- pass materialized videos as `file://` URIs while preserving non-data URLs
- normalize folded Base64 payloads before strict validation, derive MIME-based suffixes, and clean temporary media after preprocessing
- populate video metadata using the current Transformers `VideoMetadata` schema and reject non-positive sampled FPS before forwarding it to vLLM

## Release note

- vLLM multimodal chat now accepts Base64 image and video data URIs through the OpenAI-compatible content schema.

Closes #5433

## Validation

- `python -m pytest -q xinference/model/llm/vllm/tests/test_core_chat_model.py -k TestVLLMBase64Media` (13 passed)
- `pre-commit run --files xinference/model/llm/vllm/core.py xinference/model/llm/vllm/tests/test_core_chat_model.py`
- end-to-end Qwen3.5 vLLM request with a Base64 MP4 returned HTTP 200 and correctly identified the video color
- verified request-scoped `xinference-vllm-*` temporary directories are removed after processing