### PR TITLE
feat(ui): select sole available model engine

### DIFF
--- a/frontend/src/components/pages/launch-model/launch-dialog/launch-dialog.tsx
+++ b/frontend/src/components/pages/launch-model/launch-dialog/launch-dialog.tsx
@@ -181,10 +181,18 @@ export default function LaunchDialog({
 
     setModelEngineMap({});
 
-    const res = await request.get(url);
+    const res = await request.get<ModelEngine>(url);
 
-    setModelEngineMap(res || {});
-  }, [isLLM, model?.model_name, modelType]);
+    const engineMap = res || {};
+    setModelEngineMap(engineMap);
+
+    const availableEngines = Object.entries(engineMap).filter(([, engineData]) =>
+      Array.isArray(engineData)
+    );
+    if (availableEngines.length === 1) {
+      form.setFieldValue('model_engine', availableEngines[0][0]);
+    }
+  }, [form, isLLM, model?.model_name, modelType]);
 
   const engineIndex = useMemo(() => buildEngineIndex(modelEngineMap), [modelEngineMap]);
   const cacheIndex = useMemo(() => {

--- a/frontend/src/components/pages/launch-model/launch-dialog/launch-dialog.tsx
+++ b/frontend/src/components/pages/launch-model/launch-dialog/launch-dialog.tsx
@@ -190,7 +190,10 @@ export default function LaunchDialog({
       Array.isArray(engineData)
     );
     if (availableEngines.length === 1) {
-      form.setFieldValue('model_engine', availableEngines[0][0]);
+      const soleEngine = availableEngines[0][0];
+      if (form.getFieldValue('model_engine') !== soleEngine) {
+        form.setFieldValue('model_engine', soleEngine);
+      }
     }
   }, [form, isLLM, model?.model_name, modelType]);
 

--- a/frontend/src/components/pages/launch-model/launch-dialog/launch-dialog.tsx
+++ b/frontend/src/components/pages/launch-model/launch-dialog/launch-dialog.tsx
@@ -135,6 +135,7 @@ export default function LaunchDialog({
   const cacheUidRef = useRef<string | undefined>(undefined);
   const isCanceledLaunchRef = useRef(false);
   const isCanceledDownloadRef = useRef(false);
+  const modelEngineRequestIdRef = useRef(0);
   const isLLM = modelType === ModelType.LLM;
   const [modelEngineMap, setModelEngineMap] = useState<ModelEngine>({});
   const launchFormValues = useFormValues(form);
@@ -170,6 +171,8 @@ export default function LaunchDialog({
     }
   }, [clusterAuth?.auth, isAdmin, t]);
   const fetchModelEngine = useCallback(async () => {
+    const requestId = ++modelEngineRequestIdRef.current;
+
     if (!model?.model_name || !MODEL_ENGINE_TYPES.includes(modelType)) {
       setModelEngineMap({});
       return;
@@ -182,6 +185,8 @@ export default function LaunchDialog({
     setModelEngineMap({});
 
     const res = await request.get<ModelEngine>(url);
+
+    if (requestId !== modelEngineRequestIdRef.current) return;
 
     const engineMap = res || {};
     setModelEngineMap(engineMap);
@@ -1805,6 +1810,7 @@ export default function LaunchDialog({
   };
 
   const handleClose = () => {
+    modelEngineRequestIdRef.current += 1;
     setLoading(false);
     setIsDownloading(false);
     setCanceling(false);
@@ -1824,6 +1830,10 @@ export default function LaunchDialog({
       fetchModelEngine();
       fetchWorkers();
     }
+
+    return () => {
+      modelEngineRequestIdRef.current += 1;
+    };
   }, [fetchModelEngine, fetchWorkers, isOpen]);
 
   useEffect(() => {


### PR DESCRIPTION
## What do these changes do?

Automatically select the model engine when the launch dialog opens and exactly one engine is available.

Unavailable engines are excluded from the available engine count. When multiple engines are available, the existing selection behavior remains unchanged.
