### PR TITLE
chore: bump actions/checkout to v7

### DIFF
--- a/.github/workflows/build-pypiserver-image.yaml
+++ b/.github/workflows/build-pypiserver-image.yaml
@@ -29,7 +29,7 @@ jobs:
     name: Check release tag permission
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - uses: ./.github/actions/check-release-permission
@@ -59,7 +59,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Free disk space
         shell: bash

--- a/.github/workflows/docker-cd.yaml
+++ b/.github/workflows/docker-cd.yaml
@@ -17,7 +17,7 @@ jobs:
     name: Check release tag permission
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - uses: ./.github/actions/check-release-permission
@@ -31,7 +31,7 @@ jobs:
       contents: read
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           submodules: recursive
@@ -69,7 +69,7 @@ jobs:
       contents: read
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           submodules: recursive
@@ -107,7 +107,7 @@ jobs:
       contents: read
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/pr_auto_run_gen_docs.yaml
+++ b/.github/workflows/pr_auto_run_gen_docs.yaml
@@ -36,7 +36,7 @@ jobs:
           fi
 
       - name: Checkout base branch (trusted code)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.base.sha }}
           repository: ${{ github.repository }}
@@ -44,12 +44,19 @@ jobs:
           fetch-depth: 0
 
       - name: Checkout PR head (data only)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           path: pr
           fetch-depth: 0
+          # actions/checkout v7 refuses to check out a fork head under
+          # pull_request_target unless this is set. The fork tree is treated as
+          # data only: no fork code is installed or executed, and only the six
+          # model spec JSON files are copied (symlinks refused) into a workspace
+          # built from the base checkout. Pushes are still limited to same-repo
+          # PRs by the "Push to same-repo PR" step below.
+          allow-unsafe-pr-checkout: true
 
       - name: Decide whether to run gen_docs for latest commit
         id: decide

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -24,7 +24,7 @@ jobs:
         python-version: [ "3.10" ]
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           submodules: recursive
@@ -69,7 +69,7 @@ jobs:
       groups: ${{ steps.gpu.outputs.groups }}
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           submodules: recursive
@@ -199,7 +199,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           submodules: recursive
@@ -380,7 +380,7 @@ jobs:
         shell: bash -l {0}
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ jobs:
     name: Check release tag permission
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - uses: ./.github/actions/check-release-permission
@@ -31,7 +31,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.10"
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Install pypa/build


### PR DESCRIPTION
## Why

Every workflow run is annotated with the Node 20 deprecation notice, and `python.yaml` / `release.yaml` are still on `actions/checkout@v3`, which declares `runs.using: node16`. The runner is force-overriding both to Node 24, so those steps execute on a runtime they were never built or tested against — and the override is temporary. This moves every pin to the current major, which targets node24 natively.

| tag | runtime | released |
| --- | --- | --- |
| `v3` | node16 | 2022-09-26 |
| `v4` | node20 | 2023-10-17 |
| `v5` | node24 | 2025-08-11 |
| `v6` | node24 | 2025-11-20 |
| `v7` (latest `v7.0.1`) | node24 | 2026-07-20 |

Going straight to `v7` rather than the minimum hop, because only one intervening breaking change touches this repo (see below).

## Breaking-change review

- **v5 — node24 runtime, requires Actions Runner >= 2.327.1.** All jobs but one are on hosted runners (`ubuntu-latest`, `ubuntu-22.04`, `ubuntu-24.04`, `ubuntu-24.04-arm`, or a hosted `matrix.os` / `matrix.runner`). The exception is `gpu_test_job` in `python.yaml`, which is `runs-on: gpu-t4`. Self-hosted runners auto-update by default, so this should already be well past the floor — worth a glance at the runner's agent version before merge, since I can't read `/actions/runners` without admin on the repo.
- **v6 — [credentials persist to a file in `$RUNNER_TEMP`](https://github.com/actions/checkout/pull/2286)** via `includeIf.gitdir` instead of `.git/config`'s `http.extraheader`. Authenticated git in later steps still works through the conditional include. Nothing in `.github/` reads `.git/config`, greps `extraheader`, or sets `persist-credentials`; the one authenticated git command is `git push origin` in `pr_auto_run_gen_docs.yaml`, which keeps working. No `container:` jobs, so the higher 2.329.0 floor for container-action credential access does not apply.
- **v6 — `submodules: recursive`** is used by 7 steps and is unchanged through v7.
- **v7 — [blocks checking out fork PR heads](https://github.com/actions/checkout/pull/2454) under `pull_request_target` / `workflow_run`.** This one does hit us; details below.
- Inputs in use are `fetch-depth: 0`, `submodules: recursive`, `ref:`, `repository:`, and `path:`. All unchanged through v7.

## The one behavioral decision: `pr_auto_run_gen_docs.yaml`

That workflow triggers on `pull_request_target` and has two checkouts. Reading [`assertSafePrCheckout`](https://github.com/actions/checkout/blob/main/src/unsafe-pr-checkout-helper.ts), the guardrail throws only when the head repo id differs from the base repo id **and** the resolved input points at the fork head:

- **"Checkout base branch (trusted code)"** — `repository: github.repository`, `ref: base.sha`. Neither the repository nor the ref/commit matches the PR head, so the helper returns early. Unaffected, fork PR or not.
- **"Checkout PR head (data only)"** — `repository: head.repo.full_name`. For a same-repo PR the head repo id equals the base repo id and the check returns early. For a **fork** PR it throws, which would break the job.

Fork PRs currently do reach that step: the job's `if` gates on `startsWith(head.ref, 'chore/models-sync/')`, which a fork branch can satisfy, and there is an explicit "Skip fork PR push" step downstream. So I set `allow-unsafe-pr-checkout: true` on that step only, with a comment, to preserve today's behavior.

I think that's defensible rather than reflexive: the workflow was already written against the pwn-request risk the guardrail targets. It never installs or executes fork code — it copies only the six whitelisted model spec JSON files out of `pr/` (refusing symlinks) into a workspace cloned from the trusted `base` checkout, installs `./base[doc]`, runs `base`'s `gen_docs.py`, validates every generated path against a strict regex, and pushes only when `head.repo.full_name == github.repository`.

Note that pinning back to `v6` is **not** an escape hatch: the guardrail was backported, so the floating `v5`, `v6`, `v6.1.0`, and `v5.1.0` tags all carry it. Only `v6.0.3` and older avoid it.

**If you'd rather honor the guardrail than opt out of it**, the alternative is to stop checking out fork heads at all — gate the job on `head.repo.full_name == github.repository`, or fetch the six JSON files through the API instead of via checkout. Both change behavior for fork PRs, so I kept them out of a version bump. Happy to do either as a follow-up.

## What changed

The version string on all 14 occurrences across 5 workflow files, plus the one `allow-unsafe-pr-checkout` input and its comment. No step names, other inputs, or surrounding logic touched.

## Verification

- `actionlint` reports zero findings on any `actions/checkout` line and accepts the new input. The findings it does report are all pre-existing and untouched by this PR: `actions/setup-python@v4` and `actions/setup-node@v1` in `python.yaml` are flagged as hard errors ("the runner of this action is too old to run on GitHub Actions" — both are node16), plus assorted `SC2086` shellcheck infos.
- `grep -rn "actions/checkout"` finds no hits outside `.github/workflows/`, and no test or lint file in the repo asserts action versions, so there is nothing to update alongside.
- The real check is this PR's own CI: `python.yaml` runs on `pull_request`, so its four bumped checkouts exercise `lint`, `changes`, and `build_test_job` here, and the Node deprecation annotation should be gone from those runs. `docker-cd.yaml` and `build-pypiserver-image.yaml` don't run on PRs but both support `workflow_dispatch` if you want to smoke-test them from this branch. `release.yaml` is tag-only. `pr_auto_run_gen_docs.yaml` needs a `chore/models-sync/*` PR to exercise — the same-repo path is the one that matters and is unaffected by the v7 check either way.

## Not in scope

`actions/checkout` only, to keep the diff one line per site. Several other actions carry the same deprecation; the two node16 ones are the urgent follow-up. Current majors verified against the GitHub API:

| action | current here | target | notes |
| --- | --- | --- | --- |
| `actions/setup-python` | `v4` (x3), `v5` | `v7` | the `v4` uses are **node16** and actionlint already errors on them — most urgent of the batch |
| `actions/setup-node` | `v1` | `v7` | also **node16**, also an actionlint error |
| `actions/cache` | `v4` | `v6` | |
| `actions/github-script` | SHA-pinned (`60a0d83`, v7) | `v9` | v9 drops `require('@actions/github')` |
| `docker/build-push-action` | `v7` | current | already recent |
| `docker/setup-buildx-action` | `v4` | current | already recent |
| `pypa/gh-action-pypi-publish` | `v1.5.0` | `v1.x` | Docker action, no node runtime, but very old |

Already fine: `docker/login-action@v4`, `actions/stale@v9`, and the local composite `./.github/actions/check-release-permission`.
