### PR TITLE
fix(llm): emit streaming tool call metadata once

### DIFF
--- a/xinference/model/llm/mlx/tests/test_mlx.py
+++ b/xinference/model/llm/mlx/tests/test_mlx.py
@@ -572,11 +572,16 @@ async def test_mlx_streaming_parses_multiple_qwen_tool_calls():
             )["query"]
             for index in sorted(calls_by_index)
         ] == ["Dario Amodei recent news", "Dario Amodei gossip"]
+        first_calls = {index: calls[0] for index, calls in calls_by_index.items()}
         assert all(
-            len({call["id"] for call in calls}) == 1
+            sum("id" in call for call in calls) == 1
+            and sum("type" in call for call in calls) == 1
+            and "id" in calls[0]
+            and calls[0]["type"] == "function"
+            and all("id" not in call and "type" not in call for call in calls[1:])
             for calls in calls_by_index.values()
         )
-        assert calls_by_index[0][0]["id"] != calls_by_index[1][0]["id"]
+        assert first_calls[0]["id"] != first_calls[1]["id"]
         assert results[-1]["choices"][0]["finish_reason"] == "tool_calls"
         assert (
             "".join(

--- a/xinference/model/llm/tests/test_utils.py
+++ b/xinference/model/llm/tests/test_utils.py
@@ -307,6 +307,17 @@ class _IncrementalToolParser:
         return (None, "get_weather", {"city": "Beijing"}, 0)
 
 
+class _InterleavedIncrementalToolParser:
+    def extract_tool_calls_streaming(self, previous_texts, current_text, delta_text):
+        events = {
+            "call0-start": (None, "get_weather", None, 0),
+            "call1-start": (None, "get_time", None, 1),
+            "call0-complete": (None, "get_weather", {"city": "Beijing"}, 0),
+            "call1-complete": (None, "get_time", {"timezone": "UTC+8"}, 1),
+        }
+        return events[delta_text]
+
+
 def test_post_process_completion_chunk_supports_multiple_tool_calls():
     mixin = ChatModelMixin()
     mixin.tool_parser = _MultiToolParser()
@@ -329,10 +340,12 @@ def test_post_process_completion_chunk_supports_multiple_tool_calls():
     choice = result["choices"][0]
     assert choice["finish_reason"] == "tool_calls"
     assert choice["delta"]["content"] == " tail"
-    assert [call["index"] for call in choice["delta"]["tool_calls"]] == [0, 1]
+    tool_calls = choice["delta"]["tool_calls"]
+    assert [call["index"] for call in tool_calls] == [0, 1]
+    assert all(call["id"].startswith("call_") for call in tool_calls)
+    assert all(call["type"] == "function" for call in tool_calls)
     assert [
-        (call["function"]["name"], call["function"]["arguments"])
-        for call in choice["delta"]["tool_calls"]
+        (call["function"]["name"], call["function"]["arguments"]) for call in tool_calls
     ] == [
         ("get_weather", '{"city": "Beijing"}'),
         ("get_time", '{"timezone": "UTC+8"}'),
@@ -408,7 +421,7 @@ def test_post_process_completion_chunk_preserves_absolute_tool_call_index():
     assert final["choices"][0]["finish_reason"] == "tool_calls"
 
 
-def test_post_process_completion_chunk_reuses_incremental_tool_call_id():
+def test_post_process_completion_chunk_emits_incremental_metadata_once():
     mixin = ChatModelMixin()
     mixin.tool_parser = _IncrementalToolParser()
     previous_texts = [""]
@@ -445,9 +458,66 @@ def test_post_process_completion_chunk_reuses_incremental_tool_call_id():
     assert complete is not None
     first_call = first["choices"][0]["delta"]["tool_calls"][0]
     complete_call = complete["choices"][0]["delta"]["tool_calls"][0]
-    assert first_call["id"] == complete_call["id"]
+    assert first_call["id"] == tool_call_state["call_ids"][0]
+    assert first_call["type"] == "function"
     assert first_call["function"] == {"name": "get_weather", "arguments": ""}
+    assert "id" not in complete_call
+    assert "type" not in complete_call
     assert complete_call["function"] == {"arguments": '{"city": "Beijing"}'}
+    assert tool_call_state["sent_metadata"] == {0}
+
+
+def test_post_process_completion_chunk_tracks_metadata_per_tool_call_index():
+    mixin = ChatModelMixin()
+    mixin.tool_parser = _InterleavedIncrementalToolParser()
+    previous_texts = [""]
+    tool_call_state = {"seen": False}
+
+    def process(delta_text):
+        result = mixin._post_process_completion_chunk(
+            "test-family",
+            "test-model",
+            {
+                "choices": [
+                    {
+                        "delta": {"content": delta_text},
+                        "finish_reason": None,
+                        "logprobs": None,
+                    }
+                ]
+            },
+            previous_texts=previous_texts,
+            tool_call_state=tool_call_state,
+        )
+        assert result is not None
+        return result["choices"][0]["delta"]["tool_calls"][0]
+
+    first_call0 = process("call0-start")
+    first_call1 = process("call1-start")
+    complete_call0 = process("call0-complete")
+    complete_call1 = process("call1-complete")
+
+    assert first_call0["index"] == 0
+    assert first_call1["index"] == 1
+    assert first_call0["id"] != first_call1["id"]
+    assert first_call0["type"] == first_call1["type"] == "function"
+    assert first_call0["function"] == {"name": "get_weather", "arguments": ""}
+    assert first_call1["function"] == {"name": "get_time", "arguments": ""}
+
+    assert complete_call0 == {
+        "index": 0,
+        "function": {"arguments": '{"city": "Beijing"}'},
+    }
+    assert complete_call1 == {
+        "index": 1,
+        "function": {"arguments": '{"timezone": "UTC+8"}'},
+    }
+    assert tool_call_state["call_ids"] == {
+        0: first_call0["id"],
+        1: first_call1["id"],
+    }
+    assert tool_call_state["sent_names"] == {0, 1}
+    assert tool_call_state["sent_metadata"] == {0, 1}
 
 
 def test_post_process_completion_chunk_preserves_length_finish_reason():

--- a/xinference/model/llm/utils.py
+++ b/xinference/model/llm/utils.py
@@ -55,6 +55,7 @@ from ...types import (
     CompletionChunk,
     CompletionLogprobs,
     CompletionUsage,
+    ToolCallDelta,
 )
 from .core import chat_context_var
 from .reasoning_parser import ReasoningParser
@@ -604,7 +605,9 @@ class ChatModelMixin:
                 if reasoning_parser and reasoning_parser.check_content_parser():
                     delta["reasoning_content"] = None
             elif "tool_calls" in choice:
-                delta["tool_calls"] = choice["tool_calls"]
+                # CompletionChoice keeps its non-streaming public type for
+                # compatibility, while engine-provided chunks contain deltas.
+                delta["tool_calls"] = cast(List[ToolCallDelta], choice["tool_calls"])
             choices_list.append(
                 {
                     "index": i,
@@ -976,6 +979,7 @@ class ChatModelMixin:
                     continue
                 call_id = f"call_{str(uuid.uuid4())}"
                 function_name: Optional[str] = func
+                include_metadata = True
                 if tool_call_state is not None:
                     call_ids = tool_call_state.setdefault("call_ids", {})
                     call_id = call_ids.setdefault(tool_call_index, call_id)
@@ -984,6 +988,10 @@ class ChatModelMixin:
                         function_name = None
                     else:
                         sent_names.add(tool_call_index)
+                    sent_metadata = tool_call_state.setdefault("sent_metadata", set())
+                    include_metadata = tool_call_index not in sent_metadata
+                    if include_metadata:
+                        sent_metadata.add(tool_call_index)
 
                 function_delta: Dict[str, Any] = {
                     "arguments": (
@@ -992,14 +1000,14 @@ class ChatModelMixin:
                 }
                 if function_name is not None:
                     function_delta["name"] = function_name
-                tool_calls.append(
-                    {
-                        "index": tool_call_index,
-                        "id": call_id,
-                        "type": "function",
-                        "function": function_delta,
-                    }
-                )
+                tool_call_delta: Dict[str, Any] = {
+                    "index": tool_call_index,
+                    "function": function_delta,
+                }
+                if include_metadata:
+                    tool_call_delta["id"] = call_id
+                    tool_call_delta["type"] = "function"
+                tool_calls.append(tool_call_delta)
             elif parsed_content:
                 failed_contents.append(parsed_content)
 

--- a/xinference/model/llm/utils.py
+++ b/xinference/model/llm/utils.py
@@ -988,7 +988,9 @@ class ChatModelMixin:
                         function_name = None
                     else:
                         sent_names.add(tool_call_index)
-                    sent_metadata = tool_call_state.setdefault("sent_metadata", set())
+                    sent_metadata = tool_call_state.get("sent_metadata")
+                    if sent_metadata is None:
+                        sent_metadata = tool_call_state["sent_metadata"] = set()
                     include_metadata = tool_call_index not in sent_metadata
                     if include_metadata:
                         sent_metadata.add(tool_call_index)

--- a/xinference/types.py
+++ b/xinference/types.py
@@ -201,6 +201,18 @@ class ToolCalls(TypedDict):
     function: ToolCallFunction
 
 
+class ToolCallDeltaFunction(TypedDict, total=False):
+    name: str
+    arguments: str
+
+
+class ToolCallDelta(TypedDict):
+    index: int
+    id: NotRequired[str]
+    type: NotRequired[Literal["function"]]
+    function: NotRequired[ToolCallDeltaFunction]
+
+
 class CompletionChoice(TypedDict):
     text: NotRequired[str]
     index: int
@@ -274,7 +286,7 @@ class ChatCompletionChunkDelta(TypedDict):
     role: NotRequired[str]
     reasoning_content: NotRequired[Union[str, None]]
     content: NotRequired[Union[str, None]]
-    tool_calls: NotRequired[List[ToolCalls]]
+    tool_calls: NotRequired[List[ToolCallDelta]]
 
 
 class ChatCompletionChunkChoice(TypedDict):


### PR DESCRIPTION
## Summary
- Emit tool-call `id` and `type` metadata only in the first streaming chunk for each tool call.
- Keep subsequent chunks focused on argument deltas.
- Preserve compatibility for stateless tool-call generation.

## Tests
- `pytest -q xinference/model/llm/tests/test_utils.py` (36 passed)
- Pre-commit checks passed.