### PR TITLE
fix(llm): gate Hy-MT2 remote code execution

### DIFF
--- a/xinference/model/llm/tests/test_llm_family.py
+++ b/xinference/model/llm/tests/test_llm_family.py
@@ -970,6 +970,42 @@ def test_match_deepseek_v4_flash_0731():
     assert preview.model_specs[0].model_id == "deepseek-ai/DeepSeek-V4-Flash"
 
 
+def test_hy_mt2_remote_code_policy():
+    import copy
+
+    from ..llm_family import match_llm
+    from ..transformers.hy_mt2 import HyMT2PytorchModel
+
+    family = match_llm(
+        "Hy-MT2-1.8B",
+        model_format="pytorch",
+        model_size_in_billions=2,
+        quantization="none",
+        download_hub="modelscope",
+    )
+
+    assert family is not None
+    assert family.is_builtin is True
+    assert family.architectures == ["HunYuanDenseV1ForCausalLM"]
+    assert family.model_specs[0].model_hub == "modelscope"
+    assert family.model_specs[0].model_id == "Tencent-Hunyuan/Hy-MT2-1.8B"
+    assert (
+        HyMT2PytorchModel.match_json(
+            family, family.model_specs[0], family.model_specs[0].quantization
+        )
+        is True
+    )
+
+    builtin_model = HyMT2PytorchModel("hy-mt2-builtin-test", family, "/tmp/hy-mt2")
+    assert builtin_model._pytorch_model_config["torch_dtype"] == "bfloat16"
+    assert builtin_model._pytorch_model_config["trust_remote_code"] is True
+
+    custom_family = copy.copy(family)
+    custom_family.is_builtin = False
+    custom_model = HyMT2PytorchModel("hy-mt2-custom-test", custom_family, "/tmp/hy-mt2")
+    assert custom_model._pytorch_model_config["trust_remote_code"] is False
+
+
 def test_is_valid_file_uri():
     with tempfile.NamedTemporaryFile() as tmp_file:
         assert is_valid_model_uri(f"file://{tmp_file.name}") is True

--- a/xinference/model/llm/transformers/hy_mt2.py
+++ b/xinference/model/llm/transformers/hy_mt2.py
@@ -15,6 +15,7 @@
 from typing import List, Optional, Tuple, Union
 
 from ....types import LoRA, PytorchModelConfig
+from ...utils import allow_trust_remote_code
 from ..llm_family import LLMFamilyV2, LLMSpecV1, register_transformer
 from .core import PytorchChatModel, register_non_default_model
 
@@ -59,7 +60,7 @@ class HyMT2PytorchModel(PytorchChatModel):
         # Hy-MT2 official README pins bfloat16; the default MPS preferred
         # dtype (float16) breaks the custom HunYuanDense embedding path.
         config.setdefault("torch_dtype", "bfloat16")
-        config.setdefault("trust_remote_code", True)
+        config["trust_remote_code"] = allow_trust_remote_code(self.model_family)
         return config  # type: ignore
 
     @classmethod


### PR DESCRIPTION
## Summary

- Apply Xinference's standard `allow_trust_remote_code` policy to the Hy-MT2 Transformers adapter.
- Allow vetted built-in Hy-MT2 models to load their bundled Transformers code while keeping custom model families gated by the existing security policy.
- Add regression coverage for both built-in and custom model-family behavior.

## Testing

- `pytest -q xinference/model/llm/tests/test_llm_family.py -k hy_mt2_remote_code_policy`
- `pre-commit run --files xinference/model/llm/transformers/hy_mt2.py xinference/model/llm/tests/test_llm_family.py`
