### PR TITLE
FIX: Restore supported vLLM and SGLang model engines

### DIFF
--- a/doc/source/getting_started/installation.rst
+++ b/doc/source/getting_started/installation.rst
@@ -123,7 +123,8 @@ Currently, supported models include:
 - ``GLM-4.7-Flash``
 - ``glm-5``, ``glm-5.1``, ``glm-5.2``
 - ``DeepSeek-V4-Flash``, ``DeepSeek-V4-Flash-0731``, ``DeepSeek-V4-Pro``
-- ``Hy-MT2-1.8B``, ``Hy-MT2-7B``, ``Hy-MT2-30B-A3B``
+- ``Hy-MT2-1.8B``, ``Hy-MT2-7B``
+- ``Hy-MT2-30B-A3B``
 
 .. vllm_end
 

--- a/doc/source/models/builtin/llm/hy-mt2-1.8b.rst
+++ b/doc/source/models/builtin/llm/hy-mt2-1.8b.rst
@@ -20,7 +20,7 @@ Model Spec 1 (pytorch, 2 Billion)
 - **Model Format:** pytorch
 - **Model Size (in billions):** 2
 - **Quantizations:** none
-- **Engines**: Transformers, SGLang
+- **Engines**: vLLM, Transformers, SGLang
 - **Model ID:** tencent/Hy-MT2-1.8B
 - **Model Hubs**:  `Hugging Face <https://huggingface.co/tencent/Hy-MT2-1.8B>`__, `ModelScope <https://modelscope.cn/models/Tencent-Hunyuan/Hy-MT2-1.8B>`__
 
@@ -52,7 +52,7 @@ Model Spec 3 (ggufv2, 2 Billion)
 - **Model Format:** ggufv2
 - **Model Size (in billions):** 2
 - **Quantizations:** Q4_K_M, Q6_K, Q8_0
-- **Engines**: llama.cpp
+- **Engines**: vLLM, llama.cpp
 - **Model ID:** tencent/Hy-MT2-1.8B-GGUF
 - **Model Hubs**:  `Hugging Face <https://huggingface.co/tencent/Hy-MT2-1.8B-GGUF>`__, `ModelScope <https://modelscope.cn/models/Tencent-Hunyuan/Hy-MT2-1.8B-GGUF>`__
 

--- a/doc/source/models/builtin/llm/hy-mt2-30b-a3b.rst
+++ b/doc/source/models/builtin/llm/hy-mt2-30b-a3b.rst
@@ -20,7 +20,7 @@ Model Spec 1 (pytorch, 30 Billion)
 - **Model Format:** pytorch
 - **Model Size (in billions):** 30
 - **Quantizations:** none
-- **Engines**: Transformers, SGLang
+- **Engines**: vLLM, Transformers, SGLang
 - **Model ID:** tencent/Hy-MT2-30B-A3B
 - **Model Hubs**:  `Hugging Face <https://huggingface.co/tencent/Hy-MT2-30B-A3B>`__, `ModelScope <https://modelscope.cn/models/Tencent-Hunyuan/Hy-MT2-30B-A3B>`__
 

--- a/doc/source/models/builtin/llm/hy-mt2-7b.rst
+++ b/doc/source/models/builtin/llm/hy-mt2-7b.rst
@@ -20,7 +20,7 @@ Model Spec 1 (pytorch, 7 Billion)
 - **Model Format:** pytorch
 - **Model Size (in billions):** 7
 - **Quantizations:** none
-- **Engines**: Transformers, SGLang
+- **Engines**: vLLM, Transformers, SGLang
 - **Model ID:** tencent/Hy-MT2-7B
 - **Model Hubs**:  `Hugging Face <https://huggingface.co/tencent/Hy-MT2-7B>`__, `ModelScope <https://modelscope.cn/models/Tencent-Hunyuan/Hy-MT2-7B>`__
 
@@ -52,7 +52,7 @@ Model Spec 3 (ggufv2, 7 Billion)
 - **Model Format:** ggufv2
 - **Model Size (in billions):** 7
 - **Quantizations:** Q4_K_M, Q6_K, Q8_0
-- **Engines**: llama.cpp
+- **Engines**: vLLM, llama.cpp
 - **Model ID:** tencent/Hy-MT2-7B-GGUF
 - **Model Hubs**:  `Hugging Face <https://huggingface.co/tencent/Hy-MT2-7B-GGUF>`__, `ModelScope <https://modelscope.cn/models/Tencent-Hunyuan/Hy-MT2-7B-GGUF>`__
 

--- a/doc/source/models/builtin/llm/minicpm-v-4.6-thinking.rst
+++ b/doc/source/models/builtin/llm/minicpm-v-4.6-thinking.rst
@@ -20,7 +20,7 @@ Model Spec 1 (pytorch, 1 Billion)
 - **Model Format:** pytorch
 - **Model Size (in billions):** 1
 - **Quantizations:** none
-- **Engines**: Transformers, SGLang
+- **Engines**: vLLM, Transformers, SGLang
 - **Model ID:** openbmb/MiniCPM-V-4.6-Thinking
 - **Model Hubs**:  `Hugging Face <https://huggingface.co/openbmb/MiniCPM-V-4.6-Thinking>`__, `ModelScope <https://modelscope.cn/models/OpenBMB/MiniCPM-V-4.6-Thinking>`__
 
@@ -36,7 +36,7 @@ Model Spec 2 (bnb, 1 Billion)
 - **Model Format:** bnb
 - **Model Size (in billions):** 1
 - **Quantizations:** 4-bit
-- **Engines**: Transformers, SGLang
+- **Engines**: vLLM, Transformers, SGLang
 - **Model ID:** openbmb/MiniCPM-V-4.6-Thinking-BNB
 - **Model Hubs**:  `Hugging Face <https://huggingface.co/openbmb/MiniCPM-V-4.6-Thinking-BNB>`__, `ModelScope <https://modelscope.cn/models/OpenBMB/MiniCPM-V-4.6-Thinking-BNB>`__
 
@@ -52,7 +52,7 @@ Model Spec 3 (awq, 1 Billion)
 - **Model Format:** awq
 - **Model Size (in billions):** 1
 - **Quantizations:** Int4
-- **Engines**: Transformers, SGLang
+- **Engines**: vLLM, Transformers, SGLang
 - **Model ID:** openbmb/MiniCPM-V-4.6-Thinking-AWQ
 - **Model Hubs**:  `Hugging Face <https://huggingface.co/openbmb/MiniCPM-V-4.6-Thinking-AWQ>`__, `ModelScope <https://modelscope.cn/models/OpenBMB/MiniCPM-V-4.6-Thinking-AWQ>`__
 
@@ -68,7 +68,7 @@ Model Spec 4 (gptq, 1 Billion)
 - **Model Format:** gptq
 - **Model Size (in billions):** 1
 - **Quantizations:** Int4
-- **Engines**: Transformers, SGLang
+- **Engines**: vLLM, Transformers, SGLang
 - **Model ID:** openbmb/MiniCPM-V-4.6-Thinking-GPTQ
 - **Model Hubs**:  `Hugging Face <https://huggingface.co/openbmb/MiniCPM-V-4.6-Thinking-GPTQ>`__, `ModelScope <https://modelscope.cn/models/OpenBMB/MiniCPM-V-4.6-Thinking-GPTQ>`__
 

--- a/doc/source/models/builtin/llm/minimax-m3.rst
+++ b/doc/source/models/builtin/llm/minimax-m3.rst
@@ -20,7 +20,7 @@ Model Spec 1 (pytorch, 428 Billion)
 - **Model Format:** pytorch
 - **Model Size (in billions):** 428
 - **Quantizations:** none
-- **Engines**: vLLM, Transformers
+- **Engines**: vLLM, Transformers, SGLang
 - **Model ID:** MiniMaxAI/MiniMax-M3
 - **Model Hubs**:  `Hugging Face <https://huggingface.co/MiniMaxAI/MiniMax-M3>`__, `ModelScope <https://modelscope.cn/models/MiniMax/MiniMax-M3>`__
 

--- a/doc/source/user_guide/backends.rst
+++ b/doc/source/user_guide/backends.rst
@@ -177,7 +177,8 @@ Currently, supported model includes:
 - ``GLM-4.7-Flash``
 - ``glm-5``, ``glm-5.1``, ``glm-5.2``
 - ``DeepSeek-V4-Flash``, ``DeepSeek-V4-Flash-0731``, ``DeepSeek-V4-Pro``
-- ``Hy-MT2-1.8B``, ``Hy-MT2-7B``, ``Hy-MT2-30B-A3B``
+- ``Hy-MT2-1.8B``, ``Hy-MT2-7B``
+- ``Hy-MT2-30B-A3B``
 
 .. vllm_end
 

--- a/xinference/model/llm/llm_family.json
+++ b/xinference/model/llm/llm_family.json
@@ -1785,9 +1785,10 @@
         "accelerate>=0.28.0 ; #engine# == \"Transformers\"",
         "torchvision ; #engine# == \"Transformers\"",
         "av ; #engine# == \"Transformers\"",
-        "#vllm_dependencies# ; #engine# == \"vllm\"",
+        "vllm>=0.22.0 ; #engine# == \"vllm\"",
         "#llama_cpp_dependencies# ; #engine# == \"llama.cpp\"",
         "#sglang_dependencies# ; #engine# == \"sglang\"",
+        "sglang>=0.5.12 ; #engine# == \"sglang\"",
         "#system_numpy# ; #engine# == \"vllm\""
       ]
     }
@@ -1943,9 +1944,10 @@
         "accelerate>=0.28.0 ; #engine# == \"Transformers\"",
         "torchvision ; #engine# == \"Transformers\"",
         "av ; #engine# == \"Transformers\"",
-        "#vllm_dependencies# ; #engine# == \"vllm\"",
+        "vllm>=0.22.0 ; #engine# == \"vllm\"",
         "#llama_cpp_dependencies# ; #engine# == \"llama.cpp\"",
         "#sglang_dependencies# ; #engine# == \"sglang\"",
+        "sglang>=0.5.12 ; #engine# == \"sglang\"",
         "#system_numpy# ; #engine# == \"vllm\""
       ]
     }
@@ -33963,8 +33965,9 @@
       "packages": [
         "#transformers_dependencies# ; #engine# == \"Transformers\"",
         "#mlx_dependencies# ; #engine# == \"MLX\"",
-        "#vllm_dependencies# ; #engine# == \"vllm\"",
+        "vllm>=0.24.0 ; #engine# == \"vllm\"",
         "#sglang_dependencies# ; #engine# == \"sglang\"",
+        "sglang>=0.5.16 ; #engine# == \"sglang\"",
         "#system_numpy# ; #engine# == \"vllm\"",
         "#llama_cpp_dependencies# ; #engine# == \"llama.cpp\""
       ]

--- a/xinference/model/llm/sglang/core.py
+++ b/xinference/model/llm/sglang/core.py
@@ -136,6 +136,7 @@ SGLANG_SUPPORTED_CHAT_MODELS = [
     "DeepseekV2ForCausalLM",
     "DeepseekV3ForCausalLM",
     "Qwen3ForCausalLM",
+    "Qwen3NextForCausalLM",
     "Qwen3_5MoeForCausalLM",
     "HunYuanDenseV1ForCausalLM",
     "HYV3ForCausalLM",
@@ -148,6 +149,7 @@ SGLANG_SUPPORTED_VISION_MODEL_LIST = [
     "MllamaForConditionalGeneration",
     "Qwen3_5ForConditionalGeneration",
     "Qwen3_5MoeForConditionalGeneration",
+    "MiniMaxM3SparseForConditionalGeneration",
 ]
 
 

--- a/xinference/model/llm/tests/test_llm_family.py
+++ b/xinference/model/llm/tests/test_llm_family.py
@@ -742,6 +742,181 @@ def test_match_llm():
         os.environ.pop(XINFERENCE_ENV_MODEL_SRC)
 
 
+@pytest.mark.parametrize(
+    "model_name,expected_architecture,expected_formats",
+    [
+        (
+            "Qwen3-Next-Instruct",
+            "Qwen3NextForCausalLM",
+            {
+                "pytorch": {"none"},
+                "fp8": {"fp8"},
+                "awq": {"4bit", "8bit"},
+            },
+        ),
+        (
+            "Qwen3-Next-Thinking",
+            "Qwen3NextForCausalLM",
+            {
+                "pytorch": {"none"},
+                "fp8": {"fp8"},
+                "awq": {"4bit", "8bit"},
+            },
+        ),
+        (
+            "MiniCPM-V-4.6",
+            "MiniCPMV4_6ForConditionalGeneration",
+            {
+                "pytorch": {"none"},
+                "bnb": {"4-bit"},
+                "awq": {"Int4"},
+                "gptq": {"Int4"},
+            },
+        ),
+        (
+            "MiniCPM-V-4.6-Thinking",
+            "MiniCPMV4_6ForConditionalGeneration",
+            {
+                "pytorch": {"none"},
+                "bnb": {"4-bit"},
+                "awq": {"Int4"},
+                "gptq": {"Int4"},
+            },
+        ),
+        (
+            "MiniMax-M3",
+            "MiniMaxM3SparseForConditionalGeneration",
+            {"pytorch": {"none"}},
+        ),
+    ],
+)
+def test_recent_sglang_engine_registration(
+    monkeypatch, model_name, expected_architecture, expected_formats
+):
+    import xinference.model.llm as llm_module
+
+    from ..llm_family import BUILTIN_LLM_FAMILIES
+    from ..sglang import core as sglang_core
+
+    family = next(
+        family for family in BUILTIN_LLM_FAMILIES if family.model_name == model_name
+    )
+    assert family.architectures == [expected_architecture]
+
+    monkeypatch.setattr(
+        llm_module,
+        "SUPPORTED_ENGINES",
+        {
+            "SGLang": [
+                sglang_core.SGLANGModel,
+                sglang_core.SGLANGChatModel,
+                sglang_core.SGLANGVisionModel,
+            ]
+        },
+    )
+    monkeypatch.setattr(llm_module, "LLM_ENGINES", {})
+    monkeypatch.setattr(sglang_core, "SGLANG_INSTALLED", True)
+    monkeypatch.setattr(sglang_core, "check_dependency_available", lambda *_args: True)
+    monkeypatch.setattr(sglang_core.SGLANGModel, "_has_cuda_device", lambda: True)
+    monkeypatch.setattr(sglang_core.SGLANGModel, "_is_linux", lambda: True)
+
+    llm_module.generate_engine_config_by_model_family(family)
+
+    registrations = llm_module.LLM_ENGINES[model_name]["SGLang"]
+    registered_formats = {
+        registration["model_format"]: set(registration["quantizations"])
+        for registration in registrations
+    }
+    assert registered_formats == expected_formats
+
+
+@pytest.mark.parametrize(
+    "model_name,expected_version,expected_formats",
+    [
+        ("Hy-MT2-1.8B", "0.21.0", {"pytorch", "ggufv2"}),
+        ("Hy-MT2-7B", "0.21.0", {"pytorch", "ggufv2"}),
+        ("Hy-MT2-30B-A3B", "0.21.0", {"pytorch"}),
+        (
+            "MiniCPM-V-4.6",
+            "0.22.0",
+            {"pytorch", "bnb", "awq", "gptq"},
+        ),
+        (
+            "MiniCPM-V-4.6-Thinking",
+            "0.22.0",
+            {"pytorch", "bnb", "awq", "gptq"},
+        ),
+        ("MiniMax-M3", "0.24.0", {"pytorch"}),
+    ],
+)
+def test_recent_vllm_engine_registration(
+    monkeypatch, model_name, expected_version, expected_formats
+):
+    import xinference.model.llm as llm_module
+
+    from ..llm_family import BUILTIN_LLM_FAMILIES
+    from ..vllm import core as vllm_core
+
+    family = next(
+        family for family in BUILTIN_LLM_FAMILIES if family.model_name == model_name
+    )
+    assert vllm_core._get_effective_vllm_version_for_family(family) == version.parse(
+        expected_version
+    )
+
+    monkeypatch.setattr(
+        llm_module,
+        "SUPPORTED_ENGINES",
+        {
+            "vLLM": [
+                vllm_core.VLLMModel,
+                vllm_core.VLLMChatModel,
+                vllm_core.VLLMMultiModel,
+            ]
+        },
+    )
+    monkeypatch.setattr(llm_module, "LLM_ENGINES", {})
+    monkeypatch.setattr(vllm_core, "VLLM_INSTALLED", True)
+    monkeypatch.setattr(vllm_core, "VLLM_VERSION", version.parse("1.0.0"))
+    monkeypatch.setattr(vllm_core.VLLMModel, "check_lib", classmethod(lambda cls: True))
+    monkeypatch.setattr(vllm_core.VLLMModel, "_has_cuda_device", lambda: True)
+    monkeypatch.setattr(vllm_core.VLLMModel, "_is_linux", lambda: True)
+
+    llm_module.generate_engine_config_by_model_family(family)
+
+    registrations = llm_module.LLM_ENGINES[model_name]["vLLM"]
+    assert {registration["model_format"] for registration in registrations} == (
+        expected_formats
+    )
+
+
+@pytest.mark.parametrize(
+    "model_name,engine_name,minimum_version",
+    [
+        ("MiniCPM-V-4.6", "vllm", "0.22.0"),
+        ("MiniCPM-V-4.6-Thinking", "vllm", "0.22.0"),
+        ("MiniCPM-V-4.6", "sglang", "0.5.12"),
+        ("MiniCPM-V-4.6-Thinking", "sglang", "0.5.12"),
+        ("MiniMax-M3", "vllm", "0.24.0"),
+        ("MiniMax-M3", "sglang", "0.5.16"),
+    ],
+)
+def test_recent_model_engine_minimum_versions(model_name, engine_name, minimum_version):
+    from ..llm_family import BUILTIN_LLM_FAMILIES
+
+    family = next(
+        family for family in BUILTIN_LLM_FAMILIES if family.model_name == model_name
+    )
+    assert family.virtualenv is not None
+    requirements = {
+        requirement.name: requirement
+        for package in family.virtualenv.packages
+        if not package.startswith("#")
+        for requirement in [Requirement(package.split(";", 1)[0].strip())]
+    }
+    assert requirements[engine_name].specifier.contains(minimum_version)
+
+
 def test_match_deepseek_v4_flash_0731():
     family = match_llm(
         "DeepSeek-V4-Flash-0731",

--- a/xinference/model/llm/vllm/core.py
+++ b/xinference/model/llm/vllm/core.py
@@ -459,14 +459,16 @@ def _update_vllm_supported_lists() -> None:
     if effective_version >= version.parse("0.20.1"):
         _append_unique(VLLM_SUPPORTED_CHAT_MODELS, "DeepseekV4ForCausalLM")
 
-    if effective_version >= version.parse("0.22.0"):
-        _append_unique(
-            VLLM_SUPPORTED_MULTI_MODEL_LIST, "MiniCPMV4_6ForConditionalGeneration"
-        )
+    if effective_version >= version.parse("0.21.0"):
         _append_unique(
             VLLM_SUPPORTED_CHAT_MODELS,
             "HunYuanDenseV1ForCausalLM",
             "HYV3ForCausalLM",
+        )
+
+    if effective_version >= version.parse("0.22.0"):
+        _append_unique(
+            VLLM_SUPPORTED_MULTI_MODEL_LIST, "MiniCPMV4_6ForConditionalGeneration"
         )
 
     if is_npu_available() and effective_version >= version.parse("0.18.0"):
@@ -2368,6 +2370,14 @@ class VLLMMultiModel(VLLMModel, ChatModelMixin):
                     return False, "gptq quantization must be 4 bit for vLLM <0.3.3"
         supported_architectures = list(VLLM_SUPPORTED_MULTI_MODEL_LIST)
         effective_version = _get_effective_vllm_version_for_family(llm_family)
+        if effective_version >= version.parse("0.22.0"):
+            _append_unique(
+                supported_architectures, "MiniCPMV4_6ForConditionalGeneration"
+            )
+        if effective_version >= version.parse("0.24.0"):
+            _append_unique(
+                supported_architectures, "MiniMaxM3SparseForConditionalGeneration"
+            )
         if effective_version >= version.parse("0.27.0"):
             _append_unique(supported_architectures, "KimiK3ForConditionalGeneration")
         if not llm_family.matches_supported_architectures(supported_architectures):


### PR DESCRIPTION
## Summary

- register Qwen3-Next for the SGLang chat engine so regenerated docs keep SGLang for pytorch, FP8, and AWQ specs
- correct the vLLM version gates for Hy-MT2, MiniCPM-V-4.6 (including Thinking), and MiniMax-M3
- register MiniMax-M3 for SGLang and declare verified per-model minimum engine versions
- regenerate the affected model and backend documentation from the corrected registry

## Context

A full engine-line scan of #5442 found three incorrect removals:

- SGLang from Qwen3-Next Instruct and Thinking
- vLLM from MiniCPM-V-4.6
- vLLM from MiniMax-M3, plus Hy-MT2 from the vLLM backend lists

The same registry audit also found two already-stale entries outside #5442: vLLM was missing from MiniCPM-V-4.6-Thinking and SGLang was missing from MiniMax-M3. They are fixed here as well. The Kimi-K3 Transformers addition and Ornith-1.5-397B SGLang addition in #5442 are valid and are left unchanged.

This PR is based independently on `main`. After it merges, #5442 can be refreshed and regenerated without dropping supported engines. Qwen3-Next has no generated-page diff in this PR because `main` already shows SGLang; the registry fix makes that existing documentation reproducible.

Upstream support used for the version gates:

- Qwen3-Next: SGLang >= 0.5.2
- Hy-MT2: vLLM >= 0.21.0
- MiniCPM-V-4.6: vLLM >= 0.22.0 and SGLang >= 0.5.12
- MiniMax-M3: vLLM >= 0.24.0 and SGLang >= 0.5.16

## Validation

- `pytest -q xinference/model/llm/tests/test_llm_family.py` (62 passed, 2 skipped)
- `pre-commit run --files <all changed files>`
- `python doc/source/gen_docs.py` followed by an idempotency check
- Sphinx dummy build completed successfully (17 pre-existing unresolved-label warnings)