### PR TITLE
feat(cache): open cached models for launch

### DIFF
--- a/frontend/src/components/pages/cache-management/index.tsx
+++ b/frontend/src/components/pages/cache-management/index.tsx
@@ -21,6 +21,7 @@ import { toast } from 'sonner';
 
 import DownloadProgressDetails from '@/components/pages/launch-model/launch-dialog/download-progress-details';
 import {
+  createLatestRequestGuard,
   findModelRegistration,
   getLaunchModelHref,
   getSuccessfulRegistrationGroups,
@@ -175,6 +176,7 @@ export default function CacheManagement() {
   const [pendingAction, setPendingAction] = useState<PendingAction>();
   const [lastUpdated, setLastUpdated] = useState<number>();
   const downloadsInFlight = useRef(false);
+  const launchRequestGuardRef = useRef(createLatestRequestGuard());
   const previousDownloadUids = useRef<Set<string>>(new Set());
 
   const availableTabs = useMemo<TabValue[]>(() => {
@@ -286,6 +288,8 @@ export default function CacheManagement() {
   };
 
   const handleLaunchModel = async (item: ModelCachedItem) => {
+    const requestGuard = launchRequestGuardRef.current;
+    const requestId = requestGuard.start();
     setLaunchingModelName(item.model_name);
     try {
       const registrationResults = await Promise.allSettled(
@@ -297,6 +301,9 @@ export default function CacheManagement() {
         }))
       );
       const registrationGroups = getSuccessfulRegistrationGroups(registrationResults);
+
+      if (!requestGuard.isLatest(requestId)) return;
+
       const registration = findModelRegistration(registrationGroups, item.model_name);
       const href = registration
         ? getLaunchModelHref(registration.modelType, item.model_name, registration.isBuiltin)
@@ -311,7 +318,9 @@ export default function CacheManagement() {
     } catch {
       // Request errors are surfaced by the global request handler.
     } finally {
-      setLaunchingModelName(undefined);
+      if (requestGuard.isLatest(requestId)) {
+        setLaunchingModelName(undefined);
+      }
     }
   };
 

--- a/frontend/src/components/pages/cache-management/index.tsx
+++ b/frontend/src/components/pages/cache-management/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Fragment, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { useRouter } from 'next/navigation';
 import {
   Ban,
   Box,
@@ -9,6 +10,7 @@ import {
   Copy,
   Database,
   Download,
+  ExternalLink,
   Pause,
   Play,
   RefreshCw,
@@ -18,6 +20,11 @@ import {
 import { toast } from 'sonner';
 
 import DownloadProgressDetails from '@/components/pages/launch-model/launch-dialog/download-progress-details';
+import {
+  findModelRegistration,
+  getLaunchModelHref,
+  setPendingLaunchModelTarget,
+} from '@/components/pages/launch-model/navigation-utils.mjs';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
@@ -39,12 +46,23 @@ import { InfoTooltip } from '@/components/ui/tooltip';
 import { useGlobal } from '@/contexts/global-context';
 import { useI18n } from '@/contexts/i18n-context';
 import { useMenuAuth } from '@/hooks/use-menu-auth';
+import { ModelType } from '@/constants';
 import request from '@/lib/request';
 import { cn, copyToClipboard } from '@/lib/utils';
 import type { ModelCachedItem, ModelDownloadItem, ModelEnvItem } from '@/types/services';
 
 type TabValue = 'models' | 'environments';
 const ACTIVE_CACHE_DOWNLOAD_STAGES = new Set(['pending', 'resuming', 'downloading', 'pausing']);
+const MODEL_REGISTRATION_TYPES = [
+  ModelType.LLM,
+  ModelType.Embedding,
+  ModelType.Rerank,
+  ModelType.Image,
+  ModelType.Audio,
+  ModelType.Video,
+  ModelType.World,
+  ModelType.Flexible,
+] as const;
 type PendingAction =
   | { kind: 'download'; item: ModelDownloadItem }
   | { kind: 'downloadDelete'; item: ModelDownloadItem }
@@ -57,6 +75,11 @@ interface ListResponse<T> {
 
 interface DeleteResponse {
   result?: boolean;
+}
+
+interface ModelRegistrationListItem {
+  model_name?: string;
+  is_builtin?: boolean;
 }
 
 function asList<T>(response: ListResponse<T>): T[] {
@@ -127,6 +150,7 @@ function PathCell({ path, copyLabel }: { path?: string; copyLabel: string }) {
 
 export default function CacheManagement() {
   const { t } = useI18n();
+  const router = useRouter();
   const { clusterAuth, clusterUIConfig } = useGlobal();
   const auth = useMenuAuth();
   const unrestricted = clusterAuth?.auth === false || !clusterUIConfig?.auth_advanced;
@@ -145,6 +169,7 @@ export default function CacheManagement() {
   const [refreshing, setRefreshing] = useState(false);
   const [actionLoading, setActionLoading] = useState(false);
   const [downloadActionUid, setDownloadActionUid] = useState<string>();
+  const [launchingModelName, setLaunchingModelName] = useState<string>();
   const [expandedDownloadUids, setExpandedDownloadUids] = useState<Set<string>>(() => new Set());
   const [pendingAction, setPendingAction] = useState<PendingAction>();
   const [lastUpdated, setLastUpdated] = useState<number>();
@@ -256,6 +281,35 @@ export default function CacheManagement() {
       await Promise.all([loadDownloads(), loadCachedModels(), loadEnvironments()]);
     } finally {
       setRefreshing(false);
+    }
+  };
+
+  const handleLaunchModel = async (item: ModelCachedItem) => {
+    setLaunchingModelName(item.model_name);
+    try {
+      const registrationGroups = await Promise.all(
+        MODEL_REGISTRATION_TYPES.map(async (modelType) => ({
+          modelType,
+          registrations: await request.get<ModelRegistrationListItem[]>(
+            `/v1/model_registrations/${modelType}`
+          ),
+        }))
+      );
+      const registration = findModelRegistration(registrationGroups, item.model_name);
+      const href = registration
+        ? getLaunchModelHref(registration.modelType, item.model_name, registration.isBuiltin)
+        : null;
+
+      if (href && registration) {
+        setPendingLaunchModelTarget(registration.modelType, item.model_name);
+        router.push(href);
+      } else {
+        toast.error(t('cacheManagement.resolveModelTypeFailed'));
+      }
+    } catch {
+      // Request errors are surfaced by the global request handler.
+    } finally {
+      setLaunchingModelName(undefined);
     }
   };
 
@@ -739,18 +793,35 @@ export default function CacheManagement() {
                         {item.actor_ip_address}
                       </TableCell>
                       <TableCell className="text-center">
-                        {canDeleteCache ? (
-                          <InfoTooltip content={t('cacheManagement.deleteCache')}>
-                            <Button
-                              variant="ghost"
-                              size="icon"
-                              aria-label={t('cacheManagement.deleteCache')}
-                              className="hover:bg-destructive/10 hover:text-destructive"
-                              onClick={() => setPendingAction({ kind: 'cache', item })}
-                            >
-                              <Trash2 />
-                            </Button>
-                          </InfoTooltip>
+                        {canViewDownloads || canDeleteCache ? (
+                          <div className="flex items-center justify-center gap-1">
+                            {canViewDownloads && (
+                              <InfoTooltip content={t('menu.launchModel')}>
+                                <Button
+                                  variant="ghost"
+                                  size="icon"
+                                  aria-label={t('menu.launchModel')}
+                                  loading={launchingModelName === item.model_name}
+                                  onClick={() => void handleLaunchModel(item)}
+                                >
+                                  {launchingModelName !== item.model_name && <ExternalLink />}
+                                </Button>
+                              </InfoTooltip>
+                            )}
+                            {canDeleteCache && (
+                              <InfoTooltip content={t('cacheManagement.deleteCache')}>
+                                <Button
+                                  variant="ghost"
+                                  size="icon"
+                                  aria-label={t('cacheManagement.deleteCache')}
+                                  className="hover:bg-destructive/10 hover:text-destructive"
+                                  onClick={() => setPendingAction({ kind: 'cache', item })}
+                                >
+                                  <Trash2 />
+                                </Button>
+                              </InfoTooltip>
+                            )}
+                          </div>
                         ) : (
                           '-'
                         )}

--- a/frontend/src/components/pages/cache-management/index.tsx
+++ b/frontend/src/components/pages/cache-management/index.tsx
@@ -23,6 +23,7 @@ import DownloadProgressDetails from '@/components/pages/launch-model/launch-dial
 import {
   findModelRegistration,
   getLaunchModelHref,
+  getSuccessfulRegistrationGroups,
   setPendingLaunchModelTarget,
 } from '@/components/pages/launch-model/navigation-utils.mjs';
 import { Badge } from '@/components/ui/badge';
@@ -287,7 +288,7 @@ export default function CacheManagement() {
   const handleLaunchModel = async (item: ModelCachedItem) => {
     setLaunchingModelName(item.model_name);
     try {
-      const registrationGroups = await Promise.all(
+      const registrationResults = await Promise.allSettled(
         MODEL_REGISTRATION_TYPES.map(async (modelType) => ({
           modelType,
           registrations: await request.get<ModelRegistrationListItem[]>(
@@ -295,6 +296,7 @@ export default function CacheManagement() {
           ),
         }))
       );
+      const registrationGroups = getSuccessfulRegistrationGroups(registrationResults);
       const registration = findModelRegistration(registrationGroups, item.model_name);
       const href = registration
         ? getLaunchModelHref(registration.modelType, item.model_name, registration.isBuiltin)

--- a/frontend/src/components/pages/launch-model/index.tsx
+++ b/frontend/src/components/pages/launch-model/index.tsx
@@ -2,16 +2,7 @@
 
 import { type MouseEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import {
-  ExternalLink,
-  Info,
-  Loader2,
-  RefreshCw,
-  Rocket,
-  Search,
-  Star,
-  Trash2,
-} from 'lucide-react';
+import { ExternalLink, Info, Loader2, RefreshCw, Rocket, Search, Star, Trash2 } from 'lucide-react';
 import request from '@/lib/request';
 import PageContainer from '@/components/ui/page-container';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -39,8 +30,14 @@ import {
   isRecord,
   normalizeModels,
   getLaunchModelEndpointType,
+  getInitialCustomType,
   getSortedModels,
 } from './utils';
+import {
+  clearPendingLaunchModelTarget,
+  peekPendingLaunchModelTarget,
+  prioritizeModelByName,
+} from './navigation-utils.mjs';
 
 interface LaunchModelProps {
   routeType: RouteModelType;
@@ -51,8 +48,14 @@ const LaunchModel = ({ routeType, initialCustomType }: LaunchModelProps) => {
   const { t } = useI18n();
   const router = useRouter();
   const isCustomRoute = routeType === ModelType.Custom;
+  const launchTargetRef = useRef(peekPendingLaunchModelTarget());
+  const launchTarget = launchTargetRef.current;
+  const targetModelName = launchTarget?.modelName;
+  const targetCustomType = launchTarget?.modelType
+    ? getInitialCustomType(launchTarget.modelType)
+    : initialCustomType;
   const [gpuAvailable, setGPUAvailable] = useState(-1);
-  const [customType, setCustomType] = useState<RequestModelType>(initialCustomType);
+  const [customType, setCustomType] = useState<RequestModelType>(targetCustomType);
   const [models, setModels] = useState<CatalogModel[]>([]);
   const modelRequestIdRef = useRef(0);
   const [virtualenvs, setVirtualenvs] = useState<VirtualEnv[]>([]);
@@ -65,6 +68,7 @@ const LaunchModel = ({ routeType, initialCustomType }: LaunchModelProps) => {
   const [favorites, setFavorites] = useState<string[]>([]);
   const [selectedModel, setSelectedModel] = useState<CatalogModel>();
   const [deleteModel, setDeleteModel] = useState<CatalogModel>();
+  const handledLaunchTargetRef = useRef('');
   const requestType = isCustomRoute ? customType : (routeType as RequestModelType);
   const showAbilityFilter = ![ModelType.Embedding, ModelType.Rerank, ModelType.Custom].includes(
     routeType
@@ -161,13 +165,19 @@ const LaunchModel = ({ routeType, initialCustomType }: LaunchModelProps) => {
     setQuery('');
 
     if (isCustomRoute) {
-      setCustomType(initialCustomType);
+      setCustomType(targetCustomType);
       setRefreshType(ModelType.LLM);
       return;
     }
 
     setRefreshType(routeType as RequestModelType);
-  }, [isCustomRoute, initialCustomType, routeType]);
+  }, [isCustomRoute, routeType, targetCustomType]);
+
+  useEffect(() => {
+    if (launchTarget) {
+      clearPendingLaunchModelTarget(launchTarget);
+    }
+  }, [launchTarget]);
 
   useEffect(() => {
     fetDevices();
@@ -184,6 +194,19 @@ const LaunchModel = ({ routeType, initialCustomType }: LaunchModelProps) => {
   useEffect(() => {
     fetchVirtualenvs();
   }, [fetchVirtualenvs]);
+
+  useEffect(() => {
+    if (!targetModelName || loading) return;
+
+    const targetKey = `${requestType}:${targetModelName}`;
+    if (handledLaunchTargetRef.current === targetKey) return;
+
+    const targetModel = models.find((model) => model.model_name === targetModelName);
+    if (!targetModel) return;
+
+    handledLaunchTargetRef.current = targetKey;
+    setSelectedModel(targetModel);
+  }, [loading, models, requestType, targetModelName]);
 
   useEffect(() => {
     const rawValue = window.localStorage.getItem(COLLECTION_STORAGE_KEY);
@@ -235,8 +258,17 @@ const LaunchModel = ({ routeType, initialCustomType }: LaunchModelProps) => {
       return matchesKeyword && matchesAbility && matchesStatus;
     });
 
-    return getSortedModels(filteredModels, favorites);
-  }, [ability, favorites, models, query, showAbilityFilter, showStatusFilter, status]);
+    return prioritizeModelByName(getSortedModels(filteredModels, favorites), targetModelName);
+  }, [
+    ability,
+    favorites,
+    models,
+    query,
+    showAbilityFilter,
+    showStatusFilter,
+    status,
+    targetModelName,
+  ]);
 
   const onTabChange = (value: string) => {
     const target = LAUNCH_MODEL_ROUTE_TABS.find((item) => item.key === value);
@@ -276,7 +308,7 @@ const LaunchModel = ({ routeType, initialCustomType }: LaunchModelProps) => {
     setDeleteModel(model);
   };
   const handleDeleteModel = () => {
-    if(!deleteModel) return;
+    if (!deleteModel) return;
     request
       .delete(`/v1/model_registrations/${customType}/${deleteModel?.model_name}`)
       .then(() => {

--- a/frontend/src/components/pages/launch-model/navigation-utils.mjs
+++ b/frontend/src/components/pages/launch-model/navigation-utils.mjs
@@ -1,0 +1,68 @@
+const LAUNCH_MODEL_PATHS = new Set([
+  'llm',
+  'embedding',
+  'rerank',
+  'image',
+  'audio',
+  'video',
+  'world',
+]);
+const CUSTOM_MODEL_TYPES = new Set(['llm', 'embedding', 'rerank', 'image', 'audio', 'flexible']);
+let pendingLaunchModelTarget = null;
+
+export function setPendingLaunchModelTarget(modelType, modelName) {
+  pendingLaunchModelTarget = { modelType, modelName };
+}
+
+export function peekPendingLaunchModelTarget() {
+  return pendingLaunchModelTarget;
+}
+
+export function clearPendingLaunchModelTarget(target) {
+  if (pendingLaunchModelTarget === target) {
+    pendingLaunchModelTarget = null;
+  }
+}
+
+export function findModelRegistration(registrationGroups, targetModelName) {
+  if (!targetModelName) return null;
+
+  for (const { modelType, registrations } of registrationGroups) {
+    const registration = registrations.find((item) => item.model_name === targetModelName);
+    if (registration) {
+      return {
+        modelType,
+        isBuiltin: registration.is_builtin,
+      };
+    }
+  }
+
+  return null;
+}
+
+export function getLaunchModelHref(modelType, modelName, isBuiltin) {
+  const normalizedType = String(modelType ?? '')
+    .trim()
+    .toLowerCase();
+  const normalizedName = String(modelName ?? '').trim();
+
+  if (!normalizedName) return null;
+
+  const useCustomRoute = isBuiltin === false || normalizedType === 'flexible';
+  if (useCustomRoute) {
+    if (!CUSTOM_MODEL_TYPES.has(normalizedType)) return null;
+  } else if (!LAUNCH_MODEL_PATHS.has(normalizedType)) {
+    return null;
+  }
+
+  return `/launch-model/${useCustomRoute ? 'custom' : normalizedType}`;
+}
+
+export function prioritizeModelByName(models, targetModelName) {
+  if (!targetModelName) return models;
+
+  const targetIndex = models.findIndex((model) => model.model_name === targetModelName);
+  if (targetIndex <= 0) return models;
+
+  return [models[targetIndex], ...models.slice(0, targetIndex), ...models.slice(targetIndex + 1)];
+}

--- a/frontend/src/components/pages/launch-model/navigation-utils.mjs
+++ b/frontend/src/components/pages/launch-model/navigation-utils.mjs
@@ -24,11 +24,17 @@ export function clearPendingLaunchModelTarget(target) {
   }
 }
 
+export function getSuccessfulRegistrationGroups(results) {
+  return results.flatMap((result) => (result.status === 'fulfilled' ? [result.value] : []));
+}
+
 export function findModelRegistration(registrationGroups, targetModelName) {
   if (!targetModelName) return null;
 
   for (const { modelType, registrations } of registrationGroups) {
-    const registration = registrations.find((item) => item.model_name === targetModelName);
+    if (!Array.isArray(registrations)) continue;
+
+    const registration = registrations.find((item) => item?.model_name === targetModelName);
     if (registration) {
       return {
         modelType,

--- a/frontend/src/components/pages/launch-model/navigation-utils.mjs
+++ b/frontend/src/components/pages/launch-model/navigation-utils.mjs
@@ -24,6 +24,20 @@ export function clearPendingLaunchModelTarget(target) {
   }
 }
 
+export function createLatestRequestGuard() {
+  let latestRequestId = 0;
+
+  return {
+    start() {
+      latestRequestId += 1;
+      return latestRequestId;
+    },
+    isLatest(requestId) {
+      return requestId === latestRequestId;
+    },
+  };
+}
+
 export function getSuccessfulRegistrationGroups(results) {
   return results.flatMap((result) => (result.status === 'fulfilled' ? [result.value] : []));
 }

--- a/frontend/src/components/pages/launch-model/navigation-utils.test.mjs
+++ b/frontend/src/components/pages/launch-model/navigation-utils.test.mjs
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  clearPendingLaunchModelTarget,
+  findModelRegistration,
+  getLaunchModelHref,
+  peekPendingLaunchModelTarget,
+  prioritizeModelByName,
+  setPendingLaunchModelTarget,
+} from './navigation-utils.mjs';
+
+test('finds a model type from existing registration lists', () => {
+  assert.deepEqual(
+    findModelRegistration(
+      [
+        { modelType: 'LLM', registrations: [{ model_name: 'qwen', is_builtin: true }] },
+        {
+          modelType: 'embedding',
+          registrations: [{ model_name: 'bge-m3', is_builtin: false }],
+        },
+      ],
+      'bge-m3'
+    ),
+    { modelType: 'embedding', isBuiltin: false }
+  );
+  assert.equal(findModelRegistration([], 'missing'), null);
+});
+
+test('builds a launch deep link for a built-in model type', () => {
+  assert.equal(getLaunchModelHref('LLM', 'qwen 2.5', true), '/launch-model/llm');
+});
+
+test('routes flexible models through the custom model tab', () => {
+  assert.equal(getLaunchModelHref('flexible', 'custom/model', false), '/launch-model/custom');
+});
+
+test('does not build a deep link without a supported model type', () => {
+  assert.equal(getLaunchModelHref(undefined, 'qwen', true), null);
+  assert.equal(getLaunchModelHref('unknown', 'qwen', true), null);
+});
+
+test('routes a custom model through its inner model type tab', () => {
+  assert.equal(getLaunchModelHref('LLM', 'custom-llm', false), '/launch-model/custom');
+});
+
+test('clears the one-time launch target after the destination reads it', () => {
+  setPendingLaunchModelTarget('embedding', 'bge-m3');
+  const target = peekPendingLaunchModelTarget();
+
+  assert.deepEqual(target, { modelType: 'embedding', modelName: 'bge-m3' });
+  clearPendingLaunchModelTarget(target);
+  assert.equal(peekPendingLaunchModelTarget(), null);
+});
+
+test('moves the target model first without changing remaining order', () => {
+  const models = [{ model_name: 'featured' }, { model_name: 'target' }, { model_name: 'other' }];
+
+  assert.deepEqual(prioritizeModelByName(models, 'target'), [models[1], models[0], models[2]]);
+  assert.deepEqual(
+    models.map((model) => model.model_name),
+    ['featured', 'target', 'other']
+  );
+});

--- a/frontend/src/components/pages/launch-model/navigation-utils.test.mjs
+++ b/frontend/src/components/pages/launch-model/navigation-utils.test.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
   clearPendingLaunchModelTarget,
+  createLatestRequestGuard,
   findModelRegistration,
   getLaunchModelHref,
   getSuccessfulRegistrationGroups,
@@ -9,6 +10,28 @@ import {
   prioritizeModelByName,
   setPendingLaunchModelTarget,
 } from './navigation-utils.mjs';
+
+test('allows only the latest overlapping request to apply', async () => {
+  const guard = createLatestRequestGuard();
+  const applied = [];
+  let finishFirst = () => {};
+  const firstCompletion = new Promise((resolve) => {
+    finishFirst = resolve;
+  });
+  const applyAfter = async (name, completion) => {
+    const requestId = guard.start();
+    await completion;
+    if (guard.isLatest(requestId)) applied.push(name);
+  };
+
+  const first = applyAfter('first', firstCompletion);
+  const second = applyAfter('second', Promise.resolve());
+  await second;
+  finishFirst();
+  await first;
+
+  assert.deepEqual(applied, ['second']);
+});
 
 test('keeps registration groups from successful requests', async () => {
   const successfulGroup = { modelType: 'LLM', registrations: [] };

--- a/frontend/src/components/pages/launch-model/navigation-utils.test.mjs
+++ b/frontend/src/components/pages/launch-model/navigation-utils.test.mjs
@@ -4,10 +4,21 @@ import {
   clearPendingLaunchModelTarget,
   findModelRegistration,
   getLaunchModelHref,
+  getSuccessfulRegistrationGroups,
   peekPendingLaunchModelTarget,
   prioritizeModelByName,
   setPendingLaunchModelTarget,
 } from './navigation-utils.mjs';
+
+test('keeps registration groups from successful requests', async () => {
+  const successfulGroup = { modelType: 'LLM', registrations: [] };
+  const results = await Promise.allSettled([
+    Promise.resolve(successfulGroup),
+    Promise.reject(new Error('unsupported model type')),
+  ]);
+
+  assert.deepEqual(getSuccessfulRegistrationGroups(results), [successfulGroup]);
+});
 
 test('finds a model type from existing registration lists', () => {
   assert.deepEqual(
@@ -24,6 +35,23 @@ test('finds a model type from existing registration lists', () => {
     { modelType: 'embedding', isBuiltin: false }
   );
   assert.equal(findModelRegistration([], 'missing'), null);
+});
+
+test('skips malformed registration lists and entries', () => {
+  assert.deepEqual(
+    findModelRegistration(
+      [
+        { modelType: 'LLM', registrations: null },
+        { modelType: 'embedding', registrations: { model_name: 'bge-m3' } },
+        {
+          modelType: 'rerank',
+          registrations: [null, { model_name: 'bge-reranker', is_builtin: true }],
+        },
+      ],
+      'bge-reranker'
+    ),
+    { modelType: 'rerank', isBuiltin: true }
+  );
 });
 
 test('builds a launch deep link for a built-in model type', () => {

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -68,6 +68,7 @@ const en = {
     downloadInterruptedHint:
       'The download was interrupted unexpectedly. Existing cache files were preserved; resume to continue.',
     deleteCacheFailed: 'Failed to delete model cache',
+    resolveModelTypeFailed: 'Failed to find the model type',
     cancelCacheDownloadConfirm:
       'Cancel the download of model {{model}} and remove this task? Downloaded files will be kept for reuse.',
     deleteDownloadConfirm:

--- a/frontend/src/i18n/locales/ja.ts
+++ b/frontend/src/i18n/locales/ja.ts
@@ -68,6 +68,7 @@ const ja = {
     downloadInterruptedHint:
       'ダウンロードが異常終了しました。既存キャッシュは保持されています。「ダウンロードを再開」で続行できます。',
     deleteCacheFailed: 'モデルキャッシュを削除できませんでした',
+    resolveModelTypeFailed: 'モデルタイプを特定できませんでした',
     cancelCacheDownloadConfirm:
       'モデル {{model}} のダウンロードをキャンセルしてタスクを削除しますか？ダウンロード済みファイルは再利用のため保持されます。',
     deleteDownloadConfirm:

--- a/frontend/src/i18n/locales/ko.ts
+++ b/frontend/src/i18n/locales/ko.ts
@@ -68,6 +68,7 @@ const ko = {
     downloadInterruptedHint:
       '다운로드가 비정상적으로 중단되었습니다. 기존 캐시는 보존되며 다운로드를 재개할 수 있습니다.',
     deleteCacheFailed: '모델 캐시를 삭제하지 못했습니다',
+    resolveModelTypeFailed: '모델 유형을 찾지 못했습니다',
     cancelCacheDownloadConfirm:
       '모델 {{model}} 다운로드를 취소하고 작업을 삭제하시겠습니까? 다운로드된 파일은 재사용을 위해 유지됩니다.',
     deleteDownloadConfirm:

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -67,6 +67,7 @@ const zh = {
     resumeDownloadSuccess: '已恢复下载',
     downloadInterruptedHint: '下载被异常中断，已有缓存已保留，可点击“恢复下载”继续。',
     deleteCacheFailed: '删除模型缓存失败',
+    resolveModelTypeFailed: '未找到对应的模型类型',
     cancelCacheDownloadConfirm:
       '确定取消模型 {{model}} 的下载并删除该下载任务吗？已下载的文件会保留以便再次下载时复用。',
     deleteDownloadConfirm:


### PR DESCRIPTION
## Summary

- Add a launch shortcut to the operation column for completed model caches.
- Resolve the model type by comparing `model_name` against existing model registration list APIs.
- Navigate to the corresponding launch-model tab and move the target model card to the first position.
- Open the existing deployment dialog for the target model.
- Use one-time in-memory navigation state to keep the URL clean and prevent the dialog from reopening after refresh.

<img width="1679" height="497" alt="89c8b5e583f467b98b7a435cf9c16714" src="https://github.com/user-attachments/assets/f7bd3f24-b166-41fc-aa82-9fef8dba66c3" />
