### PR TITLE
FIX: preserve available model download hubs

### DIFF
--- a/frontend/src/components/pages/launch-model/launch-dialog/launch-dialog.tsx
+++ b/frontend/src/components/pages/launch-model/launch-dialog/launch-dialog.tsx
@@ -344,19 +344,29 @@ export default function LaunchDialog({
   }, [gpuAvailable, modelType, form]);
 
   const downloadHubOptions = useMemo(() => {
-    const engineHubs = Array.from(
+    const allSpecHubs = Array.from(
       new Set(
-        (model?.modelSpecs || [])
-          .filter(
-            (spec) =>
-              !modelEngineValue ||
-              toOptionValue(spec.model_engine).toLowerCase() === modelEngineValue.toLowerCase()
-          )
-          .map((spec) => toOptionValue(spec.model_hub))
-          .filter(Boolean)
+        (model?.modelSpecs || []).map((spec) => toOptionValue(spec.model_hub)).filter(Boolean)
       )
     );
-    const availableHubs = engineHubs.length > 0 ? engineHubs : model?.download_hubs || [];
+    const modelHubs = Array.from(
+      new Set((model?.download_hubs || []).map(toOptionValue).filter(Boolean))
+    );
+    const engineHubs = modelEngineValue
+      ? Array.from(
+          new Set(
+            (model?.modelSpecs || [])
+              .filter(
+                (spec) =>
+                  toOptionValue(spec.model_engine).toLowerCase() === modelEngineValue.toLowerCase()
+              )
+              .map((spec) => toOptionValue(spec.model_hub))
+              .filter(Boolean)
+          )
+        )
+      : [];
+    const availableHubs =
+      engineHubs.length > 0 ? engineHubs : modelHubs.length > 0 ? modelHubs : allSpecHubs;
     return ['auto', 'none', ...availableHubs].map((item) => ({
       label: item,
       value: item,


### PR DESCRIPTION
## Summary

Fix the download hub selector incorrectly hiding supported model sources.

Some catalog responses contain a complete model-level `download_hubs` list but only a partial or deduplicated `model_specs` list. For example, FireRedTTS3-Instruct reports both Hugging Face and ModelScope in `download_hubs`, while `model_specs` may contain only the Hugging Face entry. The previous frontend logic treated the partial specification list as authoritative and hid ModelScope.

## Changes

- Use model-level `download_hubs` when no model engine is selected.
- Preserve engine-specific hub filtering after an engine is selected.
- Fall back to model-level hubs when engine metadata is missing or incomplete.
- Fall back to specification hubs when `download_hubs` is unavailable.
- Deduplicate generated download hub options.
- Keep the implementation inside `launch-dialog.tsx`.
