### PR TITLE
DOC: fix model type card layout

### DIFF
--- a/doc/source/models/index.rst
+++ b/doc/source/models/index.rst
@@ -70,13 +70,13 @@ The following ``MODEL_TYPE`` is supported by Xinference:
 
       Video models
 
+.. grid:: 2
+
     .. grid-item-card::  world
       :link: models_world_index
       :link-type: ref
 
       World generation models
-
-.. grid:: 2
 
     .. grid-item-card::  flexible
       :link: flexible


### PR DESCRIPTION
## Summary

- keep the model type cards in balanced two-column rows
- pair `world` and `flexible` in the same grid

## Validation

- `git diff --check`
- `pre-commit run --files doc/source/models/index.rst`
- Sphinx dummy builder (target page parsed without warnings)