### PR TITLE
fix(transformers): support legacy cache conversion

### DIFF
--- a/xinference/model/llm/transformers/tests/test_cache_compatibility.py
+++ b/xinference/model/llm/transformers/tests/test_cache_compatibility.py
@@ -17,6 +17,7 @@ import pytest
 import torch
 from transformers import DynamicCache, LlamaConfig
 
+from .. import utils as transformers_utils
 from ..core import PytorchModel
 from ..utils import (
     convert_to_cache_cls,
@@ -95,6 +96,28 @@ def test_convert_to_cache_cls_supports_tuple_and_list_legacy_cache():
         converted_key, converted_value = get_kv_cache_layer(converted, 0)
         torch.testing.assert_close(converted_key, key)
         torch.testing.assert_close(converted_value, value)
+
+
+def test_convert_to_cache_cls_falls_back_to_update(monkeypatch):
+    key = torch.ones((2, 2, 3, 4))
+    value = torch.ones((2, 2, 3, 4))
+
+    class _DynamicCache:
+        def __init__(self):
+            self.layers = []
+
+        def update(self, key_states, value_states, layer_idx):
+            assert layer_idx == len(self.layers)
+            self.layers.append((key_states, value_states))
+
+    monkeypatch.setattr(transformers_utils, "DynamicCache", _DynamicCache)
+
+    converted = transformers_utils.convert_to_cache_cls(((key, value),))
+
+    assert isinstance(converted, _DynamicCache)
+    converted_key, converted_value = converted.layers[0]
+    torch.testing.assert_close(converted_key, key)
+    torch.testing.assert_close(converted_value, value)
 
 
 def test_empty_cache_layers_are_reported_without_indexing_failures():

--- a/xinference/model/llm/transformers/tests/test_cache_compatibility.py
+++ b/xinference/model/llm/transformers/tests/test_cache_compatibility.py
@@ -18,7 +18,11 @@ import torch
 from transformers import DynamicCache, LlamaConfig
 
 from ..core import PytorchModel
-from ..utils import get_batch_size_and_seq_len_from_kv_cache, get_kv_cache_layer
+from ..utils import (
+    convert_to_cache_cls,
+    get_batch_size_and_seq_len_from_kv_cache,
+    get_kv_cache_layer,
+)
 
 _HAS_LAYER_BASED_CACHE = hasattr(DynamicCache(), "layers")
 
@@ -78,6 +82,19 @@ def test_get_batch_size_supports_legacy_and_layer_cache_layouts():
     assert get_batch_size_and_seq_len_from_kv_cache(
         legacy_cache_with_skipped_layer, model
     ) == (4, 6)
+
+
+def test_convert_to_cache_cls_supports_tuple_and_list_legacy_cache():
+    key = torch.ones((2, 2, 3, 4))
+    value = torch.ones((2, 2, 3, 4))
+
+    for legacy_cache in (((key, value),), [(key, value)]):
+        converted = convert_to_cache_cls(legacy_cache)
+
+        assert isinstance(converted, DynamicCache)
+        converted_key, converted_value = get_kv_cache_layer(converted, 0)
+        torch.testing.assert_close(converted_key, key)
+        torch.testing.assert_close(converted_value, value)
 
 
 def test_empty_cache_layers_are_reported_without_indexing_failures():

--- a/xinference/model/llm/transformers/utils.py
+++ b/xinference/model/llm/transformers/utils.py
@@ -271,7 +271,13 @@ def convert_to_cache_cls(cache) -> DynamicCache:
     if isinstance(cache, (tuple, list)):
         if hasattr(DynamicCache, "from_legacy_cache"):
             return DynamicCache.from_legacy_cache(cache)
-        return DynamicCache(ddp_cache_data=cache)
+        try:
+            return DynamicCache(ddp_cache_data=cache)
+        except TypeError:
+            cache_obj = DynamicCache()
+            for layer_idx, (key, value) in enumerate(cache):
+                cache_obj.update(key, value, layer_idx)
+            return cache_obj
     return cache
 
 

--- a/xinference/model/llm/transformers/utils.py
+++ b/xinference/model/llm/transformers/utils.py
@@ -260,11 +260,18 @@ def get_batch_size_and_seq_len_from_kv_cache(kv, xinf_model_obj: "PytorchModel")
 
 
 def convert_to_cache_cls(cache) -> DynamicCache:
+    """Convert legacy ``past_key_values`` to the active Cache API.
+
+    Transformers releases before the layer-based Cache API exposed
+    ``DynamicCache.from_legacy_cache``. Newer releases removed that
+    classmethod and accept legacy layer tuples through ``ddp_cache_data``.
+    Support both APIs so model outputs can be passed back into the batching
+    code across supported Transformers versions.
     """
-    Compatible with some old models
-    """
-    if isinstance(cache, tuple):
-        return DynamicCache.from_legacy_cache(cache)
+    if isinstance(cache, (tuple, list)):
+        if hasattr(DynamicCache, "from_legacy_cache"):
+            return DynamicCache.from_legacy_cache(cache)
+        return DynamicCache(ddp_cache_data=cache)
     return cache
 
 


### PR DESCRIPTION
## Summary

- support tuple and list legacy `past_key_values` across Transformers Cache API versions
- use `from_legacy_cache` when available and `ddp_cache_data` otherwise
- add compatibility coverage for both legacy container types

## Validation

- `pytest -q xinference/model/llm/transformers/tests/test_cache_compatibility.py`
- `pre-commit run --files xinference/model/llm/transformers/utils.py xinference/model/llm/transformers/tests/test_cache_compatibility.py`
