### PR TITLE
docs: add v3.3.0 to release notes index and locale catalogs

### DIFF
--- a/doc/source/getting_started/release_notes.rst
+++ b/doc/source/getting_started/release_notes.rst
@@ -9,6 +9,8 @@ For detailed updates, please visit the corresponding links below.
 +-----------------+--------------------------------------------------------------------------------+
 | Version         | Release Notes                                                                  |
 +=================+================================================================================+
+| v3.3.0          | `View release notes <https://xinference.co/release_notes/v3.3.0.html>`_        |
++-----------------+--------------------------------------------------------------------------------+
 | v3.2.0          | `View release notes <https://xinference.co/release_notes/v3.2.0.html>`_        |
 +-----------------+--------------------------------------------------------------------------------+
 | v3.1.0          | `View release notes <https://xinference.co/release_notes/v3.1.0.html>`_        |

--- a/doc/source/locale/de/LC_MESSAGES/getting_started/release_notes.po
+++ b/doc/source/locale/de/LC_MESSAGES/getting_started/release_notes.po
@@ -257,6 +257,14 @@ msgstr ""
 " Releases: https://github.com/xorbitsai/inference/releases"
 
 #: ../../source/getting_started/release_notes.rst:12
+msgid "v3.3.0"
+msgstr "v3.3.0"
+
+#: ../../source/getting_started/release_notes.rst:12
+msgid "`View release notes <https://xinference.co/release_notes/v3.3.0.html>`_"
+msgstr "`Versionshinweise anzeigen <https://xinference.co/release_notes/v3.3.0.html>`_"
+
+#: ../../source/getting_started/release_notes.rst:12
 msgid "v3.2.0"
 msgstr "v3.2.0"
 

--- a/doc/source/locale/es/LC_MESSAGES/getting_started/release_notes.po
+++ b/doc/source/locale/es/LC_MESSAGES/getting_started/release_notes.po
@@ -258,6 +258,14 @@ msgstr ""
 " https://github.com/xorbitsai/inference/releases"
 
 #: ../../source/getting_started/release_notes.rst:12
+msgid "v3.3.0"
+msgstr "v3.3.0"
+
+#: ../../source/getting_started/release_notes.rst:12
+msgid "`View release notes <https://xinference.co/release_notes/v3.3.0.html>`_"
+msgstr "`Ver las notas de la versión <https://xinference.co/release_notes/v3.3.0.html>`_"
+
+#: ../../source/getting_started/release_notes.rst:12
 msgid "v3.2.0"
 msgstr "v3.2.0"
 

--- a/doc/source/locale/fr/LC_MESSAGES/getting_started/release_notes.po
+++ b/doc/source/locale/fr/LC_MESSAGES/getting_started/release_notes.po
@@ -258,6 +258,14 @@ msgstr ""
 " versions GitHub : https://github.com/xorbitsai/inference/releases"
 
 #: ../../source/getting_started/release_notes.rst:12
+msgid "v3.3.0"
+msgstr "v3.3.0"
+
+#: ../../source/getting_started/release_notes.rst:12
+msgid "`View release notes <https://xinference.co/release_notes/v3.3.0.html>`_"
+msgstr "`Voir les notes de version <https://xinference.co/release_notes/v3.3.0.html>`_"
+
+#: ../../source/getting_started/release_notes.rst:12
 msgid "v3.2.0"
 msgstr "v3.2.0"
 

--- a/doc/source/locale/it/LC_MESSAGES/getting_started/release_notes.po
+++ b/doc/source/locale/it/LC_MESSAGES/getting_started/release_notes.po
@@ -257,6 +257,14 @@ msgstr ""
 "Releases: https://github.com/xorbitsai/inference/releases"
 
 #: ../../source/getting_started/release_notes.rst:12
+msgid "v3.3.0"
+msgstr "v3.3.0"
+
+#: ../../source/getting_started/release_notes.rst:12
+msgid "`View release notes <https://xinference.co/release_notes/v3.3.0.html>`_"
+msgstr "`Visualizza le note di rilascio <https://xinference.co/release_notes/v3.3.0.html>`_"
+
+#: ../../source/getting_started/release_notes.rst:12
 msgid "v3.2.0"
 msgstr "v3.2.0"
 

--- a/doc/source/locale/ja/LC_MESSAGES/getting_started/release_notes.po
+++ b/doc/source/locale/ja/LC_MESSAGES/getting_started/release_notes.po
@@ -212,6 +212,14 @@ msgstr ""
 "Releasesをご覧ください：https://github.com/xorbitsai/inference/releases"
 
 #: ../../source/getting_started/release_notes.rst:12
+msgid "v3.3.0"
+msgstr "v3.3.0"
+
+#: ../../source/getting_started/release_notes.rst:12
+msgid "`View release notes <https://xinference.co/release_notes/v3.3.0.html>`_"
+msgstr "`バージョン説明を確認 <https://xinference.co/release_notes/v3.3.0.html>`_"
+
+#: ../../source/getting_started/release_notes.rst:12
 msgid "v3.2.0"
 msgstr "v3.2.0"
 

--- a/doc/source/locale/ko/LC_MESSAGES/getting_started/release_notes.po
+++ b/doc/source/locale/ko/LC_MESSAGES/getting_started/release_notes.po
@@ -213,6 +213,14 @@ msgstr ""
 "https://github.com/xorbitsai/inference/releases"
 
 #: ../../source/getting_started/release_notes.rst:12
+msgid "v3.3.0"
+msgstr "v3.3.0"
+
+#: ../../source/getting_started/release_notes.rst:12
+msgid "`View release notes <https://xinference.co/release_notes/v3.3.0.html>`_"
+msgstr "`버전 설명 보기 <https://xinference.co/release_notes/v3.3.0.html>`_"
+
+#: ../../source/getting_started/release_notes.rst:12
 msgid "v3.2.0"
 msgstr "v3.2.0"
 

--- a/doc/source/locale/pt_BR/LC_MESSAGES/getting_started/release_notes.po
+++ b/doc/source/locale/pt_BR/LC_MESSAGES/getting_started/release_notes.po
@@ -241,6 +241,14 @@ msgstr ""
 "https://github.com/xorbitsai/inference/releases"
 
 #: ../../source/getting_started/release_notes.rst:12
+msgid "v3.3.0"
+msgstr "v3.3.0"
+
+#: ../../source/getting_started/release_notes.rst:12
+msgid "`View release notes <https://xinference.co/release_notes/v3.3.0.html>`_"
+msgstr "`Ver notas da versão <https://xinference.co/release_notes/v3.3.0.html>`_"
+
+#: ../../source/getting_started/release_notes.rst:12
 msgid "v3.2.0"
 msgstr "v3.2.0"
 

--- a/doc/source/locale/zh_CN/LC_MESSAGES/getting_started/release_notes.po
+++ b/doc/source/locale/zh_CN/LC_MESSAGES/getting_started/release_notes.po
@@ -213,6 +213,14 @@ msgstr ""
 "Releases：https://github.com/xorbitsai/inference/releases"
 
 #: ../../source/getting_started/release_notes.rst:12
+msgid "v3.3.0"
+msgstr "v3.3.0"
+
+#: ../../source/getting_started/release_notes.rst:12
+msgid "`View release notes <https://xinference.co/release_notes/v3.3.0.html>`_"
+msgstr "`查看版本说明 <https://xinference.cn/release_notes/v3.3.0.html>`_"
+
+#: ../../source/getting_started/release_notes.rst:12
 msgid "v3.2.0"
 msgstr "v3.2.0"
 

--- a/doc/source/locale/zh_TW/LC_MESSAGES/getting_started/release_notes.po
+++ b/doc/source/locale/zh_TW/LC_MESSAGES/getting_started/release_notes.po
@@ -213,6 +213,14 @@ msgstr ""
 "Releases：https://github.com/xorbitsai/inference/releases"
  
 #: ../../source/getting_started/release_notes.rst:12
+msgid "v3.3.0"
+msgstr "v3.3.0"
+
+#: ../../source/getting_started/release_notes.rst:12
+msgid "`View release notes <https://xinference.co/release_notes/v3.3.0.html>`_"
+msgstr "`查看版本說明 <https://xinference.cn/release_notes/v3.3.0.html>`_"
+
+#: ../../source/getting_started/release_notes.rst:12
 msgid "v3.2.0"
 msgstr "v3.2.0"
 


### PR DESCRIPTION
Add v3.3.0 to the release notes index (doc/source/getting_started/release_notes.rst) and add the corresponding entries to all locale catalogs (de, es, fr, it, ja, ko, pt_BR, zh_CN, zh_TW). zh_CN/zh_TW point to xinference.cn; other locales use xinference.co, matching the existing v3.2.0 rows.