### PR TITLE
FIX: Restore audio streaming with TorchCodec

### DIFF
--- a/xinference/model/audio/tests/test_audio_utils.py
+++ b/xinference/model/audio/tests/test_audio_utils.py
@@ -96,3 +96,66 @@ def test_audio_stream_generator_uses_torchcodec_and_flushes_tail(monkeypatch):
         assert [sample.shape for sample in captured["samples"]] == [(1, 4), (1, 3)]
         assert all(sample.dtype == torch.float32 for sample in captured["samples"])
         assert all(sample.device.type == "cpu" for sample in captured["samples"])
+
+
+def test_audio_stream_generator_uses_legacy_torchcodec_audio_encoder(monkeypatch):
+    captured = {}
+
+    class FakeAudioEncoder:
+        def __init__(self, samples, *, sample_rate):
+            captured["samples"] = samples.clone()
+            captured["sample_rate"] = sample_rate
+
+        def to_tensor(self, *, format):
+            captured["format"] = format
+            return torch.tensor(list(b"encoded"), dtype=torch.uint8)
+
+    torchaudio = ModuleType("torchaudio")
+    torchcodec = ModuleType("torchcodec")
+    torchcodec.__path__ = []
+    encoders = ModuleType("torchcodec.encoders")
+    encoders.AudioEncoder = FakeAudioEncoder
+    torchcodec.encoders = encoders
+    monkeypatch.setitem(sys.modules, "torchaudio", torchaudio)
+    monkeypatch.setitem(sys.modules, "torchcodec", torchcodec)
+    monkeypatch.setitem(sys.modules, "torchcodec.encoders", encoders)
+
+    chunks = [torch.ones((4, 1), dtype=torch.float64), torch.ones(3)]
+    result = list(
+        audio_utils.audio_stream_generator("mp3", 24000, chunks, lambda chunk: chunk)
+    )
+
+    assert result == [b"encoded"]
+    assert captured["sample_rate"] == 24000
+    assert captured["format"] == "mp3"
+    assert captured["samples"].shape == (1, 7)
+    assert captured["samples"].dtype == torch.float32
+    assert captured["samples"].device.type == "cpu"
+
+
+def test_audio_stream_generator_legacy_path_with_real_audio_encoder(monkeypatch):
+    torchcodec_encoders = pytest.importorskip("torchcodec.encoders")
+    torchcodec_decoders = pytest.importorskip("torchcodec.decoders")
+    torchaudio = pytest.importorskip("torchaudio")
+    if not hasattr(torchcodec_encoders, "AudioEncoder"):
+        pytest.skip("TorchCodec AudioEncoder is unavailable")
+
+    # Exercise the public API exposed by TorchCodec 0.9/0.10 even when the
+    # installed test version also provides the newer incremental Encoder.
+    monkeypatch.delattr(torchcodec_encoders, "Encoder", raising=False)
+    monkeypatch.delattr(torchaudio, "io", raising=False)
+
+    sample_rate = 24000
+    chunks = [
+        torch.linspace(-0.25, 0.25, 1200).reshape(-1, 1),
+        torch.linspace(0.25, -0.25, 1200).reshape(-1, 1),
+    ]
+    encoded = b"".join(
+        audio_utils.audio_stream_generator(
+            "wav", sample_rate, chunks, lambda chunk: chunk
+        )
+    )
+    decoded = torchcodec_decoders.AudioDecoder(encoded).get_all_samples()
+
+    assert decoded.sample_rate == sample_rate
+    assert decoded.data.shape == (1, 2400)

--- a/xinference/model/audio/tests/test_audio_utils.py
+++ b/xinference/model/audio/tests/test_audio_utils.py
@@ -1,0 +1,87 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+from types import ModuleType
+
+import torch
+
+from .. import utils as audio_utils
+
+
+def test_audio_stream_generator_uses_torchcodec_and_flushes_tail(monkeypatch):
+    captured = {}
+
+    class FakeAudioStream:
+        def __init__(self, encoder):
+            self._encoder = encoder
+
+        def add_samples(self, samples):
+            captured.setdefault("samples", []).append(samples.clone())
+            self._encoder.destination.write(b"chunk")
+
+    class FakeEncoder:
+        def add_audio(self, *, sample_rate, num_channels):
+            captured["audio_config"] = (sample_rate, num_channels)
+            return FakeAudioStream(self)
+
+        def open_file_like(self, destination, *, format):
+            self.destination = destination
+            captured["format"] = format
+            return self
+
+        def __enter__(self):
+            self.destination.write(b"header-")
+            return self
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            if captured["format"] == "mp4":
+                self.destination.seek(0)
+                self.destination.write(b"fixed--")
+                self.destination.seek(0, 2)
+            self.destination.write(b"tail")
+
+    torchaudio = ModuleType("torchaudio")
+    torchcodec = ModuleType("torchcodec")
+    torchcodec.__path__ = []
+    encoders = ModuleType("torchcodec.encoders")
+    encoders.Encoder = FakeEncoder
+    monkeypatch.setitem(sys.modules, "torchaudio", torchaudio)
+    monkeypatch.setitem(sys.modules, "torchcodec", torchcodec)
+    monkeypatch.setitem(sys.modules, "torchcodec.encoders", encoders)
+
+    chunks = [torch.ones((4, 1), dtype=torch.float64), torch.ones(3)]
+    format_pairs = (
+        ("mp3", "mp3"),
+        ("AAC", "adts"),
+        ("m4a", "mp4"),
+        ("wave", "wav"),
+    )
+    for response_format, container_format in format_pairs:
+        captured.clear()
+        result = list(
+            audio_utils.audio_stream_generator(
+                response_format, 24000, chunks, lambda chunk: chunk
+            )
+        )
+
+        if container_format == "mp4":
+            assert result == [b"fixed--chunkchunktail"]
+        else:
+            assert result == [b"header-chunk", b"chunk", b"tail"]
+        assert captured["audio_config"] == (24000, 1)
+        assert captured["format"] == container_format
+        assert [sample.shape for sample in captured["samples"]] == [(1, 4), (1, 3)]
+        assert all(sample.dtype == torch.float32 for sample in captured["samples"])
+        assert all(sample.device.type == "cpu" for sample in captured["samples"])

--- a/xinference/model/audio/tests/test_audio_utils.py
+++ b/xinference/model/audio/tests/test_audio_utils.py
@@ -15,9 +15,20 @@
 import sys
 from types import ModuleType
 
+import pytest
 import torch
 
 from .. import utils as audio_utils
+
+
+def test_audio_stream_generator_reports_missing_torchcodec(monkeypatch):
+    torchaudio = ModuleType("torchaudio")
+    monkeypatch.setitem(sys.modules, "torchaudio", torchaudio)
+    monkeypatch.setitem(sys.modules, "torchcodec", None)
+    monkeypatch.setitem(sys.modules, "torchcodec.encoders", None)
+
+    with pytest.raises(ImportError, match="Failed to import 'torchcodec'"):
+        list(audio_utils.audio_stream_generator("mp3", 24000, iter(()), lambda x: x))
 
 
 def test_audio_stream_generator_uses_torchcodec_and_flushes_tail(monkeypatch):

--- a/xinference/model/audio/utils.py
+++ b/xinference/model/audio/utils.py
@@ -110,7 +110,14 @@ def _audio_stream_generator_with_torchcodec(
     output_generator: typing.Iterator[typing.Any],
     output_chunk_transformer: Callable,
 ):
-    from torchcodec.encoders import Encoder
+    try:
+        from torchcodec.encoders import Encoder
+    except ImportError as exc:
+        raise ImportError(
+            "Failed to import 'torchcodec'. It is required for audio streaming "
+            "when 'torchaudio.io.StreamWriter' is unavailable. Install a "
+            "TorchCodec build compatible with the installed PyTorch version."
+        ) from exc
 
     normalized_format = response_format.lower().lstrip(".")
     response_pcm = normalized_format == "pcm"

--- a/xinference/model/audio/utils.py
+++ b/xinference/model/audio/utils.py
@@ -104,6 +104,74 @@ def ensure_sample_rate(
     return audio
 
 
+def _audio_stream_generator_with_torchcodec(
+    response_format: str,
+    sample_rate: int,
+    output_generator: typing.Iterator[typing.Any],
+    output_chunk_transformer: Callable,
+):
+    from torchcodec.encoders import Encoder
+
+    normalized_format = response_format.lower().lstrip(".")
+    response_pcm = normalized_format == "pcm"
+    container_format = {
+        "aac": "adts",
+        "m4a": "mp4",
+        "pcm": "wav",
+        "wave": "wav",
+    }.get(normalized_format, normalized_format)
+    finalize_before_read = container_format == "mp4"
+    with io.BytesIO() as out:
+        encoder = Encoder()
+        audio_stream = encoder.add_audio(sample_rate=sample_rate, num_channels=1)
+        strip_header = True
+        last_pos = 0
+        has_audio = False
+
+        def read_encoded_bytes() -> typing.Optional[bytes]:
+            nonlocal last_pos, strip_header
+
+            new_last_pos = out.tell()
+            if new_last_pos == last_pos:
+                return None
+            out.seek(last_pos)
+            encoded_bytes = out.read()
+            last_pos = new_last_pos
+            if response_pcm and strip_header:
+                # http://soundfile.sapp.org/doc/WaveFormat
+                encoded_bytes = _extract_pcm_from_wav_bytes(encoded_bytes)
+                strip_header = False
+            return encoded_bytes or None
+
+        if response_pcm:
+            logger.info(
+                f"PCM stream output, num_channels: 1, sample_rate: {sample_rate}"
+            )
+        with encoder.open_file_like(out, format=container_format):
+            for chunk in output_generator:
+                trans_chunk = output_chunk_transformer(chunk)
+                trans_chunk = trans_chunk.detach().to(device="cpu", dtype=torch.float32)
+                if trans_chunk.ndim == 1:
+                    trans_chunk = trans_chunk.unsqueeze(1)
+                audio_stream.add_samples(trans_chunk.transpose(0, 1).contiguous())
+                has_audio = True
+                if not finalize_before_read:
+                    encoded_bytes = read_encoded_bytes()
+                    if encoded_bytes is not None:
+                        yield encoded_bytes
+
+        # Some codecs buffer the final packet until the encoder is closed.
+        if has_audio:
+            if finalize_before_read:
+                # MP4 rewrites container metadata while closing, so bytes read
+                # before this point would contain a stale header.
+                encoded_bytes = out.getvalue()
+            else:
+                encoded_bytes = read_encoded_bytes()
+            if encoded_bytes is not None:
+                yield encoded_bytes
+
+
 def audio_stream_generator(
     response_format: str,
     sample_rate: int,
@@ -113,18 +181,29 @@ def audio_stream_generator(
     import torch
     import torchaudio
 
+    # torchaudio 2.9 removed StreamWriter in favor of TorchCodec.
+    stream_writer = getattr(getattr(torchaudio, "io", None), "StreamWriter", None)
+    if stream_writer is None:
+        yield from _audio_stream_generator_with_torchcodec(
+            response_format,
+            sample_rate,
+            output_generator,
+            output_chunk_transformer,
+        )
+        return
+
     response_pcm = response_format.lower() == "pcm"
     with io.BytesIO() as out:
         if response_pcm:
             logger.info(
                 f"PCM stream output, num_channels: 1, sample_rate: {sample_rate}"
             )
-            writer = torchaudio.io.StreamWriter(out, format="wav")
+            writer = stream_writer(out, format="wav")
             writer.add_audio_stream(
                 sample_rate=sample_rate, num_channels=1, format="s16"
             )
         else:
-            writer = torchaudio.io.StreamWriter(out, format=response_format)
+            writer = stream_writer(out, format=response_format)
             writer.add_audio_stream(sample_rate=sample_rate, num_channels=1)
         strip_header = True
         last_pos = 0

--- a/xinference/model/audio/utils.py
+++ b/xinference/model/audio/utils.py
@@ -111,7 +111,7 @@ def _audio_stream_generator_with_torchcodec(
     output_chunk_transformer: Callable,
 ):
     try:
-        from torchcodec.encoders import Encoder
+        from torchcodec import encoders as torchcodec_encoders
     except ImportError as exc:
         raise ImportError(
             "Failed to import 'torchcodec'. It is required for audio streaming "
@@ -128,8 +128,46 @@ def _audio_stream_generator_with_torchcodec(
         "wave": "wav",
     }.get(normalized_format, normalized_format)
     finalize_before_read = container_format == "mp4"
+
+    def prepare_audio_chunk(chunk):
+        trans_chunk = output_chunk_transformer(chunk)
+        trans_chunk = trans_chunk.detach().to(device="cpu", dtype=torch.float32)
+        if trans_chunk.ndim == 1:
+            trans_chunk = trans_chunk.unsqueeze(1)
+        return trans_chunk.transpose(0, 1).contiguous()
+
+    encoder_cls = getattr(torchcodec_encoders, "Encoder", None)
+    if encoder_cls is None:
+        # TorchCodec 0.9/0.10, the compatible releases for PyTorch 2.9/2.10,
+        # only expose the batch AudioEncoder API. Preserve compatibility by
+        # returning one valid encoded container after generation completes.
+        audio_encoder_cls = getattr(torchcodec_encoders, "AudioEncoder", None)
+        if audio_encoder_cls is None:
+            raise ImportError(
+                "The installed 'torchcodec' does not expose a supported audio "
+                "encoder. Install a TorchCodec build compatible with the "
+                "installed PyTorch version."
+            )
+        logger.warning(
+            "TorchCodec's incremental Encoder API is unavailable; buffering "
+            "the %s response until audio generation completes.",
+            normalized_format,
+        )
+        audio_chunks = [prepare_audio_chunk(chunk) for chunk in output_generator]
+        if not audio_chunks:
+            return
+        encoded_tensor = audio_encoder_cls(
+            torch.cat(audio_chunks, dim=1), sample_rate=sample_rate
+        ).to_tensor(format=container_format)
+        encoded_bytes = encoded_tensor.detach().cpu().contiguous().numpy().tobytes()
+        if response_pcm:
+            encoded_bytes = _extract_pcm_from_wav_bytes(encoded_bytes)
+        if encoded_bytes:
+            yield encoded_bytes
+        return
+
     with io.BytesIO() as out:
-        encoder = Encoder()
+        encoder = encoder_cls()
         audio_stream = encoder.add_audio(sample_rate=sample_rate, num_channels=1)
         strip_header = True
         last_pos = 0
@@ -156,11 +194,7 @@ def _audio_stream_generator_with_torchcodec(
             )
         with encoder.open_file_like(out, format=container_format):
             for chunk in output_generator:
-                trans_chunk = output_chunk_transformer(chunk)
-                trans_chunk = trans_chunk.detach().to(device="cpu", dtype=torch.float32)
-                if trans_chunk.ndim == 1:
-                    trans_chunk = trans_chunk.unsqueeze(1)
-                audio_stream.add_samples(trans_chunk.transpose(0, 1).contiguous())
+                audio_stream.add_samples(prepare_audio_chunk(chunk))
                 has_audio = True
                 if not finalize_before_read:
                     encoded_bytes = read_encoded_bytes()


### PR DESCRIPTION
## Summary

- Fall back to TorchCodec when `torchaudio.io.StreamWriter` is unavailable.
- Preserve the existing StreamWriter path for older torchaudio versions.
- Convert audio chunks to the layout and dtype required by TorchCodec.
- Flush buffered encoder packets when streaming completes.
- Normalize AAC, M4A, PCM, and WAVE container formats.
- Delay MP4 reads until container metadata has been finalized.
- Add regression coverage for format mapping and final packet delivery.

## Motivation

torchaudio 2.9 and later removed `torchaudio.io.StreamWriter`. Any TTS
implementation using the shared `audio_stream_generator` could therefore return
HTTP 200 and then fail while consuming the streamed response with:

`AttributeError: module 'torchaudio' has no attribute 'io'`

The issue was first reproduced with Breeze TTS, but it belongs to the shared
audio encoding layer and can affect other streaming TTS implementations.
