### PR TITLE
ENH: support JoyAI image editing models

### DIFF
--- a/doc/source/models/builtin/image/index.rst
+++ b/doc/source/models/builtin/image/index.rst
@@ -48,6 +48,10 @@ The following is a list of built-in image models in Xinference:
    hunyuanocr
   
    ideogram4
+
+   joyai-image-edit
+
+   joyai-image-edit-plus
   
    kolors
 

--- a/doc/source/models/builtin/image/joyai-image-edit-plus.rst
+++ b/doc/source/models/builtin/image/joyai-image-edit-plus.rst
@@ -1,0 +1,19 @@
+.. _models_builtin_joyai-image-edit-plus:
+
+=====================
+joyai-image-edit-plus
+=====================
+
+- **Model Name:** joyai-image-edit-plus
+- **Model Family:** stable_diffusion
+- **Abilities:** image2image
+- **Available ControlNet:** None
+
+Specifications
+^^^^^^^^^^^^^^
+
+- **Model ID:** jdopensource/JoyAI-Image-Edit-Plus-Diffusers
+
+Execute the following command to launch the model::
+
+   xinference launch --model-name joyai-image-edit-plus --model-type image

--- a/doc/source/models/builtin/image/joyai-image-edit.rst
+++ b/doc/source/models/builtin/image/joyai-image-edit.rst
@@ -1,0 +1,19 @@
+.. _models_builtin_joyai-image-edit:
+
+================
+joyai-image-edit
+================
+
+- **Model Name:** joyai-image-edit
+- **Model Family:** stable_diffusion
+- **Abilities:** image2image
+- **Available ControlNet:** None
+
+Specifications
+^^^^^^^^^^^^^^
+
+- **Model ID:** jdopensource/JoyAI-Image-Edit-Diffusers
+
+Execute the following command to launch the model::
+
+   xinference launch --model-name joyai-image-edit --model-type image

--- a/xinference/model/image/model_spec.json
+++ b/xinference/model/image/model_spec.json
@@ -2321,5 +2321,89 @@
     },
     "featured": false,
     "updated_at": 1786731484
+  },
+  {
+    "version": 2,
+    "model_name": "joyai-image-edit",
+    "model_family": "stable_diffusion",
+    "model_description": "JoyAI-Image-Edit is a single-image instruction-guided editing model with spatial understanding for precise object, viewpoint, and scene edits.",
+    "model_ability": [
+      "image2image"
+    ],
+    "model_src": {
+      "huggingface": {
+        "model_id": "jdopensource/JoyAI-Image-Edit-Diffusers",
+        "model_revision": "main"
+      },
+      "modelscope": {
+        "model_id": "jd-opensource/JoyAI-Image-Edit-Diffusers",
+        "model_revision": "master"
+      }
+    },
+    "default_model_config": {
+      "torch_dtype": "bfloat16"
+    },
+    "default_generate_config": {
+      "num_inference_steps": 40,
+      "guidance_scale": 4.0
+    },
+    "virtualenv": {
+      "packages": [
+        "diffusers>=0.40.0 ; #engine# == \"diffusers\"",
+        "transformers>=5.2.0,<6 ; #engine# == \"diffusers\"",
+        "accelerate>=1.0.0 ; #engine# == \"diffusers\"",
+        "sentencepiece ; #engine# == \"diffusers\"",
+        "huggingface-hub>=1.23.0,<2.0 ; #engine# == \"diffusers\"",
+        "#system_torch# ; #engine# == \"diffusers\"",
+        "#system_torchvision# ; #engine# == \"diffusers\"",
+        "#system_numpy# ; #engine# == \"diffusers\""
+      ],
+      "no_build_isolation": false,
+      "index_strategy": "unsafe-best-match"
+    },
+    "featured": false,
+    "updated_at": 1788101544
+  },
+  {
+    "version": 2,
+    "model_name": "joyai-image-edit-plus",
+    "model_family": "stable_diffusion",
+    "model_description": "JoyAI-Image-Edit-Plus is a multi-image instruction-guided editing model that combines content from one to six reference images.",
+    "model_ability": [
+      "image2image"
+    ],
+    "model_src": {
+      "huggingface": {
+        "model_id": "jdopensource/JoyAI-Image-Edit-Plus-Diffusers",
+        "model_revision": "main"
+      },
+      "modelscope": {
+        "model_id": "jd-opensource/JoyAI-Image-Edit-Plus-Diffusers",
+        "model_revision": "master"
+      }
+    },
+    "default_model_config": {
+      "torch_dtype": "bfloat16"
+    },
+    "default_generate_config": {
+      "num_inference_steps": 30,
+      "guidance_scale": 4.0
+    },
+    "virtualenv": {
+      "packages": [
+        "diffusers>=0.40.0 ; #engine# == \"diffusers\"",
+        "transformers>=5.2.0,<6 ; #engine# == \"diffusers\"",
+        "accelerate>=1.0.0 ; #engine# == \"diffusers\"",
+        "sentencepiece ; #engine# == \"diffusers\"",
+        "huggingface-hub>=1.23.0,<2.0 ; #engine# == \"diffusers\"",
+        "#system_torch# ; #engine# == \"diffusers\"",
+        "#system_torchvision# ; #engine# == \"diffusers\"",
+        "#system_numpy# ; #engine# == \"diffusers\""
+      ],
+      "no_build_isolation": false,
+      "index_strategy": "unsafe-best-match"
+    },
+    "featured": false,
+    "updated_at": 1788101545
   }
 ]

--- a/xinference/model/image/stable_diffusion/core.py
+++ b/xinference/model/image/stable_diffusion/core.py
@@ -769,10 +769,17 @@ class DiffusionModel(SDAPIDiffusionModelMixin):
                 self._deepcache_helper.pipe = None
 
     @staticmethod
-    def _process_progressor(kwargs: dict):
+    def _process_progressor(
+        kwargs: dict,
+        *,
+        progressor: Optional["Progressor"] = None,
+        pipeline_call_index: int = 0,
+        pipeline_call_count: int = 1,
+    ):
         import diffusers
 
-        progressor: Progressor = kwargs.pop("progressor", None)
+        if progressor is None:
+            progressor = kwargs.pop("progressor", None)
 
         def report_status_callback(
             pipe: diffusers.DiffusionPipeline,
@@ -781,7 +788,10 @@ class DiffusionModel(SDAPIDiffusionModelMixin):
             callback_kwargs: dict,
         ):
             num_steps = pipe.num_timesteps
-            progressor.set_progress((step + 1) / num_steps)
+            local_progress = (step + 1) / num_steps
+            progressor.set_progress(
+                (pipeline_call_index + local_progress) / pipeline_call_count
+            )
 
             return callback_kwargs
 
@@ -817,7 +827,7 @@ class DiffusionModel(SDAPIDiffusionModelMixin):
             kwargs["generator"] = generator = torch.Generator(device=get_available_device())  # type: ignore
             kwargs["generator"] = generator.manual_seed(seed)
         sampler_name = kwargs.pop("sampler_name", None)
-        self._process_progressor(kwargs)
+        progressor = kwargs.pop("progressor", None)
         if self._is_ideogram4_model() and kwargs.get("guidance_scale") is not None:
             # Ideogram4 defaults to a per-step guidance schedule. Its pipeline
             # rejects passing that default together with a constant scale.
@@ -832,19 +842,25 @@ class DiffusionModel(SDAPIDiffusionModelMixin):
             # Some pipelines (e.g., Z-Image img2img) can't handle guidance_scale=None.
             if kwargs.get("guidance_scale", "unset") is None:
                 kwargs.pop("guidance_scale", None)
-            self._filter_kwargs(model, kwargs)
             if _num_pipeline_calls == 1:
+                self._process_progressor(kwargs, progressor=progressor)
+                self._filter_kwargs(model, kwargs)
                 images = model(**kwargs).images
             else:
+                self._filter_kwargs(model, kwargs)
                 images = []
                 generators = kwargs.get("generator")
                 for call_index in range(_num_pipeline_calls):
-                    per_call_kwargs = kwargs
+                    per_call_kwargs = kwargs.copy()
                     if isinstance(generators, list):
-                        per_call_kwargs = {
-                            **kwargs,
-                            "generator": generators[call_index],
-                        }
+                        per_call_kwargs["generator"] = generators[call_index]
+                    self._process_progressor(
+                        per_call_kwargs,
+                        progressor=progressor,
+                        pipeline_call_index=call_index,
+                        pipeline_call_count=_num_pipeline_calls,
+                    )
+                    self._filter_kwargs(model, per_call_kwargs)
                     images.extend(model(**per_call_kwargs).images)
 
         if images and isinstance(images[0], (list, tuple)):

--- a/xinference/model/image/stable_diffusion/core.py
+++ b/xinference/model/image/stable_diffusion/core.py
@@ -792,6 +792,7 @@ class DiffusionModel(SDAPIDiffusionModelMixin):
         self,
         response_format: str,
         model=None,
+        _num_pipeline_calls: int = 1,
         **kwargs,
     ):
         model = model if model is not None else self._model
@@ -799,9 +800,12 @@ class DiffusionModel(SDAPIDiffusionModelMixin):
         origin_size = kwargs.pop("origin_size", None)
         seed = kwargs.pop("seed", None)
         return_images = kwargs.pop("_return_images", None)
-        seeds = resolve_image_seed_list(
-            seed, int(kwargs.get("num_images_per_prompt", 1))
+        seed_count = (
+            _num_pipeline_calls
+            if _num_pipeline_calls > 1
+            else int(kwargs.get("num_images_per_prompt", 1))
         )
+        seeds = resolve_image_seed_list(seed, seed_count)
         if seeds is not None:
             kwargs["generator"] = [
                 torch.Generator(  # type: ignore
@@ -829,7 +833,19 @@ class DiffusionModel(SDAPIDiffusionModelMixin):
             if kwargs.get("guidance_scale", "unset") is None:
                 kwargs.pop("guidance_scale", None)
             self._filter_kwargs(model, kwargs)
-            images = model(**kwargs).images
+            if _num_pipeline_calls == 1:
+                images = model(**kwargs).images
+            else:
+                images = []
+                generators = kwargs.get("generator")
+                for call_index in range(_num_pipeline_calls):
+                    per_call_kwargs = kwargs
+                    if isinstance(generators, list):
+                        per_call_kwargs = {
+                            **kwargs,
+                            "generator": generators[call_index],
+                        }
+                    images.extend(model(**per_call_kwargs).images)
 
         if images and isinstance(images[0], (list, tuple)):
             images = list(itertools.chain.from_iterable(images))
@@ -1078,12 +1094,14 @@ class DiffusionModel(SDAPIDiffusionModelMixin):
             kwargs["images"] = image
             image = None
 
+        # JoyAI Image Edit Plus produces one image per pipeline invocation.
         return self._call_model(
             image=image,
             prompt=prompt,
-            num_images_per_prompt=n,
+            num_images_per_prompt=1 if is_joyai_image_edit_plus else n,
             response_format=response_format,
             model=model,
+            _num_pipeline_calls=n if is_joyai_image_edit_plus else 1,
             **kwargs,
         )
 

--- a/xinference/model/image/stable_diffusion/core.py
+++ b/xinference/model/image/stable_diffusion/core.py
@@ -1074,15 +1074,16 @@ class DiffusionModel(SDAPIDiffusionModelMixin):
         # generate config for lightning
         self._gen_config_for_lightning(kwargs)
 
-        model_input = (
-            {"images": image} if is_joyai_image_edit_plus else {"image": image}
-        )
+        if is_joyai_image_edit_plus:
+            kwargs["images"] = image
+            image = None
+
         return self._call_model(
+            image=image,
             prompt=prompt,
             num_images_per_prompt=n,
             response_format=response_format,
             model=model,
-            **model_input,
             **kwargs,
         )
 

--- a/xinference/model/image/stable_diffusion/core.py
+++ b/xinference/model/image/stable_diffusion/core.py
@@ -148,6 +148,18 @@ class DiffusionModel(SDAPIDiffusionModelMixin):
         model_name = self._model_spec.model_name.lower().replace("_", "-")
         return model_name.startswith("glm-image")
 
+    def _is_joyai_image_model(self) -> bool:
+        if self._model_spec is None:
+            return False
+        model_name = self._model_spec.model_name.lower().replace("_", "-")
+        return model_name.startswith("joyai-image-edit")
+
+    def _is_joyai_image_edit_plus_model(self) -> bool:
+        if self._model_spec is None:
+            return False
+        model_name = self._model_spec.model_name.lower().replace("_", "-")
+        return model_name == "joyai-image-edit-plus"
+
     @staticmethod
     def _get_pipeline_type(ability: str) -> type:
         if ability == "text2image":
@@ -264,7 +276,11 @@ class DiffusionModel(SDAPIDiffusionModelMixin):
             return getattr(module, class_name)
 
     def load(self):
-        if self._is_glm_image_model():
+        if self._is_joyai_image_model():
+            # JoyAI pipelines are image-edit-only and are not registered in
+            # Diffusers' AutoPipelineForText2Image mapping.
+            from diffusers import DiffusionPipeline as AutoPipelineModel
+        elif self._is_glm_image_model():
             from diffusers import GlmImagePipeline as AutoPipelineModel
         elif "text2image" in self._abilities or "image2image" in self._abilities:
             from diffusers import AutoPipelineForText2Image as AutoPipelineModel
@@ -995,12 +1011,14 @@ class DiffusionModel(SDAPIDiffusionModelMixin):
                 raise RuntimeError(f"{self._model_uid} does not support image2image")
             model = self._get_model(ability)
 
-        # These pipelines consume all reference images through their ``image``
-        # argument. The OpenAI-compatible endpoint exposes the first upload as
-        # ``image`` and the remaining uploads as ``reference_images``.
+        # Multi-reference pipelines consume all uploaded images through one
+        # pipeline argument. The OpenAI-compatible endpoint exposes the first
+        # upload as ``image`` and the rest as ``reference_images``.
+        is_joyai_image_edit_plus = self._is_joyai_image_edit_plus_model()
         if kwargs.get("reference_images") and (
             type(model).__name__ == "QwenImageEditPlusPipeline"
             or self._is_glm_image_model()
+            or is_joyai_image_edit_plus
         ):
             reference_images = kwargs.pop("reference_images")
             primary_images = image if isinstance(image, list) else [image]
@@ -1010,6 +1028,10 @@ class DiffusionModel(SDAPIDiffusionModelMixin):
                 else [reference_images]
             )
             image = primary_images + reference_images
+
+        # JoyImageEditPlusPipeline always expects a list, including one image.
+        if is_joyai_image_edit_plus and not isinstance(image, list):
+            image = [image]
 
         # GlmImagePipeline expects a list even for one conditioning image.
         if self._is_glm_image_model() and not isinstance(image, list):
@@ -1038,7 +1060,7 @@ class DiffusionModel(SDAPIDiffusionModelMixin):
         else:
             # SD3 image2image cannot accept width and height
             allow_width_height = model_accept_param(["width", "height"], model)
-            if allow_width_height:
+            if allow_width_height and not is_joyai_image_edit_plus:
                 if isinstance(image, list):
                     kwargs["width"], kwargs["height"] = image[0].size
                 else:
@@ -1052,12 +1074,15 @@ class DiffusionModel(SDAPIDiffusionModelMixin):
         # generate config for lightning
         self._gen_config_for_lightning(kwargs)
 
+        model_input = (
+            {"images": image} if is_joyai_image_edit_plus else {"image": image}
+        )
         return self._call_model(
-            image=image,
             prompt=prompt,
             num_images_per_prompt=n,
             response_format=response_format,
             model=model,
+            **model_input,
             **kwargs,
         )
 

--- a/xinference/model/image/tests/test_joyai_image.py
+++ b/xinference/model/image/tests/test_joyai_image.py
@@ -1,0 +1,205 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+from PIL import Image
+
+from .. import load_model_family_from_json
+from ..core import ImageModelFamilyV2
+from ..stable_diffusion.core import DiffusionModel
+
+
+@pytest.fixture
+def joyai_families():
+    families = {}
+    spec_path = Path(__file__).parents[1] / "model_spec.json"
+    load_model_family_from_json(str(spec_path), families)
+    return families
+
+
+def test_joyai_image_model_metadata(joyai_families):
+    model_ids = {
+        "joyai-image-edit": "JoyAI-Image-Edit-Diffusers",
+        "joyai-image-edit-plus": "JoyAI-Image-Edit-Plus-Diffusers",
+    }
+
+    assert set(joyai_families) >= set(model_ids)
+    for model_name, model_id in model_ids.items():
+        specs = {spec.model_hub: spec for spec in joyai_families[model_name]}
+        assert specs["huggingface"].model_id == f"jdopensource/{model_id}"
+        assert specs["huggingface"].model_revision == "main"
+        assert specs["modelscope"].model_id == f"jd-opensource/{model_id}"
+        assert specs["modelscope"].model_revision == "master"
+
+        for spec in specs.values():
+            assert spec.model_family == "stable_diffusion"
+            assert spec.model_ability == ["image2image"]
+            assert spec.default_model_config == {"torch_dtype": "bfloat16"}
+            assert spec.virtualenv.no_build_isolation is False
+            assert (
+                'diffusers>=0.40.0 ; #engine# == "diffusers"'
+                in spec.virtualenv.packages
+            )
+            assert (
+                'huggingface-hub>=1.23.0,<2.0 ; #engine# == "diffusers"'
+                in spec.virtualenv.packages
+            )
+            assert (
+                '#system_torchvision# ; #engine# == "diffusers"'
+                in spec.virtualenv.packages
+            )
+
+    assert joyai_families["joyai-image-edit"][0].default_generate_config == {
+        "num_inference_steps": 40,
+        "guidance_scale": 4.0,
+    }
+    assert joyai_families["joyai-image-edit-plus"][0].default_generate_config == {
+        "num_inference_steps": 30,
+        "guidance_scale": 4.0,
+    }
+
+
+@pytest.mark.parametrize(
+    "model_name",
+    ["joyai-image-edit", "joyai-image-edit-plus"],
+)
+def test_joyai_image_loads_with_diffusion_pipeline(monkeypatch, model_name):
+    loaded = {}
+
+    class FakePipeline:
+        @classmethod
+        def from_pretrained(cls, model_path, **kwargs):
+            loaded.update(model_path=model_path, kwargs=kwargs)
+            return cls()
+
+    monkeypatch.setitem(
+        sys.modules,
+        "diffusers",
+        SimpleNamespace(DiffusionPipeline=FakePipeline),
+    )
+
+    model = DiffusionModel(
+        "joyai",
+        "/models/joyai",
+        model_spec=ImageModelFamilyV2(
+            model_family="stable_diffusion",
+            model_name=model_name,
+            model_id="test/joyai",
+            model_revision="main",
+            model_ability=["image2image"],
+        ),
+        torch_dtype="bfloat16",
+        device_map="balanced",
+    )
+
+    model.load()
+
+    assert isinstance(model._model, FakePipeline)
+    assert loaded == {
+        "model_path": "/models/joyai",
+        "kwargs": {
+            "torch_dtype": torch.bfloat16,
+            "device_map": "balanced",
+        },
+    }
+
+
+def test_joyai_image_edit_plus_uses_multi_image_pipeline_argument(monkeypatch):
+    calls = []
+
+    monkeypatch.setitem(
+        sys.modules,
+        "diffusers",
+        SimpleNamespace(DiffusionPipeline=object),
+    )
+
+    class FakeJoyImageEditPlusPipeline:
+        def __call__(
+            self,
+            images=None,
+            prompt=None,
+            height=None,
+            width=None,
+            num_inference_steps=30,
+            guidance_scale=4.0,
+            negative_prompt=None,
+            generator=None,
+        ):
+            calls.append(
+                {
+                    "images": images,
+                    "prompt": prompt,
+                    "height": height,
+                    "width": width,
+                    "num_inference_steps": num_inference_steps,
+                    "guidance_scale": guidance_scale,
+                }
+            )
+            return SimpleNamespace(images=[Image.new("RGB", (32, 32))])
+
+    model = DiffusionModel(
+        "joyai-plus",
+        model_spec=ImageModelFamilyV2(
+            model_family="stable_diffusion",
+            model_name="joyai-image-edit-plus",
+            model_id="test/joyai-plus",
+            model_revision="main",
+            model_ability=["image2image"],
+            default_generate_config={
+                "num_inference_steps": 30,
+                "guidance_scale": 4.0,
+            },
+        ),
+    )
+    model._model = FakeJoyImageEditPlusPipeline()
+
+    primary_image = Image.new("RGB", (64, 32))
+    reference_image = Image.new("RGB", (96, 48))
+    single_result = model.image_to_image(
+        primary_image,
+        prompt="Edit one image",
+        _return_images=True,
+    )
+    multi_result = model.image_to_image(
+        primary_image,
+        prompt="Combine both images",
+        reference_images=[reference_image],
+        _return_images=True,
+    )
+
+    assert len(single_result) == 1
+    assert len(multi_result) == 1
+    assert calls == [
+        {
+            "images": [primary_image],
+            "prompt": "Edit one image",
+            "height": None,
+            "width": None,
+            "num_inference_steps": 30,
+            "guidance_scale": 4.0,
+        },
+        {
+            "images": [primary_image, reference_image],
+            "prompt": "Combine both images",
+            "height": None,
+            "width": None,
+            "num_inference_steps": 30,
+            "guidance_scale": 4.0,
+        },
+    ]

--- a/xinference/model/image/tests/test_joyai_image.py
+++ b/xinference/model/image/tests/test_joyai_image.py
@@ -120,8 +120,9 @@ def test_joyai_image_loads_with_diffusion_pipeline(monkeypatch, model_name):
     }
 
 
-def test_joyai_image_edit_plus_uses_multi_image_input_and_honors_n(monkeypatch):
+def test_joyai_image_edit_plus_honors_n_and_reports_overall_progress(monkeypatch):
     calls = []
+    pipeline_progress = []
     pipeline_seeds = []
 
     monkeypatch.setitem(
@@ -131,6 +132,8 @@ def test_joyai_image_edit_plus_uses_multi_image_input_and_honors_n(monkeypatch):
     )
 
     class FakeJoyImageEditPlusPipeline:
+        num_timesteps = 2
+
         def __call__(
             self,
             images=None,
@@ -141,9 +144,13 @@ def test_joyai_image_edit_plus_uses_multi_image_input_and_honors_n(monkeypatch):
             guidance_scale=4.0,
             negative_prompt=None,
             generator=None,
+            callback_on_step_end=None,
         ):
             if generator is not None:
                 pipeline_seeds.append(generator.initial_seed())
+            if callback_on_step_end is not None:
+                for step in range(self.num_timesteps):
+                    callback_on_step_end(self, step, step, {})
             calls.append(
                 {
                     "images": images,
@@ -191,11 +198,16 @@ def test_joyai_image_edit_plus_uses_multi_image_input_and_honors_n(monkeypatch):
         n=2,
         seed=[11, 22],
         response_format="b64_json",
+        progressor=SimpleNamespace(
+            request_id="joyai-progress",
+            set_progress=pipeline_progress.append,
+        ),
     )
 
     assert len(single_result) == 1
     assert len(multi_result) == 1
     assert len(repeated_result["data"]) == 2
+    assert pipeline_progress == [0.25, 0.5, 0.75, 1.0]
     assert pipeline_seeds == [11, 22]
     assert calls == [
         {

--- a/xinference/model/image/tests/test_joyai_image.py
+++ b/xinference/model/image/tests/test_joyai_image.py
@@ -120,8 +120,9 @@ def test_joyai_image_loads_with_diffusion_pipeline(monkeypatch, model_name):
     }
 
 
-def test_joyai_image_edit_plus_uses_multi_image_pipeline_argument(monkeypatch):
+def test_joyai_image_edit_plus_uses_multi_image_input_and_honors_n(monkeypatch):
     calls = []
+    pipeline_seeds = []
 
     monkeypatch.setitem(
         sys.modules,
@@ -141,6 +142,8 @@ def test_joyai_image_edit_plus_uses_multi_image_pipeline_argument(monkeypatch):
             negative_prompt=None,
             generator=None,
         ):
+            if generator is not None:
+                pipeline_seeds.append(generator.initial_seed())
             calls.append(
                 {
                     "images": images,
@@ -182,9 +185,18 @@ def test_joyai_image_edit_plus_uses_multi_image_pipeline_argument(monkeypatch):
         reference_images=[reference_image],
         _return_images=True,
     )
+    repeated_result = model.image_to_image(
+        primary_image,
+        prompt="Create two images",
+        n=2,
+        seed=[11, 22],
+        response_format="b64_json",
+    )
 
     assert len(single_result) == 1
     assert len(multi_result) == 1
+    assert len(repeated_result["data"]) == 2
+    assert pipeline_seeds == [11, 22]
     assert calls == [
         {
             "images": [primary_image],
@@ -197,6 +209,22 @@ def test_joyai_image_edit_plus_uses_multi_image_pipeline_argument(monkeypatch):
         {
             "images": [primary_image, reference_image],
             "prompt": "Combine both images",
+            "height": None,
+            "width": None,
+            "num_inference_steps": 30,
+            "guidance_scale": 4.0,
+        },
+        {
+            "images": [primary_image],
+            "prompt": "Create two images",
+            "height": None,
+            "width": None,
+            "num_inference_steps": 30,
+            "guidance_scale": 4.0,
+        },
+        {
+            "images": [primary_image],
+            "prompt": "Create two images",
             "height": None,
             "width": None,
             "num_inference_steps": 30,


### PR DESCRIPTION
## Summary

Add built-in support for the following JoyAI image editing models:

- `joyai-image-edit`
- `joyai-image-edit-plus`

Both Hugging Face and ModelScope sources are supported.

## Implementation

- Register model metadata, default generation settings, and virtualenv dependencies.
- Use `DiffusionPipeline` because JoyAI edit pipelines are not registered in `AutoPipelineForText2Image`.
- Support JoyAI Image Edit Plus multi-image input:
  - Merge the primary image and `reference_images`.
  - Pass images through the pipeline's `images` argument.
  - Always provide a list, including single-image requests.
  - Avoid passing unsupported `width` and `height` arguments.
- Add built-in model documentation.
- Add focused metadata, loading, and multi-image tests.

## Model Sources

| Model | Hugging Face | Revision | ModelScope | Revision |
| --- | --- | --- | --- | --- |
| `joyai-image-edit` | `jdopensource/JoyAI-Image-Edit-Diffusers` | `main` | `jd-opensource/JoyAI-Image-Edit-Diffusers` | `master` |
| `joyai-image-edit-plus` | `jdopensource/JoyAI-Image-Edit-Plus-Diffusers` | `main` | `jd-opensource/JoyAI-Image-Edit-Plus-Diffusers` | `master` |

Official project: https://github.com/jd-opensource/JoyAI-Image
