### PR TITLE
fix(scheduler): isolate batch inference failures

### DIFF
--- a/xinference/model/scheduler/batch.py
+++ b/xinference/model/scheduler/batch.py
@@ -112,11 +112,51 @@ class BatchScheduler:
 
         empty_cache()
 
+    async def _fail_batch_requests(
+        self, req_list: List[InferenceRequest], error: Exception
+    ):
+        """Fail a batch without stopping the scheduler task.
+
+        Requests are removed from the scheduler queues and are completed with
+        an explicit error so a model or cache failure cannot leave callers
+        waiting forever.
+        """
+        error_message = f"Batch inference failed: {error}"
+        failed_requests = set(req_list)
+        self._running_queue = deque(
+            req for req in self._running_queue if req not in failed_requests
+        )
+
+        for req in req_list:
+            req.stopped = True
+            req.error_msg = error_message
+            req.kv_cache = None
+
+            rid = req.request_id
+            if rid is not None:
+                self._id_to_req.pop(rid, None)
+                self._abort_req_ids.discard(rid)
+
+            if req.stream:
+                await req.future_or_queue.put(
+                    XINFERENCE_STREAMING_ERROR_FLAG + error_message
+                )
+            else:
+                future = req.future_or_queue
+                if not future.done():
+                    future.set_exception(RuntimeError(error_message))
+
     async def step(self):
         req_list = self._handle_request()
         if not req_list:
             return
-        self._model.batch_inference(req_list)
+        try:
+            self._model.batch_inference(req_list)
+        except Exception as e:
+            logger.exception("Batch inference failed: %s", e)
+            await self._fail_batch_requests(req_list, e)
+            self._empty_cache()
+            return
 
         stopped_batch_indexes = set()
         for idx, r in enumerate(req_list):
@@ -165,9 +205,16 @@ class BatchScheduler:
         # Some requests have been completed. Batch size needs to be reduced for kv cache.
         if stopped_batch_indexes and len(self._running_queue) > 0:
             kv_cache = self._running_queue[0].kv_cache
-            reduced_kv_cache = self._model.build_reduced_kv_cache(
-                kv_cache, stopped_batch_indexes
-            )
+            active_requests = [r for r in req_list if not r.stopped]
+            try:
+                reduced_kv_cache = self._model.build_reduced_kv_cache(
+                    kv_cache, stopped_batch_indexes
+                )
+            except Exception as e:
+                logger.exception("KV cache reduction failed: %s", e)
+                await self._fail_batch_requests(active_requests, e)
+                self._empty_cache()
+                return
             for r in self._running_queue:
                 r.kv_cache = reduced_kv_cache
 
@@ -205,12 +252,18 @@ class BatchScheduler:
             return AbortRequestMessage.DONE.name
 
     async def _run(self):
-        try:
-            while self._running:
+        while self._running:
+            try:
                 # wait 10ms
                 await asyncio.sleep(0.01)
                 await self.step()
-        except asyncio.CancelledError:
-            logger.debug(f"Scheduler stopped")
-        except Exception as e:
-            logger.exception(f"Scheduler run with error: {e}")
+            except asyncio.CancelledError:
+                logger.debug("Scheduler stopped")
+                raise
+            except Exception as e:
+                # Keep the scheduler alive for subsequent requests. Known
+                # batch failures are handled in step() and complete their
+                # requests explicitly; this is a final guard for unexpected
+                # scheduler errors.
+                logger.exception("Scheduler step failed: %s", e)
+                await asyncio.sleep(0.1)

--- a/xinference/model/scheduler/tests/test_batch_scheduler.py
+++ b/xinference/model/scheduler/tests/test_batch_scheduler.py
@@ -94,8 +94,7 @@ async def test_scheduler_survives_batch_failure(no_empty_cache):
 
     model = FailOnceModel()
     scheduler = BatchScheduler(model)
-    scheduler._running = True
-    task = asyncio.create_task(scheduler._run())
+    await scheduler.start()
     try:
         first = asyncio.get_running_loop().create_future()
         await scheduler.add_request("first", first, "generate", {"request_id": "first"})
@@ -107,12 +106,10 @@ async def test_scheduler_survives_batch_failure(no_empty_cache):
             "second", second, "generate", {"request_id": "second"}
         )
         assert await asyncio.wait_for(second, timeout=1) == {"text": "second"}
-        assert not task.done()
+        assert scheduler._task is not None
+        assert not scheduler._task.done()
     finally:
-        scheduler._running = False
-        task.cancel()
-        with pytest.raises(asyncio.CancelledError):
-            await task
+        await scheduler.stop()
 
 
 @pytest.mark.asyncio

--- a/xinference/model/scheduler/tests/test_batch_scheduler.py
+++ b/xinference/model/scheduler/tests/test_batch_scheduler.py
@@ -1,0 +1,150 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+
+import pytest
+
+from ..batch import BatchScheduler
+from ..core import XINFERENCE_STREAMING_ERROR_FLAG
+
+
+@pytest.fixture
+def no_empty_cache(monkeypatch):
+    monkeypatch.setattr(BatchScheduler, "_empty_cache", staticmethod(lambda: None))
+
+
+@pytest.mark.asyncio
+async def test_batch_inference_failure_completes_non_streaming_request(no_empty_cache):
+    class FailingModel:
+        def get_max_num_seqs(self):
+            return 2
+
+        def batch_inference(self, req_list):
+            raise RuntimeError("cache failure")
+
+    scheduler = BatchScheduler(FailingModel())
+    future = asyncio.get_running_loop().create_future()
+    await scheduler.add_request(
+        "prompt", future, "generate", {"request_id": "cache-failure"}
+    )
+
+    await scheduler.step()
+
+    with pytest.raises(RuntimeError, match="Batch inference failed: cache failure"):
+        await future
+    assert not scheduler._running_queue
+    assert not scheduler._waiting_queue
+    assert not scheduler._id_to_req
+
+
+@pytest.mark.asyncio
+async def test_batch_inference_failure_emits_streaming_error(no_empty_cache):
+    class FailingModel:
+        def get_max_num_seqs(self):
+            return 2
+
+        def batch_inference(self, req_list):
+            raise RuntimeError("model failure")
+
+    scheduler = BatchScheduler(FailingModel())
+    queue = asyncio.Queue()
+    await scheduler.add_request(
+        "prompt",
+        queue,
+        "generate",
+        {"request_id": "stream-failure", "stream": True},
+    )
+
+    await scheduler.step()
+
+    assert await queue.get() == (
+        XINFERENCE_STREAMING_ERROR_FLAG + "Batch inference failed: model failure"
+    )
+    assert not scheduler._id_to_req
+
+
+@pytest.mark.asyncio
+async def test_scheduler_survives_batch_failure(no_empty_cache):
+    class FailOnceModel:
+        def __init__(self):
+            self.failed = False
+
+        def get_max_num_seqs(self):
+            return 2
+
+        def batch_inference(self, req_list):
+            if not self.failed:
+                self.failed = True
+                raise RuntimeError("temporary failure")
+            for req in req_list:
+                req.stopped = True
+                req.completion = [{"text": req.prompt}]
+
+    model = FailOnceModel()
+    scheduler = BatchScheduler(model)
+    scheduler._running = True
+    task = asyncio.create_task(scheduler._run())
+    try:
+        first = asyncio.get_running_loop().create_future()
+        await scheduler.add_request("first", first, "generate", {"request_id": "first"})
+        with pytest.raises(RuntimeError, match="temporary failure"):
+            await asyncio.wait_for(first, timeout=1)
+
+        second = asyncio.get_running_loop().create_future()
+        await scheduler.add_request(
+            "second", second, "generate", {"request_id": "second"}
+        )
+        assert await asyncio.wait_for(second, timeout=1) == {"text": "second"}
+        assert not task.done()
+    finally:
+        scheduler._running = False
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+
+@pytest.mark.asyncio
+async def test_cache_reduction_failure_fails_active_requests(no_empty_cache):
+    class ReductionFailingModel:
+        def get_max_num_seqs(self):
+            return 2
+
+        def batch_inference(self, req_list):
+            completed, active = req_list
+            completed.stopped = True
+            completed.new_tokens.append(1)
+            completed.completion = [{"text": "done"}]
+            active.kv_cache = object()
+
+        def build_reduced_kv_cache(self, cache, skipped_indexes):
+            raise RuntimeError("reduction failure")
+
+    scheduler = BatchScheduler(ReductionFailingModel())
+    completed_future = asyncio.get_running_loop().create_future()
+    active_future = asyncio.get_running_loop().create_future()
+    await scheduler.add_request(
+        "completed", completed_future, "generate", {"request_id": "completed"}
+    )
+    await scheduler.add_request(
+        "active", active_future, "generate", {"request_id": "active"}
+    )
+
+    await scheduler.step()
+
+    assert await completed_future == {"text": "done"}
+    with pytest.raises(RuntimeError, match="Batch inference failed: reduction failure"):
+        await active_future
+    assert not scheduler._running_queue
+    assert not scheduler._id_to_req


### PR DESCRIPTION
## Summary

- complete batch requests with explicit errors when model inference fails
- clean request, queue, abort, and KV-cache bookkeeping after failures
- isolate KV-cache reduction failures and keep the scheduler loop alive
- cover streaming, non-streaming, reduction-failure, and recovery paths with tests

## Validation

- `pytest -q xinference/model/scheduler/tests/test_batch_scheduler.py`
- `pre-commit run --files xinference/model/scheduler/batch.py xinference/model/scheduler/tests/__init__.py xinference/model/scheduler/tests/test_batch_scheduler.py`
