### PR TITLE
feat(embedding): add WeMM-Embedding support

### DIFF
--- a/doc/source/models/builtin/embedding/index.rst
+++ b/doc/source/models/builtin/embedding/index.rst
@@ -96,4 +96,9 @@ The following is a list of built-in embedding models in Xinference:
    text2vec-base-multilingual
   
    text2vec-large-chinese
-  
+
+   wemm-embedding-2b
+
+   wemm-embedding-4b
+
+   wemm-embedding-9b

--- a/doc/source/models/builtin/embedding/wemm-embedding-2b.rst
+++ b/doc/source/models/builtin/embedding/wemm-embedding-2b.rst
@@ -1,0 +1,21 @@
+.. _models_builtin_wemm-embedding-2b:
+
+=================
+WeMM-Embedding-2B
+=================
+
+- **Model Name:** WeMM-Embedding-2B
+- **Languages:** zh, en
+- **Abilities:** embed
+
+Specifications
+^^^^^^^^^^^^^^
+
+- **Dimensions:** 2048
+- **Max Tokens:** 262144
+- **Model ID:** tencent/WeMM-Embedding-2B
+- **Model Hubs**: `Hugging Face <https://huggingface.co/tencent/WeMM-Embedding-2B>`__, `ModelScope <https://modelscope.cn/models/Tencent-Hunyuan/WeMM-Embedding-2B>`__
+
+Execute the following command to launch the model::
+
+   xinference launch --model-name WeMM-Embedding-2B --model-type embedding

--- a/doc/source/models/builtin/embedding/wemm-embedding-4b.rst
+++ b/doc/source/models/builtin/embedding/wemm-embedding-4b.rst
@@ -1,0 +1,21 @@
+.. _models_builtin_wemm-embedding-4b:
+
+=================
+WeMM-Embedding-4B
+=================
+
+- **Model Name:** WeMM-Embedding-4B
+- **Languages:** zh, en
+- **Abilities:** embed
+
+Specifications
+^^^^^^^^^^^^^^
+
+- **Dimensions:** 2560
+- **Max Tokens:** 262144
+- **Model ID:** tencent/WeMM-Embedding-4B
+- **Model Hubs**: `Hugging Face <https://huggingface.co/tencent/WeMM-Embedding-4B>`__, `ModelScope <https://modelscope.cn/models/Tencent-Hunyuan/WeMM-Embedding-4B>`__
+
+Execute the following command to launch the model::
+
+   xinference launch --model-name WeMM-Embedding-4B --model-type embedding

--- a/doc/source/models/builtin/embedding/wemm-embedding-9b.rst
+++ b/doc/source/models/builtin/embedding/wemm-embedding-9b.rst
@@ -1,0 +1,21 @@
+.. _models_builtin_wemm-embedding-9b:
+
+=================
+WeMM-Embedding-9B
+=================
+
+- **Model Name:** WeMM-Embedding-9B
+- **Languages:** zh, en
+- **Abilities:** embed
+
+Specifications
+^^^^^^^^^^^^^^
+
+- **Dimensions:** 4096
+- **Max Tokens:** 262144
+- **Model ID:** tencent/WeMM-Embedding-9B
+- **Model Hubs**: `Hugging Face <https://huggingface.co/tencent/WeMM-Embedding-9B>`__, `ModelScope <https://modelscope.cn/models/Tencent-Hunyuan/WeMM-Embedding-9B>`__
+
+Execute the following command to launch the model::
+
+   xinference launch --model-name WeMM-Embedding-9B --model-type embedding

--- a/doc/source/models/model_abilities/embed.rst
+++ b/doc/source/models/model_abilities/embed.rst
@@ -46,7 +46,7 @@ When launching an embedding model, you can pick the serving engine with the
   models.
 * ``vllm``: high-throughput serving for supported model families — currently
   models whose names start with ``bge``, ``gte``, ``text2vec``, ``m3e``,
-  ``Qwen3``, or ``bce`` (e.g. ``bce-embedding-base_v1``).
+  ``Qwen3``, ``WeMM``, or ``bce`` (e.g. ``bce-embedding-base_v1``).
 * ``flag``: FlagEmbedding-based engine; also supports hybrid (sparse+dense)
   output, see the FAQ below.
 * ``llama.cpp``: serve GGUF-format embedding models.
@@ -71,6 +71,45 @@ to cap the token length of each input before encoding:
         "input": "A very long document ...",
         "truncate_prompt_tokens": 512
       }'
+
+
+Multimodal WeMM-Embedding input
+-------------------------------
+
+The WeMM-Embedding family accepts text, image, video, visual-document, and
+interleaved multimodal input. Audio is not supported. Supported engines are
+``sentence_transformers`` (default) and ``vllm``.
+
+A flat input dictionary can contain any ordered combination of ``text``,
+``image``, and ``video``. For precise interleaving, pass a ``role``/``content``
+message. ``image_url`` and ``video_url`` content items are also accepted.
+Local media paths refer to files on the Xinference server.
+
+.. code-block:: bash
+
+    xinference launch \
+      --model-name WeMM-Embedding-2B \
+      --model-type embedding \
+      --model-engine sentence_transformers
+
+    curl -X POST \
+      'http://<XINFERENCE_HOST>:<XINFERENCE_PORT>/v1/embeddings' \
+      -H 'Content-Type: application/json' \
+      -d '{
+        "model": "<MODEL_UID>",
+        "input": {
+          "role": "user",
+          "content": [
+            {"type": "image_url", "image_url": {"url": "https://example.com/image.jpg"}},
+            {"type": "text", "text": "Find content related to this image."},
+            {"type": "video_url", "video_url": {"url": "https://example.com/video.mp4"}}
+          ]
+        },
+        "dimensions": 256
+      }'
+
+``dimensions`` selects one of the model's Matryoshka dimensions. By default,
+Xinference truncates the vector and applies L2 normalization again.
 
 
 Quickstart

--- a/xinference/api/schemas/requests.py
+++ b/xinference/api/schemas/requests.py
@@ -25,7 +25,13 @@ class CreateCompletionRequest(CreateCompletion):
 class CreateEmbeddingRequest(BaseModel):
     model: str
     input: Union[
-        str, List[str], List[int], List[List[int]], Dict[str, str], List[Dict[str, str]]
+        str,
+        List[str],
+        List[int],
+        List[List[int]],
+        Dict[str, Any],
+        List[Dict[str, Any]],
+        List[Union[str, Dict[str, Any]]],
     ] = Field(description="The input to embed.")
     user: Optional[str] = None
     # Truncate each input to this many tokens before encoding. Mirrors the

--- a/xinference/client/restful/async_restful_client.py
+++ b/xinference/client/restful/async_restful_client.py
@@ -99,16 +99,27 @@ class AsyncRESTfulModelHandle:
 
 class AsyncRESTfulEmbeddingModelHandle(AsyncRESTfulModelHandle):
     async def create_embedding(
-        self, input: Union[str, List[str]], **kwargs
+        self,
+        input: Union[
+            str,
+            List[str],
+            List[int],
+            List[List[int]],
+            Dict[str, Any],
+            List[Dict[str, Any]],
+            List[Union[str, Dict[str, Any]]],
+        ],
+        **kwargs,
     ) -> "Embedding":
         """
         Create an Embedding from user input via RESTful APIs.
 
         Parameters
         ----------
-        input: Union[str, List[str]]
-            Input text to embed, encoded as a string or array of tokens.
-            To embed multiple inputs in a single request, pass an array of strings or array of token arrays.
+        input: Union[str, List[str], List[int], List[List[int]], Dict[str, Any],
+                     List[Dict[str, Any]], List[Union[str, Dict[str, Any]]]]
+            Text, token IDs, or multimodal input. Multimodal dictionaries may
+            contain text, image, video, or interleaved role/content messages.
 
         Returns
         -------

--- a/xinference/client/restful/restful_client.py
+++ b/xinference/client/restful/restful_client.py
@@ -76,15 +76,28 @@ class RESTfulModelHandle:
 
 
 class RESTfulEmbeddingModelHandle(RESTfulModelHandle):
-    def create_embedding(self, input: Union[str, List[str]], **kwargs) -> "Embedding":
+    def create_embedding(
+        self,
+        input: Union[
+            str,
+            List[str],
+            List[int],
+            List[List[int]],
+            Dict[str, Any],
+            List[Dict[str, Any]],
+            List[Union[str, Dict[str, Any]]],
+        ],
+        **kwargs,
+    ) -> "Embedding":
         """
         Create an Embedding from user input via RESTful APIs.
 
         Parameters
         ----------
-        input: Union[str, List[str]]
-            Input text to embed, encoded as a string or array of tokens.
-            To embed multiple inputs in a single request, pass an array of strings or array of token arrays.
+        input: Union[str, List[str], List[int], List[List[int]], Dict[str, Any],
+                     List[Dict[str, Any]], List[Union[str, Dict[str, Any]]]]
+            Text, token IDs, or multimodal input. Multimodal dictionaries may
+            contain text, image, video, or interleaved role/content messages.
 
         Returns
         -------

--- a/xinference/model/embedding/core.py
+++ b/xinference/model/embedding/core.py
@@ -211,7 +211,8 @@ class EmbeddingModel(abc.ABC):
         """
 
     def _fix_langchain_openai_inputs(
-        self, sentences: Union[str, List[str], Dict[str, str], List[Dict[str, str]]]
+        self,
+        sentences: Union[str, Dict[str, Any], List[Union[str, Dict[str, Any]]]],
     ):
         # Check if sentences is a two-dimensional list of integers
         if (
@@ -261,7 +262,7 @@ class EmbeddingModel(abc.ABC):
     @abstractmethod
     def _create_embedding(
         self,
-        sentences: Union[str, List[str]],
+        sentences: Union[str, Dict[str, Any], List[Union[str, Dict[str, Any]]]],
         **kwargs,
     ):
         """
@@ -269,9 +270,9 @@ class EmbeddingModel(abc.ABC):
 
         Parameters
         ----------
-        sentences: Union[str, List[str]]
-            Input text to embed, encoded as a string or array of tokens.
-            To embed multiple inputs in a single request, pass an array of strings or array of token arrays.
+        sentences: Union[str, Dict[str, Any], List[Union[str, Dict[str, Any]]]]
+            Text or multimodal input. To embed multiple inputs in one request,
+            pass a list of strings or multimodal dictionaries.
 
         Returns
         -------
@@ -282,7 +283,7 @@ class EmbeddingModel(abc.ABC):
     @extensible
     def create_embedding(
         self,
-        sentences: Union[str, List[str]],
+        sentences: Union[str, Dict[str, Any], List[Union[str, Dict[str, Any]]]],
         **kwargs,
     ):
         truncate_prompt_tokens = kwargs.pop("truncate_prompt_tokens", None)
@@ -299,7 +300,7 @@ class EmbeddingModel(abc.ABC):
         # 1. Group by kwargs hash
         for i, (args, kwargs) in enumerate(zip(args_list, kwargs_list)):
             sentences, extra_kwargs = self._extract_sentences_kwargs(args, kwargs)
-            if isinstance(sentences, str):
+            if isinstance(sentences, (str, dict)):
                 sentences = [sentences]
 
             key = make_hashable(extra_kwargs)
@@ -399,8 +400,9 @@ class EmbeddingModel(abc.ABC):
             List[str],
             List[int],
             List[List[int]],
-            Dict[str, str],
-            List[Dict[str, str]],
+            Dict[str, Any],
+            List[Dict[str, Any]],
+            List[Union[str, Dict[str, Any]]],
         ],
         truncate_prompt_tokens: Optional[int],
     ) -> Union[
@@ -408,8 +410,9 @@ class EmbeddingModel(abc.ABC):
         List[str],
         List[int],
         List[List[int]],
-        Dict[str, str],
-        List[Dict[str, str]],
+        Dict[str, Any],
+        List[Dict[str, Any]],
+        List[Union[str, Dict[str, Any]]],
     ]:
         """Truncate input to ``truncate_prompt_tokens`` tokens before encoding.
 
@@ -418,8 +421,8 @@ class EmbeddingModel(abc.ABC):
         empty (``max_length=0``), ``<0`` = cap at the model's own ``max_tokens``.
 
         Structure-preserving: token arrays (``List[int]`` / ``List[List[int]]``)
-        are sliced to N ids; multimodal dicts (``Dict[str, str]`` /
-        ``List[Dict[str, str]]``) keep their keys and non-text values, and only
+        are sliced to N ids; multimodal dicts (``Dict[str, Any]`` /
+        ``List[Dict[str, Any]]``) keep their keys and non-text values, and only
         the ``text`` field is truncated (``image`` / ``video`` / ``audio`` and
         other media fields are preserved verbatim). Plain ``str`` / ``List[str]`` are
         truncated token-based (sentence_transformers / flag / vllm) with a

--- a/xinference/model/embedding/core.py
+++ b/xinference/model/embedding/core.py
@@ -262,7 +262,7 @@ class EmbeddingModel(abc.ABC):
     @abstractmethod
     def _create_embedding(
         self,
-        sentences: Union[str, Dict[str, Any], List[Union[str, Dict[str, Any]]]],
+        sentences: Any,
         **kwargs,
     ):
         """

--- a/xinference/model/embedding/model_spec.json
+++ b/xinference/model/embedding/model_spec.json
@@ -1911,7 +1911,7 @@
     ],
     "virtualenv": {
       "packages": [
-        "sentence-transformers>=5.7.0 ; #engine# == \"sentence_transformers\"",
+        "sentence-transformers==5.7.0 ; #engine# == \"sentence_transformers\"",
         "transformers==5.2.0 ; #engine# == \"sentence_transformers\"",
         "accelerate>=1.1.0 ; #engine# == \"sentence_transformers\"",
         "qwen-vl-utils==0.0.14 ; #engine# == \"sentence_transformers\"",
@@ -1955,7 +1955,7 @@
     ],
     "virtualenv": {
       "packages": [
-        "sentence-transformers>=5.7.0 ; #engine# == \"sentence_transformers\"",
+        "sentence-transformers==5.7.0 ; #engine# == \"sentence_transformers\"",
         "transformers==5.2.0 ; #engine# == \"sentence_transformers\"",
         "accelerate>=1.1.0 ; #engine# == \"sentence_transformers\"",
         "qwen-vl-utils==0.0.14 ; #engine# == \"sentence_transformers\"",
@@ -1999,7 +1999,7 @@
     ],
     "virtualenv": {
       "packages": [
-        "sentence-transformers>=5.7.0 ; #engine# == \"sentence_transformers\"",
+        "sentence-transformers==5.7.0 ; #engine# == \"sentence_transformers\"",
         "transformers==5.2.0 ; #engine# == \"sentence_transformers\"",
         "accelerate>=1.1.0 ; #engine# == \"sentence_transformers\"",
         "qwen-vl-utils==0.0.14 ; #engine# == \"sentence_transformers\"",

--- a/xinference/model/embedding/model_spec.json
+++ b/xinference/model/embedding/model_spec.json
@@ -1878,5 +1878,137 @@
     },
     "featured": false,
     "updated_at": 1784276332
+  },
+  {
+    "version": 2,
+    "model_name": "WeMM-Embedding-2B",
+    "dimensions": 2048,
+    "max_tokens": 262144,
+    "language": [
+      "zh",
+      "en"
+    ],
+    "model_specs": [
+      {
+        "model_format": "pytorch",
+        "model_src": {
+          "huggingface": {
+            "model_id": "tencent/WeMM-Embedding-2B",
+            "model_revision": "main",
+            "quantizations": [
+              "none"
+            ]
+          },
+          "modelscope": {
+            "model_id": "Tencent-Hunyuan/WeMM-Embedding-2B",
+            "model_revision": "master",
+            "quantizations": [
+              "none"
+            ]
+          }
+        }
+      }
+    ],
+    "virtualenv": {
+      "packages": [
+        "sentence-transformers>=5.7.0 ; #engine# == \"sentence_transformers\"",
+        "transformers==5.2.0 ; #engine# == \"sentence_transformers\"",
+        "accelerate>=1.1.0 ; #engine# == \"sentence_transformers\"",
+        "qwen-vl-utils==0.0.14 ; #engine# == \"sentence_transformers\"",
+        "#system_torch# ; #engine# == \"sentence_transformers\"",
+        "#system_torchvision# ; #engine# == \"sentence_transformers\"",
+        "vllm>=0.27.0 ; #engine# == \"vllm\""
+      ]
+    },
+    "featured": true,
+    "updated_at": 1787982666
+  },
+  {
+    "version": 2,
+    "model_name": "WeMM-Embedding-4B",
+    "dimensions": 2560,
+    "max_tokens": 262144,
+    "language": [
+      "zh",
+      "en"
+    ],
+    "model_specs": [
+      {
+        "model_format": "pytorch",
+        "model_src": {
+          "huggingface": {
+            "model_id": "tencent/WeMM-Embedding-4B",
+            "model_revision": "main",
+            "quantizations": [
+              "none"
+            ]
+          },
+          "modelscope": {
+            "model_id": "Tencent-Hunyuan/WeMM-Embedding-4B",
+            "model_revision": "master",
+            "quantizations": [
+              "none"
+            ]
+          }
+        }
+      }
+    ],
+    "virtualenv": {
+      "packages": [
+        "sentence-transformers>=5.7.0 ; #engine# == \"sentence_transformers\"",
+        "transformers==5.2.0 ; #engine# == \"sentence_transformers\"",
+        "accelerate>=1.1.0 ; #engine# == \"sentence_transformers\"",
+        "qwen-vl-utils==0.0.14 ; #engine# == \"sentence_transformers\"",
+        "#system_torch# ; #engine# == \"sentence_transformers\"",
+        "#system_torchvision# ; #engine# == \"sentence_transformers\"",
+        "vllm>=0.27.0 ; #engine# == \"vllm\""
+      ]
+    },
+    "featured": false,
+    "updated_at": 1787982666
+  },
+  {
+    "version": 2,
+    "model_name": "WeMM-Embedding-9B",
+    "dimensions": 4096,
+    "max_tokens": 262144,
+    "language": [
+      "zh",
+      "en"
+    ],
+    "model_specs": [
+      {
+        "model_format": "pytorch",
+        "model_src": {
+          "huggingface": {
+            "model_id": "tencent/WeMM-Embedding-9B",
+            "model_revision": "main",
+            "quantizations": [
+              "none"
+            ]
+          },
+          "modelscope": {
+            "model_id": "Tencent-Hunyuan/WeMM-Embedding-9B",
+            "model_revision": "master",
+            "quantizations": [
+              "none"
+            ]
+          }
+        }
+      }
+    ],
+    "virtualenv": {
+      "packages": [
+        "sentence-transformers>=5.7.0 ; #engine# == \"sentence_transformers\"",
+        "transformers==5.2.0 ; #engine# == \"sentence_transformers\"",
+        "accelerate>=1.1.0 ; #engine# == \"sentence_transformers\"",
+        "qwen-vl-utils==0.0.14 ; #engine# == \"sentence_transformers\"",
+        "#system_torch# ; #engine# == \"sentence_transformers\"",
+        "#system_torchvision# ; #engine# == \"sentence_transformers\"",
+        "vllm>=0.27.0 ; #engine# == \"vllm\""
+      ]
+    },
+    "featured": false,
+    "updated_at": 1787982666
   }
 ]

--- a/xinference/model/embedding/sentence_transformers/core.py
+++ b/xinference/model/embedding/sentence_transformers/core.py
@@ -26,8 +26,10 @@ from ...utils import (
     allow_trust_remote_code,
     check_dependency_available,
     is_flash_attn_available,
+    virtual_env_allows_missing_engine,
 )
 from ..core import EmbeddingModel, EmbeddingModelFamilyV2, EmbeddingSpecV1
+from ..wemm import ensure_wemm_video_reader, is_wemm_model, normalize_wemm_inputs
 
 logger = logging.getLogger(__name__)
 SENTENCE_TRANSFORMER_MODEL_LIST: List[str] = []
@@ -305,10 +307,21 @@ class SentenceTransformerEmbeddingModel(EmbeddingModel, BatchMixin):
 
         if hasattr(self._model, "tokenizer"):
             self._tokenizer = self._model.tokenizer
+        if is_wemm_model(self.model_family.model_name) and dimensions is not None:
+            self._validate_wemm_dimensions(dimensions)
+
+    def _validate_wemm_dimensions(self, dimensions: int) -> None:
+        assert self._model is not None
+        config = self._model[0].auto_model.config
+        supported = getattr(config, "matryoshka_dimensions", None)
+        if supported is not None and dimensions not in supported:
+            raise ValueError(
+                f"WeMM-Embedding dimensions must be one of {list(supported)}, got {dimensions}."
+            )
 
     def _create_embedding(
         self,
-        sentences: Union[str, List[str]],
+        sentences: Union[str, Dict[str, Any], List[Union[str, Dict[str, Any]]]],
         **kwargs,
     ):
         if self._embedder is not None:
@@ -582,6 +595,45 @@ class SentenceTransformerEmbeddingModel(EmbeddingModel, BatchMixin):
                 objs,
                 **encode_kwargs,
             )
+        elif is_wemm_model(self.model_family.model_name):
+            # WeMM relies on Sentence Transformers 5.7's modality-aware
+            # ``encode`` path. The local text-only helper above bypasses its
+            # role/content conversion and vision preprocessing.
+            input_was_single = isinstance(sentences, (str, dict))
+            wemm_inputs = normalize_wemm_inputs(sentences)
+            ensure_wemm_video_reader()
+
+            wemm_kwargs = dict(kwargs)
+            wemm_kwargs.pop("convert_to_numpy", None)
+            wemm_kwargs.pop("return_sparse", None)
+            if "normalize_embedding" in wemm_kwargs:
+                wemm_kwargs["normalize_embeddings"] = wemm_kwargs.pop(
+                    "normalize_embedding"
+                )
+            dimensions = wemm_kwargs.pop("dimensions", None)
+            if dimensions is not None:
+                self._validate_wemm_dimensions(dimensions)
+                wemm_kwargs["truncate_dim"] = dimensions
+            wemm_kwargs.setdefault("batch_size", 1)
+
+            assert self._model is not None
+            with torch.inference_mode():
+                wemm_out = self._model.encode(
+                    wemm_inputs,
+                    convert_to_numpy=True,
+                    **wemm_kwargs,
+                )
+            if input_was_single:
+                if hasattr(wemm_out, "ndim") and getattr(wemm_out, "ndim", 0) > 1:
+                    all_embeddings = [wemm_out[0]]
+                else:
+                    all_embeddings = [wemm_out]
+                sentences = [sentences]
+            elif hasattr(wemm_out, "ndim") and getattr(wemm_out, "ndim", 0) == 1:
+                all_embeddings = [wemm_out]
+            else:
+                all_embeddings = list(wemm_out)
+            all_token_nums = len(wemm_inputs)
         elif "jina-embeddings-v5-omni" in self.model_family.model_name.lower():
             # jina-embeddings-v5-omni accepts text, image, video and audio.
             # Per the model card, the SentenceTransformer wrapper auto-detects
@@ -772,6 +824,48 @@ class SentenceTransformerEmbeddingModel(EmbeddingModel, BatchMixin):
         model_spec: EmbeddingSpecV1,
         quantization: str,
     ) -> Union[bool, Tuple[bool, str]]:
+        if is_wemm_model(model_family.model_name):
+            if not virtual_env_allows_missing_engine():
+                dep_check = check_dependency_available(
+                    "sentence_transformers", "sentence-transformers"
+                )
+                if dep_check != True:
+                    return dep_check
+                dep_check = check_dependency_available("qwen_vl_utils", "qwen-vl-utils")
+                if dep_check != True:
+                    return dep_check
+                from importlib.metadata import PackageNotFoundError, version
+
+                from packaging.version import Version
+                from sentence_transformers import __version__ as st_version
+                from transformers import __version__ as transformers_version
+
+                if Version(st_version) < Version("5.7.0"):
+                    return (
+                        False,
+                        "WeMM-Embedding requires sentence-transformers>=5.7.0, "
+                        f"current: {st_version}",
+                    )
+                if Version(transformers_version) < Version("5.2.0"):
+                    return (
+                        False,
+                        "WeMM-Embedding requires transformers>=5.2.0, "
+                        f"current: {transformers_version}",
+                    )
+                try:
+                    qwen_utils_version = version("qwen-vl-utils")
+                except PackageNotFoundError:
+                    return False, "Cannot determine the installed qwen-vl-utils version"
+                if Version(qwen_utils_version) < Version("0.0.14"):
+                    return (
+                        False,
+                        "WeMM-Embedding requires qwen-vl-utils>=0.0.14, "
+                        f"current: {qwen_utils_version}",
+                    )
+            if model_spec.model_format != "pytorch":
+                return False, "WeMM-Embedding supports pytorch format only"
+            return True
+
         from ....constants import XINFERENCE_ENABLE_VIRTUAL_ENV
 
         if model_family.model_name.startswith("Qwen3-VL-Embedding"):

--- a/xinference/model/embedding/sentence_transformers/tests/test_wemm_embedding.py
+++ b/xinference/model/embedding/sentence_transformers/tests/test_wemm_embedding.py
@@ -1,0 +1,74 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import numpy as np
+
+from .. import core as core_module
+from ..core import SentenceTransformerEmbeddingModel
+
+
+def _make_model(monkeypatch):
+    fake_st = types.ModuleType("sentence_transformers")
+    fake_st.SentenceTransformer = object
+    monkeypatch.setitem(sys.modules, "sentence_transformers", fake_st)
+    monkeypatch.setattr(core_module, "ensure_wemm_video_reader", lambda: None)
+
+    model = SentenceTransformerEmbeddingModel.__new__(SentenceTransformerEmbeddingModel)
+    model.model_family = SimpleNamespace(model_name="WeMM-Embedding-2B")
+    model._model_name = "WeMM-Embedding-2B"
+    model._model_uid = "wemm"
+    model._embedder = None
+    model._kwargs = {}
+    model._model = MagicMock()
+    model._model.__getitem__.return_value.auto_model.config = SimpleNamespace(
+        matryoshka_dimensions=[64, 128, 256, 512, 1024, 2048]
+    )
+    model._model.encode.side_effect = lambda inputs, **kwargs: np.ones(
+        (len(inputs), kwargs.get("truncate_dim", 2048)), dtype=np.float32
+    )
+    model._fix_langchain_openai_inputs = lambda value: value
+    model._clean_cache_if_needed = lambda *args, **kwargs: None
+    return model
+
+
+def test_wemm_sentence_transformers_keeps_interleaved_dict(monkeypatch):
+    model = _make_model(monkeypatch)
+    input_value = {
+        "role": "user",
+        "content": [
+            {"type": "image", "image": "x.jpg"},
+            {"type": "text", "text": "caption"},
+        ],
+    }
+
+    result = model._create_embedding(input_value, dimensions=256)
+
+    assert len(result["data"]) == 1
+    assert len(result["data"][0]["embedding"]) == 256
+    args, kwargs = model._model.encode.call_args
+    assert args[0] == [[input_value]]
+    assert kwargs["truncate_dim"] == 256
+    assert kwargs["normalize_embeddings"] is True
+    assert kwargs["batch_size"] == 1
+
+
+def test_wemm_sentence_transformers_preserves_batch_cardinality(monkeypatch):
+    model = _make_model(monkeypatch)
+    result = model._create_embedding(["text", {"image": "x.jpg"}, {"video": "x.mp4"}])
+    assert len(result["data"]) == 3

--- a/xinference/model/embedding/tests/test_embedding_batch.py
+++ b/xinference/model/embedding/tests/test_embedding_batch.py
@@ -113,3 +113,15 @@ def test_create_embedding_batch_single_input_at_nonzero_offset():
 
     assert [d["index"] for d in results[0]["data"]] == [0]
     assert [d["index"] for d in results[1]["data"]] == [0]
+
+
+def test_create_embedding_batch_treats_dict_as_one_multimodal_input():
+    model = _make_stub_model()
+    results = model.create_embedding.batch(
+        _ExtensibleWrapper.delay({"image": "one.jpg", "text": "first"}),
+        _ExtensibleWrapper.delay({"video": "two.mp4", "text": "second"}),
+    )
+
+    assert len(results) == 2
+    assert [len(result["data"]) for result in results] == [1, 1]
+    assert [result["data"][0]["index"] for result in results] == [0, 0]

--- a/xinference/model/embedding/tests/test_wemm_embedding.py
+++ b/xinference/model/embedding/tests/test_wemm_embedding.py
@@ -58,6 +58,11 @@ def test_wemm_builtin_specs_have_both_sources_and_revisions():
             "quantizations": ["none"],
         }
         packages = item["virtualenv"]["packages"]
+        assert (
+            'sentence-transformers==5.7.0 ; #engine# == "sentence_transformers"'
+            in packages
+        )
+        assert 'transformers==5.2.0 ; #engine# == "sentence_transformers"' in packages
         assert any(package.startswith("qwen-vl-utils==0.0.14") for package in packages)
         assert any(package.startswith("#system_torch#") for package in packages)
         assert any(package.startswith("#system_torchvision#") for package in packages)

--- a/xinference/model/embedding/tests/test_wemm_embedding.py
+++ b/xinference/model/embedding/tests/test_wemm_embedding.py
@@ -1,0 +1,150 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from xinference.api.schemas.requests import CreateEmbeddingRequest
+from xinference.model.embedding import _install
+from xinference.model.utils import get_engine_params_by_name_with_virtual_env
+
+from ..wemm import ensure_wemm_video_reader, iter_wemm_media, normalize_wemm_inputs
+
+
+def test_wemm_builtin_specs_have_both_sources_and_revisions():
+    spec_path = Path(__file__).parents[1] / "model_spec.json"
+    specs = {
+        item["model_name"]: item
+        for item in json.loads(spec_path.read_text())
+        if item["model_name"].startswith("WeMM-Embedding-")
+    }
+    assert set(specs) == {
+        "WeMM-Embedding-2B",
+        "WeMM-Embedding-4B",
+        "WeMM-Embedding-9B",
+    }
+    assert {name: item["dimensions"] for name, item in specs.items()} == {
+        "WeMM-Embedding-2B": 2048,
+        "WeMM-Embedding-4B": 2560,
+        "WeMM-Embedding-9B": 4096,
+    }
+    for name, item in specs.items():
+        assert item["max_tokens"] == 262144
+        sources = item["model_specs"][0]["model_src"]
+        assert sources["huggingface"] == {
+            "model_id": f"tencent/{name}",
+            "model_revision": "main",
+            "quantizations": ["none"],
+        }
+        assert sources["modelscope"] == {
+            "model_id": f"Tencent-Hunyuan/{name}",
+            "model_revision": "master",
+            "quantizations": ["none"],
+        }
+        packages = item["virtualenv"]["packages"]
+        assert any(package.startswith("qwen-vl-utils==0.0.14") for package in packages)
+        assert any(package.startswith("#system_torch#") for package in packages)
+        assert any(package.startswith("#system_torchvision#") for package in packages)
+        assert not any("[decord]" in package for package in packages)
+
+
+def test_wemm_engines_are_discoverable_with_virtualenv():
+    _install()
+    for model_name in (
+        "WeMM-Embedding-2B",
+        "WeMM-Embedding-4B",
+        "WeMM-Embedding-9B",
+    ):
+        params = get_engine_params_by_name_with_virtual_env(
+            "embedding", model_name, enable_virtual_env=True
+        )
+        assert isinstance(params, dict)
+        available = {
+            engine
+            for engine, engine_params in params.items()
+            if isinstance(engine_params, list)
+        }
+        assert available == {"sentence_transformers", "vllm"}, (model_name, params)
+        for engine in ("sentence_transformers", "vllm"):
+            assert isinstance(params.get(engine), list), (model_name, engine, params)
+
+
+def test_wemm_api_schema_preserves_mixed_multimodal_batch():
+    request = CreateEmbeddingRequest(
+        model="wemm",
+        input=["text", {"image": "x.jpg"}, {"video": "x.mp4"}],
+    )
+    assert request.input == ["text", {"image": "x.jpg"}, {"video": "x.mp4"}]
+
+
+def test_normalize_wemm_interleaved_message_and_openai_media_keys():
+    messages_batch = normalize_wemm_inputs(
+        {
+            "role": "user",
+            "content": [
+                {"type": "image_url", "image_url": {"url": "image.jpg"}},
+                {"type": "text", "text": "find this"},
+                {"type": "video_url", "video_url": {"url": "clip.mp4"}},
+            ],
+        }
+    )
+    messages = messages_batch[0]
+    assert messages[0]["content"] == [
+        {"type": "image", "image": "image.jpg"},
+        {"type": "text", "text": "find this"},
+        {"type": "video", "video": "clip.mp4"},
+    ]
+    assert list(iter_wemm_media(messages)) == [
+        ("image", "image.jpg"),
+        ("video", "clip.mp4"),
+    ]
+
+
+def test_normalize_wemm_flat_multimodal_input_preserves_order():
+    messages = normalize_wemm_inputs(
+        {"image": "one.png", "text": "caption", "video": ["a.mp4", "b.mp4"]}
+    )[0]
+    assert messages[0]["content"] == [
+        {"type": "image", "image": "one.png"},
+        {"type": "text", "text": "caption"},
+        {"type": "video", "video": "a.mp4"},
+        {"type": "video", "video": "b.mp4"},
+    ]
+
+
+def test_normalize_wemm_rejects_audio():
+    with pytest.raises(ValueError, match="does not support audio"):
+        normalize_wemm_inputs({"audio": "sample.wav"})
+
+
+def test_normalize_wemm_rejects_empty_media():
+    with pytest.raises(ValueError, match="image input cannot be empty"):
+        normalize_wemm_inputs({"image_url": {}})
+
+
+def test_wemm_installs_pyav_fallback_when_torchvision_reader_is_absent(monkeypatch):
+    vision_process = SimpleNamespace(io=SimpleNamespace(), VIDEO_READER_BACKENDS={})
+    qwen_utils = types.ModuleType("qwen_vl_utils")
+    qwen_utils.vision_process = vision_process
+    monkeypatch.setitem(sys.modules, "qwen_vl_utils", qwen_utils)
+
+    ensure_wemm_video_reader()
+
+    assert callable(vision_process.VIDEO_READER_BACKENDS["torchvision"])
+    assert vision_process._xinference_wemm_pyav_fallback is True

--- a/xinference/model/embedding/vllm/core.py
+++ b/xinference/model/embedding/vllm/core.py
@@ -22,9 +22,18 @@ from ....types import Embedding, EmbeddingData, EmbeddingUsage
 from ...batch import BatchMixin
 from ...utils import check_dependency_available
 from ..core import EmbeddingModel, EmbeddingModelFamilyV2, EmbeddingSpecV1
+from ..wemm import WeMMInput, is_wemm_model, iter_wemm_media, normalize_wemm_inputs
 
 logger = logging.getLogger(__name__)
-SUPPORTED_MODELS_PREFIXES = ["bge", "gte", "text2vec", "m3e", "Qwen3", "bce"]
+SUPPORTED_MODELS_PREFIXES = [
+    "bge",
+    "gte",
+    "text2vec",
+    "m3e",
+    "Qwen3",
+    "bce",
+    "WeMM",
+]
 
 
 class VLLMEmbeddingModel(EmbeddingModel, BatchMixin):
@@ -32,6 +41,7 @@ class VLLMEmbeddingModel(EmbeddingModel, BatchMixin):
         EmbeddingModel.__init__(self, *args, **kwargs)
         BatchMixin.__init__(self, self.create_embedding, **kwargs)  # type: ignore
         self._context_length = None
+        self._chat_template = None
 
     def load(self):
         try:
@@ -68,7 +78,21 @@ class VLLMEmbeddingModel(EmbeddingModel, BatchMixin):
                     is_matryoshka=True,
                 )
 
-        if self.model_family.model_name.startswith("Qwen3-VL-Embedding"):
+        if is_wemm_model(self.model_family.model_name):
+            if Version(vllm_version) < Version("0.27.0"):
+                raise ValueError("WeMM-Embedding requires vLLM>=0.27.0")
+            template_path = os.path.join(
+                self._model_path, "embedding_chat_template.jinja"
+            )
+            if not os.path.isfile(template_path):
+                raise FileNotFoundError(
+                    f"Missing WeMM-Embedding chat template: {template_path}"
+                )
+            with open(template_path, encoding="utf-8") as template_file:
+                self._chat_template = template_file.read()
+            self._kwargs.setdefault("gpu_memory_utilization", 0.6)
+            self._model = LLM(model=self._model_path, runner="pooling", **self._kwargs)
+        elif self.model_family.model_name.startswith("Qwen3-VL-Embedding"):
             if Version(vllm_version) < Version("0.14.0"):
                 raise ValueError("Qwen3-VL embedding requires vLLM>=0.14.0")
             self._model = LLM(model=self._model_path, runner="pooling", **self._kwargs)
@@ -87,7 +111,7 @@ class VLLMEmbeddingModel(EmbeddingModel, BatchMixin):
 
     def _create_embedding(
         self,
-        sentences: Union[str, List[str]],
+        sentences: Union[str, Dict[str, Any], List[Union[str, Dict[str, Any]]]],
         **kwargs,
     ):
         from packaging.version import Version
@@ -103,7 +127,9 @@ class VLLMEmbeddingModel(EmbeddingModel, BatchMixin):
         assert self._model is not None
 
         # Check and truncate sentences that exceed context_length
-        if self._context_length is not None:
+        if self._context_length is not None and not is_wemm_model(
+            self.model_family.model_name
+        ):
             truncated_sentences = []
             for sentence in sentences if isinstance(sentences, list) else [sentences]:
                 # Use tokenizer to check token length
@@ -143,7 +169,9 @@ class VLLMEmbeddingModel(EmbeddingModel, BatchMixin):
                     f"Please upgrade to v0.10.1 or later."
                 )
             pool_params = PoolingParams(dimensions=dimensions)
-        if self.model_family.model_name.startswith("Qwen3-VL-Embedding"):
+        if is_wemm_model(self.model_family.model_name):
+            outputs = self._embed_wemm(sentences, pool_params)
+        elif self.model_family.model_name.startswith("Qwen3-VL-Embedding"):
             outputs = self._embed_vl(sentences)
         else:
             outputs = self._model.embed(
@@ -172,6 +200,62 @@ class VLLMEmbeddingModel(EmbeddingModel, BatchMixin):
         self._clean_cache_if_needed(all_token_nums)
 
         return result
+
+    def _embed_wemm(self, inputs: WeMMInput, pool_params):
+        from vllm.multimodal.utils import fetch_image, fetch_video
+
+        messages_batch = normalize_wemm_inputs(inputs)
+        assert self._model is not None
+        assert self._chat_template is not None
+
+        def _media_url(value: Any, modality: str) -> Any:
+            if not isinstance(value, str):
+                return value
+            if value.startswith(("http://", "https://", "data:", "file://")):
+                return value
+            path = os.path.abspath(value)
+            if not os.path.exists(path):
+                raise FileNotFoundError(f"WeMM-Embedding {modality} not found: {path}")
+            return f"file://{path}"
+
+        vllm_inputs: List[Dict[str, Any]] = []
+        for messages in messages_batch:
+            prompt = self._tokenizer.apply_chat_template(
+                messages,
+                tokenize=False,
+                add_generation_prompt=False,
+                chat_template=self._chat_template,
+            )
+            media: Dict[str, List[Any]] = {"image": [], "video": []}
+            for modality, value in iter_wemm_media(messages):
+                url_or_data = _media_url(value, modality)
+                if modality == "image":
+                    media[modality].append(
+                        fetch_image(url_or_data)
+                        if isinstance(url_or_data, str)
+                        else url_or_data
+                    )
+                else:
+                    media[modality].append(
+                        fetch_video(url_or_data)
+                        if isinstance(url_or_data, str)
+                        else url_or_data
+                    )
+            multi_modal_data = {
+                modality: values[0] if len(values) == 1 else values
+                for modality, values in media.items()
+                if values
+            }
+            item: Dict[str, Any] = {"prompt": prompt}
+            if multi_modal_data:
+                item["multi_modal_data"] = multi_modal_data
+            vllm_inputs.append(item)
+
+        return self._model.embed(
+            vllm_inputs,
+            use_tqdm=False,
+            pooling_params=pool_params,
+        )
 
     def _embed_vl(
         self, inputs: Union[str, List[str], Dict[str, Any], List[Dict[str, Any]]]
@@ -298,7 +382,12 @@ class VLLMEmbeddingModel(EmbeddingModel, BatchMixin):
         quantization: str,
     ) -> Union[bool, Tuple[bool, str]]:
 
-        if model_family.model_name.startswith("Qwen3-VL-Embedding"):
+        required_vllm_version = None
+        if is_wemm_model(model_family.model_name):
+            required_vllm_version = "0.27.0"
+        elif model_family.model_name.startswith("Qwen3-VL-Embedding"):
+            required_vllm_version = "0.14.0"
+        if required_vllm_version is not None:
             # In virtualenv mode vLLM (and a compatible version) can be
             # installed on demand, so only the missing-library / old-version
             # rejection is exempt here; the format/prefix compatibility checks
@@ -316,10 +405,11 @@ class VLLMEmbeddingModel(EmbeddingModel, BatchMixin):
             else:
                 if not allow_missing_env and version.parse(
                     vllm.__version__
-                ) < version.parse("0.14.0"):
+                ) < version.parse(required_vllm_version):
                     return (
                         False,
-                        f"Qwen3-VL embedding requires vLLM>=0.14.0, current: {vllm.__version__}",
+                        f"{model_family.model_name} requires "
+                        f"vLLM>={required_vllm_version}, current: {vllm.__version__}",
                     )
         if model_spec.model_format not in ["pytorch"]:
             return False, "vLLM embedding engine only supports pytorch format"

--- a/xinference/model/embedding/vllm/tests/test_wemm_embedding.py
+++ b/xinference/model/embedding/vllm/tests/test_wemm_embedding.py
@@ -1,0 +1,137 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from ..core import VLLMEmbeddingModel
+
+
+def test_wemm_vllm_load_uses_memory_default_and_preserves_override(
+    monkeypatch, tmp_path
+):
+    (tmp_path / "embedding_chat_template.jinja").write_text(
+        "{{ messages }}", encoding="utf-8"
+    )
+    calls = []
+
+    class FakeLLM:
+        def __init__(self, **kwargs):
+            calls.append(kwargs)
+
+        @staticmethod
+        def get_tokenizer():
+            return object()
+
+    fake_vllm = types.ModuleType("vllm")
+    fake_vllm.LLM = FakeLLM
+    fake_vllm.__version__ = "0.28.0"
+    monkeypatch.setitem(sys.modules, "vllm", fake_vllm)
+
+    for kwargs in ({}, {"gpu_memory_utilization": 0.4}):
+        model = VLLMEmbeddingModel.__new__(VLLMEmbeddingModel)
+        model.model_family = SimpleNamespace(model_name="WeMM-Embedding-2B")
+        model._model_path = str(tmp_path)
+        model._kwargs = kwargs
+        model.load()
+
+    assert calls == [
+        {
+            "model": str(tmp_path),
+            "runner": "pooling",
+            "gpu_memory_utilization": 0.6,
+        },
+        {
+            "model": str(tmp_path),
+            "runner": "pooling",
+            "gpu_memory_utilization": 0.4,
+        },
+    ]
+
+
+def test_wemm_vllm_builds_prompt_and_multimodal_data(monkeypatch, tmp_path):
+    image_path = tmp_path / "image.png"
+    video_path = tmp_path / "video.mp4"
+    image_path.write_bytes(b"image")
+    video_path.write_bytes(b"video")
+
+    fake_vllm = types.ModuleType("vllm")
+    fake_multimodal = types.ModuleType("vllm.multimodal")
+    fake_utils = types.ModuleType("vllm.multimodal.utils")
+    fake_utils.fetch_image = lambda value: f"image:{value}"
+    fake_utils.fetch_video = lambda value: f"video:{value}"
+    monkeypatch.setitem(sys.modules, "vllm", fake_vllm)
+    monkeypatch.setitem(sys.modules, "vllm.multimodal", fake_multimodal)
+    monkeypatch.setitem(sys.modules, "vllm.multimodal.utils", fake_utils)
+
+    model = VLLMEmbeddingModel.__new__(VLLMEmbeddingModel)
+    model._model = MagicMock()
+    model._tokenizer = MagicMock()
+    model._tokenizer.apply_chat_template.return_value = "rendered"
+    model._chat_template = "template"
+    pool_params = object()
+    input_value = {
+        "role": "user",
+        "content": [
+            {"type": "image", "image": str(image_path)},
+            {"type": "text", "text": "caption"},
+            {"type": "video", "video": str(video_path)},
+        ],
+    }
+
+    model._embed_wemm(input_value, pool_params)
+
+    model._tokenizer.apply_chat_template.assert_called_once_with(
+        [input_value],
+        tokenize=False,
+        add_generation_prompt=False,
+        chat_template="template",
+    )
+    embed_input = model._model.embed.call_args.args[0][0]
+    assert embed_input["prompt"] == "rendered"
+    assert embed_input["multi_modal_data"] == {
+        "image": f"image:file://{image_path}",
+        "video": f"video:file://{video_path}",
+    }
+    assert model._model.embed.call_args.kwargs == {
+        "use_tqdm": False,
+        "pooling_params": pool_params,
+    }
+
+
+def test_wemm_vllm_match_requires_supported_prefix_and_format(monkeypatch):
+    from xinference.model.utils import virtualenv_discovery_var
+
+    fake_vllm = types.ModuleType("vllm")
+    fake_vllm.__version__ = "0.27.0"
+    monkeypatch.setitem(sys.modules, "vllm", fake_vllm)
+    family = SimpleNamespace(model_name="WeMM-Embedding-2B")
+    token = virtualenv_discovery_var.set(False)
+    try:
+        assert (
+            VLLMEmbeddingModel.match_json(
+                family, SimpleNamespace(model_format="pytorch"), "none"
+            )
+            is True
+        )
+        assert (
+            VLLMEmbeddingModel.match_json(
+                family, SimpleNamespace(model_format="ggufv2"), "none"
+            )[0]
+            is False
+        )
+    finally:
+        virtualenv_discovery_var.reset(token)

--- a/xinference/model/embedding/wemm.py
+++ b/xinference/model/embedding/wemm.py
@@ -1,0 +1,226 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from typing import Any, Dict, Iterator, List, Tuple, Union, cast
+
+WeMMInput = Union[str, Dict[str, Any], List[Union[str, Dict[str, Any]]]]
+logger = logging.getLogger(__name__)
+
+
+def is_wemm_model(model_name: str) -> bool:
+    return model_name.startswith("WeMM-Embedding-")
+
+
+def ensure_wemm_video_reader() -> None:
+    """Install a PyAV fallback when qwen-vl-utils' torchvision reader is absent.
+
+    torchvision 0.24+ removes ``io.read_video``. qwen-vl-utils 0.0.14 still
+    falls back to that function when decord/torchcodec is unavailable or
+    unusable. PyAV is already a required dependency of qwen-vl-utils.
+    """
+    from qwen_vl_utils import vision_process
+
+    if getattr(vision_process, "_xinference_wemm_pyav_fallback", False):
+        return
+    if callable(getattr(vision_process.io, "read_video", None)):
+        return
+
+    def _read_video_pyav(
+        item: Dict[str, Any],
+    ) -> Tuple[Any, Dict[str, Any], float]:
+        import base64
+        import io
+        from urllib.parse import unquote_to_bytes
+
+        import av
+        import numpy as np
+        import torch
+
+        source = item["video"]
+        if not isinstance(source, str):
+            raise TypeError("The PyAV video fallback requires a string source.")
+        if source.startswith("file://"):
+            source = source[7:]
+        elif source.startswith("data:"):
+            header, payload = source.split(",", 1)
+            raw = (
+                base64.b64decode(payload)
+                if ";base64" in header
+                else unquote_to_bytes(payload)
+            )
+            source = io.BytesIO(raw)  # type: ignore[assignment]
+
+        start = float(item.get("video_start", 0.0) or 0.0)
+        end_value = item.get("video_end")
+        end = float(end_value) if end_value is not None else None
+        decoded_frames = []
+        with av.open(source) as container:
+            stream = container.streams.video[0]
+            rate = stream.average_rate or getattr(stream, "guessed_rate", None)
+            video_fps = float(rate) if rate else 2.0
+            for frame_index, frame in enumerate(container.decode(stream)):
+                timestamp = (
+                    float(frame.time)
+                    if frame.time is not None
+                    else frame_index / video_fps
+                )
+                if timestamp < start:
+                    continue
+                if end is not None and timestamp > end:
+                    break
+                decoded_frames.append(frame.to_ndarray(format="rgb24"))
+
+        if not decoded_frames:
+            raise ValueError("No video frames were decoded by the PyAV fallback.")
+        total_frames = len(decoded_frames)
+        nframes = vision_process.smart_nframes(
+            item,
+            total_frames=total_frames,
+            video_fps=video_fps,
+        )
+        indices = torch.linspace(0, total_frames - 1, nframes).round().long()
+        selected = np.stack([decoded_frames[index] for index in indices.tolist()])
+        video = torch.from_numpy(selected).permute(0, 3, 1, 2)
+        sample_fps = nframes / total_frames * video_fps
+        metadata = {
+            "fps": video_fps,
+            "frames_indices": indices,
+            "total_num_frames": total_frames,
+            "video_backend": "pyav",
+        }
+        return video, metadata, sample_fps
+
+    # qwen-vl-utils hard-codes "torchvision" as its final exception fallback,
+    # so replace that unavailable slot rather than changing backend selection.
+    vision_process.VIDEO_READER_BACKENDS["torchvision"] = _read_video_pyav
+    vision_process._xinference_wemm_pyav_fallback = True
+    logger.info("Using PyAV as the WeMM-Embedding video reader fallback.")
+
+
+def _normalize_content_item(item: Dict[str, Any]) -> Dict[str, Any]:
+    item = dict(item)
+    content_type = item.get("type")
+    if content_type in {"audio", "audio_url", "input_audio"} or any(
+        key in item for key in ("audio", "audio_url", "input_audio")
+    ):
+        raise ValueError("WeMM-Embedding does not support audio input.")
+    if content_type in {"image", "image_url"} or "image" in item or "image_url" in item:
+        value = item.pop("image", None)
+        if value is None:
+            value = item.pop("image_url", None)
+        if isinstance(value, dict):
+            value = value.get("url")
+        if value is None:
+            raise ValueError("WeMM-Embedding image input cannot be empty.")
+        item["type"] = "image"
+        item["image"] = value
+        return item
+    if content_type in {"video", "video_url"} or "video" in item or "video_url" in item:
+        value = item.pop("video", None)
+        if value is None:
+            value = item.pop("video_url", None)
+        if isinstance(value, dict):
+            value = value.get("url")
+        if value is None:
+            raise ValueError("WeMM-Embedding video input cannot be empty.")
+        item["type"] = "video"
+        item["video"] = value
+        return item
+    if content_type == "text" or "text" in item:
+        text = item.get("text", "")
+        if not isinstance(text, str):
+            raise ValueError("WeMM-Embedding text input must be a string.")
+        item["type"] = "text"
+        item["text"] = text
+        return item
+    raise ValueError(f"Unsupported WeMM-Embedding content item: {item!r}")
+
+
+def _normalize_message(message: Dict[str, Any]) -> Dict[str, Any]:
+    role = message.get("role", "user")
+    content = message.get("content", "")
+    if isinstance(content, str):
+        return {"role": role, "content": content}
+    if not isinstance(content, list):
+        raise ValueError("WeMM-Embedding message content must be a string or list.")
+    if not all(isinstance(item, dict) for item in content):
+        raise ValueError("WeMM-Embedding message content items must be dictionaries.")
+    return {
+        "role": role,
+        "content": [
+            _normalize_content_item(cast(Dict[str, Any], item)) for item in content
+        ],
+    }
+
+
+def normalize_wemm_messages(sample: Union[str, Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Convert one API embedding input into WeMM chat messages.
+
+    A flat dictionary supports any ordered combination of ``text``, ``image``
+    and ``video``. A role/content dictionary expresses an interleaved message;
+    ``{"messages": [...]}`` expresses a multi-message conversation.
+    """
+    if isinstance(sample, str):
+        return [{"role": "user", "content": [{"type": "text", "text": sample}]}]
+    if not isinstance(sample, dict):
+        raise ValueError("Each WeMM-Embedding input must be a string or dictionary.")
+    if "messages" in sample:
+        messages = sample["messages"]
+        if not isinstance(messages, list) or not messages:
+            raise ValueError("WeMM-Embedding `messages` must be a non-empty list.")
+        if not all(isinstance(message, dict) for message in messages):
+            raise ValueError("WeMM-Embedding `messages` items must be dictionaries.")
+        return [_normalize_message(cast(Dict[str, Any], msg)) for msg in messages]
+    if "role" in sample or "content" in sample:
+        return [_normalize_message(sample)]
+
+    content: List[Dict[str, Any]] = []
+    for key, value in sample.items():
+        if key in {"audio", "audio_url", "input_audio"}:
+            raise ValueError("WeMM-Embedding does not support audio input.")
+        if key not in {"text", "image", "image_url", "video", "video_url"}:
+            continue
+        values = value if key != "text" and isinstance(value, list) else [value]
+        for one_value in values:
+            content.append(_normalize_content_item({"type": key, key: one_value}))
+    if not content:
+        raise ValueError(
+            "WeMM-Embedding input must contain text, image, video, content, or messages."
+        )
+    return [{"role": "user", "content": content}]
+
+
+def normalize_wemm_inputs(inputs: WeMMInput) -> List[List[Dict[str, Any]]]:
+    if isinstance(inputs, (str, dict)):
+        samples: List[Union[str, Dict[str, Any]]] = [inputs]
+    elif isinstance(inputs, list):
+        samples = cast(List[Union[str, Dict[str, Any]]], inputs)
+    else:
+        raise ValueError("Unsupported input type for WeMM-Embedding.")
+    return [normalize_wemm_messages(sample) for sample in samples]
+
+
+def iter_wemm_media(
+    messages: List[Dict[str, Any]],
+) -> Iterator[Tuple[str, Any]]:
+    for message in messages:
+        content = message.get("content")
+        if not isinstance(content, list):
+            continue
+        for item in content:
+            if item.get("type") == "image":
+                yield "image", item.get("image")
+            elif item.get("type") == "video":
+                yield "video", item.get("video")

--- a/xinference/model/llm/lmdeploy/core.py
+++ b/xinference/model/llm/lmdeploy/core.py
@@ -362,7 +362,7 @@ class LMDeployChatModel(LMDeployModel, ChatModelMixin):
             f"session_id={session_id}, "  # type: ignore
             f"history_tokens={self._model.id2step[str(session_id)]}, "
             f"input_tokens={len(input_ids)}, "
-            f"max_new_tokens={generate_config.max_new_tokens}, "
+            f"max_new_tokens={generate_config.max_new_tokens}, "  # type: ignore[union-attr]
             f"seq_start={sequence_start}, seq_end={sequence_end}, "
             f"step={step}, prep={do_preprocess}"
         )


### PR DESCRIPTION
Support multimodal text, image, video, and interleaved inputs through sentence-transformers and vLLM with Hugging Face and ModelScope sources.

## Summary

Add built-in support for Tencent's multimodal WeMM-Embedding model family:

- `WeMM-Embedding-2B`
- `WeMM-Embedding-4B`
- `WeMM-Embedding-9B`

Models are available from:

- Hugging Face, revision `main`
- ModelScope, revision `master`

Supported embedding engines are intentionally limited to existing Xinference backends:

- `sentence_transformers`
- `vllm`

## Model Metadata

| Model | Dimensions | Max tokens |
| --- | ---: | ---: |
| WeMM-Embedding-2B | 2048 | 262144 |
| WeMM-Embedding-4B | 2560 | 262144 |
| WeMM-Embedding-9B | 4096 | 262144 |
