### PR TITLE
FIX: restore GPU and aarch64 Docker builds

### DIFF
--- a/build_backend.py
+++ b/build_backend.py
@@ -13,9 +13,12 @@
 # limitations under the License.
 """In-tree PEP 517 build backend.
 
-Wraps ``setuptools.build_meta`` to run two extra steps before producing
+Wraps ``setuptools.build_meta`` to run three extra steps before producing
 wheels, sdists, and editable installs:
 
+- validate the built-in model metadata (set
+  ``XINFERENCE_SKIP_MODEL_SPEC_VALIDATION=1`` only for a partial source tree
+  used to install dependencies; the complete project build must still validate);
 - build the Web UI (see ``build_web.py``; set ``NO_WEB_UI=1`` to skip);
 - record the full git revision in ``xinference/_commit.py`` so the
   ``/v1/cluster/version`` API keeps exposing the 40-character SHA that the
@@ -128,7 +131,11 @@ def _record_full_revision(root=None):
 
 
 def _pre_build():
-    _validate_builtin_model_specs()
+    skip_model_spec_validation = os.environ.get(
+        "XINFERENCE_SKIP_MODEL_SPEC_VALIDATION", "0"
+    ).strip().lower() in ("1", "true", "yes", "on")
+    if not skip_model_spec_validation:
+        _validate_builtin_model_specs()
     _record_full_revision()
     build_web()
 

--- a/xinference/deploy/docker/Dockerfile
+++ b/xinference/deploy/docker/Dockerfile
@@ -115,14 +115,16 @@ WORKDIR /opt/inference
 # Install third-party dependencies from the smallest viable project skeleton.
 # This layer is invalidated by packaging metadata changes, not ordinary source
 # edits. The complete project is installed separately below without resolving
-# dependencies again.
+# dependencies again. The skeleton intentionally omits model metadata, so defer
+# its validation until that complete project install.
 COPY pyproject.toml build_backend.py build_web.py ./
 COPY xinference/__init__.py ./xinference/
 RUN --mount=type=cache,target=/root/.cache/pip \
     --mount=type=cache,target=/root/.cache/uv \
     touch README.md && \
     pip install -i "$PIP_INDEX" uv && \
-    NO_WEB_UI=1 uv pip install --system --index-url "$PIP_INDEX" \
+    XINFERENCE_SKIP_MODEL_SPEC_VALIDATION=1 NO_WEB_UI=1 \
+      uv pip install --system --index-url "$PIP_INDEX" \
       --extra-index-url "$TORCH_INDEX" --index-strategy unsafe-best-match \
       --constraint /opt/requirements-runtime.txt \
       ".[otel]" transformers accelerate

--- a/xinference/deploy/docker/pypiserver/tests/test_scripts.py
+++ b/xinference/deploy/docker/pypiserver/tests/test_scripts.py
@@ -364,6 +364,19 @@ def test_runtime_dockerfiles_keep_dependency_layers_source_independent():
         assert dependency_install < project_sources < project_install
 
 
+def test_runtime_docker_dependency_skeleton_defers_model_spec_validation():
+    dockerfile = (REPO_ROOT / "xinference/deploy/docker/Dockerfile").read_text(
+        encoding="utf-8"
+    )
+
+    dependency_install = dockerfile.index('".[otel]" transformers accelerate')
+    project_sources = dockerfile.index("COPY . /opt/inference", dependency_install)
+    validation_skip = dockerfile.index("XINFERENCE_SKIP_MODEL_SPEC_VALIDATION=1")
+
+    assert validation_skip < dependency_install < project_sources
+    assert dockerfile.count("XINFERENCE_SKIP_MODEL_SPEC_VALIDATION=1") == 1
+
+
 def test_transformers_optional_dependencies_are_scoped_and_mirrored(
     monkeypatch, tmp_path
 ):

--- a/xinference/tests/test_build_backend.py
+++ b/xinference/tests/test_build_backend.py
@@ -232,6 +232,40 @@ def test_reports_entry_index_for_unnamed_invalid_llm_families(backend, tmp_path)
     assert all(f"'entry {index}'" in message for index in range(3))
 
 
+def test_pre_build_can_skip_model_validation_for_dependency_skeleton(
+    backend, monkeypatch
+):
+    calls = []
+    monkeypatch.setenv("XINFERENCE_SKIP_MODEL_SPEC_VALIDATION", "1")
+    monkeypatch.setattr(
+        backend, "_validate_builtin_model_specs", lambda: calls.append("validate")
+    )
+    monkeypatch.setattr(
+        backend, "_record_full_revision", lambda: calls.append("record")
+    )
+    monkeypatch.setattr(backend, "build_web", lambda: calls.append("web"))
+
+    backend._pre_build()
+
+    assert calls == ["record", "web"]
+
+
+def test_pre_build_validates_model_specs_by_default(backend, monkeypatch):
+    calls = []
+    monkeypatch.delenv("XINFERENCE_SKIP_MODEL_SPEC_VALIDATION", raising=False)
+    monkeypatch.setattr(
+        backend, "_validate_builtin_model_specs", lambda: calls.append("validate")
+    )
+    monkeypatch.setattr(
+        backend, "_record_full_revision", lambda: calls.append("record")
+    )
+    monkeypatch.setattr(backend, "build_web", lambda: calls.append("web"))
+
+    backend._pre_build()
+
+    assert calls == ["validate", "record", "web"]
+
+
 def test_project_declares_router_dependencies_and_all_includes_router():
     with open(os.path.join(_REPO_ROOT, "pyproject.toml"), "rb") as f:
         project = tomllib.load(f)


### PR DESCRIPTION
## Summary

- skip built-in model-spec validation only for the source-independent Docker dependency skeleton
- keep validation enabled for the complete project installation
- add regressions for the build-backend default and override behavior, plus Dockerfile override placement

## Root cause

PR #5353 made the PEP 517 build hook require xinference/model/llm/llm_family.json. The shared GPU/aarch64 Dockerfile builds a dependency-only wheel from a deliberately incomplete source skeleton before copying the full repository, so both jobs failed before reaching the complete install. The CPU Dockerfile copies the full source first and remained green.

## Validation

- python -m pytest -q xinference/tests/test_build_backend.py (12 passed)
- focused Dockerfile tests in xinference/deploy/docker/pypiserver/tests/test_scripts.py (2 passed)
- pre-commit on all four modified files
- isolated dependency-skeleton wheel build with setuptools>=77,<82; it fails without the scoped override and succeeds with it

Closes #5382
Closes #5450