### PR TITLE
fix(embedding): align Jina flash-attn version

### DIFF
--- a/xinference/model/embedding/model_spec.json
+++ b/xinference/model/embedding/model_spec.json
@@ -1461,7 +1461,7 @@
         "#system_torchvision# ; #engine# == \"sentence_transformers\"",
         "#system_torch# ; #engine# == \"sentence_transformers\"",
         "transformers==4.52.0",
-        "flash-attn==2.8.3.post1+cvte1"
+        "flash-attn==2.8.3.post1"
       ]
     }
   },

--- a/xinference/model/embedding/tests/test_embedding_models.py
+++ b/xinference/model/embedding/tests/test_embedding_models.py
@@ -123,7 +123,7 @@ def test_jina_v3_pins_custom_flash_attn_wheel():
     family = BUILTIN_EMBEDDING_MODELS["jina-embeddings-v3"][0]
 
     assert family.virtualenv is not None
-    assert "flash-attn==2.8.3.post1+cvte1" in family.virtualenv.packages
+    assert "flash-attn==2.8.3.post1" in family.virtualenv.packages
 
 
 def test_bce_embedding_vllm_engine_params_with_virtualenv():


### PR DESCRIPTION
## Summary

- Align the `jina-embeddings-v3` `flash-attn` requirement with the wheel metadata version `2.8.3.post1`.
- Update the corresponding built-in model specification regression test.

## Motivation

The configured Jina wheel reports version `2.8.3.post1`, while the model specification required the exact version `2.8.3.post1+cvte1`. Because the requirement is exact, the available wheel could not satisfy it even when provided through `find_links`.

This is intentionally limited to the Jina model specification and its test; no virtual-environment installation flow or xoscar code is changed.

## Validation

- `python -m json.tool xinference/model/embedding/model_spec.json`
- `pytest -vv xinference/model/embedding/tests/test_embedding_models.py -k jina_v3` — 1 passed
- `pre-commit run --files xinference/model/embedding/model_spec.json xinference/model/embedding/tests/test_embedding_models.py` — all hooks passed
- `git diff --check` — passed

The full embedding test file was not completed locally because the environment lacks optional `sentence_transformers` and has an unrelated existing engine expectation failure.
