### PR TITLE
fix(venv): require xoscar native find-links support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "xoscar>=0.9.7",
+    "xoscar>=0.9.10",
     "psutil>=5.9.0",
     "torch",
     "pillow",


### PR DESCRIPTION
## Summary
- Raise the minimum xoscar version from `0.9.7` to `0.9.10`.
- Rely on xoscar native support for forwarding `find_links` and `trusted_host` during virtual-environment dependency resolution.
- Keep this PR limited to the dependency requirement; no local compatibility wrapper is included.

## Tests
- `pyproject.toml` TOML parsing passed.
- `git diff --check` passed.
- Pre-commit checks passed.