### PR TITLE
fix(audio): correct F5-TTS logging format

### DIFF
--- a/xinference/model/audio/f5tts.py
+++ b/xinference/model/audio/f5tts.py
@@ -107,9 +107,9 @@ class F5TTSModel:
             ) = preprocess_ref_audio_text(
                 voices[voice]["ref_audio"], voices[voice]["ref_text"]
             )
-            logger.info("Voice:", voice)
-            logger.info("Ref_audio:", voices[voice]["ref_audio"])
-            logger.info("Ref_text:", voices[voice]["ref_text"])
+            logger.info("Voice: %s", voice)
+            logger.info("Ref_audio: %s", voices[voice]["ref_audio"])
+            logger.info("Ref_text: %s", voices[voice]["ref_text"])
 
         final_sample_rate = None
         generated_audio_segments = []


### PR DESCRIPTION
### Description

Three log calls in the F5-TTS voice-preprocessing loop are written in `print()` style, passing the value as a second positional argument to a format string with no placeholder:

```python
logger.info("Voice:", voice)
logger.info("Ref_audio:", voices[voice]["ref_audio"])
logger.info("Ref_text:", voices[voice]["ref_text"])
```

`logging` treats the extra argument as a `%`-format operand, so rendering the record raises:

```
--- Logging error ---
TypeError: not all arguments converted during string formatting
Message: 'Voice:'
Arguments: ('main',)
```

Each call emits a logging error instead of the intended line, and the voice name, reference audio path and reference text never reach the log — which is exactly the information you want when debugging a multi-voice run.

`ruff --select PLE1205` flags all three; the file is clean afterwards.

### Change

Add the missing `%s` to each of the three calls. No behaviour change beyond the lines now actually being logged.
