### PR TITLE
fix(transformers): handle multi-device cache reduction

### DIFF
--- a/xinference/model/llm/transformers/core.py
+++ b/xinference/model/llm/transformers/core.py
@@ -998,7 +998,13 @@ class PytorchModel(LLM):
 
         batch_select_indices = getattr(cache, "batch_select_indices", None)
         if batch_select_indices is not None:
-            batch_select_indices(torch.tensor(batch_slices, dtype=torch.long))
+            # A DynamicCache can contain layers on different devices when the
+            # model is loaded with ``device_map="auto"``.  CPU indices are
+            # accepted by PyTorch for tensors on any device and avoid tying
+            # the selection to the device of the first cache layer.
+            batch_select_indices(
+                torch.as_tensor(batch_slices, dtype=torch.long, device="cpu")
+            )
         else:
             for idx in range(len(cache)):
                 key, value = get_kv_cache_layer(cache, idx)

--- a/xinference/model/llm/transformers/tests/test_cache_compatibility.py
+++ b/xinference/model/llm/transformers/tests/test_cache_compatibility.py
@@ -192,7 +192,11 @@ def test_dynamic_cache_reduction_supports_layers_on_multiple_cuda_devices():
         1,
     )
 
-    reduced = model.build_reduced_kv_cache(cache, {1})
+    # Exercise the historical failure mode: without an explicit CPU device,
+    # torch.tensor() follows this non-CPU default and produces indices on
+    # cuda:0, which cannot be used for the cache layer on cuda:1.
+    with torch.device("cuda:0"):
+        reduced = model.build_reduced_kv_cache(cache, {1})
 
     assert [layer.keys.device for layer in reduced.layers] == [
         torch.device("cuda:0"),

--- a/xinference/model/llm/transformers/tests/test_cache_compatibility.py
+++ b/xinference/model/llm/transformers/tests/test_cache_compatibility.py
@@ -172,3 +172,31 @@ def test_merge_preserves_sliding_cache_state_and_shared_layers():
         shared_key[:, :, 1:],
         torch.full((1, 2, 2, 4), 2, dtype=torch.float32),
     )
+
+
+@pytest.mark.skipif(
+    torch.cuda.device_count() < 2,
+    reason="requires at least two CUDA devices",
+)
+def test_dynamic_cache_reduction_supports_layers_on_multiple_cuda_devices():
+    model = _model_for_cache_tests()
+    cache = DynamicCache(
+        ddp_cache_data=[
+            (
+                torch.ones((3, 2, 4, 4), device="cuda:0"),
+                torch.ones((3, 2, 4, 4), device="cuda:0"),
+            ),
+            (
+                torch.ones((3, 2, 4, 4), device="cuda:1"),
+                torch.ones((3, 2, 4, 4), device="cuda:1"),
+            ),
+        ]
+    )
+
+    reduced = model.build_reduced_kv_cache(cache, {1})
+
+    assert [layer.keys.device for layer in reduced.layers] == [
+        torch.device("cuda:0"),
+        torch.device("cuda:1"),
+    ]
+    assert all(layer.keys.shape[0] == 2 for layer in reduced.layers)

--- a/xinference/model/llm/transformers/tests/test_cache_compatibility.py
+++ b/xinference/model/llm/transformers/tests/test_cache_compatibility.py
@@ -175,22 +175,21 @@ def test_merge_preserves_sliding_cache_state_and_shared_layers():
 
 
 @pytest.mark.skipif(
-    torch.cuda.device_count() < 2,
-    reason="requires at least two CUDA devices",
+    torch.cuda.device_count() < 2 or not _HAS_LAYER_BASED_CACHE,
+    reason="requires at least two CUDA devices and layer-based DynamicCache",
 )
 def test_dynamic_cache_reduction_supports_layers_on_multiple_cuda_devices():
     model = _model_for_cache_tests()
-    cache = DynamicCache(
-        ddp_cache_data=[
-            (
-                torch.ones((3, 2, 4, 4), device="cuda:0"),
-                torch.ones((3, 2, 4, 4), device="cuda:0"),
-            ),
-            (
-                torch.ones((3, 2, 4, 4), device="cuda:1"),
-                torch.ones((3, 2, 4, 4), device="cuda:1"),
-            ),
-        ]
+    cache = DynamicCache()
+    cache.update(
+        torch.ones((3, 2, 4, 4), device="cuda:0"),
+        torch.ones((3, 2, 4, 4), device="cuda:0"),
+        0,
+    )
+    cache.update(
+        torch.ones((3, 2, 4, 4), device="cuda:1"),
+        torch.ones((3, 2, 4, 4), device="cuda:1"),
+        1,
     )
 
     reduced = model.build_reduced_kv_cache(cache, {1})


### PR DESCRIPTION
## Summary

- make DynamicCache batch-selection indices explicitly CPU-resident
- avoid tying cache reduction to the device of the first cache layer when layers are distributed by `device_map="auto"`
- add a regression test for DynamicCache layers spread across multiple CUDA devices

## Validation

- `pytest -q xinference/model/llm/transformers/tests/test_cache_compatibility.py` (`6 passed, 1 skipped` locally; the CUDA regression test was skipped because this environment has fewer than two CUDA devices)
- `pre-commit run --files xinference/model/llm/transformers/core.py xinference/model/llm/transformers/tests/test_cache_compatibility.py`
