### PR TITLE
ENH(UI): Add configurable speech and music output formats

### DIFF
--- a/doc/source/models/model_abilities/audio.rst
+++ b/doc/source/models/model_abilities/audio.rst
@@ -378,7 +378,8 @@ generating an instrumental track.
 ``duration`` defaults to 60 seconds. It accepts ``-1`` for model-selected
 duration or a value from 10 through 600 seconds. ``seed=-1`` selects a random
 seed; non-negative integers provide reproducible generation. Supported output
-formats are ``aac``, ``flac``, ``mp3``, ``opus``, ``wav``, and ``wav32``.
+formats are ``aac``, ``flac``, ``mp3``, ``ogg``, ``opus``, ``wav``, and
+``wav32``.
 Generation is non-streaming, ``speed`` must be ``1.0``, and ``voice`` must be
 ``default``, an empty string, or null.
 
@@ -392,7 +393,8 @@ same ``kwargs`` channel.
 When the LM is loaded, ``thinking=false`` disables audio-code reasoning by
 default. An explicitly enabled ``use_cot_caption``, ``use_cot_language``, or
 ``use_cot_metas`` still uses the LM for that planning step. MP3, AAC, and Opus
-output require a working FFmpeg installation.
+output require a working FFmpeg installation. OGG output is generated as WAV
+and then encoded as OGG/Vorbis with libsndfile.
 
 Raw REST requests encode ``kwargs`` as a JSON string. The Xinference sync and
 async clients accept these names through their existing ``**kwargs`` argument.
@@ -446,14 +448,16 @@ put tags such as ``[Verse]`` and ``[Chorus]`` on their own lines.
 through 360 and its default is 60. Xinference passes it directly to the
 Diffusers pipeline as ``audio_duration``. The model may emit an end-of-audio
 token and finish before the limit.
-The initial integration only accepts ``response_format=wav``, ``stream=false``,
-``speed=1.0``, and ``voice`` set to ``default``, an empty string, or null.
+Supported output formats are ``flac``, ``mp3``, ``ogg``, and ``wav``; WAV is
+the default. Generation requires ``stream=false``, ``speed=1.0``, and
+``voice`` set to ``default``, an empty string, or null.
 Inference requires NVIDIA CUDA. Sampling steps and classifier-free guidance
 remain at the Diffusers defaults and are not request parameters.
 
 Xinference preserves the Diffusers pipeline's native 44.1 kHz stereo samples.
 It wraps them in an IEEE-float WAV container without resampling or integer PCM
-quantization.
+quantization. FLAC, MP3, and OGG responses are encoded from those samples
+with libsndfile.
 
 ``instruct``, ``seed``, and ``duration`` are model options passed through the
 existing ``kwargs`` channel rather than additional Speech API parameters. Raw

--- a/frontend/src/components/pages/running-model-detail/capability-config.tsx
+++ b/frontend/src/components/pages/running-model-detail/capability-config.tsx
@@ -820,6 +820,7 @@ export const CAPABILITY_CONFIGS: Partial<Record<ModelAbility, CapabilityConfig>>
         },
         { key: 'voice', value: 'Voice ID', comment: 'Optional' },
         { key: 'speed', value: 1, comment: 'Optional' },
+        { key: 'response_format', value: 'mp3', comment: 'Optional' },
         {
           key: 'kwargs',
           value: { seed: 11 },
@@ -832,6 +833,7 @@ export const CAPABILITY_CONFIGS: Partial<Record<ModelAbility, CapabilityConfig>>
       input: '',
       voice: '',
       speed: 1,
+      response_format: 'mp3',
       seed: -1,
       prompt_speech: [],
       prompt_text: '',
@@ -852,6 +854,7 @@ export const CAPABILITY_CONFIGS: Partial<Record<ModelAbility, CapabilityConfig>>
       const promptText = stringValue(values.prompt_text).trim();
       const instruct = stringValue(values.instruct).trim();
       const seed = parseScalarSeed(values.seed);
+      const responseFormat = stringValue(values.response_format).trim().toLowerCase() || 'mp3';
 
       if (seed !== undefined) {
         kwargs.seed = seed;
@@ -885,7 +888,7 @@ export const CAPABILITY_CONFIGS: Partial<Record<ModelAbility, CapabilityConfig>>
         formData.append('input', stringValue(values.input));
         formData.append('voice', stringValue(values.voice));
         formData.append('speed', String(numberValue(values.speed, 1)));
-        formData.append('response_format', 'mp3');
+        formData.append('response_format', responseFormat);
         formData.append('stream', 'false');
         formData.append('prompt_speech', promptSpeech.file);
         appendKwargsIfPresent(formData, kwargs);
@@ -897,7 +900,7 @@ export const CAPABILITY_CONFIGS: Partial<Record<ModelAbility, CapabilityConfig>>
           input: stringValue(values.input),
           voice: values.voice || undefined,
           speed: numberValue(values.speed, 1),
-          response_format: 'mp3',
+          response_format: responseFormat,
           stream: false,
         },
         kwargs

--- a/frontend/src/components/pages/running-model-detail/capability-config.tsx
+++ b/frontend/src/components/pages/running-model-detail/capability-config.tsx
@@ -940,6 +940,7 @@ export const CAPABILITY_CONFIGS: Partial<Record<ModelAbility, CapabilityConfig>>
       instruct: '',
       seed: -1,
       duration: 60,
+      response_format: 'wav',
     },
     formPanel: SpeechPanel,
     resultPanel: ResultPanels.Universal,
@@ -948,7 +949,7 @@ export const CAPABILITY_CONFIGS: Partial<Record<ModelAbility, CapabilityConfig>>
       model: modelUid,
       input: stringValue(values.input),
       voice: 'default',
-      response_format: 'wav',
+      response_format: stringValue(values.response_format).trim().toLowerCase() || 'wav',
       kwargs: JSON.stringify({
         instruct: stringValue(values.instruct),
         seed: parseScalarSeed(values.seed) ?? -1,

--- a/frontend/src/components/pages/running-model-detail/panels/form-panels.tsx
+++ b/frontend/src/components/pages/running-model-detail/panels/form-panels.tsx
@@ -62,6 +62,11 @@ const SPEECH_RESPONSE_FORMAT_OPTIONS = ['mp3', 'wav', 'flac', 'ogg'].map((value)
   value,
 }));
 
+const FISH_SPEECH_RESPONSE_FORMAT_OPTIONS = ['mp3', 'wav', 'pcm'].map((value) => ({
+  label: value.toUpperCase(),
+  value,
+}));
+
 const MUSIC_RESPONSE_FORMAT_OPTIONS = ['mp3', 'wav', 'flac', 'ogg'].map((value) => ({
   label: value.toUpperCase(),
   value,
@@ -701,6 +706,10 @@ function EmotionVectorInput({ value, onChange, disabled, error }: BaseFormFieldP
 
 export function SpeechPanel({ form, model }: CapabilityFormProps) {
   const isMusicGeneration = model.model_ability.includes(ModelAbility.Text2music);
+  const speechResponseFormatOptions =
+    model.model_family === 'FishAudio'
+      ? FISH_SPEECH_RESPONSE_FORMAT_OPTIONS
+      : SPEECH_RESPONSE_FORMAT_OPTIONS;
   const supportsVoiceCloning = model.model_ability.includes(ModelAbility.Text2audioVoiceCloning);
   const supportsVoiceDesign = model.model_ability.includes(ModelAbility.Text2audioVoiceDesign);
   const promptSpeech = useWatch('prompt_speech', form);
@@ -746,7 +755,7 @@ export function SpeechPanel({ form, model }: CapabilityFormProps) {
           </FormField>
         ) : (
           <FormField name="response_format" label="Output Format">
-            <Select options={SPEECH_RESPONSE_FORMAT_OPTIONS} allowClear={false} />
+            <Select options={speechResponseFormatOptions} allowClear={false} />
           </FormField>
         )}
       </div>

--- a/frontend/src/components/pages/running-model-detail/panels/form-panels.tsx
+++ b/frontend/src/components/pages/running-model-detail/panels/form-panels.tsx
@@ -57,6 +57,11 @@ const DOCUMENT_LANGUAGE_OPTIONS = [
 
 const DOCUMENT_OUTPUT_OPTIONS = ['markdown', 'json'].map((value) => ({ label: value, value }));
 
+const SPEECH_RESPONSE_FORMAT_OPTIONS = ['mp3', 'wav', 'flac', 'ogg'].map((value) => ({
+  label: value.toUpperCase(),
+  value,
+}));
+
 const ASTRA_CAMERA_MOTION_OPTIONS = [
   { label: '↑ Move forward', value: 1 },
   { label: '↺ Rotate left in place', value: 2 },
@@ -728,11 +733,18 @@ export function SpeechPanel({ form, model }: CapabilityFormProps) {
           </FormField>
         </div>
       )}
-      <div className={isMusicGeneration ? 'grid grid-cols-2 gap-3' : undefined}>
+      <div className="grid grid-cols-2 gap-3">
         <ScalarSeedField form={form} />
-        {isMusicGeneration && (
+        {isMusicGeneration ? (
           <FormField name="duration" label="Duration (seconds)" normalize={normalizeNumberInput}>
             <Input type="number" />
+          </FormField>
+        ) : (
+          <FormField
+            name="response_format"
+            label="Output Format"
+          >
+            <Select options={SPEECH_RESPONSE_FORMAT_OPTIONS} allowClear={false} />
           </FormField>
         )}
       </div>

--- a/frontend/src/components/pages/running-model-detail/panels/form-panels.tsx
+++ b/frontend/src/components/pages/running-model-detail/panels/form-panels.tsx
@@ -62,6 +62,11 @@ const SPEECH_RESPONSE_FORMAT_OPTIONS = ['mp3', 'wav', 'flac', 'ogg'].map((value)
   value,
 }));
 
+const MUSIC_RESPONSE_FORMAT_OPTIONS = ['mp3', 'wav', 'flac', 'ogg'].map((value) => ({
+  label: value.toUpperCase(),
+  value,
+}));
+
 const ASTRA_CAMERA_MOTION_OPTIONS = [
   { label: '↑ Move forward', value: 1 },
   { label: '↺ Rotate left in place', value: 2 },
@@ -740,14 +745,16 @@ export function SpeechPanel({ form, model }: CapabilityFormProps) {
             <Input type="number" />
           </FormField>
         ) : (
-          <FormField
-            name="response_format"
-            label="Output Format"
-          >
+          <FormField name="response_format" label="Output Format">
             <Select options={SPEECH_RESPONSE_FORMAT_OPTIONS} allowClear={false} />
           </FormField>
         )}
       </div>
+      {isMusicGeneration && (
+        <FormField name="response_format" label="Output Format">
+          <Select options={MUSIC_RESPONSE_FORMAT_OPTIONS} allowClear={false} />
+        </FormField>
+      )}
       {showPromptSpeech && (
         <FormField name="prompt_speech">
           <FileUpload

--- a/xinference/model/audio/ace_step.py
+++ b/xinference/model/audio/ace_step.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import io
 import os
 import shutil
 import sys
@@ -78,7 +79,7 @@ class AceStepModel:
     _bundled_dit_model = "acestep-v15-turbo"
     _bundled_lm_model = "acestep-5Hz-lm-1.7B"
     _lm_backends = {"mlx", "pt", "vllm"}
-    _response_formats = {"aac", "flac", "mp3", "opus", "wav", "wav32"}
+    _response_formats = {"aac", "flac", "mp3", "ogg", "opus", "wav", "wav32"}
     _generation_options = {
         "bpm",
         "cfg_interval_end",
@@ -373,6 +374,25 @@ class AceStepModel:
             )
         return audio_format
 
+    @staticmethod
+    def _wav_file_to_ogg(audio_path: str) -> bytes:
+        import soundfile
+
+        audio, sample_rate = soundfile.read(
+            audio_path,
+            dtype="float32",
+            always_2d=True,
+        )
+        with io.BytesIO() as output:
+            soundfile.write(
+                output,
+                audio,
+                sample_rate,
+                format="OGG",
+                subtype="VORBIS",
+            )
+            return output.getvalue()
+
     def speech(
         self,
         input: str,
@@ -434,11 +454,12 @@ class AceStepModel:
             generation_kwargs.setdefault(name, thinking)
 
         params = self._generation_params_cls(**generation_kwargs)
+        generation_audio_format = "wav" if audio_format == "ogg" else audio_format
         generation_config = self._generation_config_cls(
             batch_size=1,
             use_random_seed=seed == -1,
             seeds=None if seed == -1 else [seed],
-            audio_format=audio_format,
+            audio_format=generation_audio_format,
         )
 
         with tempfile.TemporaryDirectory(prefix="xinference-ace-step-") as output_dir:
@@ -456,5 +477,7 @@ class AceStepModel:
             if len(result.audios) != 1 or not result.audios[0].get("path"):
                 raise RuntimeError("ACE-Step 1.5 returned no saved audio output.")
             audio_path = result.audios[0]["path"]
+            if audio_format == "ogg":
+                return self._wav_file_to_ogg(audio_path)
             with open(audio_path, "rb") as audio_file:
                 return audio_file.read()

--- a/xinference/model/audio/minimax_music3.py
+++ b/xinference/model/audio/minimax_music3.py
@@ -28,6 +28,8 @@ logger = logging.getLogger(__name__)
 class MiniMaxMusic3Model:
     """Diffusers-backed MiniMax-Music3 text-to-music model."""
 
+    _response_formats = {"flac", "mp3", "ogg", "wav"}
+
     def __init__(
         self,
         model_uid: str,
@@ -157,7 +159,7 @@ class MiniMaxMusic3Model:
         seed: int,
         duration: float,
         kwargs: dict,
-    ) -> None:
+    ) -> str:
         if not isinstance(input, str) or not input.strip():
             raise ValueError("MiniMax-Music3 requires non-empty lyrics in `input`.")
         if not isinstance(instruct, str) or not instruct.strip():
@@ -170,9 +172,13 @@ class MiniMaxMusic3Model:
                 "MiniMax-Music3 only accepts `voice` as null, an empty string, "
                 "or 'default'."
             )
-        if response_format is None or response_format.lower() != "wav":
+        if response_format is not None and not isinstance(response_format, str):
+            raise ValueError("MiniMax-Music3 `response_format` must be a string.")
+        audio_format = (response_format or "wav").lower()
+        if audio_format not in MiniMaxMusic3Model._response_formats:
+            formats = ", ".join(sorted(MiniMaxMusic3Model._response_formats))
             raise ValueError(
-                "MiniMax-Music3 currently supports `response_format=wav` only."
+                f"MiniMax-Music3 supports these response formats: {formats}."
             )
         if speed != 1.0:
             raise ValueError("MiniMax-Music3 only supports `speed=1.0`.")
@@ -193,9 +199,10 @@ class MiniMaxMusic3Model:
                 "MiniMax-Music3 does not support speech parameter(s): "
                 + ", ".join(sorted(kwargs))
             )
+        return audio_format
 
     @staticmethod
-    def _audio_to_native_wav(audio, sample_rate: int) -> bytes:
+    def _normalize_audio(audio):
         import numpy as np
 
         if hasattr(audio, "detach"):
@@ -213,7 +220,11 @@ class MiniMaxMusic3Model:
                 "stereo output was expected."
             )
 
-        audio = np.ascontiguousarray(audio, dtype="<f4")
+        return np.ascontiguousarray(audio, dtype="<f4")
+
+    @classmethod
+    def _audio_to_native_wav(cls, audio, sample_rate: int) -> bytes:
+        audio = cls._normalize_audio(audio)
         channels = audio.shape[1]
         bytes_per_sample = audio.dtype.itemsize
         block_align = channels * bytes_per_sample
@@ -247,6 +258,25 @@ class MiniMaxMusic3Model:
             output.write(audio_bytes)
             return output.getvalue()
 
+    @classmethod
+    def _audio_to_bytes(cls, audio, sample_rate: int, response_format: str) -> bytes:
+        if response_format == "wav":
+            return cls._audio_to_native_wav(audio, sample_rate)
+
+        import soundfile
+
+        audio = cls._normalize_audio(audio)
+        with io.BytesIO() as output:
+            with soundfile.SoundFile(
+                output,
+                "w",
+                sample_rate,
+                audio.shape[1],
+                format=response_format.upper(),
+            ) as audio_file:
+                audio_file.write(audio)
+            return output.getvalue()
+
     def speech(
         self,
         input: str,
@@ -260,7 +290,7 @@ class MiniMaxMusic3Model:
         instruct = kwargs.pop("instruct", None)
         seed = kwargs.pop("seed", 0)
         duration = kwargs.pop("duration", 60.0)
-        self._validate_speech_request(
+        response_format = self._validate_speech_request(
             input,
             instruct,
             voice,
@@ -284,4 +314,4 @@ class MiniMaxMusic3Model:
         )
         audio = result[0]
         sample_rate = int(self._model.sampling_rate)
-        return self._audio_to_native_wav(audio, sample_rate)
+        return self._audio_to_bytes(audio, sample_rate, response_format)

--- a/xinference/model/audio/model_spec.json
+++ b/xinference/model/audio/model_spec.json
@@ -2533,6 +2533,7 @@
         "accelerate>=1.13.0",
         "huggingface-hub>=1.23.0,<2.0",
         "safetensors>=0.8.0",
+        "soundfile>=0.13.1",
         "#system_torch#",
         "#system_numpy#"
       ]

--- a/xinference/model/audio/tests/test_ace_step.py
+++ b/xinference/model/audio/tests/test_ace_step.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import io
 import os
 import re
 import sys
@@ -19,6 +20,7 @@ from pathlib import Path
 from types import ModuleType, SimpleNamespace
 from unittest.mock import ANY, Mock
 
+import numpy as np
 import pytest
 
 from .. import ace_step
@@ -209,7 +211,7 @@ def test_prepare_runtime_checkpoint_isolates_mutable_model_files(tmp_path, model
             "only accepts `voice` as null",
         ),
         (
-            {"input": "lyrics", "instruct": "piano", "response_format": "ogg"},
+            {"input": "lyrics", "instruct": "piano", "response_format": "m4a"},
             "supports these response formats",
         ),
         (
@@ -306,6 +308,63 @@ def test_speech_returns_generated_audio(loaded_model):
     )
     assert len(generated_paths) == 1
     assert not generated_paths[0].exists()
+
+
+def test_speech_transcodes_ogg_from_native_wav(loaded_model):
+    generated_paths = []
+
+    def generate_music(*args, save_dir, **kwargs):
+        audio_path = Path(save_dir) / "output.wav"
+        audio_path.write_bytes(b"native wav")
+        generated_paths.append(audio_path)
+        return SimpleNamespace(
+            success=True,
+            error=None,
+            status_message="success",
+            audios=[{"path": str(audio_path)}],
+        )
+
+    loaded_model._generate_music.side_effect = generate_music
+    loaded_model._wav_file_to_ogg = Mock(return_value=b"encoded ogg")
+
+    result = loaded_model.speech(
+        "lyrics",
+        instruct="piano",
+        response_format="ogg",
+        seed=7,
+        duration=30,
+    )
+
+    assert result == b"encoded ogg"
+    loaded_model._generation_config_cls.assert_called_once_with(
+        batch_size=1,
+        use_random_seed=False,
+        seeds=[7],
+        audio_format="wav",
+    )
+    assert len(generated_paths) == 1
+    loaded_model._wav_file_to_ogg.assert_called_once_with(str(generated_paths[0]))
+    assert not generated_paths[0].exists()
+
+
+def test_wav_file_to_ogg_encodes_vorbis(tmp_path):
+    soundfile = pytest.importorskip("soundfile", minversion="0.13.1")
+    wav_path = tmp_path / "native.wav"
+    soundfile.write(
+        wav_path,
+        np.zeros((2400, 2), dtype=np.float32),
+        24000,
+        format="WAV",
+    )
+
+    encoded = AceStepModel._wav_file_to_ogg(str(wav_path))
+    info = soundfile.info(io.BytesIO(encoded))
+
+    assert encoded.startswith(b"OggS")
+    assert info.format == "OGG"
+    assert info.subtype == "VORBIS"
+    assert info.samplerate == 24000
+    assert info.channels == 2
 
 
 @pytest.mark.parametrize(

--- a/xinference/model/audio/tests/test_minimax_music3.py
+++ b/xinference/model/audio/tests/test_minimax_music3.py
@@ -1,0 +1,93 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import io
+import re
+
+import numpy as np
+import pytest
+
+from ..minimax_music3 import MiniMaxMusic3Model
+
+
+@pytest.mark.parametrize(
+    ("response_format", "expected"),
+    [
+        (None, "wav"),
+        ("", "wav"),
+        ("WAV", "wav"),
+        ("mp3", "mp3"),
+        ("flac", "flac"),
+        ("ogg", "ogg"),
+    ],
+)
+def test_validate_speech_request_normalizes_response_format(response_format, expected):
+    actual = MiniMaxMusic3Model._validate_speech_request(
+        "lyrics",
+        "warm piano",
+        "default",
+        response_format,
+        1.0,
+        False,
+        0,
+        60,
+        {},
+    )
+
+    assert actual == expected
+
+
+def test_validate_speech_request_rejects_unsupported_response_format():
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "MiniMax-Music3 supports these response formats: flac, mp3, ogg, wav."
+        ),
+    ):
+        MiniMaxMusic3Model._validate_speech_request(
+            "lyrics",
+            "warm piano",
+            "default",
+            "aac",
+            1.0,
+            False,
+            0,
+            60,
+            {},
+        )
+
+
+def test_audio_to_bytes_preserves_native_wav_output():
+    audio = np.zeros((2, 32), dtype=np.float32)
+
+    encoded = MiniMaxMusic3Model._audio_to_bytes(audio, 44100, "wav")
+
+    assert encoded.startswith(b"RIFF")
+    assert encoded[8:12] == b"WAVE"
+
+
+@pytest.mark.parametrize(
+    ("response_format", "expected_container"),
+    [("flac", "FLAC"), ("mp3", "MP3"), ("ogg", "OGG")],
+)
+def test_audio_to_bytes_encodes_requested_format(response_format, expected_container):
+    soundfile = pytest.importorskip("soundfile", minversion="0.13.1")
+    audio = np.zeros((2, 4410), dtype=np.float32)
+
+    encoded = MiniMaxMusic3Model._audio_to_bytes(audio, 44100, response_format)
+    info = soundfile.info(io.BytesIO(encoded))
+
+    assert info.format == expected_container
+    assert info.samplerate == 44100
+    assert info.channels == 2


### PR DESCRIPTION
## Summary

Add output-format selection to the built-in Web UI for speech and music generation, and provide a common `mp3` / `wav` / `flac` / `ogg` output surface for the built-in music models.

## Changes

- Add an `Output Format` selector to the TTS WebUI.
- Forward the selected format through JSON and multipart speech requests.
- Add an `Output Format` selector for text-to-music generation.
- Keep TTS defaulting to MP3 and music generation defaulting to WAV.
- Extend MiniMax-Music3 output support to:
  - MP3
  - WAV
  - FLAC
  - OGG
- Preserve MiniMax-Music3 native IEEE-float WAV output.
- Encode MiniMax-Music3 MP3, FLAC, and OGG responses with libsndfile.
- Add OGG support to ACE-Step1.5:
  - Generate WAV through the native ACE-Step backend.
  - Transcode the generated WAV to OGG/Vorbis with libsndfile.
  - Preserve all existing native ACE-Step output formats.
- Update model dependencies, documentation, and audio model tests.

## Compatibility

- No Speech API schema or route changes.
- Existing defaults remain unchanged:
  - TTS: MP3
  - Music: WAV
- TTS models continue validating their supported formats individually.

<img width="1096" height="1168" alt="f30f9ab2-2750-4fe2-af25-5e94c348c1fe" src="https://github.com/user-attachments/assets/dbeba55a-ee33-4fef-859a-e7aacb0df95f" />
