### PR TITLE
BUG: Merge engine capabilities across workers

### DIFF
--- a/doc/source/getting_started/using_xinference.rst
+++ b/doc/source/getting_started/using_xinference.rst
@@ -135,6 +135,12 @@ is closely related to the inference engine.
 You can use ``xinference engine`` command to query the combination of parameters of the model you want to launch.
 This will demonstrate under what conditions a model can run on which inference engines.
 
+For LLM, embedding and rerank models, engine discovery combines results from all registered workers.
+Engine names and parameter combinations retain their first-seen order, with duplicate combinations
+removed; an available engine takes precedence over another worker's unavailability message. Empty
+worker results are skipped, and local discovery is used if all results are empty. A worker query
+error fails the request instead of returning an incomplete capability list.
+
 For example:
 
 #. I would like to query about which inference engines the ``qwen-chat`` model can run on, and what are their respective parameters.

--- a/doc/source/locale/de/LC_MESSAGES/getting_started/using_xinference.po
+++ b/doc/source/locale/de/LC_MESSAGES/getting_started/using_xinference.po
@@ -658,3 +658,7 @@ msgstr ""
 #~ "xprobe/xinference:<your_version>-cu129 xinference-local -H 0.0.0.0 --log-"
 #~ "level debug"
 #~ msgstr ""
+
+#: ../../source/getting_started/using_xinference.rst:138
+msgid "For LLM, embedding and rerank models, engine discovery combines results from all registered workers. Engine names and parameter combinations retain their first-seen order, with duplicate combinations removed; an available engine takes precedence over another worker's unavailability message. Empty worker results are skipped, and local discovery is used if all results are empty. A worker query error fails the request instead of returning an incomplete capability list."
+msgstr "Bei LLM-, Embedding- und Rerank-Modellen werden die Ergebnisse der Engine-Ermittlung aller registrierten Worker zusammengeführt. Engine-Namen und Parameterkombinationen behalten die Reihenfolge ihres ersten Auftretens bei; doppelte Kombinationen werden entfernt. Eine verfügbare Engine hat Vorrang vor der Meldung eines anderen Workers, dass sie nicht verfügbar ist. Leere Worker-Ergebnisse werden übersprungen. Sind alle Ergebnisse leer, wird die lokale Engine-Ermittlung verwendet. Ein Fehler bei der Abfrage eines Workers lässt die Anfrage fehlschlagen, statt eine unvollständige Liste der Fähigkeiten zurückzugeben."

--- a/doc/source/locale/es/LC_MESSAGES/getting_started/using_xinference.po
+++ b/doc/source/locale/es/LC_MESSAGES/getting_started/using_xinference.po
@@ -650,3 +650,7 @@ msgstr ""
 #~ "xprobe/xinference:<your_version>-cu129 xinference-local -H 0.0.0.0 --log-"
 #~ "level debug"
 #~ msgstr ""
+
+#: ../../source/getting_started/using_xinference.rst:138
+msgid "For LLM, embedding and rerank models, engine discovery combines results from all registered workers. Engine names and parameter combinations retain their first-seen order, with duplicate combinations removed; an available engine takes precedence over another worker's unavailability message. Empty worker results are skipped, and local discovery is used if all results are empty. A worker query error fails the request instead of returning an incomplete capability list."
+msgstr "Para los modelos LLM, de embeddings y de reranking, la consulta de motores combina los resultados de todos los workers registrados. Los nombres de los motores y las combinaciones de parámetros conservan el orden de su primera aparición y se eliminan las combinaciones duplicadas; un motor disponible tiene prioridad sobre el mensaje de otro worker que indique que no está disponible. Se omiten los resultados vacíos y, si todos están vacíos, se realiza la consulta local. Si falla la consulta a un worker, la solicitud falla en lugar de devolver una lista incompleta de capacidades."

--- a/doc/source/locale/fr/LC_MESSAGES/getting_started/using_xinference.po
+++ b/doc/source/locale/fr/LC_MESSAGES/getting_started/using_xinference.po
@@ -652,3 +652,7 @@ msgstr ":ref:`Choisir le bon moteur d'inférence <user_guide_backends>`"
 #~ "xprobe/xinference:<your_version>-cu129 xinference-local -H 0.0.0.0 --log-"
 #~ "level debug"
 #~ msgstr ""
+
+#: ../../source/getting_started/using_xinference.rst:138
+msgid "For LLM, embedding and rerank models, engine discovery combines results from all registered workers. Engine names and parameter combinations retain their first-seen order, with duplicate combinations removed; an available engine takes precedence over another worker's unavailability message. Empty worker results are skipped, and local discovery is used if all results are empty. A worker query error fails the request instead of returning an incomplete capability list."
+msgstr "Pour les modèles LLM, d'embedding et de reranking, la découverte des moteurs combine les résultats de tous les workers enregistrés. Les noms des moteurs et les combinaisons de paramètres conservent leur ordre de première apparition, sans combinaisons en double ; un moteur disponible prévaut sur le message d'un autre worker indiquant son indisponibilité. Les résultats vides sont ignorés et, si tous les résultats sont vides, la découverte locale est utilisée. Une erreur lors de l'interrogation d'un worker fait échouer la requête au lieu de renvoyer une liste incomplète des capacités."

--- a/doc/source/locale/it/LC_MESSAGES/getting_started/using_xinference.po
+++ b/doc/source/locale/it/LC_MESSAGES/getting_started/using_xinference.po
@@ -652,3 +652,7 @@ msgstr ""
 #~ "xprobe/xinference:<your_version>-cu129 xinference-local -H 0.0.0.0 --log-"
 #~ "level debug"
 #~ msgstr ""
+
+#: ../../source/getting_started/using_xinference.rst:138
+msgid "For LLM, embedding and rerank models, engine discovery combines results from all registered workers. Engine names and parameter combinations retain their first-seen order, with duplicate combinations removed; an available engine takes precedence over another worker's unavailability message. Empty worker results are skipped, and local discovery is used if all results are empty. A worker query error fails the request instead of returning an incomplete capability list."
+msgstr "Per i modelli LLM, di embedding e di reranking, la ricerca dei motori combina i risultati di tutti i worker registrati. I nomi dei motori e le combinazioni di parametri mantengono il loro ordine di prima apparizione, eliminando le combinazioni duplicate; un motore disponibile ha la precedenza sul messaggio di un altro worker che ne segnala la mancata disponibilità. I risultati vuoti vengono ignorati e, se sono tutti vuoti, viene eseguita la ricerca locale. Un errore nella richiesta a un worker fa fallire la richiesta anziché restituire un elenco incompleto delle funzionalità disponibili."

--- a/doc/source/locale/ja/LC_MESSAGES/getting_started/using_xinference.po
+++ b/doc/source/locale/ja/LC_MESSAGES/getting_started/using_xinference.po
@@ -571,3 +571,7 @@ msgstr ":ref:`正しい推論エンジンを選択する <user_guide_backends>`"
 #~ "xprobe/xinference:<your_version>-cu129 xinference-local -H 0.0.0.0 --log-"
 #~ "level debug"
 #~ msgstr ""
+
+#: ../../source/getting_started/using_xinference.rst:138
+msgid "For LLM, embedding and rerank models, engine discovery combines results from all registered workers. Engine names and parameter combinations retain their first-seen order, with duplicate combinations removed; an available engine takes precedence over another worker's unavailability message. Empty worker results are skipped, and local discovery is used if all results are empty. A worker query error fails the request instead of returning an incomplete capability list."
+msgstr "LLM、embedding、rerank モデルのエンジン検出では、登録されているすべての worker の結果を統合します。エンジン名とパラメーターの組み合わせは最初に出現した順序を保ち、重複する組み合わせは削除されます。利用可能なエンジンの情報は、別の worker が返す利用不可のメッセージより優先されます。空の結果はスキップされ、すべての結果が空の場合はローカルでエンジンを検出します。worker への問い合わせでエラーが発生した場合、不完全な機能一覧を返すのではなく、リクエストが失敗します。"

--- a/doc/source/locale/ko/LC_MESSAGES/getting_started/using_xinference.po
+++ b/doc/source/locale/ko/LC_MESSAGES/getting_started/using_xinference.po
@@ -578,3 +578,7 @@ msgstr ":ref:`올바른 추론 엔진 선택 <user_guide_backends>`"
 #~ "xprobe/xinference:<your_version>-cu129 xinference-local -H 0.0.0.0 --log-"
 #~ "level debug"
 #~ msgstr ""
+
+#: ../../source/getting_started/using_xinference.rst:138
+msgid "For LLM, embedding and rerank models, engine discovery combines results from all registered workers. Engine names and parameter combinations retain their first-seen order, with duplicate combinations removed; an available engine takes precedence over another worker's unavailability message. Empty worker results are skipped, and local discovery is used if all results are empty. A worker query error fails the request instead of returning an incomplete capability list."
+msgstr "LLM, embedding, rerank 모델의 엔진 검색은 등록된 모든 worker의 결과를 통합합니다. 엔진 이름과 매개변수 조합은 처음 나타난 순서를 유지하며 중복 조합은 제거됩니다. 사용 가능한 엔진 정보는 다른 worker의 사용 불가 메시지보다 우선합니다. 빈 결과는 건너뛰고, 모든 결과가 비어 있으면 로컬에서 엔진을 검색합니다. worker 조회 중 오류가 발생하면 불완전한 기능 목록을 반환하는 대신 요청이 실패합니다."

--- a/doc/source/locale/pt_BR/LC_MESSAGES/getting_started/using_xinference.po
+++ b/doc/source/locale/pt_BR/LC_MESSAGES/getting_started/using_xinference.po
@@ -646,3 +646,7 @@ msgstr ""
 #~ "xprobe/xinference:<your_version>-cu129 xinference-local -H 0.0.0.0 --log-"
 #~ "level debug"
 #~ msgstr ""
+
+#: ../../source/getting_started/using_xinference.rst:138
+msgid "For LLM, embedding and rerank models, engine discovery combines results from all registered workers. Engine names and parameter combinations retain their first-seen order, with duplicate combinations removed; an available engine takes precedence over another worker's unavailability message. Empty worker results are skipped, and local discovery is used if all results are empty. A worker query error fails the request instead of returning an incomplete capability list."
+msgstr "Para modelos LLM, de embedding e de reranking, a descoberta de motores combina os resultados de todos os workers registrados. Os nomes dos motores e as combinações de parâmetros mantêm a ordem da primeira ocorrência, removendo combinações duplicadas; um motor disponível tem prioridade sobre a mensagem de outro worker que indique sua indisponibilidade. Resultados vazios são ignorados e, se todos estiverem vazios, a descoberta local é utilizada. Um erro na consulta a um worker faz a solicitação falhar, em vez de retornar uma lista incompleta de capacidades."

--- a/doc/source/locale/zh_CN/LC_MESSAGES/getting_started/using_xinference.po
+++ b/doc/source/locale/zh_CN/LC_MESSAGES/getting_started/using_xinference.po
@@ -579,3 +579,7 @@ msgstr ":ref:`选择正确的推理引擎 <user_guide_backends>` "
 #~ "xprobe/xinference:<your_version>-cu129 xinference-local"
 #~ " -H 0.0.0.0 --log-level debug"
 #~ msgstr ""
+
+#: ../../source/getting_started/using_xinference.rst:138
+msgid "For LLM, embedding and rerank models, engine discovery combines results from all registered workers. Engine names and parameter combinations retain their first-seen order, with duplicate combinations removed; an available engine takes precedence over another worker's unavailability message. Empty worker results are skipped, and local discovery is used if all results are empty. A worker query error fails the request instead of returning an incomplete capability list."
+msgstr "对于 LLM、embedding 和 rerank 模型，引擎查询会合并所有已注册 worker 的结果。引擎名称和参数组合按首次出现的顺序排列，并去除重复组合；可用引擎的信息优先于其他 worker 返回的不可用提示。空结果会被跳过；如果所有结果均为空，则执行本地引擎查询。如果查询某个 worker 时出错，请求会失败，而不会返回不完整的能力列表。"

--- a/doc/source/locale/zh_TW/LC_MESSAGES/getting_started/using_xinference.po
+++ b/doc/source/locale/zh_TW/LC_MESSAGES/getting_started/using_xinference.po
@@ -548,3 +548,7 @@ msgstr ":ref:`選擇正確的推理引擎 <user_guide_backends>`"
 #~ "xprobe/xinference:<your_version>-cu129 xinference-local -H 0.0.0.0 --log-"
 #~ "level debug"
 #~ msgstr ""
+
+#: ../../source/getting_started/using_xinference.rst:138
+msgid "For LLM, embedding and rerank models, engine discovery combines results from all registered workers. Engine names and parameter combinations retain their first-seen order, with duplicate combinations removed; an available engine takes precedence over another worker's unavailability message. Empty worker results are skipped, and local discovery is used if all results are empty. A worker query error fails the request instead of returning an incomplete capability list."
+msgstr "對於 LLM、embedding 和 rerank 模型，引擎查詢會合併所有已註冊 worker 的結果。引擎名稱和參數組合按首次出現的順序排列，並移除重複組合；可用引擎的資訊優先於其他 worker 傳回的不可用提示。空結果會被略過；如果所有結果皆為空，則執行本機引擎查詢。如果查詢某個 worker 時發生錯誤，請求會失敗，而不會傳回不完整的能力清單。"

--- a/xinference/core/supervisor.py
+++ b/xinference/core/supervisor.py
@@ -2120,7 +2120,13 @@ class SupervisorActor(xo.StatelessActor):
     ):
         # search in worker first
         workers = list(self._worker_address_to_worker.values())
-        if (model_type or "").lower() in ("audio", "world"):
+        if (model_type or "").lower() in (
+            "llm",
+            "embedding",
+            "rerank",
+            "audio",
+            "world",
+        ):
             worker_results = await asyncio.gather(
                 *[
                     worker.query_engines_by_model_name(

--- a/xinference/core/tests/test_engine_discovery.py
+++ b/xinference/core/tests/test_engine_discovery.py
@@ -1,0 +1,118 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from ..supervisor import SupervisorActor
+
+
+@pytest.fixture
+def supervisor():
+    actor = SupervisorActor.__new__(SupervisorActor)
+    actor._worker_address_to_worker = {}
+    return actor
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model_type", ["LLM", "embedding", "rerank", "audio", "world"])
+@pytest.mark.parametrize("reverse_workers", [False, True])
+async def test_merge_heterogeneous_worker_engines(
+    supervisor, model_type, reverse_workers
+):
+    pytorch = {"model_format": "pytorch", "quantizations": ["none"]}
+    quantized = {"model_format": "pytorch", "quantizations": ["int8"]}
+    gpu = SimpleNamespace(
+        query_engines_by_model_name=AsyncMock(
+            return_value={"transformers": [pytorch], "MindIE": "Not installed"}
+        )
+    )
+    npu = SimpleNamespace(
+        query_engines_by_model_name=AsyncMock(
+            return_value={"MindIE": [pytorch], "transformers": [pytorch, quantized]}
+        )
+    )
+    missing = SimpleNamespace(query_engines_by_model_name=AsyncMock(return_value=None))
+    workers = [missing, gpu, npu]
+    if reverse_workers:
+        workers.reverse()
+    supervisor._worker_address_to_worker = dict(enumerate(workers))
+
+    with patch("xinference.core.supervisor.get_engine_params_by_name") as fallback:
+        result = await supervisor.query_engines_by_model_name(
+            "mixed-model", model_type=model_type, enable_virtual_env=False
+        )
+        fallback.assert_not_called()
+
+    assert result == {"transformers": [pytorch, quantized], "MindIE": [pytorch]}
+    assert list(result) == (
+        ["MindIE", "transformers"] if reverse_workers else ["transformers", "MindIE"]
+    )
+    for worker in workers:
+        worker.query_engines_by_model_name.assert_awaited_once_with(
+            "mixed-model", model_type=model_type, enable_virtual_env=False
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("worker_results", [[], [None, None], [{}, None]])
+@pytest.mark.parametrize("enable_virtual_env", [False, True])
+async def test_empty_worker_engines_use_local_fallback(
+    supervisor, worker_results, enable_virtual_env
+):
+    supervisor._worker_address_to_worker = {
+        str(index): SimpleNamespace(
+            query_engines_by_model_name=AsyncMock(return_value=result)
+        )
+        for index, result in enumerate(worker_results)
+    }
+    fallback_name = "get_engine_params_by_name"
+    if enable_virtual_env:
+        fallback_name += "_with_virtual_env"
+    with patch(
+        f"xinference.core.supervisor.{fallback_name}", return_value={"local": []}
+    ) as fallback:
+        result = await supervisor.query_engines_by_model_name(
+            "missing-model", model_type="LLM", enable_virtual_env=enable_virtual_env
+        )
+
+    assert result == {"local": []}
+    fallback.assert_called_once_with(
+        "LLM", "missing-model", enable_virtual_env=enable_virtual_env
+    )
+    for worker in supervisor._worker_address_to_worker.values():
+        worker.query_engines_by_model_name.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model_type", ["LLM", "embedding", "rerank"])
+async def test_worker_engine_error_is_not_hidden_by_partial_results(
+    supervisor, model_type
+):
+    supervisor._worker_address_to_worker = {
+        "healthy": SimpleNamespace(
+            query_engines_by_model_name=AsyncMock(return_value={"transformers": []})
+        ),
+        "unavailable": SimpleNamespace(
+            query_engines_by_model_name=AsyncMock(
+                side_effect=RuntimeError("Worker offline")
+            )
+        ),
+    }
+    with pytest.raises(RuntimeError, match="Worker offline"):
+        await supervisor.query_engines_by_model_name(
+            "mixed-model", model_type=model_type, enable_virtual_env=False
+        )

--- a/xinference/core/tests/test_engine_discovery.py
+++ b/xinference/core/tests/test_engine_discovery.py
@@ -30,8 +30,9 @@ def supervisor():
 @pytest.mark.asyncio
 @pytest.mark.parametrize("model_type", ["LLM", "embedding", "rerank", "audio", "world"])
 @pytest.mark.parametrize("reverse_workers", [False, True])
+@pytest.mark.parametrize("enable_virtual_env", [False, True])
 async def test_merge_heterogeneous_worker_engines(
-    supervisor, model_type, reverse_workers
+    supervisor, model_type, reverse_workers, enable_virtual_env
 ):
     pytorch = {"model_format": "pytorch", "quantizations": ["none"]}
     quantized = {"model_format": "pytorch", "quantizations": ["int8"]}
@@ -51,9 +52,12 @@ async def test_merge_heterogeneous_worker_engines(
         workers.reverse()
     supervisor._worker_address_to_worker = dict(enumerate(workers))
 
-    with patch("xinference.core.supervisor.get_engine_params_by_name") as fallback:
+    fallback_name = "get_engine_params_by_name"
+    if enable_virtual_env:
+        fallback_name += "_with_virtual_env"
+    with patch(f"xinference.core.supervisor.{fallback_name}") as fallback:
         result = await supervisor.query_engines_by_model_name(
-            "mixed-model", model_type=model_type, enable_virtual_env=False
+            "mixed-model", model_type=model_type, enable_virtual_env=enable_virtual_env
         )
         fallback.assert_not_called()
 
@@ -63,7 +67,7 @@ async def test_merge_heterogeneous_worker_engines(
     )
     for worker in workers:
         worker.query_engines_by_model_name.assert_awaited_once_with(
-            "mixed-model", model_type=model_type, enable_virtual_env=False
+            "mixed-model", model_type=model_type, enable_virtual_env=enable_virtual_env
         )
 
 
@@ -98,7 +102,7 @@ async def test_empty_worker_engines_use_local_fallback(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("model_type", ["LLM", "embedding", "rerank"])
+@pytest.mark.parametrize("model_type", ["LLM", "embedding", "rerank", "audio", "world"])
 async def test_worker_engine_error_is_not_hidden_by_partial_results(
     supervisor, model_type
 ):


### PR DESCRIPTION
Fixes #5467.

Engine discovery for LLM, embedding and rerank models currently stops at the first worker result. In a heterogeneous cluster, this can omit engines supported by later workers or report them as unavailable.

Extend the existing audio/world aggregation path to these model types. This reuses the current merge helper to preserve first-seen order, deduplicate parameter combinations and prefer available engine parameters over unavailability messages. Empty results retain the local fallback; worker query exceptions propagate rather than returning a partial capability list.

Add focused async regression tests and document the behavior, including the corresponding gettext message in all nine existing locales.

Validation:
- Initial regression tests against the original implementation: 11 failed, 8 passed.
- Focused engine discovery, audio metadata and worker address tests after the fix and review follow-up: 35 passed.
- All configured pre-commit hooks passed for the changed Python files; `git diff --check` passed.
- All nine modified catalogs passed `msgfmt --check --check-format`; `python doc/build_i18n.py --all` completed.
- Scoped Sphinx HTML builds succeeded for English and all nine locales, with the new paragraph verified in each output. Cross-page reference warnings remain in these single-page builds.

No UI, GPU inference or full CI suite was run locally; the regression tests use mocked worker responses and require no models or cluster.

AI assistance: prepared with OpenAI Codex; the validation above was executed locally.
