### PR TITLE
fix(security): report bans lifted, not records dropped, from bulk unban

### DIFF
--- a/xinference/api/oauth2/advanced/rate_limiter.py
+++ b/xinference/api/oauth2/advanced/rate_limiter.py
@@ -84,6 +84,12 @@ class RateLimiter:
             for k in stale_keys:
                 del records[k]
 
+    @staticmethod
+    def _count_banned(records: Dict) -> int:
+        """How many of these records are under an active ban. Must hold self._lock."""
+        now = time.time()
+        return sum(1 for r in records.values() if r.banned_until > now)
+
     def _update_ban_gauges(self) -> None:
         try:
             from ....core.metrics import banned_ips_total, banned_keys_total
@@ -263,7 +269,12 @@ class RateLimiter:
 
     def unban_all_ips(self) -> int:
         with self._lock:
-            count = len(self._ip_records)
+            # Count the bans lifted, not the records dropped: _ip_records also
+            # holds every IP with a failure short of the ban threshold, and an
+            # expired ban that nothing has read since. Those were never banned,
+            # so reporting them makes the admin response read far higher than
+            # get_banned_ips() shows.
+            count = self._count_banned(self._ip_records)
             self._ip_records.clear()
             self._update_ban_gauges()
         return count
@@ -277,7 +288,7 @@ class RateLimiter:
 
     def unban_all_keys(self) -> int:
         with self._lock:
-            count = len(self._key_records)
+            count = self._count_banned(self._key_records)
             self._key_records.clear()
             self._update_ban_gauges()
         return count
@@ -287,8 +298,10 @@ class RateLimiter:
 
     def unban_key_all(self, key_id: int) -> int:
         with self._lock:
+            now = time.time()
             to_remove = [k for k in self._key_records if k[1] == key_id]
+            count = sum(1 for k in to_remove if self._key_records[k].banned_until > now)
             for k in to_remove:
                 del self._key_records[k]
             self._update_ban_gauges()
-        return len(to_remove)
+        return count

--- a/xinference/api/tests/test_rate_limiter_unban_counts.py
+++ b/xinference/api/tests/test_rate_limiter_unban_counts.py
@@ -1,0 +1,75 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""The bulk-unban endpoints report how many bans they lifted.
+
+The record maps also hold IPs and keys that failed without reaching the ban
+threshold, so counting records overstates the answer the admin API returns.
+"""
+
+from ..oauth2.advanced.rate_limiter import RateLimitConfig, RateLimiter
+
+KEY_CONFIG = RateLimitConfig(max_failures=2, window_seconds=300, ban_seconds=600)
+
+
+def _ban_ip(limiter: RateLimiter, ip: str) -> None:
+    for _ in range(limiter._ip_config.max_failures):
+        limiter.record_invalid_key(ip)
+
+
+def _ban_key(limiter: RateLimiter, ip: str, key_id: int) -> None:
+    for _ in range(KEY_CONFIG.max_failures):
+        limiter.record_key_failure(ip, key_id, KEY_CONFIG)
+
+
+def test_unban_all_ips_counts_bans_not_records():
+    limiter = RateLimiter()
+    _ban_ip(limiter, "10.0.0.1")
+    # One failure short of the threshold: recorded, never banned.
+    for _ in range(limiter._ip_config.max_failures - 1):
+        limiter.record_invalid_key("10.0.0.2")
+
+    assert len(limiter.get_banned_ips()) == 1
+    assert limiter.unban_all_ips() == 1
+    assert limiter.get_banned_ips() == []
+
+
+def test_unban_all_ips_ignores_an_expired_ban():
+    limiter = RateLimiter()
+    _ban_ip(limiter, "10.0.0.1")
+    # An expired ban nothing has read back still leaves its record in place.
+    limiter._ip_records["10.0.0.1"].banned_until = 0.0
+
+    assert limiter.get_banned_ips() == []
+    assert limiter.unban_all_ips() == 0
+
+
+def test_unban_all_keys_counts_bans_not_records():
+    limiter = RateLimiter()
+    _ban_key(limiter, "10.0.0.1", 1)
+    limiter.record_key_failure("10.0.0.2", 2, KEY_CONFIG)
+
+    assert len(limiter.get_banned_keys()) == 1
+    assert limiter.unban_all_keys() == 1
+
+
+def test_unban_key_all_counts_bans_not_records():
+    limiter = RateLimiter()
+    _ban_key(limiter, "10.0.0.1", 7)
+    _ban_key(limiter, "10.0.0.2", 7)
+    limiter.record_key_failure("10.0.0.3", 7, KEY_CONFIG)
+    # A different key, banned: neither counted nor removed.
+    _ban_key(limiter, "10.0.0.4", 8)
+
+    assert limiter.unban_key_all(7) == 2
+    assert [ban["key_id"] for ban in limiter.get_banned_keys()] == [8]


### PR DESCRIPTION
## Problem

The bulk-unban endpoints answer with `len()` of the record map:

```python
def unban_all_ips(self) -> int:
    count = len(self._ip_records)
    self._ip_records.clear()
```

But `_ip_records` is not a map of bans. `record_invalid_key` creates an entry on the **first** failure, so the map holds every IP that ever mistyped a key, plus expired bans whose records are only dropped when `is_ip_banned` happens to read them back.

So `POST /unban_all_ips` reports a number far above what `GET /banned_ips` just listed:

```
get_banned_ips()  -> 1 banned IP
_ip_records       -> 2 records          (one IP, one failure short of the threshold)
unban_all_ips()   -> "unbanned": 2      ← should be 1
```

`unban_all_keys` has the same defect. `unban_key_all(key_id)` is the worst of the three: it reports a count scoped to one key id, so the number reads as specific and verifiable when it is neither —

```
two IPs banned on key 7, one more with a single failure
unban_key_all(7) -> 3                   ← should be 2
```

An operator reading "unbanned: 340" after a burst of bad requests cannot tell it from a real ban count, which is the number that matters when judging whether a lockout was working.

## Fix

Count records under an active ban — the same `banned_until > now` predicate `get_banned_ips`, `get_banned_keys` and `_update_ban_gauges` already use — via one small helper. The unban itself is unchanged: every record for the target is still cleared, expired or not.

## Scope

`rate_limiter.py` only: one helper and the three count expressions. No route, no config, no ban decision changes.

## Test plan

- Added: `xinference/api/tests/test_rate_limiter_unban_counts.py` — bulk IP unban, bulk key unban, per-key unban, and an expired ban, each asserting the count matches what `get_banned_*` reports.
- Not run: `pytest` (`xoscar` has no wheel for this host's interpreter and fails to build from source, so `xinference/conftest.py` cannot import).
- Checked: imported `rate_limiter` directly with the same scenarios as the new tests. Before the change `unban_all_ips()` returns 2 against 1 banned IP and `unban_key_all(7)` returns 3 against 2 bans; after it, 1 and 2, with the other key's ban left in place.
- Checked: `black --check` and `isort` clean on both files.
