### PR TITLE
fix(venv): protect virtual environments in use

### DIFF
--- a/xinference/api/routers/admin.py
+++ b/xinference/api/routers/admin.py
@@ -18,6 +18,7 @@ from pydantic import BaseModel
 
 from ... import __version__
 from ...constants import XINFERENCE_TOKEN_ROUTER_ENABLED
+from ...core.virtual_env_manager import VirtualEnvConflictError
 from ..dependencies import get_api
 from ..responses import JSONResponse
 
@@ -246,6 +247,9 @@ async def remove_virtual_env(
             worker_ip=worker_ip,
         )
         return JSONResponse(content={"result": res})
+    except VirtualEnvConflictError as e:
+        logger.warning(e)
+        raise HTTPException(status_code=409, detail=str(e))
     except ValueError as re:
         logger.error(re, exc_info=True)
         raise HTTPException(status_code=400, detail=str(re))

--- a/xinference/api/tests/test_admin.py
+++ b/xinference/api/tests/test_admin.py
@@ -21,6 +21,7 @@ import pytest
 from fastapi import HTTPException
 
 from xinference.api.routers import admin
+from xinference.core.virtual_env_manager import VirtualEnvConflictError
 
 
 def _json_body(response):
@@ -256,6 +257,27 @@ async def test_remove_virtual_env_returns_result(mock_api, mock_supervisor):
     )
     assert response.status_code == 200
     assert _json_body(response) == {"result": True}
+
+
+@pytest.mark.asyncio
+async def test_remove_virtual_env_returns_conflict_for_active_model(
+    mock_api, mock_supervisor
+):
+    mock_supervisor.remove_virtual_env.side_effect = VirtualEnvConflictError(
+        "environment is used by qwen-rep0"
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await admin.remove_virtual_env(
+            api=mock_api,
+            model_name="Qwen3.8-Flash-Next",
+            model_engine="vllm",
+            python_version="3.12",
+            worker_ip=None,
+        )
+
+    assert exc_info.value.status_code == 409
+    assert "qwen-rep0" in exc_info.value.detail
 
 
 @pytest.mark.asyncio

--- a/xinference/core/supervisor.py
+++ b/xinference/core/supervisor.py
@@ -85,6 +85,7 @@ from .utils import (
     parse_model_version,
     parse_replica_model_uid,
 )
+from .virtual_env_manager import VirtualEnvConflictError
 
 if TYPE_CHECKING:
     from ..model.audio import AudioModelFamilyV2
@@ -5144,17 +5145,26 @@ class SupervisorActor(xo.StatelessActor):
             except Exception as e:
                 logger.debug(f"Failed to check worker for virtual environment: {e}")
 
-        # Then remove from those workers
+        # Then remove from those workers. Preserve a conflict so the API can
+        # report that an active/preparing model still owns the environment.
+        conflict_error: Optional[VirtualEnvConflictError] = None
         for worker in workers_with_env:
             try:
                 result = await worker.remove_virtual_env(
                     model_name, model_engine, python_version
                 )
                 ret = ret and result
+            except VirtualEnvConflictError as e:
+                if conflict_error is None:
+                    conflict_error = e
+                logger.warning("Virtual environment is still in use on a worker: %s", e)
+                ret = False
             except Exception as e:
                 logger.error(f"Failed to remove virtual environment from worker: {e}")
                 ret = False
 
+        if conflict_error is not None:
+            raise conflict_error
         return ret
 
     async def list_token_routers(self) -> List[Dict[str, Any]]:

--- a/xinference/core/tests/test_cancel_launch_cleanup.py
+++ b/xinference/core/tests/test_cancel_launch_cleanup.py
@@ -22,6 +22,7 @@ until the worker restarts — the next launch of the same uid then fails with
 """
 
 import asyncio
+import threading
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -43,6 +44,9 @@ def _make_worker():
     self._main_pool.remove_sub_pool = AsyncMock()
     self._model_uid_launching_guard = {}
     self._model_uid_to_model = {}
+    self._virtual_env_usages = {}
+    self._model_uid_to_virtual_env_path = {}
+    self._virtual_env_usage_lock = threading.Lock()
     self._launch_active = 0
     self._launch_waiting = 0
     self.release_devices = MagicMock()
@@ -55,6 +59,9 @@ def _make_worker():
     self._allocate_subpool_devices = AsyncMock(return_value=({}, [0]))
     self._upload_download_progress = MagicMock()
     self._prepare_virtual_env = AsyncMock()
+    self._release_virtual_env_usage = WorkerActor._release_virtual_env_usage.__get__(
+        self
+    )
     self.launch_builtin_model = WorkerActor.launch_builtin_model.__get__(self)
     self.cancel_launch_model = WorkerActor.cancel_launch_model.__get__(self)
     self.get_model_launch_status = WorkerActor.get_model_launch_status.__get__(self)

--- a/xinference/core/tests/test_utils.py
+++ b/xinference/core/tests/test_utils.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
 import pytest
 
 from ..utils import (
@@ -794,9 +796,27 @@ def test_mark_venv_setup_done_writes_marker(tmp_path):
     assert venv in worker_mod._venv_setup_done
     assert worker_mod._venv_setup_done[venv] == expected_fp
     assert os.path.exists(os.path.join(venv, ".xinference_setup_done"))
-    # Verify the marker file contains the fingerprint
+    # Verify the restart-safe structured marker contains all setup inputs.
+    import json
+
     with open(os.path.join(venv, ".xinference_setup_done")) as f:
-        assert f.read().strip() == str(expected_fp)
+        marker = json.load(f)
+    assert marker["schema_version"] == 1
+    assert marker["fingerprint"] == expected_fp
+    assert marker["model_name"] is None
+    assert marker["model_engine"] is None
+    assert marker["python_version"] is None
+    assert marker["setup_inputs"] == {
+        "environment_format_version": 4,
+        "model_name": None,
+        "model_engine": None,
+        "python_version": None,
+        "packages": packages,
+        "conf": {},
+        "variables": {},
+        "architectures": [],
+    }
+    assert isinstance(marker["updated_at"], int)
 
 
 def test_make_fingerprint_handles_list_valued_conf(tmp_path):
@@ -815,8 +835,10 @@ def test_make_fingerprint_handles_list_valued_conf(tmp_path):
     fp_a = worker_mod._make_fingerprint(packages, conf_a, variables, architectures)
     fp_b = worker_mod._make_fingerprint(packages, conf_b, variables, architectures)
 
-    assert isinstance(fp_a, int)
-    assert isinstance(fp_b, int)
+    assert isinstance(fp_a, str) and len(fp_a) == 64
+    assert isinstance(fp_b, str) and len(fp_b) == 64
+    int(fp_a, 16)
+    int(fp_b, 16)
     # Different list values → different fingerprints
     assert fp_a != fp_b
 
@@ -979,3 +1001,112 @@ def test_exclusive_venv_path_lock_serializes_concurrent_callers(tmp_path):
     assert (
         max_occupants == 1
     ), f"Lock failed to serialize: max_occupants={max_occupants}, expected 1"
+
+
+def test_make_fingerprint_is_order_independent_for_packages_and_architectures():
+    from .. import worker as worker_mod
+
+    fp_a = worker_mod._make_fingerprint(
+        ["vllm==0.28.0", "transformers==5.8.0"],
+        {"index_url": "https://example.invalid/simple"},
+        {"cuda_version": "13.0"},
+        ["ArchitectureB", "ArchitectureA"],
+    )
+    fp_b = worker_mod._make_fingerprint(
+        ["transformers==5.8.0", "vllm==0.28.0"],
+        {"index_url": "https://example.invalid/simple"},
+        {"cuda_version": "13.0"},
+        ["ArchitectureA", "ArchitectureB"],
+    )
+
+    assert fp_a == fp_b
+
+
+def test_should_skip_venv_setup_survives_worker_restart(tmp_path):
+    import os
+
+    from .. import worker as worker_mod
+
+    _clean_venv_setup_done()
+    venv = str(tmp_path / "restart-safe-venv")
+    packages = ["vllm==0.28.0"]
+    os.makedirs(venv, exist_ok=True)
+    worker_mod._mark_venv_setup_done(
+        venv, packages, {"index_strategy": "unsafe-best-match"}, {}, None
+    )
+
+    worker_mod._venv_setup_done.clear()
+
+    assert worker_mod._should_skip_venv_setup(
+        venv, packages, {"index_strategy": "unsafe-best-match"}, {}, None
+    )
+    assert venv in worker_mod._venv_setup_done
+
+
+def _usage_tracking_worker():
+    import threading
+
+    from ..worker import WorkerActor
+
+    worker = WorkerActor.__new__(WorkerActor)
+    worker._virtual_env_usages = {}
+    worker._model_uid_to_virtual_env_path = {}
+    worker._virtual_env_usage_lock = threading.Lock()
+    return worker
+
+
+def test_virtual_env_usage_shares_matching_fingerprint(tmp_path):
+    worker = _usage_tracking_worker()
+    env_path = str(tmp_path / "shared-venv")
+
+    worker._reserve_virtual_env_usage(env_path, "fingerprint-a", "model-0")
+    worker._activate_virtual_env_usage(env_path, "fingerprint-a", "model-0")
+    worker._reserve_virtual_env_usage(env_path, "fingerprint-a", "model-1")
+    worker._activate_virtual_env_usage(env_path, "fingerprint-a", "model-1")
+
+    usage = worker._virtual_env_usages[os.path.realpath(env_path)]
+    assert usage.active_model_uids == {"model-0", "model-1"}
+    assert not usage.preparing_model_uids
+
+
+def test_virtual_env_usage_rejects_dependency_mutation_while_active(tmp_path):
+    from ..virtual_env_manager import VirtualEnvConflictError
+
+    worker = _usage_tracking_worker()
+    env_path = str(tmp_path / "shared-venv")
+    worker._reserve_virtual_env_usage(env_path, "fingerprint-a", "model-0")
+    worker._activate_virtual_env_usage(env_path, "fingerprint-a", "model-0")
+
+    with pytest.raises(VirtualEnvConflictError, match="different setup fingerprint"):
+        worker._reserve_virtual_env_usage(env_path, "fingerprint-b", "model-1")
+
+
+def test_virtual_env_usage_rejects_mutation_when_marker_is_stale(tmp_path):
+    from ..virtual_env_manager import VirtualEnvConflictError
+
+    worker = _usage_tracking_worker()
+    env_path = str(tmp_path / "shared-venv")
+    worker._reserve_virtual_env_usage(env_path, "fingerprint-a", "model-0")
+    worker._activate_virtual_env_usage(env_path, "fingerprint-a", "model-0")
+
+    with pytest.raises(VirtualEnvConflictError, match="refusing to mutate"):
+        worker._reserve_virtual_env_usage(
+            env_path, "fingerprint-a", "model-1", setup_required=True
+        )
+
+
+def test_virtual_env_usage_final_release_clears_reference(tmp_path):
+    worker = _usage_tracking_worker()
+    env_path = str(tmp_path / "shared-venv")
+    real_path = os.path.realpath(env_path)
+    worker._reserve_virtual_env_usage(env_path, "fingerprint-a", "model-0")
+    worker._activate_virtual_env_usage(env_path, "fingerprint-a", "model-0")
+    worker._reserve_virtual_env_usage(env_path, "fingerprint-a", "model-1")
+    worker._activate_virtual_env_usage(env_path, "fingerprint-a", "model-1")
+
+    worker._release_virtual_env_usage("model-0")
+    assert worker._virtual_env_usages[real_path].active_model_uids == {"model-1"}
+
+    worker._release_virtual_env_usage("model-1")
+    assert real_path not in worker._virtual_env_usages
+    assert not worker._model_uid_to_virtual_env_path

--- a/xinference/core/tests/test_virtual_env_deletion.py
+++ b/xinference/core/tests/test_virtual_env_deletion.py
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
+import contextlib
+import os
+import threading
+
 import pytest
 
 from ..supervisor import SupervisorActor
@@ -54,3 +59,93 @@ async def test_supervisor_preserves_virtual_env_conflict_from_worker():
 
     assert busy_worker.remove_calls == 1
     assert idle_worker.remove_calls == 1
+
+
+def test_worker_serializes_virtual_env_deletion_with_concurrent_launch(
+    tmp_path, monkeypatch
+):
+    from xinference import constants
+
+    from .. import virtual_env_manager as virtual_env_manager_mod
+    from .. import worker as worker_mod
+    from ..virtual_env_manager import VirtualEnvManager
+    from ..worker import WorkerActor
+
+    virtual_env_root = tmp_path / "virtualenv"
+    env_path = virtual_env_root / "v4" / "Qwen3.8-Flash-Next" / "vllm" / "3.12"
+    env_path.mkdir(parents=True)
+    monkeypatch.setattr(constants, "XINFERENCE_VIRTUAL_ENV_DIR", str(virtual_env_root))
+    monkeypatch.setattr(worker_mod, "XINFERENCE_VIRTUAL_ENV_DIR", str(virtual_env_root))
+    monkeypatch.setattr(
+        virtual_env_manager_mod,
+        "XINFERENCE_VIRTUAL_ENV_DIR",
+        str(virtual_env_root),
+    )
+
+    worker = WorkerActor.__new__(WorkerActor)
+    worker._virtual_env_manager = VirtualEnvManager("worker-0")
+    worker._virtual_env_usages = {}
+    worker._model_uid_to_virtual_env_path = {}
+    worker._virtual_env_usage_lock = threading.Lock()
+
+    launch_reserved = threading.Event()
+    release_launch = threading.Event()
+    deletion_waiting = threading.Event()
+    deletion_finished = threading.Event()
+    deletion_errors = []
+    original_path_lock = worker_mod._exclusive_venv_path_lock
+
+    @contextlib.contextmanager
+    def observed_path_lock(path):
+        if threading.current_thread().name == "delete-virtual-env":
+            deletion_waiting.set()
+        with original_path_lock(path):
+            yield
+
+    monkeypatch.setattr(worker_mod, "_exclusive_venv_path_lock", observed_path_lock)
+
+    def launch_model():
+        with original_path_lock(str(env_path)):
+            worker._reserve_virtual_env_usage(
+                str(env_path), "fingerprint-a", "qwen-rep0", setup_required=True
+            )
+            launch_reserved.set()
+            assert release_launch.wait(timeout=5)
+
+    def delete_virtual_env():
+        try:
+            asyncio.run(
+                WorkerActor.remove_virtual_env(
+                    worker,
+                    model_name="Qwen3.8-Flash-Next",
+                    model_engine="vllm",
+                    python_version="3.12",
+                )
+            )
+        except Exception as exc:
+            deletion_errors.append(exc)
+        finally:
+            deletion_finished.set()
+
+    launch_thread = threading.Thread(target=launch_model, name="launch-model")
+    deletion_thread = threading.Thread(
+        target=delete_virtual_env, name="delete-virtual-env"
+    )
+    try:
+        launch_thread.start()
+        assert launch_reserved.wait(timeout=5)
+        deletion_thread.start()
+        assert deletion_waiting.wait(timeout=5)
+        assert not deletion_finished.is_set()
+    finally:
+        release_launch.set()
+        launch_thread.join(timeout=5)
+        if deletion_thread.ident is not None:
+            deletion_thread.join(timeout=5)
+
+    assert not launch_thread.is_alive()
+    assert not deletion_thread.is_alive()
+    assert len(deletion_errors) == 1
+    assert isinstance(deletion_errors[0], VirtualEnvConflictError)
+    assert "qwen-rep0" in str(deletion_errors[0])
+    assert os.path.isdir(env_path)

--- a/xinference/core/tests/test_virtual_env_deletion.py
+++ b/xinference/core/tests/test_virtual_env_deletion.py
@@ -1,0 +1,56 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from ..supervisor import SupervisorActor
+from ..virtual_env_manager import VirtualEnvConflictError
+
+
+class _WorkerWithVirtualEnv:
+    def __init__(self, error=None):
+        self._error = error
+        self.remove_calls = 0
+
+    async def list_virtual_envs(self, model_name, model_engine):
+        return [{"model_name": model_name, "model_engine": model_engine}]
+
+    async def remove_virtual_env(self, model_name, model_engine, python_version):
+        self.remove_calls += 1
+        if self._error is not None:
+            raise self._error
+        return True
+
+
+@pytest.mark.asyncio
+async def test_supervisor_preserves_virtual_env_conflict_from_worker():
+    conflict = VirtualEnvConflictError("environment is used by qwen-rep0")
+    busy_worker = _WorkerWithVirtualEnv(conflict)
+    idle_worker = _WorkerWithVirtualEnv()
+    supervisor = SupervisorActor.__new__(SupervisorActor)
+    supervisor._worker_address_to_worker = {
+        "worker-0": busy_worker,
+        "worker-1": idle_worker,
+    }
+
+    with pytest.raises(VirtualEnvConflictError, match="qwen-rep0"):
+        await SupervisorActor.remove_virtual_env(
+            supervisor,
+            model_name="Qwen3.8-Flash-Next",
+            model_engine="vllm",
+            python_version="3.12",
+        )
+
+    assert busy_worker.remove_calls == 1
+    assert idle_worker.remove_calls == 1

--- a/xinference/core/tests/test_virtual_env_manager.py
+++ b/xinference/core/tests/test_virtual_env_manager.py
@@ -35,6 +35,8 @@ from ..virtual_env_manager import (
     FLASHINFER_AOT_PACKAGES,
     FLASHINFER_AOT_WHEEL_URL,
     FLASHINFER_CUBIN_WHEEL_URL,
+    VirtualEnvConflictError,
+    VirtualEnvManager,
     _run_uv_install_with_source_fallback,
     _validate_flash_attn_install,
     apply_flash_attn_wheel_post_install,
@@ -1374,3 +1376,41 @@ class TestGetEngineCriticalDependencySpecs:
                 ],
             )
         assert specs == ["transformers==4.57.1"]
+
+
+def test_remove_virtual_env_rejects_active_model(tmp_path, monkeypatch):
+    from xinference import constants
+
+    virtual_env_root = tmp_path / "virtualenv"
+    env_path = virtual_env_root / "v4" / "Qwen3.8-Flash-Next" / "vllm" / "3.12"
+    env_path.mkdir(parents=True)
+    monkeypatch.setattr(constants, "XINFERENCE_VIRTUAL_ENV_DIR", str(virtual_env_root))
+    manager = VirtualEnvManager("worker-0")
+
+    with pytest.raises(VirtualEnvConflictError, match="models are using it"):
+        manager.remove_virtual_env(
+            "Qwen3.8-Flash-Next",
+            "vllm",
+            "3.12",
+            active_model_uids_by_path={str(env_path): ["qwen-rep0"]},
+        )
+
+    assert env_path.exists()
+
+
+def test_remove_virtual_env_allows_delete_after_final_release(tmp_path, monkeypatch):
+    from xinference import constants
+
+    virtual_env_root = tmp_path / "virtualenv"
+    env_path = virtual_env_root / "v4" / "Qwen3.8-Flash-Next" / "vllm" / "3.12"
+    env_path.mkdir(parents=True)
+    monkeypatch.setattr(constants, "XINFERENCE_VIRTUAL_ENV_DIR", str(virtual_env_root))
+    manager = VirtualEnvManager("worker-0")
+
+    assert manager.remove_virtual_env(
+        "Qwen3.8-Flash-Next",
+        "vllm",
+        "3.12",
+        active_model_uids_by_path={},
+    )
+    assert not env_path.exists()

--- a/xinference/core/virtual_env_manager.py
+++ b/xinference/core/virtual_env_manager.py
@@ -28,6 +28,11 @@ from ..constants import (
 
 logger = logging.getLogger(__name__)
 
+
+class VirtualEnvConflictError(ValueError):
+    """Raised when an active model prevents virtual environment mutation."""
+
+
 ENGINE_VIRTUALENV_PACKAGES: Dict[str, List[str]] = {
     "sglang": [
         "pybase64",
@@ -633,6 +638,7 @@ class VirtualEnvManager:
         model_name: str,
         model_engine: Optional[str] = None,
         python_version: Optional[str] = None,
+        active_model_uids_by_path: Optional[Dict[str, List[str]]] = None,
     ) -> bool:
         """
         Remove a virtual environment for a specific model.
@@ -660,6 +666,30 @@ class VirtualEnvManager:
             )
 
         v4_env_dir = os.path.join(XINFERENCE_VIRTUAL_ENV_DIR, "v4")
+
+        model_root = os.path.realpath(os.path.join(v4_env_dir, model_name))
+        for env_path, model_uids in (active_model_uids_by_path or {}).items():
+            if not model_uids:
+                continue
+            real_env_path = os.path.realpath(env_path)
+            try:
+                if os.path.commonpath([model_root, real_env_path]) != model_root:
+                    continue
+            except ValueError:
+                continue
+            relative_parts = Path(real_env_path).relative_to(model_root).parts
+            if model_engine and (
+                not relative_parts or relative_parts[0] != model_engine
+            ):
+                continue
+            if python_version and (
+                not relative_parts or relative_parts[-1] != python_version
+            ):
+                continue
+            raise VirtualEnvConflictError(
+                "Virtual environment cannot be removed while models are using it: "
+                f"path={real_env_path}, active_model_uids={sorted(model_uids)}"
+            )
 
         try:
             if python_version and not self._is_valid_python_version(python_version):

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -14,6 +14,7 @@
 
 import asyncio
 import errno
+import hashlib
 import json
 import logging
 import os
@@ -33,6 +34,7 @@ from logging import getLogger
 from typing import (
     TYPE_CHECKING,
     Any,
+    Callable,
     Dict,
     List,
     Literal,
@@ -114,6 +116,7 @@ from .utils import (
     purge_dir,
     rewrite_direct_url_packages_for_index,
 )
+from .virtual_env_manager import VirtualEnvConflictError
 from .virtual_env_manager import VirtualEnvManager as XinferenceVirtualEnvManager
 from .virtual_env_manager import (
     ensure_system_torch_pin,
@@ -145,20 +148,43 @@ logger = getLogger(__name__)
 # venv with the same package set, only the first one runs the full setup;
 # subsequent replicas skip it to avoid downgrade/upgrade churn that can
 # corrupt .so files while child subprocesses are importing torch/vllm.
-_venv_setup_done: Dict[str, int] = {}
+_venv_setup_done: Dict[str, str] = {}
 
 
-def _freeze(value):
-    """Recursively convert lists/dicts to hashable tuples for fingerprinting.
-
-    ``conf`` values such as ``extra_index_url`` and ``trusted_host`` are
-    ``List[str]``, which cannot be hashed directly.
-    """
+def _normalize_fingerprint_value(value: Any) -> Any:
     if isinstance(value, dict):
-        return tuple(sorted((k, _freeze(v)) for k, v in value.items()))
-    if isinstance(value, list):
-        return tuple(_freeze(v) for v in value)
+        return {
+            str(key): _normalize_fingerprint_value(item) for key, item in value.items()
+        }
+    if isinstance(value, (list, tuple)):
+        return [_normalize_fingerprint_value(item) for item in value]
+    if isinstance(value, set):
+        return sorted(_normalize_fingerprint_value(item) for item in value)
+    if isinstance(value, os.PathLike):
+        return os.fspath(value)
     return value
+
+
+def _fingerprint_payload(
+    packages: List[str],
+    conf: dict,
+    variables: dict,
+    architectures: Optional[List[str]],
+    *,
+    model_name: Optional[str] = None,
+    model_engine: Optional[str] = None,
+    python_version: Optional[str] = None,
+) -> Dict[str, Any]:
+    return {
+        "environment_format_version": 4,
+        "model_name": model_name,
+        "model_engine": model_engine.lower() if model_engine else None,
+        "python_version": python_version,
+        "packages": sorted(packages),
+        "conf": _normalize_fingerprint_value(conf),
+        "variables": _normalize_fingerprint_value(variables),
+        "architectures": sorted(architectures or []),
+    }
 
 
 def _make_fingerprint(
@@ -166,20 +192,44 @@ def _make_fingerprint(
     conf: dict,
     variables: dict,
     architectures: Optional[List[str]],
-) -> int:
-    """Return a hash fingerprint of every setup input that affects the result.
+    *,
+    model_name: Optional[str] = None,
+    model_engine: Optional[str] = None,
+    python_version: Optional[str] = None,
+) -> str:
+    """Return a stable SHA256 fingerprint of all environment setup inputs.
 
-    Includes the canonical package list, install configuration (conf),
-    template variables, and target architectures so a change to any of
-    them produces a different fingerprint and triggers a re-setup.
+    Includes the environment identity, canonical package list, install
+    configuration, template variables, and target architectures so a change
+    to any of them produces a different fingerprint and triggers a re-setup.
     """
-    key = (
-        tuple(sorted(packages)),
-        _freeze(conf),
-        _freeze(variables),
-        tuple(sorted(architectures) if architectures else ()),
+    payload = _fingerprint_payload(
+        packages,
+        conf,
+        variables,
+        architectures,
+        model_name=model_name,
+        model_engine=model_engine,
+        python_version=python_version,
     )
-    return hash(key)
+    serialized = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        default=str,
+    )
+    return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+
+
+def _read_venv_setup_marker(venv_path: str) -> Optional[Dict[str, Any]]:
+    marker_path = os.path.join(venv_path, ".xinference_setup_done")
+    try:
+        with open(marker_path, encoding="utf-8") as marker_file:
+            marker = json.load(marker_file)
+    except (OSError, ValueError, TypeError):
+        return None
+    return marker if isinstance(marker, dict) else None
 
 
 def _should_skip_venv_setup(
@@ -188,23 +238,30 @@ def _should_skip_venv_setup(
     conf: dict,
     variables: dict,
     architectures: Optional[List[str]] = None,
+    *,
+    model_name: Optional[str] = None,
+    model_engine: Optional[str] = None,
+    python_version: Optional[str] = None,
 ) -> bool:
     """Return True if the venv was already set up with the given inputs.
 
-    Checks three conditions:
-    1. The path is in the process-local done dict.
-    2. The stored fingerprint matches the current inputs (packages, conf,
-       variables, and architectures).
-    3. The on-disk marker file exists (guards against external venv deletion
-       via ``remove_virtual_env`` during the same process lifetime).
+    The JSON marker is authoritative so a restarted Worker can safely reuse a
+    fully prepared environment. The process-local map is only a fast cache.
     """
-    marker_path = os.path.join(venv_path, ".xinference_setup_done")
-    fp = _make_fingerprint(packages, conf, variables, architectures)
-    return (
-        venv_path in _venv_setup_done
-        and _venv_setup_done[venv_path] == fp
-        and os.path.exists(marker_path)
+    fp = _make_fingerprint(
+        packages,
+        conf,
+        variables,
+        architectures,
+        model_name=model_name,
+        model_engine=model_engine,
+        python_version=python_version,
     )
+    marker = _read_venv_setup_marker(venv_path)
+    if marker is None or marker.get("fingerprint") != fp:
+        return False
+    _venv_setup_done[venv_path] = fp
+    return True
 
 
 def _mark_venv_setup_done(
@@ -213,20 +270,63 @@ def _mark_venv_setup_done(
     conf: dict,
     variables: dict,
     architectures: Optional[List[str]] = None,
+    *,
+    model_name: Optional[str] = None,
+    model_engine: Optional[str] = None,
+    python_version: Optional[str] = None,
 ) -> None:
     """Record that *venv_path* has been set up with the given inputs."""
-    fp = _make_fingerprint(packages, conf, variables, architectures)
+    fp = _make_fingerprint(
+        packages,
+        conf,
+        variables,
+        architectures,
+        model_name=model_name,
+        model_engine=model_engine,
+        python_version=python_version,
+    )
     _venv_setup_done[venv_path] = fp
     marker_path = os.path.join(venv_path, ".xinference_setup_done")
+    marker_tmp_path = f"{marker_path}.{os.getpid()}.{threading.get_ident()}.tmp"
+    marker = {
+        "schema_version": 1,
+        "fingerprint": fp,
+        "model_name": model_name,
+        "model_engine": model_engine.lower() if model_engine else None,
+        "python_version": python_version,
+        "setup_inputs": _fingerprint_payload(
+            packages,
+            conf,
+            variables,
+            architectures,
+            model_name=model_name,
+            model_engine=model_engine,
+            python_version=python_version,
+        ),
+        "updated_at": int(time.time()),
+    }
     try:
-        with open(marker_path, "w") as f:
-            f.write(str(fp))
+        with open(marker_tmp_path, "w", encoding="utf-8") as marker_file:
+            json.dump(marker, marker_file, sort_keys=True, ensure_ascii=False)
+        os.replace(marker_tmp_path, marker_path)
     except OSError:
         logger.debug(
             "Failed to write .xinference_setup_done marker to %s",
             venv_path,
             exc_info=True,
         )
+        try:
+            os.unlink(marker_tmp_path)
+        except OSError:
+            pass
+
+
+@dataclass
+class VirtualEnvUsage:
+    env_path: str
+    fingerprint: str
+    active_model_uids: Set[str] = field(default_factory=set)
+    preparing_model_uids: Set[str] = field(default_factory=set)
 
 
 # Per-venv process-local locks so the check-and-setup sequence in
@@ -783,6 +883,9 @@ class WorkerActor(xo.StatelessActor):
 
         # Initialize virtual environment manager
         self._virtual_env_manager = XinferenceVirtualEnvManager(self.address)
+        self._virtual_env_usages: Dict[str, VirtualEnvUsage] = {}
+        self._model_uid_to_virtual_env_path: Dict[str, str] = {}
+        self._virtual_env_usage_lock = threading.Lock()
 
         self._lock = asyncio.Lock()
         self._persist_lock = asyncio.Lock()
@@ -3146,6 +3249,88 @@ class WorkerActor(xo.StatelessActor):
         resolved_model_format = getattr(model_spec, "model_format", None)
         return resolved_model_format or requested_model_format
 
+    def _reserve_virtual_env_usage(
+        self,
+        env_path: str,
+        fingerprint: str,
+        model_uid: str,
+        setup_required: bool = False,
+    ) -> None:
+        real_path = os.path.realpath(os.path.normpath(env_path))
+        with self._virtual_env_usage_lock:
+            existing_path = self._model_uid_to_virtual_env_path.get(model_uid)
+            if existing_path is not None and existing_path != real_path:
+                raise VirtualEnvConflictError(
+                    f"Model {model_uid} is already associated with virtual "
+                    f"environment {existing_path}, cannot also use {real_path}"
+                )
+
+            usage = self._virtual_env_usages.get(real_path)
+            users = (
+                sorted(usage.active_model_uids | usage.preparing_model_uids)
+                if usage is not None
+                else []
+            )
+            if usage is not None and usage.fingerprint != fingerprint:
+                if users:
+                    raise VirtualEnvConflictError(
+                        "Virtual environment is in use with a different setup "
+                        f"fingerprint: path={real_path}, active_model_uids={users}, "
+                        f"current_fingerprint={usage.fingerprint}, "
+                        f"requested_fingerprint={fingerprint}. Unload all models "
+                        "using this environment before changing dependencies."
+                    )
+                usage.fingerprint = fingerprint
+            elif usage is not None and users and setup_required:
+                raise VirtualEnvConflictError(
+                    "Virtual environment setup marker does not match while the "
+                    "environment is in use; refusing to mutate an active "
+                    f"environment: path={real_path}, active_model_uids={users}"
+                )
+            elif usage is None:
+                usage = VirtualEnvUsage(
+                    env_path=real_path,
+                    fingerprint=fingerprint,
+                )
+                self._virtual_env_usages[real_path] = usage
+
+            usage.preparing_model_uids.add(model_uid)
+            self._model_uid_to_virtual_env_path[model_uid] = real_path
+
+    def _activate_virtual_env_usage(
+        self, env_path: str, fingerprint: str, model_uid: str
+    ) -> None:
+        real_path = os.path.realpath(os.path.normpath(env_path))
+        with self._virtual_env_usage_lock:
+            usage = self._virtual_env_usages.get(real_path)
+            if usage is None or usage.fingerprint != fingerprint:
+                raise VirtualEnvConflictError(
+                    "Virtual environment usage reservation disappeared or changed "
+                    f"during setup: path={real_path}, model_uid={model_uid}"
+                )
+            usage.preparing_model_uids.discard(model_uid)
+            usage.active_model_uids.add(model_uid)
+
+    def _release_virtual_env_usage(
+        self, model_uid: str, env_path: Optional[str] = None
+    ) -> None:
+        with self._virtual_env_usage_lock:
+            real_path = (
+                os.path.realpath(os.path.normpath(env_path))
+                if env_path is not None
+                else self._model_uid_to_virtual_env_path.get(model_uid)
+            )
+            if real_path is None:
+                return
+            usage = self._virtual_env_usages.get(real_path)
+            if usage is not None:
+                usage.preparing_model_uids.discard(model_uid)
+                usage.active_model_uids.discard(model_uid)
+                if not usage.preparing_model_uids and not usage.active_model_uids:
+                    self._virtual_env_usages.pop(real_path, None)
+            if self._model_uid_to_virtual_env_path.get(model_uid) == real_path:
+                self._model_uid_to_virtual_env_path.pop(model_uid, None)
+
     @classmethod
     def _prepare_virtual_env(
         cls,
@@ -3157,7 +3342,10 @@ class WorkerActor(xo.StatelessActor):
         architectures: Optional[List[str]] = None,
         model_format: Optional[str] = None,
         virtual_env_find_links: Optional[List[str]] = None,
-    ):
+        model_uid: Optional[str] = None,
+        reserve_usage: Optional[Callable[[str, str, str, bool], None]] = None,
+        release_usage: Optional[Callable[[str, Optional[str]], None]] = None,
+    ) -> Optional[str]:
         engine_defaults = get_engine_model_format_virtualenv_packages(
             model_engine, model_format
         )
@@ -3167,7 +3355,21 @@ class WorkerActor(xo.StatelessActor):
             and not engine_defaults
         ):
             # no settings or no packages
-            return
+            venv_path = str(virtual_env_manager.env_path)
+            python_version = pathlib.Path(venv_path).name
+            fingerprint = _make_fingerprint(
+                [],
+                {},
+                {},
+                architectures,
+                model_name=model_name,
+                model_engine=model_engine,
+                python_version=python_version,
+            )
+            with _exclusive_venv_path_lock(venv_path):
+                if reserve_usage is not None and model_uid is not None:
+                    reserve_usage(venv_path, fingerprint, model_uid, False)
+            return fingerprint
 
         if settings is None:
             settings = VirtualEnvSettings(packages=virtual_env_packages or [])
@@ -3469,104 +3671,147 @@ class WorkerActor(xo.StatelessActor):
             ", ".join([f"{k}={v}" for k, v in conf.items() if v]),
         )
         venv_path = str(virtual_env_manager.env_path)
+        python_version = pathlib.Path(venv_path).name
         with _exclusive_venv_path_lock(venv_path):
-            if not _should_skip_venv_setup(
-                venv_path, setup_packages, conf, variables, architectures
-            ):
-                if modern_sglang_kernel:
-                    # SGLang 0.5.11 renamed the distribution while retaining the
-                    # same import package.  Remove the cached legacy owner before
-                    # the new wheel writes those files.
-                    cls._uninstall_venv_package(virtual_env_manager, "sgl-kernel")
-                if force_reinstall_xllamacpp:
-                    cls._uninstall_venv_package(virtual_env_manager, "xllamacpp")
-                virtual_env_manager.install_packages(
-                    regular_packages, **conf, **variables
-                )
-
-                from .virtual_env_manager import apply_flash_attn_wheel_post_install
-
-                apply_flash_attn_wheel_post_install(
-                    model_name,
-                    flash_attn_packages,
-                    virtual_env_manager,
-                    conf,
-                    flash_attn_cuda_available,
-                )
-
-                # deepdoc-lib[gpu] currently depends on both onnxruntime (base)
-                # and onnxruntime-gpu (extra). They install the same Python module,
-                # so a resolver may leave the CPU files in place even though the
-                # GPU distribution is present. Remove both distributions and put
-                # back only the GPU build after dependency resolution.
-                if model_name == "DeepDoc" and cls._is_cuda_device_available():
-                    cls._uninstall_venv_package(virtual_env_manager, "onnxruntime")
-                    cls._uninstall_venv_package(virtual_env_manager, "onnxruntime-gpu")
-                    gpu_conf = conf.copy()
-                    gpu_conf["skip_installed"] = False
+            fingerprint = _make_fingerprint(
+                setup_packages,
+                conf,
+                variables,
+                architectures,
+                model_name=model_name,
+                model_engine=model_engine,
+                python_version=python_version,
+            )
+            setup_matches = _should_skip_venv_setup(
+                venv_path,
+                setup_packages,
+                conf,
+                variables,
+                architectures,
+                model_name=model_name,
+                model_engine=model_engine,
+                python_version=python_version,
+            )
+            usage_reserved = False
+            try:
+                if reserve_usage is not None and model_uid is not None:
+                    reserve_usage(venv_path, fingerprint, model_uid, not setup_matches)
+                    usage_reserved = True
+                if not setup_matches:
+                    if modern_sglang_kernel:
+                        # SGLang 0.5.11 renamed the distribution while retaining the
+                        # same import package.  Remove the cached legacy owner before
+                        # the new wheel writes those files.
+                        cls._uninstall_venv_package(virtual_env_manager, "sgl-kernel")
+                    if force_reinstall_xllamacpp:
+                        cls._uninstall_venv_package(virtual_env_manager, "xllamacpp")
                     virtual_env_manager.install_packages(
-                        ["onnxruntime-gpu>=1.19.2"], **gpu_conf, **variables
+                        regular_packages, **conf, **variables
                     )
 
-                # Post-install: flashinfer AOT workaround for sm_120 Blackwell.
-                # vllm 0.21.0 hard-pins flashinfer-cubin==0.6.8.post1 which has JIT
-                # compilation failure on sm_120. Force-upgrade to AOT versions.
-                # Run under the same lock — uv pip install mutates the venv and
-                # must stay serialized with install_packages() and other AOT
-                # upgrades when multiple replicas/workers share this venv.
-                # See optimize/20260702/2026070209.md
-                from .virtual_env_manager import (
-                    apply_flashinfer_aot_post_install,
-                    ensure_flashinfer_cubin_matches_post_install,
-                    ensure_sglang_inherited_packages_compatible_post_install,
-                )
+                    from .virtual_env_manager import apply_flash_attn_wheel_post_install
 
-                ensure_sglang_inherited_packages_compatible_post_install(
-                    model_engine, virtual_env_manager
-                )
-                allow_public_install = not XINFERENCE_VIRTUAL_ENV_OFFLINE_INSTALL
-                apply_flashinfer_aot_post_install(
-                    model_engine,
-                    architectures,
-                    virtual_env_manager,
-                    conf,
-                    cuda_version,
-                    allow_public_install=allow_public_install,
-                )
-                ensure_flashinfer_cubin_matches_post_install(
-                    model_engine,
-                    virtual_env_manager,
-                    allow_public_install=allow_public_install,
-                    conf=conf,
-                )
+                    apply_flash_attn_wheel_post_install(
+                        model_name,
+                        flash_attn_packages,
+                        virtual_env_manager,
+                        conf,
+                        flash_attn_cuda_available,
+                    )
 
-                # Apply engine-specific post-install patches.  These mutate files
-                # inside the shared virtualenv, so they must stay under the same
-                # lock and deduplication as install_packages and post-install
-                # hooks to avoid race conditions when multiple replicas share
-                # this venv.
-                if model_engine and model_engine.lower() == "vllm":
-                    try:
-                        from xinference.model.llm.vllm.patches import apply_vllm_patches
-                    except ImportError:
-                        pass
-                    else:
-                        apply_vllm_patches(
-                            env_path=venv_path,
-                            model_name=model_name,
-                            architectures=architectures,
+                    # deepdoc-lib[gpu] currently depends on both onnxruntime (base)
+                    # and onnxruntime-gpu (extra). They install the same Python module,
+                    # so a resolver may leave the CPU files in place even though the
+                    # GPU distribution is present. Remove both distributions and put
+                    # back only the GPU build after dependency resolution.
+                    if model_name == "DeepDoc" and cls._is_cuda_device_available():
+                        cls._uninstall_venv_package(virtual_env_manager, "onnxruntime")
+                        cls._uninstall_venv_package(
+                            virtual_env_manager, "onnxruntime-gpu"
+                        )
+                        gpu_conf = conf.copy()
+                        gpu_conf["skip_installed"] = False
+                        virtual_env_manager.install_packages(
+                            ["onnxruntime-gpu>=1.19.2"], **gpu_conf, **variables
                         )
 
-                _mark_venv_setup_done(
-                    venv_path, setup_packages, conf, variables, architectures
-                )
-            else:
-                logger.info(
-                    "Virtual env %s already set up with current packages in "
-                    "this process; skipping install_packages and post-install "
-                    "hooks",
-                    venv_path,
-                )
+                    # Post-install: flashinfer AOT workaround for sm_120 Blackwell.
+                    # vllm 0.21.0 hard-pins flashinfer-cubin==0.6.8.post1 which has JIT
+                    # compilation failure on sm_120. Force-upgrade to AOT versions.
+                    # Run under the same lock — uv pip install mutates the venv and
+                    # must stay serialized with install_packages() and other AOT
+                    # upgrades when multiple replicas/workers share this venv.
+                    # See optimize/20260702/2026070209.md
+                    from .virtual_env_manager import (
+                        apply_flashinfer_aot_post_install,
+                        ensure_flashinfer_cubin_matches_post_install,
+                        ensure_sglang_inherited_packages_compatible_post_install,
+                    )
+
+                    ensure_sglang_inherited_packages_compatible_post_install(
+                        model_engine, virtual_env_manager
+                    )
+                    allow_public_install = not XINFERENCE_VIRTUAL_ENV_OFFLINE_INSTALL
+                    apply_flashinfer_aot_post_install(
+                        model_engine,
+                        architectures,
+                        virtual_env_manager,
+                        conf,
+                        cuda_version,
+                        allow_public_install=allow_public_install,
+                    )
+                    ensure_flashinfer_cubin_matches_post_install(
+                        model_engine,
+                        virtual_env_manager,
+                        allow_public_install=allow_public_install,
+                        conf=conf,
+                    )
+
+                    # Apply engine-specific post-install patches.  These mutate files
+                    # inside the shared virtualenv, so they must stay under the same
+                    # lock and deduplication as install_packages and post-install
+                    # hooks to avoid race conditions when multiple replicas share
+                    # this venv.
+                    if model_engine and model_engine.lower() == "vllm":
+                        try:
+                            from xinference.model.llm.vllm.patches import (
+                                apply_vllm_patches,
+                            )
+                        except ImportError:
+                            pass
+                        else:
+                            apply_vllm_patches(
+                                env_path=venv_path,
+                                model_name=model_name,
+                                architectures=architectures,
+                            )
+
+                    _mark_venv_setup_done(
+                        venv_path,
+                        setup_packages,
+                        conf,
+                        variables,
+                        architectures,
+                        model_name=model_name,
+                        model_engine=model_engine,
+                        python_version=python_version,
+                    )
+                else:
+                    logger.info(
+                        "Virtual env %s already matches setup fingerprint %s; "
+                        "skipping install_packages and post-install hooks",
+                        venv_path,
+                        fingerprint,
+                    )
+            except BaseException:
+                if (
+                    usage_reserved
+                    and release_usage is not None
+                    and model_uid is not None
+                ):
+                    release_usage(model_uid, venv_path)
+                raise
+            return fingerprint
 
     async def _get_progressor(self, request_id: str):
         from .progress_tracker import Progressor, ProgressTrackerActor
@@ -4007,22 +4252,46 @@ class WorkerActor(xo.StatelessActor):
 
                         # install packages in virtual env
                         if virtual_env_manager:
-                            await asyncio.to_thread(
-                                self._prepare_virtual_env,
-                                virtual_env_manager,
-                                model.model_family.virtualenv,
-                                virtual_env_packages,
-                                model_engine,
-                                model_name=model_name,
-                                architectures=getattr(
-                                    model.model_family,
-                                    "_resolve_architectures",
-                                    lambda: None,
-                                )(),
-                                model_format=self._resolve_virtualenv_model_format(
-                                    model, model_format
-                                ),
-                                virtual_env_find_links=virtual_env_find_links,
+                            prepare_task = asyncio.create_task(
+                                asyncio.to_thread(
+                                    self._prepare_virtual_env,
+                                    virtual_env_manager,
+                                    model.model_family.virtualenv,
+                                    virtual_env_packages,
+                                    model_engine,
+                                    model_name=model_name,
+                                    architectures=getattr(
+                                        model.model_family,
+                                        "_resolve_architectures",
+                                        lambda: None,
+                                    )(),
+                                    model_format=self._resolve_virtualenv_model_format(
+                                        model, model_format
+                                    ),
+                                    virtual_env_find_links=virtual_env_find_links,
+                                    model_uid=model_uid,
+                                    reserve_usage=self._reserve_virtual_env_usage,
+                                    release_usage=self._release_virtual_env_usage,
+                                )
+                            )
+                            try:
+                                virtual_env_fingerprint = await asyncio.shield(
+                                    prepare_task
+                                )
+                            except asyncio.CancelledError:
+                                # asyncio.to_thread cannot stop the underlying
+                                # installer. Wait for it to leave the path lock
+                                # before releasing the usage reservation.
+                                try:
+                                    await prepare_task
+                                except Exception:
+                                    pass
+                                raise
+                            assert virtual_env_fingerprint is not None
+                            self._activate_virtual_env_usage(
+                                virtual_env_path,
+                                virtual_env_fingerprint,
+                                model_uid,
                             )
                             launch_info.virtual_env_manager = virtual_env_manager
 
@@ -4112,6 +4381,7 @@ class WorkerActor(xo.StatelessActor):
                     except (Exception, asyncio.CancelledError):
                         logger.error(f"Failed to load model {model_uid}", exc_info=True)
                         await self._update_model_state(model_uid, "error")
+                        self._release_virtual_env_usage(model_uid)
                         self.release_devices(model_uid=model_uid)
                         for addr in all_subpool_addresses:
                             try:
@@ -4409,8 +4679,7 @@ class WorkerActor(xo.StatelessActor):
                 "Remove sub pool failed, model uid: %s, error: %s", model_uid, e
             )
         finally:
-            # Clean up virtual environment tracking
-            # Virtual environment tracking is no longer needed
+            self._release_virtual_env_usage(model_uid)
 
             self._model_uid_to_model.pop(model_uid, None)
             self._model_uid_to_model_spec.pop(model_uid, None)
@@ -5226,8 +5495,17 @@ class WorkerActor(xo.StatelessActor):
         python_version: Optional[str] = None,
     ) -> bool:
         """Remove a virtual environment for a specific model."""
+        with self._virtual_env_usage_lock:
+            active_model_uids_by_path = {
+                path: sorted(usage.active_model_uids | usage.preparing_model_uids)
+                for path, usage in self._virtual_env_usages.items()
+                if usage.active_model_uids or usage.preparing_model_uids
+            }
         return self._virtual_env_manager.remove_virtual_env(
-            model_name, model_engine, python_version
+            model_name,
+            model_engine,
+            python_version,
+            active_model_uids_by_path=active_model_uids_by_path,
         )
 
     async def get_workers_info(self) -> Dict[str, Any]:

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -28,7 +28,7 @@ import sys
 import threading
 import time
 from collections import defaultdict
-from contextlib import contextmanager
+from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass, field
 from logging import getLogger
 from typing import (
@@ -5494,19 +5494,66 @@ class WorkerActor(xo.StatelessActor):
         model_engine: Optional[str] = None,
         python_version: Optional[str] = None,
     ) -> bool:
-        """Remove a virtual environment for a specific model."""
-        with self._virtual_env_usage_lock:
-            active_model_uids_by_path = {
-                path: sorted(usage.active_model_uids | usage.preparing_model_uids)
-                for path, usage in self._virtual_env_usages.items()
-                if usage.active_model_uids or usage.preparing_model_uids
-            }
-        return self._virtual_env_manager.remove_virtual_env(
-            model_name,
-            model_engine,
-            python_version,
-            active_model_uids_by_path=active_model_uids_by_path,
-        )
+        """Remove virtual environments without racing concurrent setup."""
+        if python_version and not self._virtual_env_manager._is_valid_python_version(
+            python_version
+        ):
+            return self._virtual_env_manager.remove_virtual_env(
+                model_name, model_engine, python_version
+            )
+
+        model_engine = model_engine.lower() if model_engine else None
+        target_envs = [
+            env
+            for env in self._virtual_env_manager.list_virtual_envs(
+                model_name, model_engine
+            )
+            if python_version is None or env["python_version"] == python_version
+        ]
+
+        target_envs_by_path: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
+        for env in target_envs:
+            path = os.path.realpath(os.path.normpath(env["path"]))
+            target_envs_by_path[path].append(env)
+        ordered_paths = sorted(target_envs_by_path)
+
+        # Launch/setup takes locks in path -> usage order. Use the same order
+        # here and keep every target path locked through both the usage check
+        # and deletion so no reservation can appear between them.
+        with ExitStack() as stack:
+            for path in ordered_paths:
+                stack.enter_context(_exclusive_venv_path_lock(path))
+
+            with self._virtual_env_usage_lock:
+                for path in ordered_paths:
+                    usage = self._virtual_env_usages.get(path)
+                    model_uids = (
+                        sorted(usage.active_model_uids | usage.preparing_model_uids)
+                        if usage is not None
+                        else []
+                    )
+                    if model_uids:
+                        raise VirtualEnvConflictError(
+                            "Virtual environment cannot be removed while models "
+                            f"are using it: path={path}, "
+                            f"active_model_uids={model_uids}"
+                        )
+
+            # Delete concrete leaves instead of recursively deleting an engine or
+            # model parent, which could remove a newly created, unenumerated child.
+            result = True
+            for path in ordered_paths:
+                for env in target_envs_by_path[path]:
+                    result = (
+                        self._virtual_env_manager.remove_virtual_env(
+                            env["model_name"],
+                            env["model_engine"],
+                            env["python_version"],
+                            active_model_uids_by_path={},
+                        )
+                        and result
+                    )
+            return result
 
     async def get_workers_info(self) -> Dict[str, Any]:
         ret = {


### PR DESCRIPTION
## Summary
- Persist deterministic virtual-environment setup fingerprints in restart-safe markers.
- Track preparing and active model users per virtual environment.
- Prevent dependency mutation or deletion while models are using an environment.
- Return HTTP 409 when virtual-environment removal conflicts with active models.

## Tests
- `pytest -q xinference/core/tests/test_utils.py xinference/core/tests/test_virtual_env_manager.py xinference/core/tests/test_virtual_env_deletion.py` (144 passed)
- Admin conflict test passed (4 selected tests).
- Pre-commit checks passed.