### PR TITLE
FIX: repair pypiserver platform dependencies

### DIFF
--- a/xinference/core/tests/test_virtual_env_manager.py
+++ b/xinference/core/tests/test_virtual_env_manager.py
@@ -44,6 +44,7 @@ from ..virtual_env_manager import (
     ensure_sglang_inherited_packages_compatible_post_install,
     get_engine_critical_dependency_specs,
     is_flash_attn_requirement,
+    is_model_find_links_only_requirement,
     merge_virtual_env_find_links,
     needs_flashinfer_aot,
     validate_virtual_env_find_links,
@@ -531,6 +532,15 @@ class TestApplyFlashAttnWheelPostInstall:
     )
     def test_does_not_match_unrelated_requirements(self, requirement):
         assert not is_flash_attn_requirement(requirement)
+
+    def test_identifies_only_jina_flash_attn_as_find_links_only(self):
+        requirement = "flash-attn==2.8.3.post1+cvte1"
+
+        assert is_model_find_links_only_requirement("jina-embeddings-v3", requirement)
+        assert not is_model_find_links_only_requirement("another-model", requirement)
+        assert not is_model_find_links_only_requirement(
+            "jina-embeddings-v3", "sentence-transformers"
+        )
 
     def test_non_jina_model_is_noop(self, fake_venv_manager):
         with (

--- a/xinference/core/virtual_env_manager.py
+++ b/xinference/core/virtual_env_manager.py
@@ -1140,6 +1140,16 @@ def is_flash_attn_requirement(spec: str) -> bool:
     return canonicalize_name(requirement.name) == "flash-attn"
 
 
+def is_model_find_links_only_requirement(model_name: Optional[str], spec: str) -> bool:
+    """Return whether a model requirement is supplied only via Find Links.
+
+    These requirements are intentionally absent from package indexes.  The
+    runtime installs them from worker-local wheel directories when configured
+    and otherwise uses the model's documented fallback path.
+    """
+    return model_name == "jina-embeddings-v3" and is_flash_attn_requirement(spec)
+
+
 _SUBPROCESS_OUTPUT_LIMIT = 2048
 
 

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -121,7 +121,7 @@ from .virtual_env_manager import (
     get_engine_critical_dependency_specs,
     get_engine_model_format_virtualenv_packages,
     is_cuda_compatible,
-    is_flash_attn_requirement,
+    is_model_find_links_only_requirement,
     merge_virtual_env_find_links,
     pin_sentence_transformers_numpy_abi,
     resolve_virtualenv_python_path,
@@ -3448,22 +3448,16 @@ class WorkerActor(xo.StatelessActor):
             variables["model_engine"] = engine_value
 
         setup_packages = packages.copy()
-        if model_name == "jina-embeddings-v3":
-            flash_attn_packages = [
-                package
-                for package in setup_packages
-                if is_flash_attn_requirement(package)
-            ]
-            regular_packages = [
-                package
-                for package in setup_packages
-                if not is_flash_attn_requirement(package)
-            ]
-        else:
-            # flash-attn is a normal dependency for all other models. Only Jina
-            # uses the dedicated binary-only Find Links installation below.
-            flash_attn_packages = []
-            regular_packages = setup_packages
+        flash_attn_packages = [
+            package
+            for package in setup_packages
+            if is_model_find_links_only_requirement(model_name, package)
+        ]
+        regular_packages = [
+            package
+            for package in setup_packages
+            if not is_model_find_links_only_requirement(model_name, package)
+        ]
         flash_attn_cuda_available = bool(flash_attn_packages) and (
             cls._is_cuda_device_available()
         )

--- a/xinference/deploy/docker/pypiserver/generate_package_lists.py
+++ b/xinference/deploy/docker/pypiserver/generate_package_lists.py
@@ -237,6 +237,11 @@ def main() -> None:
     engine_index_strategy: Dict[str, str] = (
         venv_manager.ENGINE_VIRTUALENV_INDEX_STRATEGY
     )
+    is_find_links_only_requirement = getattr(
+        venv_manager,
+        "is_model_find_links_only_requirement",
+        lambda _model_name, _spec: False,
+    )
 
     excluded_engines = {
         e.strip().lower() for e in args.exclude_engines.split(",") if e.strip()
@@ -252,6 +257,7 @@ def main() -> None:
     git_sources: Set[str] = set()
     pins: Dict[str, Set[str]] = {}  # spec -> sources
     excluded_pins: Set[str] = set()
+    find_links_only_pins: Dict[str, Set[str]] = {}
 
     def _add(spec: str, source: str) -> None:
         spec = normalize_mirror_spec(spec)
@@ -320,6 +326,13 @@ def main() -> None:
                 if sysname is not None:
                     spec = sysname
                 source = rel + ":" + model_name + (f" ({cand})" if cand else "")
+                # Worker-local Find Links dependencies do not exist on the
+                # configured package indexes.  The runtime installs them via a
+                # dedicated hook when supplied, so mirroring them here would
+                # make an otherwise valid offline image build fail.
+                if is_find_links_only_requirement(model_name, spec):
+                    find_links_only_pins.setdefault(spec, set()).add(source)
+                    continue
                 _add(spec, source)
 
     (out / "urls.txt").write_text("".join(f"{u}\n" for u in sorted(urls)))
@@ -340,12 +353,17 @@ def main() -> None:
         "cuda_version": args.cuda_version,
         "excluded_engines": sorted(excluded_engines),
         "excluded_pins": sorted(excluded_pins),
+        "find_links_only_pins": [
+            {"spec": spec, "sources": sorted(sources)}
+            for spec, sources in sorted(find_links_only_pins.items())
+        ],
         "engines": engines_meta,
         "counts": {
             "engines": len(engines_meta),
             "pins": len(pins),
             "urls": len(urls),
             "git": len(git_sources),
+            "find_links_only": len(find_links_only_pins),
         },
     }
     (out / "manifest.json").write_text(json.dumps(manifest, indent=2) + "\n")

--- a/xinference/deploy/docker/pypiserver/tests/test_scripts.py
+++ b/xinference/deploy/docker/pypiserver/tests/test_scripts.py
@@ -22,7 +22,7 @@ from http.client import IncompleteRead
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
 
-from packaging.requirements import Requirement
+from packaging.requirements import InvalidRequirement, Requirement
 
 SCRIPT_DIR = Path(__file__).resolve().parents[1]
 REPO_ROOT = SCRIPT_DIR.parents[3]
@@ -130,6 +130,39 @@ def test_iter_virtualenv_packages_reads_json_as_utf8(monkeypatch, tmp_path):
         ("model.json", "中文模型", ["model-package"])
     ]
     assert encodings == ["utf-8"]
+
+
+def test_all_decord_requirements_are_scoped_to_supported_architectures():
+    generator = _load_script("generate_package_lists")
+    expected_machines = {
+        "decord": {"x86_64"},
+        "decord2": {"aarch64"},
+    }
+    seen = set()
+
+    for rel, model_name, packages in generator.iter_virtualenv_packages(
+        REPO_ROOT / "xinference" / "model"
+    ):
+        for spec in packages:
+            try:
+                requirement = Requirement(generator.normalize_mirror_spec(spec))
+            except InvalidRequirement:
+                continue
+            name = requirement.name.lower().replace("_", "-")
+            if name not in expected_machines:
+                continue
+            seen.add(name)
+            allowed_machines = {
+                machine
+                for machine in ("x86_64", "aarch64")
+                if requirement.marker is not None
+                and requirement.marker.evaluate({"platform_machine": machine})
+            }
+            assert (
+                allowed_machines == expected_machines[name]
+            ), f"{rel}:{model_name} uses incompatible requirement {spec!r}"
+
+    assert seen == set(expected_machines)
 
 
 def test_selfcheck_wheel_url_to_spec():
@@ -455,6 +488,17 @@ def test_transformers_optional_dependencies_are_scoped_and_mirrored(
     assert all("has_cuda" not in spec for spec in pin_specs)
     assert 'decord==0.6.0 ; platform_machine == "x86_64"' in pin_specs
     assert 'decord2==3.4.0 ; platform_machine == "aarch64"' in pin_specs
+    assert "flash-attn==2.8.3.post1+cvte1" not in pin_specs
+    manifest = json.loads((out / "manifest.json").read_text())
+    assert manifest["find_links_only_pins"] == [
+        {
+            "spec": "flash-attn==2.8.3.post1+cvte1",
+            "sources": [
+                "embedding/model_spec.json:jina-embeddings-v3",
+                "embedding/model_spec.json:jina-embeddings-v3 (sentence_transformers)",
+            ],
+        }
+    ]
     for spec in pin_specs:
         Requirement(spec)
 
@@ -557,6 +601,7 @@ def test_generate_package_lists_main_orchestration(monkeypatch, tmp_path):
         "pins": 1,
         "urls": 1,
         "git": 1,
+        "find_links_only": 0,
     }
 
 

--- a/xinference/model/world/model_spec.json
+++ b/xinference/model/world/model_spec.json
@@ -44,7 +44,8 @@
         "scipy",
         "einops",
         "pandas",
-        "decord",
+        "decord==0.6.0 ; platform_machine == \"x86_64\"",
+        "decord2==3.4.0 ; platform_machine == \"aarch64\"",
         "tensorboard",
         "trimesh",
         "safetensors==0.7.0"


### PR DESCRIPTION
## Summary

- scope Matrix-Game's decord dependency by architecture, using decord 0.6.0 on x86_64 and the API-compatible decord2 3.4.0 wheel on aarch64
- share the runtime's Find Links-only dependency classification with the offline mirror generator, so Jina's local flash-attn wheel is recorded but not fetched from PyPI
- add repository-wide regression coverage that rejects unscoped decord/decord2 requirements and verifies Find Links-only pins stay out of the mirror download list

## Root cause

The v3.3.0 pypiserver workflow exposed two independent manifest issues:

- arm64 failed on an unscoped `decord` requirement added by Matrix-Game. PyPI has no Linux aarch64 artifact for decord 0.6.0. This is the same architecture issue fixed for the video catalog in #5326, but the new World model reintroduced the raw dependency.
- amd64 failed on `flash-attn==2.8.3.post1+cvte1`. That local version is intentionally installed only from worker-local Find Links for `jina-embeddings-v3`; without Find Links, the runtime falls back to native PyTorch attention. The mirror generator incorrectly treated it as a public-index pin.

Failing release run: https://github.com/xorbitsai/inference/actions/runs/33307580804

## Validation

- `python -m pytest -q --confcutdir=xinference/deploy/docker/pypiserver/tests xinference/deploy/docker/pypiserver/tests/test_scripts.py` — 18 passed
- `python -m pytest -q xinference/core/tests/test_virtual_env_manager.py xinference/core/tests/test_worker.py` — 191 passed
- generated full pypiserver manifests for amd64 and arm64; effective decord dependencies are decord on amd64 and decord2 on arm64, while the Jina local flash-attn pin appears only in `find_links_only_pins`
- pre-commit on all changed files
- `python -m json.tool xinference/model/world/model_spec.json`
- `git diff --check`
