### PR TITLE
feat(ui): show full paths on hover

### DIFF
--- a/frontend/src/components/pages/launch-model/cache-management.dialog.tsx
+++ b/frontend/src/components/pages/launch-model/cache-management.dialog.tsx
@@ -6,6 +6,7 @@ import { toast } from 'sonner';
 import request from '@/lib/request';
 import { Button } from '@/components/ui/button';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
+import { InfoTooltip } from '@/components/ui/tooltip';
 import {
   Dialog,
   DialogTrigger,
@@ -127,7 +128,12 @@ const CacheManagementDialog: FC<CacheManagementDialogProps> = ({ modelDetail, on
                     <TableCell>{item.quantization || '-'}</TableCell>
                     <TableCell className="max-w-[220px]">
                       <div className="flex items-center gap-2">
-                        <span className="min-w-0 flex-1 truncate">{item?.real_path}</span>
+                        <InfoTooltip
+                          content={<span className="whitespace-nowrap">{item?.real_path}</span>}
+                          contentClassName="max-w-none"
+                        >
+                          <span className="min-w-0 flex-1 truncate">{item?.real_path}</span>
+                        </InfoTooltip>
                         <Copy
                           className="size-4 shrink-0 cursor-pointer text-muted-foreground hover:text-foreground"
                           onClick={() => copyToClipboard(item?.real_path)}
@@ -136,7 +142,12 @@ const CacheManagementDialog: FC<CacheManagementDialogProps> = ({ modelDetail, on
                     </TableCell>
                     <TableCell className="max-w-[220px]">
                       <div className="flex items-center gap-2">
-                        <span className="min-w-0 flex-1 truncate">{item?.path}</span>
+                        <InfoTooltip
+                          content={<span className="whitespace-nowrap">{item?.path}</span>}
+                          contentClassName="max-w-none"
+                        >
+                          <span className="min-w-0 flex-1 truncate">{item?.path}</span>
+                        </InfoTooltip>
                         <Copy
                           className="size-4 shrink-0 cursor-pointer text-muted-foreground hover:text-foreground"
                           onClick={() => copyToClipboard(item?.path)}

--- a/frontend/src/components/pages/launch-model/cache-management.dialog.tsx
+++ b/frontend/src/components/pages/launch-model/cache-management.dialog.tsx
@@ -129,8 +129,8 @@ const CacheManagementDialog: FC<CacheManagementDialogProps> = ({ modelDetail, on
                     <TableCell className="max-w-[220px]">
                       <div className="flex items-center gap-2">
                         <InfoTooltip
-                          content={<span className="whitespace-nowrap">{item?.real_path}</span>}
-                          contentClassName="max-w-none"
+                          content={item?.real_path}
+                          contentClassName="max-w-[calc(100vw-2rem)] break-all"
                         >
                           <span className="min-w-0 flex-1 truncate">{item?.real_path}</span>
                         </InfoTooltip>
@@ -143,8 +143,8 @@ const CacheManagementDialog: FC<CacheManagementDialogProps> = ({ modelDetail, on
                     <TableCell className="max-w-[220px]">
                       <div className="flex items-center gap-2">
                         <InfoTooltip
-                          content={<span className="whitespace-nowrap">{item?.path}</span>}
-                          contentClassName="max-w-none"
+                          content={item?.path}
+                          contentClassName="max-w-[calc(100vw-2rem)] break-all"
                         >
                           <span className="min-w-0 flex-1 truncate">{item?.path}</span>
                         </InfoTooltip>

--- a/frontend/src/components/pages/launch-model/env-management-dialog.tsx
+++ b/frontend/src/components/pages/launch-model/env-management-dialog.tsx
@@ -118,8 +118,8 @@ const EnvManagementDialog: FC<EnvManagementDialogProps> = ({ modelDetail, onEnvD
                     <TableCell className="max-w-[220px]">
                       <div className="flex items-center gap-2">
                         <InfoTooltip
-                          content={<span className="whitespace-nowrap">{item?.path}</span>}
-                          contentClassName="max-w-none"
+                          content={item?.path}
+                          contentClassName="max-w-[calc(100vw-2rem)] break-all"
                         >
                           <span className="min-w-0 flex-1 truncate">{item?.path}</span>
                         </InfoTooltip>

--- a/frontend/src/components/pages/launch-model/env-management-dialog.tsx
+++ b/frontend/src/components/pages/launch-model/env-management-dialog.tsx
@@ -6,6 +6,7 @@ import { toast } from 'sonner';
 import request from '@/lib/request';
 import { Button } from '@/components/ui/button';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
+import { InfoTooltip } from '@/components/ui/tooltip';
 import {
   Dialog,
   DialogTrigger,
@@ -116,7 +117,12 @@ const EnvManagementDialog: FC<EnvManagementDialogProps> = ({ modelDetail, onEnvD
                     <TableCell>{item.model_name}</TableCell>
                     <TableCell className="max-w-[220px]">
                       <div className="flex items-center gap-2">
-                        <span className="min-w-0 flex-1 truncate">{item?.path}</span>
+                        <InfoTooltip
+                          content={<span className="whitespace-nowrap">{item?.path}</span>}
+                          contentClassName="max-w-none"
+                        >
+                          <span className="min-w-0 flex-1 truncate">{item?.path}</span>
+                        </InfoTooltip>
                         <Copy
                           className="size-4 shrink-0 cursor-pointer text-muted-foreground hover:text-foreground"
                           onClick={() => copyToClipboard(item?.path)}


### PR DESCRIPTION
## Summary

- Add hover tooltips for cached model real paths and cache paths.
- Add hover tooltips for virtual environment paths.
- Keep table values truncated while showing complete paths in single-line tooltips.

<img width="841" height="237" alt="3f5e52e0452bf4f6d93c1a920288b120" src="https://github.com/user-attachments/assets/c204b010-b829-4248-9ae2-c228e392dcf6" />
