### PR TITLE
feat(vllm): support native multiprocessing executor routing

### DIFF
--- a/xinference/model/llm/vllm/core.py
+++ b/xinference/model/llm/vllm/core.py
@@ -92,6 +92,7 @@ if TYPE_CHECKING:
 
 
 class VLLMModelConfig(TypedDict, total=False):
+    xinference_vllm_executor_backend: str
     tokenizer_mode: Optional[str]
     trust_remote_code: bool
     tensor_parallel_size: int
@@ -505,6 +506,9 @@ class VLLMModel(LLM):
         self._context_length: Optional[int] = None
         # distributed inference
         self._device_count = None
+        self._xinference_vllm_executor_backend = model_config.pop(  # type: ignore
+            "xinference_vllm_executor_backend", None
+        )
         self._address = model_config.pop("address", None)  # type: ignore
         self._n_worker = model_config.pop("n_worker", 1)  # type: ignore
         self._shard = model_config.pop("shard", 0)  # type: ignore
@@ -535,9 +539,113 @@ class VLLMModel(LLM):
     def driver_info(self) -> Optional[dict]:
         return self._driver_info
 
+    def _get_xinference_executor_backend(self) -> str:
+        backend = self._xinference_vllm_executor_backend
+        if backend is None:
+            backend = os.getenv("XINFERENCE_VLLM_EXECUTOR_BACKEND", "auto")
+        backend = str(backend).strip().lower()
+        if backend not in {"auto", "native_mp", "xoscar"}:
+            raise ValueError(
+                "Xinference vLLM executor backend must be one of "
+                "'auto', 'native_mp', or 'xoscar'; "
+                f"got {backend!r}"
+            )
+        return backend
+
+    def _get_allocated_device_count(self) -> int:
+        accelerators = getattr(self.model_family, "accelerators", None)
+        if accelerators:
+            return len(accelerators)
+
+        if self._device_count is not None:
+            return self._device_count
+
+        configured_tp = (self._model_config or {}).get("tensor_parallel_size")
+        configured_pp = (self._model_config or {}).get("pipeline_parallel_size")
+        return int(configured_tp or 1) * int(configured_pp or 1)
+
+    def _is_qwen4_exp(self) -> bool:
+        return self.model_family.has_architecture("Qwen4ExpForConditionalGeneration")
+
+    def _native_mp_route(self) -> Tuple[bool, str]:
+        backend = self._get_xinference_executor_backend()
+        if backend == "xoscar":
+            return False, "explicit xoscar backend"
+
+        if self._n_worker != 1:
+            if backend == "native_mp":
+                raise ValueError(
+                    "native_mp only supports n_worker=1; "
+                    "use xoscar for multi-worker deployment"
+                )
+            return False, "n_worker is not 1"
+
+        if self._xavier_config is not None:
+            if backend == "native_mp":
+                raise ValueError("native_mp is not supported with Xavier")
+            return False, "Xavier is enabled"
+
+        device_count = self._get_allocated_device_count()
+        if device_count <= 1:
+            if backend == "native_mp":
+                raise ValueError("native_mp requires more than one allocated GPU")
+            return False, "allocated GPU count is not greater than 1"
+
+        if VLLM_VERSION is None:
+            if backend == "native_mp":
+                raise ValueError(
+                    "Cannot select native_mp because vLLM version is unavailable "
+                    "in the model environment"
+                )
+            return False, "vLLM version is unavailable"
+
+        if not self._is_vllm_v1():
+            if backend == "native_mp":
+                raise ValueError("native_mp requires vLLM V1")
+            return False, "vLLM V1 is not enabled"
+
+        min_version = version.parse("0.28.0")
+        if VLLM_VERSION < min_version:
+            if backend == "native_mp":
+                raise ValueError("native_mp requires vLLM >= " f"{min_version}")
+            return False, f"vLLM version is lower than {min_version}"
+
+        if backend == "native_mp":
+            self._get_native_mp_parallelism()
+            return True, "explicit native_mp backend"
+        if self._is_qwen4_exp():
+            self._get_native_mp_parallelism()
+            return True, "Qwen4Exp single-worker multi-GPU auto route"
+        return False, "auto route is limited to Qwen4Exp architecture"
+
+    def _use_native_mp_executor(self) -> bool:
+        use_native_mp, _ = self._native_mp_route()
+        return use_native_mp
+
+    def _get_native_mp_parallelism(self) -> Tuple[int, int]:
+        device_count = self._get_allocated_device_count()
+        model_config = self._model_config or {}
+        tensor_parallel_size = int(
+            model_config.get("tensor_parallel_size", device_count)
+        )
+        pipeline_parallel_size = int(model_config.get("pipeline_parallel_size", 1))
+        if tensor_parallel_size <= 0 or pipeline_parallel_size <= 0:
+            raise ValueError(
+                "native_mp tensor_parallel_size and pipeline_parallel_size "
+                "must both be positive integers"
+            )
+        if tensor_parallel_size * pipeline_parallel_size != device_count:
+            raise ValueError(
+                "native_mp requires tensor_parallel_size * "
+                "pipeline_parallel_size to equal the allocated GPU count; "
+                f"got TP={tensor_parallel_size}, PP={pipeline_parallel_size}, "
+                f"allocated_gpu_count={device_count}"
+            )
+        return tensor_parallel_size, pipeline_parallel_size
+
     @property
-    def need_create_pools(self):
-        return True
+    def need_create_pools(self) -> bool:
+        return not self._use_native_mp_executor()
 
     def set_pool_addresses(self, pool_addresses: List[str]):
         self._pool_addresses = pool_addresses  # type: ignore
@@ -560,7 +668,7 @@ class VLLMModel(LLM):
         from vllm import envs
 
         # For vLLM >= 0.11.1, v1 is default
-        if VLLM_VERSION > version.parse("0.11.0"):
+        if VLLM_VERSION is not None and VLLM_VERSION > version.parse("0.11.0"):
             return True
 
         # For older versions, check the environment variable
@@ -661,6 +769,7 @@ class VLLMModel(LLM):
             f"Enable lora: {enable_lora}. Lora count: {max_loras}."
         )
 
+        use_native_mp, native_mp_reason = self._native_mp_route()
         if self._xavier_config is not None:
             from .xavier.engine import XavierEngine
 
@@ -681,8 +790,66 @@ class VLLMModel(LLM):
             self._engine = XavierEngine.from_engine_args(
                 engine_args, xavier_config=self._xavier_config
             )
+        elif use_native_mp:
+            tensor_parallel_size, pipeline_parallel_size = (
+                self._get_native_mp_parallelism()
+            )
+            configured_backend = self._model_config.get("distributed_executor_backend")
+            if configured_backend not in (None, "mp"):
+                logger.warning(
+                    "Overriding distributed_executor_backend=%r with 'mp' for "
+                    "Xinference native_mp route of model %s",
+                    configured_backend,
+                    self.model_uid,
+                )
+            self._model_config["tensor_parallel_size"] = tensor_parallel_size
+            self._model_config["pipeline_parallel_size"] = pipeline_parallel_size
+            self._model_config["distributed_executor_backend"] = "mp"
+            engine_args = AsyncEngineArgs(
+                model=self.model_path,
+                enable_lora=enable_lora,
+                max_loras=max_loras,
+                **self._model_config,
+            )
+            self._enable_v1_if_supported(engine_args)
+
+            def _load_native_mp():
+                os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
+                architectures = getattr(
+                    self.model_family, "_resolve_architectures", lambda: None
+                )()
+                logger.info(
+                    "vLLM executor route: model_uid=%s, model_name=%s, "
+                    "requested_backend=%s, selected_backend=native_mp_local, "
+                    "reason=%s, architecture=%s, n_worker=%s, "
+                    "allocated_device_count=%s, vllm_version=%s, TP=%s, PP=%s, "
+                    "distributed_executor_backend=mp, multiproc_method=spawn, "
+                    "CUDA_VISIBLE_DEVICES=%s",
+                    self.model_uid,
+                    getattr(self.model_family, "model_name", None),
+                    self._get_xinference_executor_backend(),
+                    native_mp_reason,
+                    architectures,
+                    self._n_worker,
+                    self._get_allocated_device_count(),
+                    VLLM_VERSION,
+                    tensor_parallel_size,
+                    pipeline_parallel_size,
+                    os.environ.get("CUDA_VISIBLE_DEVICES"),
+                )
+                try:
+                    self._engine = AsyncLLMEngine.from_engine_args(engine_args)
+                except Exception:
+                    logger.exception("Creating vllm native mp engine failed")
+                    self._loading_error = sys.exc_info()
+
+            self._loading_thread = threading.Thread(target=_load_native_mp)
+            self._loading_thread.start()
+            self._loading_thread.join(1)
         elif self._n_worker > 1 or (
-            self._device_count > 1 and VLLM_VERSION >= version.parse("0.7.0")
+            self._device_count > 1
+            and VLLM_VERSION is not None
+            and VLLM_VERSION >= version.parse("0.7.0")
         ):
             from vllm.config import VllmConfig
 

--- a/xinference/model/llm/vllm/core.py
+++ b/xinference/model/llm/vllm/core.py
@@ -562,7 +562,10 @@ class VLLMModel(LLM):
 
         configured_tp = (self._model_config or {}).get("tensor_parallel_size")
         configured_pp = (self._model_config or {}).get("pipeline_parallel_size")
-        return int(configured_tp or 1) * int(configured_pp or 1)
+        if configured_tp is not None or configured_pp is not None:
+            return int(configured_tp or 1) * int(configured_pp or 1)
+
+        return self._get_cuda_count()
 
     def _is_qwen4_exp(self) -> bool:
         return self.model_family.has_architecture("Qwen4ExpForConditionalGeneration")
@@ -625,10 +628,12 @@ class VLLMModel(LLM):
     def _get_native_mp_parallelism(self) -> Tuple[int, int]:
         device_count = self._get_allocated_device_count()
         model_config = self._model_config or {}
+        configured_tp = model_config.get("tensor_parallel_size")
+        configured_pp = model_config.get("pipeline_parallel_size")
         tensor_parallel_size = int(
-            model_config.get("tensor_parallel_size", device_count)
+            device_count if configured_tp is None else configured_tp
         )
-        pipeline_parallel_size = int(model_config.get("pipeline_parallel_size", 1))
+        pipeline_parallel_size = int(1 if configured_pp is None else configured_pp)
         if tensor_parallel_size <= 0 or pipeline_parallel_size <= 0:
             raise ValueError(
                 "native_mp tensor_parallel_size and pipeline_parallel_size "

--- a/xinference/model/llm/vllm/tests/test_executor_routing.py
+++ b/xinference/model/llm/vllm/tests/test_executor_routing.py
@@ -230,3 +230,46 @@ def test_native_mp_rejects_parallelism_not_matching_allocated_gpus(
 
     with pytest.raises(ValueError, match="to equal the allocated GPU count"):
         model._get_native_mp_parallelism()
+
+
+def test_allocated_device_count_falls_back_to_cuda_count():
+    model = _model()
+    model.model_family.accelerators = []
+    model._device_count = None
+    model._model_config = {}
+    model._get_cuda_count = lambda: 8
+
+    assert model._get_allocated_device_count() == 8
+    assert model._native_mp_route() == (
+        True,
+        "Qwen4Exp single-worker multi-GPU auto route",
+    )
+
+
+def test_native_mp_parallelism_treats_none_as_default():
+    model = _model(
+        model_config={
+            "tensor_parallel_size": None,
+            "pipeline_parallel_size": None,
+        }
+    )
+
+    assert model._get_native_mp_parallelism() == (8, 1)
+
+
+@pytest.mark.parametrize(
+    ("tensor_parallel_size", "pipeline_parallel_size"),
+    [(0, 1), (8, 0)],
+)
+def test_native_mp_parallelism_rejects_zero_values(
+    tensor_parallel_size, pipeline_parallel_size
+):
+    model = _model(
+        model_config={
+            "tensor_parallel_size": tensor_parallel_size,
+            "pipeline_parallel_size": pipeline_parallel_size,
+        }
+    )
+
+    with pytest.raises(ValueError, match="must both be positive integers"):
+        model._get_native_mp_parallelism()

--- a/xinference/model/llm/vllm/tests/test_executor_routing.py
+++ b/xinference/model/llm/vllm/tests/test_executor_routing.py
@@ -1,0 +1,232 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+import pytest
+from packaging import version
+
+
+def _model(
+    *,
+    architecture="Qwen4ExpForConditionalGeneration",
+    gpu_count=8,
+    n_worker=1,
+    backend="auto",
+    model_config=None,
+    xavier=False,
+):
+    from ..core import VLLMModel
+
+    model = object.__new__(VLLMModel)
+    model.model_uid = "test-model-0"
+    model.model_family = SimpleNamespace(
+        accelerators=[str(index) for index in range(gpu_count)],
+        has_architecture=lambda candidate: candidate == architecture,
+        _resolve_architectures=lambda: [architecture],
+    )
+    model._model_config = dict(model_config or {})
+    model._xinference_vllm_executor_backend = backend
+    model._n_worker = n_worker
+    model._device_count = gpu_count
+    model._xavier_config = {} if xavier else None
+    return model
+
+
+@pytest.fixture(autouse=True)
+def native_mp_capable_vllm(monkeypatch):
+    from .. import core
+
+    monkeypatch.setattr(core, "VLLM_VERSION", version.parse("0.28.0"))
+    monkeypatch.setattr(core.VLLMModel, "_is_vllm_v1", lambda self: True)
+
+
+def test_qwen4_exp_single_worker_multi_gpu_auto_uses_native_mp():
+    model = _model()
+
+    assert model._native_mp_route() == (
+        True,
+        "Qwen4Exp single-worker multi-GPU auto route",
+    )
+    assert model.need_create_pools is False
+    assert model._get_native_mp_parallelism() == (8, 1)
+
+
+def test_qwen4_exp_single_gpu_keeps_existing_route():
+    model = _model(gpu_count=1)
+
+    use_native_mp, reason = model._native_mp_route()
+
+    assert use_native_mp is False
+    assert reason == "allocated GPU count is not greater than 1"
+    assert model.need_create_pools is True
+
+
+def test_qwen4_exp_multi_worker_keeps_xoscar_route():
+    model = _model(n_worker=2)
+
+    assert model._native_mp_route() == (False, "n_worker is not 1")
+    assert model.need_create_pools is True
+
+
+def test_non_qwen_auto_keeps_xoscar_route():
+    model = _model(architecture="LlamaForCausalLM")
+
+    assert model._native_mp_route() == (
+        False,
+        "auto route is limited to Qwen4Exp architecture",
+    )
+    assert model.need_create_pools is True
+
+
+def test_explicit_native_mp_supports_other_eligible_architecture():
+    model = _model(architecture="LlamaForCausalLM", backend="native_mp")
+
+    assert model._native_mp_route() == (True, "explicit native_mp backend")
+    assert model.need_create_pools is False
+
+
+def test_explicit_xoscar_always_keeps_existing_route():
+    model = _model(backend="xoscar")
+
+    assert model._native_mp_route() == (False, "explicit xoscar backend")
+    assert model.need_create_pools is True
+
+
+@pytest.mark.parametrize("backend", ["invalid", "ray", "mp"])
+def test_invalid_xinference_executor_selector_is_rejected(backend):
+    model = _model(backend=backend)
+
+    with pytest.raises(ValueError, match="must be one of"):
+        model._native_mp_route()
+
+
+def test_launch_parameter_takes_priority_over_environment(monkeypatch):
+    monkeypatch.setenv("XINFERENCE_VLLM_EXECUTOR_BACKEND", "native_mp")
+    model = _model(backend="xoscar")
+
+    assert model._get_xinference_executor_backend() == "xoscar"
+
+
+def test_environment_selector_is_used_when_launch_parameter_is_absent(monkeypatch):
+    monkeypatch.setenv("XINFERENCE_VLLM_EXECUTOR_BACKEND", "native_mp")
+    model = _model(backend=None)
+
+    assert model._get_xinference_executor_backend() == "native_mp"
+
+
+def test_explicit_native_mp_rejects_multi_worker():
+    model = _model(backend="native_mp", n_worker=2)
+
+    with pytest.raises(ValueError, match="only supports n_worker=1"):
+        model._native_mp_route()
+
+
+def test_explicit_native_mp_rejects_single_gpu():
+    model = _model(backend="native_mp", gpu_count=1)
+
+    with pytest.raises(ValueError, match="more than one allocated GPU"):
+        model._native_mp_route()
+
+
+def test_explicit_native_mp_rejects_xavier():
+    model = _model(backend="native_mp", xavier=True)
+
+    with pytest.raises(ValueError, match="not supported with Xavier"):
+        model._native_mp_route()
+
+
+def test_auto_route_rejects_xavier_without_failing_launch():
+    model = _model(xavier=True)
+
+    assert model._native_mp_route() == (False, "Xavier is enabled")
+
+
+def test_auto_route_keeps_existing_path_when_vllm_version_unavailable(monkeypatch):
+    from .. import core
+
+    monkeypatch.setattr(core, "VLLM_VERSION", None)
+    model = _model()
+
+    assert model._native_mp_route() == (False, "vLLM version is unavailable")
+
+
+def test_explicit_native_mp_rejects_unavailable_vllm_version(monkeypatch):
+    from .. import core
+
+    monkeypatch.setattr(core, "VLLM_VERSION", None)
+    model = _model(backend="native_mp")
+
+    with pytest.raises(ValueError, match="version is unavailable"):
+        model._native_mp_route()
+
+
+def test_auto_route_keeps_existing_path_for_old_vllm(monkeypatch):
+    from .. import core
+
+    monkeypatch.setattr(core, "VLLM_VERSION", version.parse("0.27.0"))
+    model = _model()
+
+    use_native_mp, reason = model._native_mp_route()
+
+    assert use_native_mp is False
+    assert "lower than 0.28.0" in reason
+
+
+def test_explicit_native_mp_requires_vllm_v1(monkeypatch):
+    from .. import core
+
+    monkeypatch.setattr(core.VLLMModel, "_is_vllm_v1", lambda self: False)
+    model = _model(backend="native_mp")
+
+    with pytest.raises(ValueError, match="requires vLLM V1"):
+        model._native_mp_route()
+
+
+@pytest.mark.parametrize(
+    ("tensor_parallel_size", "pipeline_parallel_size"),
+    [(8, 1), (4, 2), (2, 4)],
+)
+def test_native_mp_accepts_parallelism_covering_all_allocated_gpus(
+    tensor_parallel_size, pipeline_parallel_size
+):
+    model = _model(
+        model_config={
+            "tensor_parallel_size": tensor_parallel_size,
+            "pipeline_parallel_size": pipeline_parallel_size,
+        }
+    )
+
+    assert model._get_native_mp_parallelism() == (
+        tensor_parallel_size,
+        pipeline_parallel_size,
+    )
+
+
+@pytest.mark.parametrize(
+    ("tensor_parallel_size", "pipeline_parallel_size"),
+    [(4, 1), (8, 2)],
+)
+def test_native_mp_rejects_parallelism_not_matching_allocated_gpus(
+    tensor_parallel_size, pipeline_parallel_size
+):
+    model = _model(
+        model_config={
+            "tensor_parallel_size": tensor_parallel_size,
+            "pipeline_parallel_size": pipeline_parallel_size,
+        }
+    )
+
+    with pytest.raises(ValueError, match="to equal the allocated GPU count"):
+        model._get_native_mp_parallelism()


### PR DESCRIPTION
## Summary
- Add explicit `auto`, `native_mp`, and `xoscar` executor routing for vLLM.
- Use vLLM native multiprocessing for eligible single-worker, multi-GPU deployments.
- Validate vLLM V1, GPU allocation, and tensor/pipeline parallelism before selecting native MP.
- Force the `spawn` multiprocessing method for the native route and retain the existing xoscar route as the fallback.

## Tests
- `pytest -q xinference/model/llm/vllm/tests/test_executor_routing.py` (24 passed)
- Pre-commit checks passed.