### PR TITLE
ENH: Add TTS streaming playback to Web UI

### DIFF
--- a/frontend/src/components/pages/running-model-detail/audio-stream.ts
+++ b/frontend/src/components/pages/running-model-detail/audio-stream.ts
@@ -1,0 +1,214 @@
+export interface AudioStreamResult {
+  kind: 'audio-stream';
+  playbackUrl?: string;
+  file?: File;
+  streaming: boolean;
+}
+
+const AUDIO_MIME_TYPES: Record<string, string> = {
+  flac: 'audio/flac',
+  mp3: 'audio/mpeg',
+  ogg: 'audio/ogg',
+  pcm: 'audio/pcm',
+  wav: 'audio/wav',
+};
+
+const MEDIA_SOURCE_MIME_TYPES: Record<string, string[]> = {
+  flac: ['audio/flac'],
+  mp3: ['audio/mpeg'],
+  ogg: ['audio/ogg; codecs="vorbis"', 'audio/ogg'],
+  wav: ['audio/wav; codecs="1"', 'audio/wav'],
+};
+
+function normalizeResponseFormat(responseFormat: string): string {
+  return responseFormat.trim().toLowerCase() || 'mp3';
+}
+
+export function audioMimeType(responseFormat: string): string {
+  const normalizedFormat = normalizeResponseFormat(responseFormat);
+  return AUDIO_MIME_TYPES[normalizedFormat] || `audio/${normalizedFormat}`;
+}
+
+function abortError() {
+  return new DOMException('The audio stream was aborted.', 'AbortError');
+}
+
+function waitForEvent(
+  target: EventTarget,
+  eventName: string,
+  errorEventName: string | undefined,
+  signal: AbortSignal
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal.aborted) {
+      reject(abortError());
+      return;
+    }
+
+    const cleanup = () => {
+      target.removeEventListener(eventName, handleEvent);
+      if (errorEventName) target.removeEventListener(errorEventName, handleError);
+      signal.removeEventListener('abort', handleAbort);
+    };
+    const handleEvent = () => {
+      cleanup();
+      resolve();
+    };
+    const handleError = () => {
+      cleanup();
+      reject(new Error(`Failed while waiting for ${eventName}.`));
+    };
+    const handleAbort = () => {
+      cleanup();
+      reject(abortError());
+    };
+
+    target.addEventListener(eventName, handleEvent, { once: true });
+    if (errorEventName) target.addEventListener(errorEventName, handleError, { once: true });
+    signal.addEventListener('abort', handleAbort, { once: true });
+  });
+}
+
+async function waitForSourceBuffer(sourceBuffer: SourceBuffer, signal: AbortSignal) {
+  if (!sourceBuffer.updating) return;
+  await waitForEvent(sourceBuffer, 'updateend', 'error', signal);
+}
+
+function findMediaSourceMimeType(responseFormat: string): string | undefined {
+  if (typeof window === 'undefined' || typeof window.MediaSource === 'undefined') {
+    return undefined;
+  }
+
+  return MEDIA_SOURCE_MIME_TYPES[normalizeResponseFormat(responseFormat)]?.find((mimeType) =>
+    window.MediaSource.isTypeSupported(mimeType)
+  );
+}
+
+export class AudioStreamSession {
+  private readonly abortController = new AbortController();
+  private readonly mimeType: string;
+  private readonly mediaSourceMimeType?: string;
+  private mediaSource?: MediaSource;
+  private sourceBufferPromise?: Promise<SourceBuffer>;
+  private reader?: ReadableStreamDefaultReader<Uint8Array>;
+  private playbackUrlValue?: string;
+
+  constructor(responseFormat: string) {
+    this.mimeType = audioMimeType(responseFormat);
+    this.mediaSourceMimeType = findMediaSourceMimeType(responseFormat);
+
+    if (this.mediaSourceMimeType) {
+      this.mediaSource = new MediaSource();
+      this.playbackUrlValue = URL.createObjectURL(this.mediaSource);
+    }
+  }
+
+  get signal() {
+    return this.abortController.signal;
+  }
+
+  result(file?: File): AudioStreamResult {
+    return {
+      kind: 'audio-stream',
+      playbackUrl: this.playbackUrlValue,
+      file,
+      streaming: !file,
+    };
+  }
+
+  private async getSourceBuffer(): Promise<SourceBuffer | undefined> {
+    const mediaSource = this.mediaSource;
+    const mediaSourceMimeType = this.mediaSourceMimeType;
+    if (!mediaSource || !mediaSourceMimeType) return undefined;
+
+    if (!this.sourceBufferPromise) {
+      this.sourceBufferPromise = (async () => {
+        if (mediaSource.readyState !== 'open') {
+          await waitForEvent(mediaSource, 'sourceopen', 'error', this.signal);
+        }
+        return mediaSource.addSourceBuffer(mediaSourceMimeType);
+      })();
+    }
+
+    return this.sourceBufferPromise;
+  }
+
+  private disableStreamingPlayback() {
+    const playbackUrl = this.playbackUrlValue;
+    this.playbackUrlValue = undefined;
+    this.mediaSource = undefined;
+    this.sourceBufferPromise = undefined;
+    if (playbackUrl) URL.revokeObjectURL(playbackUrl);
+  }
+
+  private async appendChunk(chunk: ArrayBuffer): Promise<boolean> {
+    try {
+      const sourceBuffer = await this.getSourceBuffer();
+      if (!sourceBuffer) return false;
+
+      await waitForSourceBuffer(sourceBuffer, this.signal);
+      sourceBuffer.appendBuffer(chunk);
+      await waitForSourceBuffer(sourceBuffer, this.signal);
+      return true;
+    } catch (error) {
+      if (this.signal.aborted) throw error;
+      this.disableStreamingPlayback();
+      return false;
+    }
+  }
+
+  private async finishStreamingPlayback() {
+    const mediaSource = this.mediaSource;
+    if (!mediaSource || !this.sourceBufferPromise) return;
+
+    try {
+      const sourceBuffer = await this.sourceBufferPromise;
+      await waitForSourceBuffer(sourceBuffer, this.signal);
+      if (mediaSource.readyState === 'open') mediaSource.endOfStream();
+    } catch (error) {
+      if (this.signal.aborted) throw error;
+      this.disableStreamingPlayback();
+    }
+  }
+
+  async consume(
+    stream: ReadableStream<Uint8Array>,
+    onPlaybackUnavailable?: () => void
+  ): Promise<Blob> {
+    const chunks: ArrayBuffer[] = [];
+    const reader = stream.getReader();
+    this.reader = reader;
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        const chunk = value.slice().buffer as ArrayBuffer;
+        chunks.push(chunk);
+        if (this.mediaSource && !(await this.appendChunk(chunk))) {
+          onPlaybackUnavailable?.();
+        }
+      }
+
+      await this.finishStreamingPlayback();
+      return new Blob(chunks, { type: this.mimeType });
+    } finally {
+      if (this.reader === reader) this.reader = undefined;
+      reader.releaseLock();
+    }
+  }
+
+  dispose() {
+    this.abortController.abort();
+    const reader = this.reader;
+    if (reader) void reader.cancel().catch(() => undefined);
+    this.disableStreamingPlayback();
+  }
+}
+
+export function isAudioStreamResult(value: unknown): value is AudioStreamResult {
+  return (
+    typeof value === 'object' && value !== null && 'kind' in value && value.kind === 'audio-stream'
+  );
+}

--- a/frontend/src/components/pages/running-model-detail/audio-stream.ts
+++ b/frontend/src/components/pages/running-model-detail/audio-stream.ts
@@ -5,6 +5,8 @@ export interface AudioStreamResult {
   streaming: boolean;
 }
 
+const MEDIA_SOURCE_OPEN_TIMEOUT_MS = 5000;
+
 const AUDIO_MIME_TYPES: Record<string, string> = {
   flac: 'audio/flac',
   mp3: 'audio/mpeg',
@@ -37,7 +39,8 @@ function waitForEvent(
   target: EventTarget,
   eventName: string,
   errorEventName: string | undefined,
-  signal: AbortSignal
+  signal: AbortSignal,
+  timeoutMs?: number
 ): Promise<void> {
   return new Promise((resolve, reject) => {
     if (signal.aborted) {
@@ -45,10 +48,13 @@ function waitForEvent(
       return;
     }
 
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
     const cleanup = () => {
       target.removeEventListener(eventName, handleEvent);
       if (errorEventName) target.removeEventListener(errorEventName, handleError);
       signal.removeEventListener('abort', handleAbort);
+      if (timeoutId !== undefined) clearTimeout(timeoutId);
     };
     const handleEvent = () => {
       cleanup();
@@ -66,6 +72,18 @@ function waitForEvent(
     target.addEventListener(eventName, handleEvent, { once: true });
     if (errorEventName) target.addEventListener(errorEventName, handleError, { once: true });
     signal.addEventListener('abort', handleAbort, { once: true });
+
+    if (timeoutMs !== undefined) {
+      timeoutId = setTimeout(() => {
+        cleanup();
+        reject(
+          new DOMException(
+            `Timed out after ${timeoutMs}ms while waiting for ${eventName}.`,
+            'TimeoutError'
+          )
+        );
+      }, timeoutMs);
+    }
   });
 }
 
@@ -90,7 +108,7 @@ export class AudioStreamSession {
   private readonly mediaSourceMimeType?: string;
   private mediaSource?: MediaSource;
   private sourceBufferPromise?: Promise<SourceBuffer>;
-  private reader?: ReadableStreamDefaultReader<Uint8Array>;
+  private reader?: ReadableStreamDefaultReader<Uint8Array<ArrayBuffer>>;
   private playbackUrlValue?: string;
 
   constructor(responseFormat: string) {
@@ -124,7 +142,13 @@ export class AudioStreamSession {
     if (!this.sourceBufferPromise) {
       this.sourceBufferPromise = (async () => {
         if (mediaSource.readyState !== 'open') {
-          await waitForEvent(mediaSource, 'sourceopen', 'error', this.signal);
+          await waitForEvent(
+            mediaSource,
+            'sourceopen',
+            'error',
+            this.signal,
+            MEDIA_SOURCE_OPEN_TIMEOUT_MS
+          );
         }
         return mediaSource.addSourceBuffer(mediaSourceMimeType);
       })();
@@ -141,7 +165,7 @@ export class AudioStreamSession {
     if (playbackUrl) URL.revokeObjectURL(playbackUrl);
   }
 
-  private async appendChunk(chunk: ArrayBuffer): Promise<boolean> {
+  private async appendChunk(chunk: BufferSource): Promise<boolean> {
     try {
       const sourceBuffer = await this.getSourceBuffer();
       if (!sourceBuffer) return false;
@@ -172,10 +196,10 @@ export class AudioStreamSession {
   }
 
   async consume(
-    stream: ReadableStream<Uint8Array>,
+    stream: ReadableStream<Uint8Array<ArrayBuffer>>,
     onPlaybackUnavailable?: () => void
   ): Promise<Blob> {
-    const chunks: ArrayBuffer[] = [];
+    const chunks: Uint8Array<ArrayBuffer>[] = [];
     const reader = stream.getReader();
     this.reader = reader;
 
@@ -184,9 +208,8 @@ export class AudioStreamSession {
         const { done, value } = await reader.read();
         if (done) break;
 
-        const chunk = value.slice().buffer as ArrayBuffer;
-        chunks.push(chunk);
-        if (this.mediaSource && !(await this.appendChunk(chunk))) {
+        chunks.push(value);
+        if (this.mediaSource && !(await this.appendChunk(value))) {
           onPlaybackUnavailable?.();
         }
       }

--- a/frontend/src/components/pages/running-model-detail/capability-config.tsx
+++ b/frontend/src/components/pages/running-model-detail/capability-config.tsx
@@ -821,6 +821,7 @@ export const CAPABILITY_CONFIGS: Partial<Record<ModelAbility, CapabilityConfig>>
         { key: 'voice', value: 'Voice ID', comment: 'Optional' },
         { key: 'speed', value: 1, comment: 'Optional' },
         { key: 'response_format', value: 'mp3', comment: 'Optional' },
+        { key: 'stream', value: false, comment: 'Optional' },
         {
           key: 'kwargs',
           value: { seed: 11 },
@@ -834,6 +835,7 @@ export const CAPABILITY_CONFIGS: Partial<Record<ModelAbility, CapabilityConfig>>
       voice: '',
       speed: 1,
       response_format: 'mp3',
+      stream: false,
       seed: -1,
       prompt_speech: [],
       prompt_text: '',
@@ -843,7 +845,7 @@ export const CAPABILITY_CONFIGS: Partial<Record<ModelAbility, CapabilityConfig>>
     },
     formPanel: SpeechPanel,
     resultPanel: ResultPanels.Universal,
-    responseType: 'blob',
+    responseType: 'audio-stream',
     transformValues: ({ modelUid, model, values }) => {
       const supportsVoiceCloning = model.model_ability.includes(
         ModelAbility.Text2audioVoiceCloning
@@ -855,6 +857,7 @@ export const CAPABILITY_CONFIGS: Partial<Record<ModelAbility, CapabilityConfig>>
       const instruct = stringValue(values.instruct).trim();
       const seed = parseScalarSeed(values.seed);
       const responseFormat = stringValue(values.response_format).trim().toLowerCase() || 'mp3';
+      const stream = booleanValue(values.stream);
 
       if (seed !== undefined) {
         kwargs.seed = seed;
@@ -889,7 +892,7 @@ export const CAPABILITY_CONFIGS: Partial<Record<ModelAbility, CapabilityConfig>>
         formData.append('voice', stringValue(values.voice));
         formData.append('speed', String(numberValue(values.speed, 1)));
         formData.append('response_format', responseFormat);
-        formData.append('stream', 'false');
+        formData.append('stream', String(stream));
         formData.append('prompt_speech', promptSpeech.file);
         appendKwargsIfPresent(formData, kwargs);
         return formData;
@@ -901,7 +904,7 @@ export const CAPABILITY_CONFIGS: Partial<Record<ModelAbility, CapabilityConfig>>
           voice: values.voice || undefined,
           speed: numberValue(values.speed, 1),
           response_format: responseFormat,
-          stream: false,
+          stream,
         },
         kwargs
       );

--- a/frontend/src/components/pages/running-model-detail/panels/capability-task-panel.tsx
+++ b/frontend/src/components/pages/running-model-detail/panels/capability-task-panel.tsx
@@ -28,8 +28,9 @@ import type {
 } from '@/types/services';
 import type { FormValues } from '@/types/form';
 
+import { AudioStreamSession } from '../audio-stream';
 import type { CapabilityConfig } from '../types';
-import { createId } from '../utils';
+import { booleanValue, createId, stringValue } from '../utils';
 
 interface CapabilityTaskPanelProps {
   config: CapabilityConfig;
@@ -64,6 +65,7 @@ const CapabilityTaskPanel = forwardRef<CapabilityTaskPanelMethod, CapabilityTask
     const activeRequestRef = useRef<
       { modelUid: string; requestId: string; runToken: number } | undefined
     >(undefined);
+    const audioStreamRef = useRef<AudioStreamSession | undefined>(undefined);
     const ResultPanel = config.resultPanel;
     const FormPanel = config.formPanel;
     const Icon = config.icon;
@@ -167,7 +169,13 @@ const CapabilityTaskPanel = forwardRef<CapabilityTaskPanelMethod, CapabilityTask
         .catch(() => undefined);
     }, []);
 
+    const disposeAudioStream = useCallback(() => {
+      audioStreamRef.current?.dispose();
+      audioStreamRef.current = undefined;
+    }, []);
+
     const submit = () => {
+      disposeAudioStream();
       const runToken = runTokenRef.current + 1;
       const requestId = config.showProgress ? createId('request') : undefined;
       let finished = false;
@@ -178,23 +186,66 @@ const CapabilityTaskPanel = forwardRef<CapabilityTaskPanelMethod, CapabilityTask
       }
       setLoading(true);
       setProgress(showLiveProgress ? 0 : undefined);
-      setResult(undefined);
-      setResultValues(undefined);
 
       const values = form.getFieldsValue();
+      const streamAudio = config.responseType === 'audio-stream' && booleanValue(values.stream);
+      const audioStreamSession = streamAudio
+        ? new AudioStreamSession(stringValue(values.response_format, 'mp3'))
+        : undefined;
+
+      if (audioStreamSession) {
+        audioStreamRef.current = audioStreamSession;
+        setResult(audioStreamSession.result());
+        setResultValues(values);
+      } else {
+        setResult(undefined);
+        setResultValues(undefined);
+      }
+
       let requestStarted = false;
+      let streamResponseStarted = false;
       const requestPromise = Promise.resolve(
         config.transformValues({ modelUid, model, values, requestId })
-      ).then((body) => {
+      ).then(async (body) => {
         requestStarted = true;
+        if (audioStreamSession) {
+          const stream = await request.post<ReadableStream<Uint8Array>>(config.requestApi, body, {
+            adapter: 'fetch',
+            responseType: 'stream',
+            noTimeout: true,
+            signal: audioStreamSession.signal,
+          });
+
+          if (!stream || typeof stream.getReader !== 'function') {
+            throw new Error('The browser did not return a readable audio stream.');
+          }
+
+          streamResponseStarted = true;
+          return audioStreamSession.consume(stream, () => {
+            if (runTokenRef.current === runToken) {
+              setResult(audioStreamSession.result());
+            }
+          });
+        }
+
         return request.post(config.requestApi, body, {
-          ...(config.responseType === 'blob' ? { responseType: 'blob' as const } : {}),
+          ...(config.responseType ? { responseType: 'blob' as const } : {}),
           noTimeout: true,
         });
       });
       requestPromise
         .then((response) => {
           if (runTokenRef.current !== runToken) return;
+
+          if (audioStreamSession) {
+            const blob = response as Blob;
+            const file = new File([blob], audioFileName(model.model_name, blob), {
+              type: blob.type,
+            });
+            setResult(audioStreamSession.result(file));
+            setResultValues(values);
+            return;
+          }
 
           setResult(
             response instanceof Blob
@@ -206,9 +257,22 @@ const CapabilityTaskPanel = forwardRef<CapabilityTaskPanelMethod, CapabilityTask
           setResultValues(values);
         })
         .catch((error: unknown) => {
-          // HTTP errors are already reported by the shared request interceptor.
-          // File conversion and advanced-JSON errors happen before that boundary.
-          if (!requestStarted && runTokenRef.current === runToken) {
+          if (audioStreamSession && runTokenRef.current === runToken) {
+            if (audioStreamRef.current === audioStreamSession) {
+              audioStreamRef.current = undefined;
+            }
+            audioStreamSession.dispose();
+            setResult(undefined);
+            setResultValues(undefined);
+          }
+
+          // HTTP errors are reported by the shared interceptor. Transform failures and
+          // stream read failures happen outside that boundary.
+          if (
+            (!requestStarted || streamResponseStarted) &&
+            !audioStreamSession?.signal.aborted &&
+            runTokenRef.current === runToken
+          ) {
             eventBus.emit(
               RequestEvents.SERVER_ERROR,
               error instanceof Error ? error.message : String(error)
@@ -234,6 +298,7 @@ const CapabilityTaskPanel = forwardRef<CapabilityTaskPanelMethod, CapabilityTask
     };
     const reset = () => {
       abortActiveRequest();
+      disposeAudioStream();
       runTokenRef.current += 1;
       form.resetFields();
       setResult(undefined);
@@ -245,9 +310,10 @@ const CapabilityTaskPanel = forwardRef<CapabilityTaskPanelMethod, CapabilityTask
     useEffect(() => {
       return () => {
         abortActiveRequest();
+        disposeAudioStream();
         runTokenRef.current += 1;
       };
-    }, [abortActiveRequest, config.ability, modelUid]);
+    }, [abortActiveRequest, config.ability, disposeAudioStream, modelUid]);
     useImperativeHandle(ref, () => ({
       reset,
     }));
@@ -282,7 +348,7 @@ const CapabilityTaskPanel = forwardRef<CapabilityTaskPanelMethod, CapabilityTask
                 variant="secondary"
                 size="icon"
                 className="size-11 rounded-full"
-                disabled={loading && !config.showProgress}
+                disabled={loading && !config.showProgress && audioStreamRef.current === undefined}
                 onClick={reset}
               >
                 <RotateCcw className="size-4" />

--- a/frontend/src/components/pages/running-model-detail/panels/capability-task-panel.tsx
+++ b/frontend/src/components/pages/running-model-detail/panels/capability-task-panel.tsx
@@ -209,12 +209,16 @@ const CapabilityTaskPanel = forwardRef<CapabilityTaskPanelMethod, CapabilityTask
       ).then(async (body) => {
         requestStarted = true;
         if (audioStreamSession) {
-          const stream = await request.post<ReadableStream<Uint8Array>>(config.requestApi, body, {
-            adapter: 'fetch',
-            responseType: 'stream',
-            noTimeout: true,
-            signal: audioStreamSession.signal,
-          });
+          const stream = await request.post<ReadableStream<Uint8Array<ArrayBuffer>>>(
+            config.requestApi,
+            body,
+            {
+              adapter: 'fetch',
+              responseType: 'stream',
+              noTimeout: true,
+              signal: audioStreamSession.signal,
+            }
+          );
 
           if (!stream || typeof stream.getReader !== 'function') {
             throw new Error('The browser did not return a readable audio stream.');

--- a/frontend/src/components/pages/running-model-detail/panels/form-panels.tsx
+++ b/frontend/src/components/pages/running-model-detail/panels/form-panels.tsx
@@ -764,6 +764,17 @@ export function SpeechPanel({ form, model }: CapabilityFormProps) {
           <Select options={MUSIC_RESPONSE_FORMAT_OPTIONS} allowClear={false} />
         </FormField>
       )}
+      {!isMusicGeneration && (
+        <FormField
+          name="stream"
+          label="Streaming"
+          valuePropName="checked"
+          layout="horizontal"
+          tooltip="Play supported audio formats while they are generated."
+        >
+          <Switch />
+        </FormField>
+      )}
       {showPromptSpeech && (
         <FormField name="prompt_speech">
           <FileUpload

--- a/frontend/src/components/pages/running-model-detail/panels/result-panels.tsx
+++ b/frontend/src/components/pages/running-model-detail/panels/result-panels.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { Binary, ImageIcon, Sparkles } from 'lucide-react';
+import { Binary, Download, ImageIcon, LoaderCircle, Sparkles } from 'lucide-react';
 
 import ReactMarkdown from '@/components/ui/markdown-renderer';
 import { MediaPreview } from '@/components/ui/media-preview';
@@ -12,6 +12,7 @@ import { ModelAbility } from '@/constants';
 import { cn } from '@/lib/utils';
 import { isNumber } from '@/lib/is';
 
+import { isAudioStreamResult, type AudioStreamResult } from '../audio-stream';
 import type { CapabilityResultProps } from '../types';
 import { booleanValue, isRecord, stringValue } from '../utils';
 
@@ -205,6 +206,65 @@ function BlobMediaPreview({
   );
 }
 
+function StreamingAudioPreview({ result }: { result: AudioStreamResult }) {
+  const [downloadUrl, setDownloadUrl] = useState<string>();
+
+  useEffect(() => {
+    if (!result.file) {
+      setDownloadUrl(undefined);
+      return;
+    }
+
+    const objectUrl = URL.createObjectURL(result.file);
+    setDownloadUrl(objectUrl);
+    return () => URL.revokeObjectURL(objectUrl);
+  }, [result.file]);
+
+  const audioUrl = result.playbackUrl || downloadUrl;
+  const waitingForCompletePlayback = result.streaming && !result.playbackUrl;
+
+  return (
+    <div className="grid w-full max-w-full gap-3">
+      {audioUrl ? (
+        <audio
+          key={audioUrl}
+          src={audioUrl}
+          controls
+          autoPlay={Boolean(result.playbackUrl)}
+          preload="auto"
+          className="h-10 w-full"
+          onClick={(event) => event.stopPropagation()}
+        />
+      ) : (
+        <div className="flex h-10 items-center gap-2 rounded-md border px-3 text-sm text-muted-foreground">
+          <LoaderCircle className="size-4 animate-spin" />
+          Receiving audio stream
+        </div>
+      )}
+      <div className="flex min-h-9 items-center justify-between gap-3 text-xs text-muted-foreground">
+        <span aria-live="polite">
+          {result.streaming
+            ? waitingForCompletePlayback
+              ? 'This browser will start playback when the stream is complete.'
+              : 'Streaming and playing audio as it arrives.'
+            : 'Audio generation complete.'}
+        </span>
+        {downloadUrl && result.file && (
+          <a
+            href={downloadUrl}
+            download={result.file.name}
+            aria-label="Download audio"
+            className="flex size-9 shrink-0 items-center justify-center rounded-md border bg-background text-muted-foreground transition-colors hover:text-foreground"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <Download className="size-4" />
+          </a>
+        )}
+      </div>
+    </div>
+  );
+}
+
 function MediaResultPanel({ result, type }: { result: unknown; type: MediaType }) {
   const isAudio = type === 'audio';
   const isImage = type === 'image';
@@ -221,6 +281,10 @@ function MediaResultPanel({ result, type }: { result: unknown; type: MediaType }
     : isImage
       ? 'flex flex-wrap items-start'
       : 'grid grid-cols-2';
+  if (isAudio && isAudioStreamResult(result)) {
+    return <StreamingAudioPreview result={result} />;
+  }
+
   if (result instanceof Blob) {
     return (
       <BlobMediaPreview
@@ -439,7 +503,7 @@ export function UniversalResultPanel({
   progress,
   ability,
 }: CapabilityResultProps) {
-  if (loading) {
+  if (loading && !isAudioStreamResult(result)) {
     return <Generating progress={progress} />;
   }
 

--- a/frontend/src/components/pages/running-model-detail/types.ts
+++ b/frontend/src/components/pages/running-model-detail/types.ts
@@ -45,7 +45,7 @@ export interface CapabilityConfig {
   transformValues: (
     context: TransformContext
   ) => BodyInit | Record<string, unknown> | Promise<BodyInit | Record<string, unknown>>;
-  responseType?: 'blob';
+  responseType?: 'blob' | 'audio-stream';
   codeExample?: CodeExampleConfig;
 }
 


### PR DESCRIPTION
## Summary

- Add a streaming toggle to the TTS capability form.
- Pass the `stream` option through JSON and multipart requests.
- Consume streaming responses through a browser `ReadableStream`.
- Play supported audio formats progressively with `MediaSource`.
- Preserve the completed audio as a downloadable file.
- Fall back to full-response playback when streaming playback is unsupported.
- Cancel active readers and release object URLs on reset or unmount.
