### PR TITLE
fix: skip cache status update when cache tracker ref is None

### DIFF
--- a/xinference/core/tests/test_worker.py
+++ b/xinference/core/tests/test_worker.py
@@ -4145,3 +4145,29 @@ async def test_list_deletable_models_rejects_unmanaged_source(tmp_path, monkeypa
 
     with pytest.raises(ValueError, match="outside the Xinference cache directory"):
         await WorkerActor.list_deletable_models(_Worker(), "flexible-model")
+
+
+@pytest.mark.asyncio
+async def test_update_cache_status_skips_when_cache_tracker_ref_is_none():
+    # get_supervisor_ref core init can fail and _clear_supervisor_refs leaves
+    # _cache_tracker_ref as None. update_cache_status must not AttributeError,
+    # matching list_cached_models / record_model_version.
+    class _Worker:
+        def __init__(self):
+            self._cache_tracker_ref = None
+            self.address = "127.0.0.1:0"
+
+    worker = _Worker()
+    await WorkerActor.update_cache_status(
+        worker,
+        "bge-m3",
+        {
+            "model_version": "bge-m3",
+            "model_file_location": "/tmp/bge-m3",
+        },
+    )
+    await WorkerActor.update_cache_status(
+        worker,
+        "sdxl",
+        [{"model_file_location": "/tmp/sdxl"}],
+    )

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -2937,6 +2937,15 @@ class WorkerActor(xo.StatelessActor):
         return model.model_family.model_ability  # type: ignore
 
     async def update_cache_status(self, model_name: str, version_info: Any):
+        # Defensive: _cache_tracker_ref may be None if get_supervisor_ref's core
+        # init failed and cleared all refs. Skip instead of raising AttributeError
+        # (which would fail model launch). See list_cached_models.
+        if self._cache_tracker_ref is None:
+            logger.warning(
+                "cache_tracker_ref is None, skipping cache status update for %s",
+                model_name,
+            )
+            return
         if isinstance(version_info, list):  # image model
             model_path = version_info[0]["model_file_location"]
             await self._cache_tracker_ref.update_cache_status(


### PR DESCRIPTION
## Summary

`WorkerActor.update_cache_status` called `self._cache_tracker_ref.update_cache_status` with no None check. After `get_supervisor_ref` core init fails, `_clear_supervisor_refs` sets that ref to None, so replica launch crashed with:

```
AttributeError: 'NoneType' object has no attribute 'update_cache_status'
```

`list_cached_models` and `record_model_version` already skip in that state. This applies the same guard so cache tracking degrades instead of failing the launch.

Fixes #5440

## Test plan

- [x] `test_update_cache_status_skips_when_cache_tracker_ref_is_none` covers dict and list `version_info` with `_cache_tracker_ref is None`