### PR TITLE
ENH(auth): Add granular system settings permissions

### DIFF
--- a/doc/source/user_guide/auth_system.rst
+++ b/doc/source/user_guide/auth_system.rst
@@ -131,6 +131,8 @@ Xinference defines the following interface permissions:
 * ``virtualenv:list`` / ``virtualenv:delete``: Permissions to list/delete per-model virtual environments.
 * ``logs:list``: Permission to view cluster logs.
 * ``monitor:view``: Permission to view the monitoring dashboards.
+* ``settings:read``: Permission to view system settings.
+* ``settings:write``: Permission to update and restore system settings.
 * ``admin``: Administrators have all of the above.
 
 A caller may only grant permissions they themselves hold — for example, a
@@ -241,6 +243,9 @@ Everything above is also available from dedicated pages in the web UI:
 * **Security Settings**: view and tune brute-force protection (login/API-key
   failure rate limits) and unban blocked IPs or keys (requires ``admin``).
   See :ref:`user_guide_audit_security` for details.
+* **System Settings**: view model download configuration with
+  ``settings:read``; saving changes or restoring defaults additionally
+  requires ``settings:write``.
 * **Audit Center**: browse recorded API activity (requires ``admin``). See
   :ref:`user_guide_audit_security`.
 

--- a/frontend/src/app/system-settings/page.tsx
+++ b/frontend/src/app/system-settings/page.tsx
@@ -1,5 +1,10 @@
+import { PermissionGuard } from '@/components/auth/permission-guard';
 import SystemSettings from '@/components/pages/system-settings';
 
 export default function SystemSettingsPage() {
-  return <SystemSettings />;
+  return (
+    <PermissionGuard scope="settings:read">
+      <SystemSettings />
+    </PermissionGuard>
+  );
 }

--- a/frontend/src/components/auth/permission-guard.tsx
+++ b/frontend/src/components/auth/permission-guard.tsx
@@ -9,6 +9,7 @@ interface PermissionGuardProps {
   scope:
     | 'monitor:view'
     | 'logs:list'
+    | 'settings:read'
     | 'models:register'
     | 'routers:list'
     | 'routers:read'
@@ -58,6 +59,7 @@ export function PermissionGuard({ scope, children }: PermissionGuardProps) {
   const scopeMap: Record<string, boolean> = {
     'monitor:view': auth.hasMonitorView,
     'logs:list': auth.hasLogsList,
+    'settings:read': auth.hasSettingsRead,
     'models:register': auth.canRegisterModel,
     'routers:list': auth.hasRouterList,
     'routers:read': auth.hasRouterRead,

--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -282,7 +282,9 @@ export function Sidebar() {
             name: t('menu.systemSettings'),
             Icon: Settings2,
             Extra: ChevronRight,
-            show: !clusterUIConfig?.auth_advanced || hasSettingsRead,
+            show:
+              Object.keys(clusterUIConfig).length > 0 &&
+              (!clusterUIConfig.auth_advanced || hasSettingsRead),
           },
           {
             path: '/audit-center',

--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -155,6 +155,7 @@ export function Sidebar() {
     canAccessKeysPage,
     hasLogsList,
     hasMonitorView,
+    hasSettingsRead,
     canRegisterModel,
     canAccessRouterPage,
   } = useMenuAuth();
@@ -281,7 +282,7 @@ export function Sidebar() {
             name: t('menu.systemSettings'),
             Icon: Settings2,
             Extra: ChevronRight,
-            show: !clusterUIConfig?.auth_advanced || isAdmin,
+            show: !clusterUIConfig?.auth_advanced || hasSettingsRead,
           },
           {
             path: '/audit-center',
@@ -342,6 +343,7 @@ export function Sidebar() {
     isAdmin,
     hasLogsList,
     hasMonitorView,
+    hasSettingsRead,
     canRegisterModel,
     canAccessRouterPage,
   ]);

--- a/frontend/src/components/pages/system-settings/index.tsx
+++ b/frontend/src/components/pages/system-settings/index.tsx
@@ -11,7 +11,9 @@ import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import PageContainer from '@/components/ui/page-container';
+import { useGlobal } from '@/contexts/global-context';
 import { useI18n } from '@/contexts/i18n-context';
+import { useMenuAuth } from '@/hooks/use-menu-auth';
 import request from '@/lib/request';
 import { cn } from '@/lib/utils';
 
@@ -89,11 +91,14 @@ function normalizeSettings(data: SystemSettingsData): SystemSettingsForm {
 
 export default function SystemSettings() {
   const { t } = useI18n();
+  const { clusterUIConfig } = useGlobal();
+  const { canWriteSettings } = useMenuAuth();
   const [form, setForm] = useState<SystemSettingsForm>(EMPTY_FORM);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [resetting, setResetting] = useState(false);
   const [resetOpen, setResetOpen] = useState(false);
+  const canEdit = !clusterUIConfig?.auth_advanced || canWriteSettings;
 
   const loadSettings = useCallback(async () => {
     setLoading(true);
@@ -134,7 +139,7 @@ export default function SystemSettings() {
     form.model_download_workers >= 1;
 
   const saveSettings = async () => {
-    if (!isValid) return;
+    if (!canEdit || !isValid) return;
     setSaving(true);
     try {
       const data = await request.put<SystemSettingsData>('/v1/cluster/system_settings', {
@@ -151,6 +156,7 @@ export default function SystemSettings() {
   };
 
   const resetSettings = async () => {
+    if (!canEdit) return;
     setResetting(true);
     try {
       const data = await request.post<SystemSettingsData>('/v1/cluster/system_settings/reset');
@@ -244,20 +250,28 @@ export default function SystemSettings() {
         title={t('menu.systemSettings')}
         subTitle={t('systemSettings.pageDescription')}
         extraContent={
-          <div className="flex items-center gap-2">
-            <Button
-              variant="outline"
-              onClick={() => setResetOpen(true)}
-              disabled={loading || saving || resetting}
-            >
-              <RotateCcw className="h-4 w-4" />
-              {t('systemSettings.restoreSettings')}
-            </Button>
-            <Button onClick={saveSettings} disabled={loading || saving || resetting || !isValid}>
-              {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
-              {t('systemSettings.saveChanges')}
-            </Button>
-          </div>
+          canEdit ? (
+            <div className="flex items-center gap-2">
+              <Button
+                variant="outline"
+                onClick={() => setResetOpen(true)}
+                disabled={loading || saving || resetting}
+              >
+                <RotateCcw className="h-4 w-4" />
+                {t('systemSettings.restoreSettings')}
+              </Button>
+              <Button onClick={saveSettings} disabled={loading || saving || resetting || !isValid}>
+                {saving ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Save className="h-4 w-4" />
+                )}
+                {t('systemSettings.saveChanges')}
+              </Button>
+            </div>
+          ) : (
+            <Badge variant="secondary">{t('systemSettings.readOnly')}</Badge>
+          )
         }
       >
         {loading ? (
@@ -302,10 +316,12 @@ export default function SystemSettings() {
                           type="button"
                           role="radio"
                           aria-checked={selected}
+                          disabled={!canEdit}
                           onClick={() => updateField('download_source', source.value)}
                           className={cn(
                             'relative flex min-h-20 items-center gap-4 rounded-lg border p-4 text-left outline-none transition-all',
                             'hover:border-primary/40 hover:bg-muted/30 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]',
+                            'disabled:cursor-not-allowed disabled:opacity-60',
                             selected && 'border-primary bg-primary/[0.04] shadow-sm'
                           )}
                         >
@@ -346,6 +362,7 @@ export default function SystemSettings() {
                       id="hf-mirror"
                       type="url"
                       value={form.hf_endpoint}
+                      disabled={!canEdit}
                       onChange={(event) => updateField('hf_endpoint', event.target.value)}
                       placeholder={t('systemSettings.hfMirrorPlaceholder')}
                     />
@@ -360,6 +377,7 @@ export default function SystemSettings() {
                       id="hf-token"
                       type="password"
                       value={form.hf_token}
+                      disabled={!canEdit}
                       onFocus={(event) => {
                         if (form.hf_token.includes('*')) event.currentTarget.select();
                       }}
@@ -379,6 +397,7 @@ export default function SystemSettings() {
                         id="pip-mirror"
                         type="url"
                         value={form.pip_index_url}
+                        disabled={!canEdit}
                         onChange={(event) => updateField('pip_index_url', event.target.value)}
                         placeholder={t('systemSettings.pipMirrorPlaceholder')}
                       />
@@ -420,6 +439,7 @@ export default function SystemSettings() {
                         id={policy.id}
                         type="number"
                         value={form[policy.field]}
+                        disabled={!canEdit}
                         onChange={(event) => updateNumericField(policy.field, event.target.value)}
                         min={policy.min}
                         step={policy.step}

--- a/frontend/src/components/pages/user-management/permissions.tsx
+++ b/frontend/src/components/pages/user-management/permissions.tsx
@@ -28,6 +28,8 @@ export const ALL_PERMISSIONS = [
   'virtualenv:delete',
   'logs:list',
   'monitor:view',
+  'settings:read',
+  'settings:write',
 ];
 
 const PERMISSION_GROUPS = [
@@ -66,6 +68,10 @@ const PERMISSION_GROUPS = [
   {
     key: 'monitor',
     permissions: ['monitor:view'],
+  },
+  {
+    key: 'settings',
+    permissions: ['settings:read', 'settings:write'],
   },
 ];
 

--- a/frontend/src/hooks/use-menu-auth.ts
+++ b/frontend/src/hooks/use-menu-auth.ts
@@ -24,6 +24,8 @@ export function useMenuAuth() {
     canAccessKeysPage: hasScope('admin', 'keys:create', 'keys:manage'),
     hasLogsList: hasScope('admin', 'logs:list'),
     hasMonitorView: hasScope('admin', 'monitor:view'),
+    hasSettingsRead: hasScope('admin', 'settings:read'),
+    canWriteSettings: hasScope('admin', 'settings:write'),
     canRegisterModel: hasScope('admin', 'models:register', 'models:add', 'models:unregister'),
     hasRouterList: hasScope('admin', 'routers:list'),
     hasRouterRead: hasScope('admin', 'routers:read'),

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -1023,6 +1023,7 @@ const en = {
       virtualenv: 'virtualenv',
       logs: 'logs',
       monitor: 'monitor',
+      settings: 'system settings',
       routers: 'routers',
     },
     permissionLabels: {
@@ -1040,6 +1041,8 @@ const en = {
       'virtualenv:delete': 'Delete virtual environments',
       'logs:list': 'View logs',
       'monitor:view': 'View monitoring',
+      'settings:read': 'View system settings',
+      'settings:write': 'Modify system settings',
       'routers:list': 'View token router list',
       'routers:read': 'Read token router details',
       'routers:write': 'Create, update, and delete token routers',
@@ -1098,6 +1101,7 @@ const en = {
   systemSettings: {
     pageDescription:
       'Configure model download sources, mirrors, credentials, and download behavior.',
+    readOnly: 'Read-only access',
     saveChanges: 'Save Changes',
     saveSuccess: 'System settings saved and applied immediately.',
     restoreSettings: 'Restore Defaults',

--- a/frontend/src/i18n/locales/ja.ts
+++ b/frontend/src/i18n/locales/ja.ts
@@ -1008,6 +1008,7 @@ const ja = {
       virtualenv: 'virtualenv',
       logs: 'logs',
       monitor: 'monitor',
+      settings: 'システム設定',
       routers: 'ルーター',
     },
     permissionLabels: {
@@ -1025,6 +1026,8 @@ const ja = {
       'virtualenv:delete': '仮想環境を削除',
       'logs:list': 'ログを表示',
       'monitor:view': '監視を表示',
+      'settings:read': 'システム設定を表示',
+      'settings:write': 'システム設定を変更',
       'routers:list': 'Token Router 一覧を表示',
       'routers:read': 'Token Router の詳細を読み取り',
       'routers:write': 'Token Router を作成、更新、削除',
@@ -1082,6 +1085,7 @@ const ja = {
   },
   systemSettings: {
     pageDescription: 'モデルのダウンロード元、ミラー、認証情報、ダウンロード動作を設定します。',
+    readOnly: '読み取り専用',
     saveChanges: '変更を保存',
     saveSuccess: 'システム設定を保存し、すぐに適用しました。',
     restoreSettings: 'デフォルト設定に戻す',

--- a/frontend/src/i18n/locales/ko.ts
+++ b/frontend/src/i18n/locales/ko.ts
@@ -1002,6 +1002,7 @@ const ko = {
       virtualenv: 'virtualenv',
       logs: 'logs',
       monitor: 'monitor',
+      settings: '시스템 설정',
       routers: '라우터',
     },
     permissionLabels: {
@@ -1019,6 +1020,8 @@ const ko = {
       'virtualenv:delete': '가상 환경 삭제',
       'logs:list': '로그 보기',
       'monitor:view': '모니터링 보기',
+      'settings:read': '시스템 설정 보기',
+      'settings:write': '시스템 설정 수정',
       'routers:list': 'Token Router 목록 보기',
       'routers:read': 'Token Router 세부 정보 읽기',
       'routers:write': 'Token Router 생성, 수정 및 삭제',
@@ -1076,6 +1079,7 @@ const ko = {
   },
   systemSettings: {
     pageDescription: '모델 다운로드 소스, 미러, 인증 정보와 다운로드 동작을 설정합니다.',
+    readOnly: '읽기 전용',
     saveChanges: '변경 사항 저장',
     saveSuccess: '시스템 설정을 저장하고 즉시 적용했습니다.',
     restoreSettings: '기본 설정 복원',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -1016,6 +1016,7 @@ const zh = {
       virtualenv: 'virtualenv',
       logs: 'logs',
       monitor: 'monitor',
+      settings: '系统设置',
       routers: '路由管理',
     },
     permissionLabels: {
@@ -1033,6 +1034,8 @@ const zh = {
       'virtualenv:delete': '删除虚拟环境',
       'logs:list': '查看日志',
       'monitor:view': '查看监控',
+      'settings:read': '查看系统设置',
+      'settings:write': '修改系统设置',
       'routers:list': '查看 Token Router 列表',
       'routers:read': '读取 Token Router 详情',
       'routers:write': '创建、修改和删除 Token Router',
@@ -1090,6 +1093,7 @@ const zh = {
   },
   systemSettings: {
     pageDescription: '统一配置模型下载源、镜像服务与下载任务策略。',
+    readOnly: '只读权限',
     saveChanges: '保存更改',
     saveSuccess: '系统设置已保存并立即生效',
     restoreSettings: '恢复默认配置',

--- a/xinference/api/oauth2/advanced/auth_service.py
+++ b/xinference/api/oauth2/advanced/auth_service.py
@@ -88,6 +88,8 @@ INITIAL_ADMIN_PERMISSIONS = [
     "virtualenv:delete",
     "logs:list",
     "monitor:view",
+    "settings:read",
+    "settings:write",
     "routers:list",
     "routers:read",
     "routers:write",

--- a/xinference/api/routers/system_settings.py
+++ b/xinference/api/routers/system_settings.py
@@ -63,25 +63,28 @@ async def reset_system_settings(request: Request) -> JSONResponse:
 def register_routes(api: "RESTfulAPI") -> None:
     router = api._router
     auth = api._auth_service
-    dependencies = (
-        [Security(auth, scopes=["admin"])] if api.is_authenticated() else None
+    read_dependencies = (
+        [Security(auth, scopes=["settings:read"])] if api.is_authenticated() else None
+    )
+    write_dependencies = (
+        [Security(auth, scopes=["settings:write"])] if api.is_authenticated() else None
     )
 
     router.add_api_route(
         "/v1/cluster/system_settings",
         get_system_settings,
         methods=["GET"],
-        dependencies=dependencies,
+        dependencies=read_dependencies,
     )
     router.add_api_route(
         "/v1/cluster/system_settings",
         update_system_settings,
         methods=["PUT"],
-        dependencies=dependencies,
+        dependencies=write_dependencies,
     )
     router.add_api_route(
         "/v1/cluster/system_settings/reset",
         reset_system_settings,
         methods=["POST"],
-        dependencies=dependencies,
+        dependencies=write_dependencies,
     )

--- a/xinference/api/tests/test_system_settings_api.py
+++ b/xinference/api/tests/test_system_settings_api.py
@@ -13,10 +13,15 @@
 # limitations under the License.
 
 import json
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from fastapi import APIRouter, FastAPI, Header, HTTPException
+from fastapi.security import SecurityScopes
+from fastapi.testclient import TestClient
 
+from xinference.api.oauth2.advanced.auth_service import INITIAL_ADMIN_PERMISSIONS
 from xinference.api.routers import system_settings
 from xinference.core.system_settings_store import SystemSettingsStore
 
@@ -43,6 +48,98 @@ def mock_request(store):
     supervisor_ref = AsyncMock()
     request.app.state.api._get_supervisor_ref = AsyncMock(return_value=supervisor_ref)
     return request
+
+
+@pytest.fixture
+def scoped_client(store):
+    token_scopes = {
+        "reader": {"settings:read"},
+        "writer": {"settings:write"},
+    }
+
+    async def auth_service(
+        security_scopes: SecurityScopes,
+        authorization: str = Header(default=""),
+    ):
+        token = authorization.removeprefix("Bearer ")
+        scopes = token_scopes.get(token)
+        if scopes is None:
+            raise HTTPException(status_code=401, detail="Unauthorized")
+        if not set(security_scopes.scopes).issubset(scopes):
+            raise HTTPException(status_code=403, detail="Forbidden")
+        return {"username": token}
+
+    router = APIRouter()
+    api = SimpleNamespace(
+        _router=router,
+        _auth_service=auth_service,
+        _get_supervisor_ref=AsyncMock(return_value=AsyncMock()),
+        is_authenticated=lambda: True,
+    )
+    app = FastAPI()
+    app.state.api = api
+    app.state.system_settings_store = store
+    system_settings.register_routes(api)
+    app.include_router(router)
+    return TestClient(app)
+
+
+def _auth_headers(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_initial_admin_permissions_include_system_settings():
+    assert "settings:read" in INITIAL_ADMIN_PERMISSIONS
+    assert "settings:write" in INITIAL_ADMIN_PERMISSIONS
+
+
+def test_get_requires_settings_read(scoped_client):
+    assert scoped_client.get("/v1/cluster/system_settings").status_code == 401
+    assert (
+        scoped_client.get(
+            "/v1/cluster/system_settings", headers=_auth_headers("writer")
+        ).status_code
+        == 403
+    )
+    assert (
+        scoped_client.get(
+            "/v1/cluster/system_settings", headers=_auth_headers("reader")
+        ).status_code
+        == 200
+    )
+
+
+def test_update_and_reset_require_settings_write(scoped_client, store):
+    payload = store.get_public()
+    payload["download_source"] = "modelscope"
+
+    assert (
+        scoped_client.put(
+            "/v1/cluster/system_settings",
+            headers=_auth_headers("reader"),
+            json=payload,
+        ).status_code
+        == 403
+    )
+    response = scoped_client.put(
+        "/v1/cluster/system_settings",
+        headers=_auth_headers("writer"),
+        json=payload,
+    )
+    assert response.status_code == 200
+    assert response.json()["download_source"] == "modelscope"
+
+    assert (
+        scoped_client.post(
+            "/v1/cluster/system_settings/reset", headers=_auth_headers("reader")
+        ).status_code
+        == 403
+    )
+    response = scoped_client.post(
+        "/v1/cluster/system_settings/reset", headers=_auth_headers("writer")
+    )
+    assert response.status_code == 200
+    assert response.json()["download_source"] == "auto"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Add granular `settings:read` and `settings:write` permissions for System Settings under advanced authentication.

Previously, System Settings were restricted to administrators and could not be configured through User Management. This change separates viewing settings from modifying them and supports read-only access.

## Changes

- Add `settings:read` and `settings:write` to the permission registry.
- Include both permissions in initial administrator permissions.
- Require `settings:read` for `GET /v1/cluster/system_settings`.
- Require `settings:write` for updating or resetting system settings.
- Show the System Settings menu only to users with read permission.
- Protect the System Settings route with `settings:read`.
- Render the page in read-only mode without `settings:write`.
- Add permission labels in English, Chinese, Japanese, and Korean.
- Add backend authorization tests.
- Update advanced authentication documentation.

## Permission model

| Permission | Access |
| --- | --- |
| `settings:read` | View the System Settings page and read settings |
| `settings:write` | Update settings and restore defaults |
| `admin` | Full read and write access |

Users who need editable UI access should receive both `settings:read` and `settings:write`.
