### PR TITLE
feat(model): Add Fish Audio S1-mini and S2-Pro support

### DIFF
--- a/doc/source/models/builtin/audio/fishaudio-s1-mini.rst
+++ b/doc/source/models/builtin/audio/fishaudio-s1-mini.rst
@@ -1,0 +1,19 @@
+.. _models_builtin_fishaudio-s1-mini:
+
+=================
+FishAudio-S1-mini
+=================
+
+- **Model Name:** FishAudio-S1-mini
+- **Model Family:** FishAudio
+- **Abilities:** ['text2audio', 'text2audio_zero_shot', 'text2audio_voice_cloning']
+- **Multilingual:** True
+
+Specifications
+^^^^^^^^^^^^^^
+
+- **Model ID:** fishaudio/s1-mini
+
+Execute the following command to launch the model::
+
+   xinference launch --model-name FishAudio-S1-mini --model-type audio

--- a/doc/source/models/builtin/audio/fishaudio-s2-pro.rst
+++ b/doc/source/models/builtin/audio/fishaudio-s2-pro.rst
@@ -1,0 +1,19 @@
+.. _models_builtin_fishaudio-s2-pro:
+
+================
+FishAudio-S2-Pro
+================
+
+- **Model Name:** FishAudio-S2-Pro
+- **Model Family:** FishAudio
+- **Abilities:** ['text2audio', 'text2audio_zero_shot', 'text2audio_voice_cloning']
+- **Multilingual:** True
+
+Specifications
+^^^^^^^^^^^^^^
+
+- **Model ID:** fishaudio/s2-pro
+
+Execute the following command to launch the model::
+
+   xinference launch --model-name FishAudio-S2-Pro --model-type audio

--- a/doc/source/models/builtin/audio/index.rst
+++ b/doc/source/models/builtin/audio/index.rst
@@ -32,6 +32,10 @@ The following is a list of built-in audio models in Xinference:
   
    fireredtts3-instruct
   
+   fishaudio-s1-mini
+
+   fishaudio-s2-pro
+
    fishspeech-1.5
   
    fun-asr-mlt-nano-2512

--- a/xinference/model/audio/fish_speech.py
+++ b/xinference/model/audio/fish_speech.py
@@ -27,6 +27,61 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+FISH_AUDIO_S1_MINI = "FishAudio-S1-mini"
+FISH_AUDIO_S2_PRO = "FishAudio-S2-Pro"
+_MODERN_FISH_AUDIO_MODELS = {FISH_AUDIO_S1_MINI, FISH_AUDIO_S2_PRO}
+
+
+def _load_fish_speech_runtime_components(model_name: str):
+    if model_name == FISH_AUDIO_S1_MINI:
+        from ...thirdparty.fish_speech_s1.fish_speech.inference_engine import (
+            TTSInferenceEngine,
+        )
+        from ...thirdparty.fish_speech_s1.fish_speech.models.dac.inference import (
+            load_model as load_decoder_model,
+        )
+        from ...thirdparty.fish_speech_s1.fish_speech.models.text2semantic.inference import (
+            launch_thread_safe_queue,
+        )
+        from ...thirdparty.fish_speech_s1.fish_speech.utils.schema import (
+            ServeReferenceAudio,
+            ServeTTSRequest,
+        )
+    elif model_name == FISH_AUDIO_S2_PRO:
+        from ...thirdparty.fish_speech_s2.fish_speech.inference_engine import (
+            TTSInferenceEngine,
+        )
+        from ...thirdparty.fish_speech_s2.fish_speech.models.dac.inference import (
+            load_model as load_decoder_model,
+        )
+        from ...thirdparty.fish_speech_s2.fish_speech.models.text2semantic.inference import (
+            launch_thread_safe_queue,
+        )
+        from ...thirdparty.fish_speech_s2.fish_speech.utils.schema import (
+            ServeReferenceAudio,
+            ServeTTSRequest,
+        )
+    else:
+        # FishSpeech-1.5 uses the legacy upstream package layout.
+        legacy_runtime_path = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), "../../thirdparty/fish_speech")
+        )
+        if legacy_runtime_path not in sys.path:
+            sys.path.insert(0, legacy_runtime_path)
+
+        from tools.inference_engine import TTSInferenceEngine
+        from tools.llama.generate import launch_thread_safe_queue
+        from tools.schema import ServeReferenceAudio, ServeTTSRequest
+        from tools.vqgan.inference import load_model as load_decoder_model
+
+    return (
+        TTSInferenceEngine,
+        launch_thread_safe_queue,
+        load_decoder_model,
+        ServeReferenceAudio,
+        ServeTTSRequest,
+    )
+
 
 def wav_chunk_header(sample_rate=44100, bit_depth=16, channels=1):
     import wave
@@ -60,6 +115,9 @@ class FishSpeechModel:
         self._llama_queue = None
         self._model = None
         self._engine = None
+        self._serve_reference_audio = None
+        self._serve_tts_request = None
+        self._uses_modern_runtime = model_spec.model_name in _MODERN_FISH_AUDIO_MODELS
         self._kwargs = kwargs
 
     @property
@@ -67,14 +125,13 @@ class FishSpeechModel:
         return self._model_spec.model_ability
 
     def load(self):
-        # There are too many imports from fish_speech.
-        sys.path.insert(
-            0, os.path.join(os.path.dirname(__file__), "../../thirdparty/fish_speech")
-        )
-
-        from tools.inference_engine import TTSInferenceEngine
-        from tools.llama.generate import launch_thread_safe_queue
-        from tools.vqgan.inference import load_model as load_decoder_model
+        (
+            TTSInferenceEngine,
+            launch_thread_safe_queue,
+            load_decoder_model,
+            self._serve_reference_audio,
+            self._serve_tts_request,
+        ) = _load_fish_speech_runtime_components(self._model_spec.model_name)
 
         if self._device is None:
             self._device = get_available_device()
@@ -98,12 +155,16 @@ class FishSpeechModel:
         )
         logger.info("Llama model loaded, loading VQ-GAN model...")
 
-        checkpoint_path = os.path.join(
-            self._model_path,
-            "firefly-gan-vq-fsq-8x1024-21hz-generator.pth",
-        )
+        if self._uses_modern_runtime:
+            decoder_config_name = "modded_dac_vq"
+            decoder_filename = "codec.pth"
+        else:
+            decoder_config_name = "firefly_gan_vq"
+            decoder_filename = "firefly-gan-vq-fsq-8x1024-21hz-generator.pth"
+
+        checkpoint_path = os.path.join(self._model_path, decoder_filename)
         self._model = load_decoder_model(
-            config_name="firefly_gan_vq",
+            config_name=decoder_config_name,
             checkpoint_path=checkpoint_path,
             device=self._device,
         )
@@ -124,30 +185,44 @@ class FishSpeechModel:
         logger.warning("Fish speech does not support setting voice: %s.", voice)
         if speed != 1.0:
             logger.warning("Fish speech does not support setting speed: %s.", speed)
-        from tools.schema import ServeReferenceAudio, ServeTTSRequest
-
         from .utils import audio_stream_generator, audio_to_bytes
+
+        if self._serve_reference_audio is None or self._serve_tts_request is None:
+            raise RuntimeError("Fish speech model is not loaded")
 
         prompt_speech = kwargs.get("prompt_speech")
         prompt_text = kwargs.get("prompt_text", kwargs.get("reference_text", ""))
         if prompt_speech is not None:
-            r = ServeReferenceAudio(audio=prompt_speech, text=prompt_text)
+            r = self._serve_reference_audio(audio=prompt_speech, text=prompt_text)
             references = [r]
         else:
             references = []
 
+        if self._uses_modern_runtime:
+            default_top_p = 0.8
+            default_repetition_penalty = 1.1
+            default_temperature = 0.8
+        else:
+            default_top_p = 0.7
+            default_repetition_penalty = 1.2
+            default_temperature = 0.7
+
         assert self._engine is not None
         result = self._engine.inference(
-            ServeTTSRequest(
+            self._serve_tts_request(
                 text=input,
                 references=references,
                 reference_id=kwargs.get("reference_id"),
                 seed=kwargs.get("seed"),
+                use_memory_cache=kwargs.get("use_memory_cache", "off"),
+                normalize=kwargs.get("normalize", True),
                 max_new_tokens=kwargs.get("max_new_tokens", 1024),
                 chunk_length=kwargs.get("chunk_length", 200),
-                top_p=kwargs.get("top_p", 0.7),
-                repetition_penalty=kwargs.get("repetition_penalty", 1.2),
-                temperature=kwargs.get("temperature", 0.7),
+                top_p=kwargs.get("top_p", default_top_p),
+                repetition_penalty=kwargs.get(
+                    "repetition_penalty", default_repetition_penalty
+                ),
+                temperature=kwargs.get("temperature", default_temperature),
                 streaming=stream,
                 format=response_format,
             )
@@ -157,26 +232,47 @@ class FishSpeechModel:
 
             def _gen_chunk():
                 for chunk in result:
-                    if chunk.code == "final":
+                    if chunk.code == "error":
+                        raise chunk.error or RuntimeError(
+                            "Fish speech inference failed"
+                        )
+                    if chunk.code != "segment" or chunk.audio is None:
                         continue
-                    chunk = chunk.audio[1]
-                    if chunk is not None:
-                        yield chunk
+                    audio = chunk.audio[1]
+                    if audio is not None:
+                        yield audio
 
             return audio_stream_generator(
                 response_format=response_format,
-                sample_rate=self._model.spec_transform.sample_rate,
+                sample_rate=self._get_sample_rate(),
                 output_generator=_gen_chunk(),
                 output_chunk_transformer=lambda c: torch.from_numpy(
-                    c.reshape((c.shape[0], 1))
+                    np.asarray(c).reshape((-1, 1))
                 ),
             )
         else:
-            result = list(result)
-            sample_rate, audio = result[0].audio
-            audio = np.array([audio])
+            final_audio = None
+            for chunk in result:
+                if chunk.code == "error":
+                    raise chunk.error or RuntimeError("Fish speech inference failed")
+                if chunk.code == "final":
+                    final_audio = chunk.audio
+            if final_audio is None:
+                raise RuntimeError("Fish speech inference returned no audio")
+
+            sample_rate, audio = final_audio
+            audio = np.asarray(audio)
+            if audio.ndim == 1:
+                audio = audio[None, :]
             return audio_to_bytes(
                 response_format=response_format,
                 sample_rate=sample_rate,
                 tensor=torch.from_numpy(audio),
             )
+
+    def _get_sample_rate(self) -> int:
+        if self._model is None:
+            raise RuntimeError("Fish speech model is not loaded")
+        if hasattr(self._model, "spec_transform"):
+            return int(self._model.spec_transform.sample_rate)
+        return int(self._model.sample_rate)

--- a/xinference/model/audio/model_spec.json
+++ b/xinference/model/audio/model_spec.json
@@ -1066,6 +1066,95 @@
   },
   {
     "version": 2,
+    "model_name": "FishAudio-S1-mini",
+    "model_description": "Built with Fish Audio. Fish Audio S1-mini is a 0.5B multilingual text-to-speech model with zero-shot synthesis, expressive inline markers, and voice cloning. Its model weights use CC-BY-NC-SA-4.0 and require acceptance of the model repository access terms.",
+    "model_family": "FishAudio",
+    "model_ability": [
+      "text2audio",
+      "text2audio_zero_shot",
+      "text2audio_voice_cloning"
+    ],
+    "multilingual": true,
+    "model_src": {
+      "huggingface": {
+        "model_id": "fishaudio/s1-mini",
+        "model_revision": "main"
+      },
+      "modelscope": {
+        "model_id": "fishaudio/s1-mini",
+        "model_revision": "master"
+      }
+    },
+    "updated_at": 1788514328,
+    "featured": false,
+    "virtualenv": {
+      "packages": [
+        "transformers>=4.45.2,<=4.57.3",
+        "hydra-core>=1.3.2",
+        "omegaconf~=2.3.0",
+        "loguru>=0.6.0",
+        "natsort>=8.4.0",
+        "einops>=0.7.0",
+        "librosa>=0.10.1",
+        "soundfile>=0.12",
+        "click",
+        "loralib>=0.1.2",
+        "tiktoken>=0.8.0",
+        "pydantic>=2.9,<3",
+        "descript-audio-codec",
+        "descript-audiotools",
+        "#system_torch#",
+        "#system_torchaudio#",
+        "#system_numpy#"
+      ]
+    }
+  },
+  {
+    "version": 2,
+    "model_name": "FishAudio-S2-Pro",
+    "model_description": "Built with Fish Audio. Fish Audio S2-Pro supports multilingual zero-shot synthesis, voice cloning, multi-speaker speech, and fine-grained inline prosody and emotion control. The Fish Audio Research License permits research and non-commercial use; commercial use requires a separate license.",
+    "model_family": "FishAudio",
+    "model_ability": [
+      "text2audio",
+      "text2audio_zero_shot",
+      "text2audio_voice_cloning"
+    ],
+    "multilingual": true,
+    "model_src": {
+      "huggingface": {
+        "model_id": "fishaudio/s2-pro",
+        "model_revision": "main"
+      },
+      "modelscope": {
+        "model_id": "fishaudio/s2-pro",
+        "model_revision": "master"
+      }
+    },
+    "updated_at": 1788514328,
+    "featured": false,
+    "virtualenv": {
+      "packages": [
+        "transformers>=4.45.2,<=4.57.3",
+        "hydra-core>=1.3.2",
+        "omegaconf~=2.3.0",
+        "loguru>=0.6.0",
+        "natsort>=8.4.0",
+        "einops>=0.7.0",
+        "soundfile>=0.12",
+        "click",
+        "loralib>=0.1.2",
+        "pydantic>=2.9,<3",
+        "descript-audio-codec",
+        "descript-audiotools",
+        "safetensors>=0.5.2",
+        "#system_torch#",
+        "#system_torchaudio#",
+        "#system_numpy#"
+      ]
+    }
+  },
+  {
+    "version": 2,
     "model_name": "F5-TTS",
     "model_family": "F5-TTS",
     "engine": "PyTorch",

--- a/xinference/model/audio/model_spec.json
+++ b/xinference/model/audio/model_spec.json
@@ -1105,6 +1105,7 @@
         "descript-audiotools",
         "#system_torch#",
         "#system_torchaudio#",
+        "#system_torchcodec#",
         "#system_numpy#"
       ]
     }
@@ -1149,6 +1150,7 @@
         "safetensors>=0.5.2",
         "#system_torch#",
         "#system_torchaudio#",
+        "#system_torchcodec#",
         "#system_numpy#"
       ]
     }

--- a/xinference/model/audio/tests/test_fish_speech.py
+++ b/xinference/model/audio/tests/test_fish_speech.py
@@ -14,6 +14,261 @@
 import inspect
 import os
 import tempfile
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from .. import fish_speech as fish_speech_module
+from .. import load_model_family_from_json
+from ..core import create_audio_model_instance
+from ..fish_speech import FISH_AUDIO_S1_MINI, FISH_AUDIO_S2_PRO, FishSpeechModel
+
+
+def _model_spec(model_name):
+    return SimpleNamespace(
+        model_name=model_name,
+        model_family="FishAudio",
+        model_ability=[
+            "text2audio",
+            "text2audio_zero_shot",
+            "text2audio_voice_cloning",
+        ],
+        engine=None,
+    )
+
+
+class _FakeSchema:
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+@pytest.mark.parametrize("model_name", [FISH_AUDIO_S1_MINI, FISH_AUDIO_S2_PRO])
+def test_load_modern_fish_audio_runtime(monkeypatch, model_name):
+    captured = {}
+    queue = object()
+    decoder = SimpleNamespace(sample_rate=44100)
+
+    def launch_thread_safe_queue(**kwargs):
+        captured["llama"] = kwargs
+        return queue
+
+    def load_decoder_model(**kwargs):
+        captured["decoder"] = kwargs
+        return decoder
+
+    class FakeEngine:
+        def __init__(self, *args):
+            captured["engine"] = args
+
+    components = (
+        FakeEngine,
+        launch_thread_safe_queue,
+        load_decoder_model,
+        _FakeSchema,
+        _FakeSchema,
+    )
+    monkeypatch.setattr(
+        fish_speech_module,
+        "_load_fish_speech_runtime_components",
+        lambda name: components,
+    )
+    monkeypatch.setattr(fish_speech_module, "is_device_available", lambda device: True)
+
+    model = FishSpeechModel(
+        "fish", "/models/fish", _model_spec(model_name), device="cpu"
+    )
+    model.load()
+
+    assert captured["llama"]["checkpoint_path"] == "/models/fish"
+    assert captured["llama"]["device"] == "cpu"
+    assert captured["decoder"] == {
+        "config_name": "modded_dac_vq",
+        "checkpoint_path": "/models/fish/codec.pth",
+        "device": "cpu",
+    }
+    assert captured["engine"][0:2] == (queue, decoder)
+
+
+def test_load_keeps_legacy_decoder_contract(monkeypatch):
+    captured = {}
+
+    def load_decoder_model(**kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(spec_transform=SimpleNamespace(sample_rate=44100))
+
+    components = (
+        lambda *args: object(),
+        lambda **kwargs: object(),
+        load_decoder_model,
+        _FakeSchema,
+        _FakeSchema,
+    )
+    monkeypatch.setattr(
+        fish_speech_module,
+        "_load_fish_speech_runtime_components",
+        lambda name: components,
+    )
+    monkeypatch.setattr(fish_speech_module, "is_device_available", lambda device: True)
+
+    model = FishSpeechModel(
+        "fish", "/models/fish", _model_spec("FishSpeech-1.5"), device="cpu"
+    )
+    model.load()
+
+    assert captured == {
+        "config_name": "firefly_gan_vq",
+        "checkpoint_path": (
+            "/models/fish/firefly-gan-vq-fsq-8x1024-21hz-generator.pth"
+        ),
+        "device": "cpu",
+    }
+
+
+def test_modern_speech_builds_reference_request(monkeypatch):
+    captured = {}
+
+    class FakeReference(_FakeSchema):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            captured["reference"] = kwargs
+
+    class FakeRequest(_FakeSchema):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            captured["request"] = kwargs
+
+    class FakeEngine:
+        def inference(self, request):
+            yield SimpleNamespace(
+                code="final",
+                audio=(44100, np.array([0.1, -0.1], dtype=np.float32)),
+                error=None,
+            )
+
+    from .. import utils as audio_utils
+
+    def audio_to_bytes(response_format, sample_rate, tensor):
+        captured["encoded"] = (response_format, sample_rate, tensor.numpy())
+        return b"audio"
+
+    monkeypatch.setattr(audio_utils, "audio_to_bytes", audio_to_bytes)
+    model = FishSpeechModel(
+        "fish", "/models/fish", _model_spec(FISH_AUDIO_S1_MINI), device="cpu"
+    )
+    model._serve_reference_audio = FakeReference
+    model._serve_tts_request = FakeRequest
+    model._engine = FakeEngine()
+    model._model = SimpleNamespace(sample_rate=44100)
+
+    result = model.speech(
+        input="Hello",
+        voice="",
+        response_format="wav",
+        prompt_speech=b"reference-audio",
+        prompt_text="Reference text",
+        seed=7,
+        use_memory_cache="on",
+    )
+
+    assert result == b"audio"
+    assert captured["reference"] == {
+        "audio": b"reference-audio",
+        "text": "Reference text",
+    }
+    assert len(captured["request"]["references"]) == 1
+    assert captured["request"]["references"][0].audio == b"reference-audio"
+    assert captured["request"]["references"][0].text == "Reference text"
+    assert captured["request"]["top_p"] == pytest.approx(0.8)
+    assert captured["request"]["repetition_penalty"] == pytest.approx(1.1)
+    assert captured["request"]["temperature"] == pytest.approx(0.8)
+    assert captured["request"]["use_memory_cache"] == "on"
+    assert captured["encoded"][0:2] == ("wav", 44100)
+    np.testing.assert_allclose(
+        captured["encoded"][2], np.array([[0.1, -0.1]], dtype=np.float32)
+    )
+
+
+def test_stream_ignores_upstream_header_and_final(monkeypatch):
+    captured = {}
+    segment = np.array([0.1, 0.2], dtype=np.float32)
+
+    class FakeEngine:
+        def inference(self, request):
+            yield SimpleNamespace(code="header", audio=(44100, b"header"), error=None)
+            yield SimpleNamespace(code="segment", audio=(44100, segment), error=None)
+            yield SimpleNamespace(code="final", audio=(44100, segment), error=None)
+
+    from .. import utils as audio_utils
+
+    def audio_stream_generator(
+        response_format, sample_rate, output_generator, output_chunk_transformer
+    ):
+        chunks = list(output_generator)
+        captured["chunks"] = chunks
+        captured["tensor"] = output_chunk_transformer(chunks[0]).numpy()
+        yield b"stream"
+
+    monkeypatch.setattr(audio_utils, "audio_stream_generator", audio_stream_generator)
+    model = FishSpeechModel(
+        "fish", "/models/fish", _model_spec(FISH_AUDIO_S2_PRO), device="cpu"
+    )
+    model._serve_reference_audio = _FakeSchema
+    model._serve_tts_request = _FakeSchema
+    model._engine = FakeEngine()
+    model._model = SimpleNamespace(sample_rate=44100)
+
+    assert list(model.speech("Hello", "", stream=True)) == [b"stream"]
+    assert captured["chunks"] == [segment]
+    np.testing.assert_allclose(
+        captured["tensor"], np.array([[0.1], [0.2]], dtype=np.float32)
+    )
+
+
+def test_builtin_catalog_has_fish_audio_s1_and_s2_sources():
+    models = {}
+    load_model_family_from_json("model_spec.json", models)
+
+    expected = {
+        FISH_AUDIO_S1_MINI: "fishaudio/s1-mini",
+        FISH_AUDIO_S2_PRO: "fishaudio/s2-pro",
+    }
+    for model_name, model_id in expected.items():
+        specs = models[model_name]
+        assert {
+            spec.model_hub: (spec.model_id, spec.model_revision) for spec in specs
+        } == {
+            "huggingface": (model_id, "main"),
+            "modelscope": (model_id, "master"),
+        }
+        assert all(
+            set(spec.model_ability)
+            == {
+                "text2audio",
+                "text2audio_zero_shot",
+                "text2audio_voice_cloning",
+            }
+            for spec in specs
+        )
+        assert all("#system_torch#" in spec.virtualenv.packages for spec in specs)
+        # transformers already provides tqdm. Listing it explicitly makes the
+        # virtualenv manager pin the host version, which may not exist on the
+        # configured PyTorch wheel index.
+        assert all("tqdm" not in spec.virtualenv.packages for spec in specs)
+
+
+@pytest.mark.parametrize("model_name", [FISH_AUDIO_S1_MINI, FISH_AUDIO_S2_PRO])
+def test_create_audio_model_instance_dispatches_modern_fish_audio(
+    monkeypatch, model_name
+):
+    from .. import core
+
+    spec = _model_spec(model_name)
+    monkeypatch.setattr(core, "match_audio", lambda *args, **kwargs: spec)
+
+    model = create_audio_model_instance("fish", model_name, model_path="/models/fish")
+
+    assert isinstance(model, FishSpeechModel)
 
 
 def test_fish_speech(setup):

--- a/xinference/model/audio/tests/test_fish_speech.py
+++ b/xinference/model/audio/tests/test_fish_speech.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import importlib
 import inspect
 import os
 import tempfile
@@ -18,6 +19,7 @@ from types import SimpleNamespace
 
 import numpy as np
 import pytest
+import torch
 
 from .. import fish_speech as fish_speech_module
 from .. import load_model_family_from_json
@@ -41,6 +43,49 @@ def _model_spec(model_name):
 class _FakeSchema:
     def __init__(self, **kwargs):
         self.__dict__.update(kwargs)
+
+
+@pytest.mark.parametrize(
+    "module_name, expected_dtype",
+    [
+        (
+            "xinference.thirdparty.fish_speech_s1.fish_speech.content_sequence",
+            torch.int,
+        ),
+        (
+            "xinference.thirdparty.fish_speech_s2.fish_speech.content_sequence",
+            torch.long,
+        ),
+    ],
+)
+def test_vendored_content_sequence_encodes_audio_parts(module_name, expected_dtype):
+    module = importlib.import_module(module_name)
+    token_ids = {
+        module.AUDIO_START_TOKEN: 10,
+        module.AUDIO_END_TOKEN: 11,
+        module.AUDIO_EMBED_TOKEN: 12,
+    }
+    tokenizer = SimpleNamespace(
+        get_token_id=token_ids.__getitem__,
+        semantic_begin_id=100,
+    )
+    features = torch.arange(6, dtype=torch.float32).reshape(2, 3)
+    sequence = module.ContentSequence(parts=[module.AudioPart(features=features)])
+
+    encoded = sequence.encode(tokenizer, add_shift=False)
+
+    assert encoded.tokens.dtype == expected_dtype
+    assert encoded.tokens.tolist() == [10, 12, 12, 11]
+    assert encoded.audio_masks.tolist() == [False, True, True, False]
+    assert len(encoded.audio_parts) == 1
+    torch.testing.assert_close(encoded.audio_parts[0], features)
+
+    values, audio_masks, audio_parts = sequence.encode_for_inference(
+        tokenizer, num_codebooks=2
+    )
+    assert values.shape == (3, 4)
+    assert audio_masks.tolist() == [[False, True, True, False]]
+    torch.testing.assert_close(audio_parts, features)
 
 
 @pytest.mark.parametrize("model_name", [FISH_AUDIO_S1_MINI, FISH_AUDIO_S2_PRO])

--- a/xinference/model/audio/tests/test_fish_speech.py
+++ b/xinference/model/audio/tests/test_fish_speech.py
@@ -296,6 +296,7 @@ def test_builtin_catalog_has_fish_audio_s1_and_s2_sources():
             for spec in specs
         )
         assert all("#system_torch#" in spec.virtualenv.packages for spec in specs)
+        assert all("#system_torchcodec#" in spec.virtualenv.packages for spec in specs)
         # transformers already provides tqdm. Listing it explicitly makes the
         # virtualenv manager pin the host version, which may not exist on the
         # configured PyTorch wheel index.

--- a/xinference/thirdparty/fish_speech_s1/LICENSE
+++ b/xinference/thirdparty/fish_speech_s1/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2024 Fish Audio
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/xinference/thirdparty/fish_speech_s1/README.md
+++ b/xinference/thirdparty/fish_speech_s1/README.md
@@ -1,0 +1,16 @@
+# Fish Audio S1 inference runtime
+
+This directory contains the inference subset vendored from
+[fishaudio/fish-speech](https://github.com/fishaudio/fish-speech) at commit
+`d3df50503b36314a964f66cac1af1e19e95bcfa3`. The upstream source code at that
+revision is licensed under Apache-2.0.
+
+Only the tokenizer, text-to-semantic runtime, ModifiedDAC codec, inference
+engine, schemas, and supporting utilities needed by Xinference are included.
+Model weights are not vendored. Fish Audio S1-mini weights are licensed under
+CC-BY-NC-SA-4.0 and remain subject to the model repository's access terms.
+
+Xinference changes upstream imports to package-qualified imports, trims the
+training-only utility initializer, and resolves the bundled Hydra codec config
+relative to this package. It also backports reference-ID validation and
+torchaudio 2.9 backend detection from the newer runtime.

--- a/xinference/thirdparty/fish_speech_s1/__init__.py
+++ b/xinference/thirdparty/fish_speech_s1/__init__.py
@@ -1,0 +1,1 @@
+"""Vendored Fish Audio S1 inference runtime."""

--- a/xinference/thirdparty/fish_speech_s1/fish_speech/__init__.py
+++ b/xinference/thirdparty/fish_speech_s1/fish_speech/__init__.py
@@ -1,0 +1,1 @@
+"""Fish Audio S1 inference subset."""

--- a/xinference/thirdparty/fish_speech_s1/fish_speech/configs/modded_dac_vq.yaml
+++ b/xinference/thirdparty/fish_speech_s1/fish_speech/configs/modded_dac_vq.yaml
@@ -1,0 +1,50 @@
+_target_: xinference.thirdparty.fish_speech_s1.fish_speech.models.dac.modded_dac.DAC
+# Model setup
+sample_rate: 44100
+encoder_dim: 64
+encoder_rates: [2, 4, 8, 8]
+decoder_dim: 1536
+decoder_rates: [8, 8, 4, 2]
+encoder_transformer_layers: [0, 0, 0, 4]
+decoder_transformer_layers: [4, 0, 0, 0]
+transformer_general_config:
+  _target_: xinference.thirdparty.fish_speech_s1.fish_speech.models.dac.modded_dac.ModelArgs
+  _partial_: true
+  block_size: 16384
+  n_local_heads: -1
+  head_dim: 64
+  rope_base: 10000
+  norm_eps: 1e-5
+  dropout_rate: 0.1
+  attn_dropout_rate: 0.1
+  channels_first: true
+# Quantization
+quantizer:
+  _target_: xinference.thirdparty.fish_speech_s1.fish_speech.models.dac.rvq.DownsampleResidualVectorQuantize
+  input_dim: 1024
+  n_codebooks: 9
+  codebook_size: 1024
+  codebook_dim: 8
+  quantizer_dropout: 0.5
+  downsample_factor: [2, 2]
+  post_module: &transformer_module
+    _target_: xinference.thirdparty.fish_speech_s1.fish_speech.models.dac.modded_dac.WindowLimitedTransformer
+    causal: true
+    window_size: 128  # empirically this does not seem to matter
+    input_dim: 1024
+    config: &transformer_config
+      _target_: xinference.thirdparty.fish_speech_s1.fish_speech.models.dac.modded_dac.ModelArgs
+      block_size: 4096
+      n_layer: 8
+      n_head: 16
+      dim: 1024
+      intermediate_size: 3072
+      n_local_heads: -1
+      head_dim: 64
+      rope_base: 10000
+      norm_eps: 1e-5
+      dropout_rate: 0.1
+      attn_dropout_rate: 0.1
+      channels_first: true
+  pre_module: *transformer_module
+  semantic_codebook_size: 4096

--- a/xinference/thirdparty/fish_speech_s1/fish_speech/content_sequence.py
+++ b/xinference/thirdparty/fish_speech_s1/fish_speech/content_sequence.py
@@ -1,0 +1,372 @@
+from dataclasses import dataclass, field
+from typing import List, Literal, Union
+
+import numpy as np
+import torch
+
+from xinference.thirdparty.fish_speech_s1.fish_speech.tokenizer import (
+    IM_END_TOKEN,
+    MODALITY_TOKENS,
+    FishTokenizer,
+)
+
+
+def restore_ndarray(obj, to_tensor: bool = False):
+    if isinstance(obj, dict) and "__ndarray__" in obj:
+        obj = np.frombuffer(obj["data"], dtype=obj["dtype"]).reshape(obj["shape"])
+
+    if to_tensor and isinstance(obj, np.ndarray):
+        obj = torch.from_numpy(obj.copy())
+
+    return obj
+
+
+@dataclass
+class BasePart:
+    type: Literal["text", "vq", "audio"] | None = None
+    cal_loss: bool = False
+
+
+@dataclass(kw_only=True)
+class VQPart(BasePart):
+    type = "vq"
+    codes: torch.Tensor
+
+    def __post_init__(self: "VQPart"):
+        self.type = "vq"
+        self.codes = restore_ndarray(self.codes, to_tensor=True)
+
+
+@dataclass(kw_only=True)
+class TextPart(BasePart):
+    type = "text"
+    text: str | None = None
+    tokens: list[int] | None = None
+
+    def __post_init__(self: "TextPart"):
+        self.type = "text"
+        if self.text is None and self.tokens is None:
+            raise ValueError("Either text or tokens must be provided")
+
+
+@dataclass(kw_only=True)
+class AudioPart(BasePart):
+    type = "audio"
+    features: torch.Tensor
+
+    def __post_init__(self: "AudioPart"):
+        self.type = "audio"
+        self.features = restore_ndarray(self.features, to_tensor=True)
+
+
+@dataclass(kw_only=True)
+class EncodedMessage:
+    tokens: torch.Tensor
+    labels: torch.Tensor
+    vq_mask_tokens: torch.Tensor | None = None
+    vq_mask_labels: torch.Tensor | None = None
+    vq_parts: list[torch.Tensor]
+    vq_require_losses: torch.Tensor | None = None
+    audio_parts: list[torch.Tensor]
+    audio_masks: torch.Tensor | None = None
+    metadata: dict | None = None
+
+
+@dataclass
+class ContentSequence:
+    """
+    Flexible sequence of content parts that supports interleaved multimodal format.
+    Example format: <|interleave|><|speaker:1|> TEXT AUDIO <|im_end|><|speaker:2|> TEXT AUDIO <|im_end|>
+    """
+
+    parts: list[BasePart] = field(default_factory=list)
+    modality: Literal["text", "voice", "interleave"] | None = None
+    metadata: dict | None = None
+
+    def __init__(
+        self: "ContentSequence",
+        parts: list[BasePart | dict] | None = None,
+        modality: Literal["text", "voice", "interleave"] | None = None,
+        metadata: dict | None = None,
+    ):
+        self.modality = modality
+        self.metadata = metadata or {}
+
+        fixed_parts = []
+        for part in parts or []:
+            if isinstance(part, dict):
+                if part["type"] == "vq":
+                    part = VQPart(**part)
+                elif part["type"] == "audio":
+                    part = AudioPart(**part)
+                elif part["type"] == "text":
+                    part = TextPart(**part)
+                else:
+                    raise ValueError(f"Unsupported part type: {part['type']}")
+            fixed_parts.append(part)
+
+        self.parts = fixed_parts
+
+        # If modality is specified, add it at the beginning if it's not already there
+        if self.modality and not (
+            len(self.parts) > 0
+            and isinstance(self.parts[0], dict) is False
+            and isinstance(self.parts[0], TextPart)
+            and self.parts[0].text is not None
+            and self.parts[0].text.startswith(MODALITY_TOKENS[self.modality])
+        ):
+            modality_token = MODALITY_TOKENS[self.modality]
+            self.parts.insert(0, TextPart(text=modality_token))
+
+    def append(
+        self: "ContentSequence",
+        part_or_parts: Union[BasePart, List[BasePart]],
+        add_end: bool = False,
+        speaker: Union[str, int] | None = None,
+    ):
+        """
+        Append a part or list of parts to the sequence.
+
+        Args:
+            part_or_parts: A single part or list of parts to add
+            add_end: Whether to add the IM_END_TOKEN after these parts
+            speaker: Optional speaker identifier (name or ID) to add before the parts
+        """
+        # Convert single part to list
+        parts_to_add = (
+            [part_or_parts] if not isinstance(part_or_parts, list) else part_or_parts
+        )
+
+        # Add speaker token if specified
+        if speaker is not None:
+            speaker_token = f"<|speaker:{speaker}|>"
+            self.parts.append(TextPart(text=speaker_token))
+
+        # Add all the parts
+        self.parts.extend(parts_to_add)
+
+        # Add end token if requested
+        if add_end:
+            self.parts.append(
+                TextPart(text=IM_END_TOKEN, cal_loss=self.parts[-1].cal_loss)
+            )
+
+    def encode(
+        self: "ContentSequence",
+        tokenizer: FishTokenizer,
+        add_shift: bool = True,
+        ignore_loss_tokens: list[str] = [],
+    ) -> EncodedMessage:
+        """
+        Encode the sequence parts into tokens for the model.
+
+        Args:
+            tokenizer: The tokenizer to use
+            add_shift: Whether to shift tokens for next-token prediction
+            ignore_loss_tokens: List of token strings to ignore when calculating loss
+
+        Returns:
+            EncodedMessage with tensors ready for the model
+        """
+        all_tokens = []
+        all_labels = []
+
+        # Multi-modal elements
+        vq_parts = []
+        vq_masks = []
+        vq_require_losses = []
+
+        audio_parts = []
+        audio_masks = []
+
+        ignore_loss_token_ids = [tokenizer.get_token_id(i) for i in ignore_loss_tokens]
+
+        for part in self.parts:
+            if isinstance(part, TextPart):
+                if part.tokens is None:
+                    assert part.text is not None
+                    tokens = tokenizer.encode(part.text)
+                else:
+                    tokens = part.tokens
+
+                tokens = torch.tensor(tokens, dtype=torch.int)
+            elif isinstance(part, VQPart):
+                curr_codes = part.codes.clone().to(torch.int)
+                tokens = torch.tensor(
+                    [
+                        tokenizer.semantic_id_to_token_id[int(i.item())]
+                        for i in curr_codes[0].int()
+                    ],
+                    dtype=torch.int,
+                )
+                vq_parts.append(curr_codes)
+                vq_require_losses.append(part.cal_loss)
+            else:
+                raise ValueError(f"Unsupported part type: {type(part)}")
+
+            all_tokens.append(tokens)
+
+            # Set masks for different part types
+            if isinstance(part, VQPart):
+                vq_masks.append(torch.ones_like(tokens, dtype=torch.bool))
+                audio_masks.append(torch.zeros_like(tokens, dtype=torch.bool))
+            elif isinstance(part, AudioPart):
+                vq_masks.append(torch.zeros_like(tokens, dtype=torch.bool))
+                audio_mask = torch.ones_like(tokens, dtype=torch.bool)
+                audio_mask[0] = False  # Skip start token
+                audio_mask[-1] = False  # Skip end token
+                audio_masks.append(audio_mask)
+            else:
+                vq_masks.append(torch.zeros_like(tokens, dtype=torch.bool))
+                audio_masks.append(torch.zeros_like(tokens, dtype=torch.bool))
+
+            # Set labels based on whether we want to calculate loss for this part
+            if part.cal_loss and not isinstance(part, AudioPart):
+                all_labels.append(tokens.clone())
+            else:
+                all_labels.append(torch.full_like(tokens, -100))
+
+        # Concatenate all tensors
+        tokens = torch.cat(all_tokens, dim=0)
+        labels = torch.cat(all_labels, dim=0)
+        vq_masks = torch.cat(vq_masks, dim=0)
+        audio_masks = torch.cat(audio_masks, dim=0)
+        vq_require_losses = torch.tensor(vq_require_losses, dtype=torch.bool)
+
+        # Apply shift if needed for next-token prediction
+        vq_mask_tokens = vq_masks
+        vq_mask_labels = vq_masks
+
+        if add_shift:
+            tokens = tokens[:-1]
+            labels = labels[1:]
+            vq_masks = vq_masks[:-1]
+            vq_mask_tokens = vq_mask_tokens[:-1]
+            vq_mask_labels = vq_mask_labels[1:]
+            audio_masks = audio_masks[:-1]
+
+        # Ignore specified tokens
+        for i in ignore_loss_token_ids:
+            assert i != -100 and i is not None
+            labels[labels == i] = -100
+
+        assert tokens.dtype in [
+            torch.int,
+            torch.long,
+        ], f"Invalid dtype: {tokens.dtype}"
+
+        return EncodedMessage(
+            tokens=tokens,
+            labels=labels,
+            vq_parts=vq_parts,
+            vq_mask_tokens=vq_mask_tokens,
+            vq_mask_labels=vq_mask_labels,
+            vq_require_losses=vq_require_losses,
+            audio_parts=audio_parts,
+            audio_masks=audio_masks,
+            metadata=self.metadata,
+        )
+
+    def encode_for_inference(
+        self: "ContentSequence",
+        tokenizer: FishTokenizer,
+        num_codebooks: int,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        encoded = self.encode(tokenizer, add_shift=False)
+        tokens = encoded.tokens
+        values = torch.zeros((num_codebooks + 1, len(tokens)), dtype=torch.int)
+        values[0] = tokens
+
+        if (encoded.vq_parts is None or len(encoded.vq_parts) == 0) and (
+            encoded.audio_parts is None or len(encoded.audio_parts) == 0
+        ):
+            return values, None, None
+
+        audio_parts = audio_masks = None
+        if encoded.vq_parts is not None and len(encoded.vq_parts) > 0:
+            vq_parts = encoded.vq_parts
+            vq_parts = torch.cat(vq_parts, dim=1)
+            values[0, encoded.vq_mask_tokens] = (
+                vq_parts[0] + tokenizer.semantic_begin_id
+            )
+            values[1:, encoded.vq_mask_tokens] = vq_parts
+
+        if encoded.audio_parts is not None and len(encoded.audio_parts) > 0:
+            audio_parts = torch.cat(encoded.audio_parts, dim=0)
+            audio_masks = encoded.audio_masks[None, :]
+
+        return values, audio_masks, audio_parts
+
+    def visualize(
+        self: "ContentSequence",
+        tokenizer: FishTokenizer,
+        ignore_loss_tokens: list[str] = [],
+        merge_semantic_tokens: bool = False,
+    ):
+        """
+        Visualize the encoded sequence with color-coded tokens.
+        Blue/cyan tokens contribute to loss, green tokens do not.
+        """
+        encoded = self.encode(
+            tokenizer, add_shift=False, ignore_loss_tokens=ignore_loss_tokens
+        )
+
+        # Colors for alternating tokens
+        colors = {
+            "blue": "\033[94m",  # Light blue
+            "cyan": "\033[96m",  # Cyan
+            "green": "\033[92m",  # Light green
+            "dark_green": "\033[32m",  # Dark green
+        }
+        blue_idx = 0
+        green_idx = 0
+
+        def print_in_blue(x):
+            nonlocal blue_idx
+            color = colors["blue"] if blue_idx % 2 == 0 else colors["cyan"]
+            print(f"{color}{x}\033[0m", end="")
+            blue_idx += 1
+
+        def print_in_green(x):
+            nonlocal green_idx
+            color = colors["green"] if green_idx % 2 == 0 else colors["dark_green"]
+            print(f"{color}{x}\033[0m", end="")
+            green_idx += 1
+
+        def print_semantic_token(x, count):
+            val = f"[<|semantic|>x{count}]"
+            if x == -100:
+                print_in_green(val)
+            else:
+                print_in_blue(val)
+
+        count_semantic_tokens = 0
+        semantic_label = None
+
+        for tok, lab in zip(encoded.tokens, encoded.labels):
+            token_id = int(tok.item())
+
+            if merge_semantic_tokens:
+                if (
+                    tokenizer.semantic_begin_id <= token_id <= tokenizer.semantic_end_id
+                    and (semantic_label is None or semantic_label == lab)
+                ):
+                    count_semantic_tokens += 1
+                    semantic_label = lab
+                    continue
+                elif count_semantic_tokens > 0:
+                    print_semantic_token(semantic_label, count_semantic_tokens)
+                    count_semantic_tokens = 0
+                    semantic_label = None
+
+            val = tokenizer.decode([int(tok.item())])
+
+            if lab == -100:
+                print_in_green(val)
+            else:
+                print_in_blue(val)
+
+        if merge_semantic_tokens and count_semantic_tokens > 0:
+            print_semantic_token(semantic_label, count_semantic_tokens)
+
+        print()

--- a/xinference/thirdparty/fish_speech_s1/fish_speech/content_sequence.py
+++ b/xinference/thirdparty/fish_speech_s1/fish_speech/content_sequence.py
@@ -5,6 +5,9 @@ import numpy as np
 import torch
 
 from xinference.thirdparty.fish_speech_s1.fish_speech.tokenizer import (
+    AUDIO_EMBED_TOKEN,
+    AUDIO_END_TOKEN,
+    AUDIO_START_TOKEN,
     IM_END_TOKEN,
     MODALITY_TOKENS,
     FishTokenizer,
@@ -201,6 +204,15 @@ class ContentSequence:
                 )
                 vq_parts.append(curr_codes)
                 vq_require_losses.append(part.cal_loss)
+            elif isinstance(part, AudioPart):
+                audio_parts.append(part.features)
+                tokens = torch.tensor(
+                    [tokenizer.get_token_id(AUDIO_START_TOKEN)]
+                    + [tokenizer.get_token_id(AUDIO_EMBED_TOKEN)]
+                    * part.features.shape[0]
+                    + [tokenizer.get_token_id(AUDIO_END_TOKEN)],
+                    dtype=torch.int,
+                )
             else:
                 raise ValueError(f"Unsupported part type: {type(part)}")
 

--- a/xinference/thirdparty/fish_speech_s1/fish_speech/inference_engine/__init__.py
+++ b/xinference/thirdparty/fish_speech_s1/fish_speech/inference_engine/__init__.py
@@ -101,7 +101,7 @@ class TTSInferenceEngine(ReferenceLoader, VQManager):
             # Check the response type
             if not isinstance(wrapped_result.response, GenerateResponse):
                 raise TypeError(
-                    "Expected GenerateResponse, got {type(wrapped_result.response).__name__}"
+                    f"Expected GenerateResponse, got {type(wrapped_result.response).__name__}"
                 )
 
             result: GenerateResponse = wrapped_result.response

--- a/xinference/thirdparty/fish_speech_s1/fish_speech/inference_engine/__init__.py
+++ b/xinference/thirdparty/fish_speech_s1/fish_speech/inference_engine/__init__.py
@@ -1,0 +1,192 @@
+import gc
+import queue
+from typing import Generator
+
+import numpy as np
+import torch
+from loguru import logger
+
+from xinference.thirdparty.fish_speech_s1.fish_speech.inference_engine.reference_loader import ReferenceLoader
+from xinference.thirdparty.fish_speech_s1.fish_speech.inference_engine.utils import InferenceResult, wav_chunk_header
+from xinference.thirdparty.fish_speech_s1.fish_speech.inference_engine.vq_manager import VQManager
+from xinference.thirdparty.fish_speech_s1.fish_speech.models.dac.modded_dac import DAC
+from xinference.thirdparty.fish_speech_s1.fish_speech.models.text2semantic.inference import (
+    GenerateRequest,
+    GenerateResponse,
+    WrappedGenerateResponse,
+)
+from xinference.thirdparty.fish_speech_s1.fish_speech.utils import autocast_exclude_mps, set_seed
+from xinference.thirdparty.fish_speech_s1.fish_speech.utils.schema import ServeTTSRequest
+
+
+class TTSInferenceEngine(ReferenceLoader, VQManager):
+
+    def __init__(
+        self,
+        llama_queue: queue.Queue,
+        decoder_model: DAC,
+        precision: torch.dtype,
+        compile: bool,
+    ) -> None:
+
+        super().__init__()
+
+        self.llama_queue = llama_queue
+        self.decoder_model = decoder_model
+        self.precision = precision
+        self.compile = compile
+
+    @torch.inference_mode()
+    def inference(self, req: ServeTTSRequest) -> Generator[InferenceResult, None, None]:
+        """
+        Main inference function:
+        - Loads the reference audio and text.
+        - Calls the LLAMA model for inference.
+        - Decodes the VQ tokens to audio.
+        """
+
+        ref_id: str | None = req.reference_id
+        prompt_tokens, prompt_texts = [], []
+        # Load the reference audio and text based on id or hash
+        if ref_id is not None:
+            prompt_tokens, prompt_texts = self.load_by_id(ref_id, req.use_memory_cache)
+
+        elif req.references:
+            prompt_tokens, prompt_texts = self.load_by_hash(
+                req.references, req.use_memory_cache
+            )
+
+        # Set the random seed if provided
+        if req.seed is not None:
+            set_seed(req.seed)
+            logger.warning(f"set seed: {req.seed}")
+
+        # Get the symbolic tokens from the LLAMA model
+        response_queue = self.send_Llama_request(req, prompt_tokens, prompt_texts)
+
+        # Get the sample rate from the decoder model
+        if hasattr(self.decoder_model, "spec_transform"):
+            sample_rate = self.decoder_model.spec_transform.sample_rate
+        else:
+            sample_rate = self.decoder_model.sample_rate
+
+        # If streaming, send the header
+        if req.streaming:
+            yield InferenceResult(
+                code="header",
+                audio=(
+                    sample_rate,
+                    np.array(wav_chunk_header(sample_rate=sample_rate)),
+                ),
+                error=None,
+            )
+
+        segments = []
+
+        while True:
+            # Get the response from the LLAMA model
+            wrapped_result: WrappedGenerateResponse = response_queue.get()
+            if wrapped_result.status == "error":
+                yield InferenceResult(
+                    code="error",
+                    audio=None,
+                    error=(
+                        wrapped_result.response
+                        if isinstance(wrapped_result.response, Exception)
+                        else Exception("Unknown error")
+                    ),
+                )
+                break
+
+            # Check the response type
+            if not isinstance(wrapped_result.response, GenerateResponse):
+                raise TypeError(
+                    "Expected GenerateResponse, got {type(wrapped_result.response).__name__}"
+                )
+
+            result: GenerateResponse = wrapped_result.response
+            if result.action != "next":
+                segment = self.get_audio_segment(result)
+
+                if req.streaming:  # Used only by the API server
+                    yield InferenceResult(
+                        code="segment",
+                        audio=(sample_rate, segment),
+                        error=None,
+                    )
+                segments.append(segment)
+            else:
+                break
+
+        # Clean up the memory
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+            gc.collect()
+
+        # Edge case: no audio generated
+        if len(segments) == 0:
+            yield InferenceResult(
+                code="error",
+                audio=None,
+                error=RuntimeError("No audio generated, please check the input text."),
+            )
+        else:
+            # Streaming or not, return the final audio
+            audio = np.concatenate(segments, axis=0)
+            yield InferenceResult(
+                code="final",
+                audio=(sample_rate, audio),
+                error=None,
+            )
+
+        return None
+
+    def send_Llama_request(
+        self, req: ServeTTSRequest, prompt_tokens: list, prompt_texts: list
+    ) -> queue.Queue:
+        """
+        Send a request to the LLAMA model to generate the symbolic tokens.
+        """
+
+        # Prepare the request
+        request = dict(
+            device=self.decoder_model.device,
+            max_new_tokens=req.max_new_tokens,
+            text=req.text,
+            top_p=req.top_p,
+            repetition_penalty=req.repetition_penalty,
+            temperature=req.temperature,
+            compile=self.compile,
+            iterative_prompt=req.chunk_length > 0,
+            chunk_length=req.chunk_length,
+            prompt_tokens=prompt_tokens,
+            prompt_text=prompt_texts,
+        )
+
+        # Create a queue to get the response
+        response_queue = queue.Queue()
+
+        # Send the request to the LLAMA model
+        self.llama_queue.put(
+            GenerateRequest(
+                request=request,
+                response_queue=response_queue,
+            )
+        )
+
+        return response_queue
+
+    def get_audio_segment(self, result: GenerateResponse) -> np.ndarray:
+        """
+        Decode the VQ tokens to audio.
+        """
+
+        # Don't use autocast on MPS devices
+        with autocast_exclude_mps(
+            device_type=self.decoder_model.device.type, dtype=self.precision
+        ):
+            # Decode the symbolic tokens to audio
+            segment = self.decode_vq_tokens(codes=result.codes)
+
+        # Convert the audio to numpy
+        return segment.float().cpu().numpy()

--- a/xinference/thirdparty/fish_speech_s1/fish_speech/inference_engine/reference_loader.py
+++ b/xinference/thirdparty/fish_speech_s1/fish_speech/inference_engine/reference_loader.py
@@ -127,9 +127,8 @@ class ReferenceLoader:
         """
         Load the audio data from a file or bytes.
         """
-        if len(reference_audio) > 255 or not Path(reference_audio).exists():
-            audio_data = reference_audio
-            reference_audio = io.BytesIO(audio_data)
+        if isinstance(reference_audio, bytes):
+            reference_audio = io.BytesIO(reference_audio)
 
         waveform, original_sr = torchaudio.load(reference_audio, backend=self.backend)
 

--- a/xinference/thirdparty/fish_speech_s1/fish_speech/inference_engine/reference_loader.py
+++ b/xinference/thirdparty/fish_speech_s1/fish_speech/inference_engine/reference_loader.py
@@ -1,0 +1,279 @@
+import io
+import re
+from hashlib import sha256
+from pathlib import Path
+from typing import Callable, Literal, Tuple
+
+import torch
+import torchaudio
+from loguru import logger
+
+from xinference.thirdparty.fish_speech_s1.fish_speech.models.dac.modded_dac import DAC
+from xinference.thirdparty.fish_speech_s1.fish_speech.utils.file import (
+    AUDIO_EXTENSIONS,
+    audio_to_bytes,
+    list_files,
+    read_ref_text,
+)
+from xinference.thirdparty.fish_speech_s1.fish_speech.utils.schema import ServeReferenceAudio
+
+_ID_PATTERN = re.compile(r"^[a-zA-Z0-9\-_ ]+$")
+
+
+class ReferenceLoader:
+    def __init__(self) -> None:
+        """
+        Component of the TTSInferenceEngine class.
+        Loads and manages the cache for the reference audio and text.
+        """
+        self.ref_by_id: dict = {}
+        self.ref_by_hash: dict = {}
+
+        # Make Pylance happy (attribut/method not defined...)
+        self.decoder_model: DAC
+        self.encode_reference: Callable
+
+        # list_audio_backends() was removed in torchaudio 2.9.
+        try:
+            backends = torchaudio.list_audio_backends()
+            self.backend = "ffmpeg" if "ffmpeg" in backends else "soundfile"
+        except AttributeError:
+            try:
+                __import__("torchaudio.io._load_audio_fileobj")
+                self.backend = "ffmpeg"
+            except (ImportError, ModuleNotFoundError):
+                self.backend = "soundfile"
+
+    @staticmethod
+    def _validate_id(id: str) -> None:
+        if not _ID_PATTERN.match(id) or len(id) > 255:
+            raise ValueError(
+                "Reference ID contains invalid characters or is too long. "
+                "Only alphanumeric, hyphens, underscores, and spaces are allowed."
+            )
+
+    def load_by_id(
+        self,
+        id: str,
+        use_cache: Literal["on", "off"],
+    ) -> Tuple:
+        self._validate_id(id)
+
+        # Load the references audio and text by id
+        ref_folder = Path("references") / id
+        ref_folder.mkdir(parents=True, exist_ok=True)
+        ref_audios = list_files(
+            ref_folder, AUDIO_EXTENSIONS, recursive=True, sort=False
+        )
+
+        if use_cache == "off" or id not in self.ref_by_id:
+            # If the references are not already loaded, encode them
+            prompt_tokens = [
+                self.encode_reference(
+                    # decoder_model=self.decoder_model,
+                    reference_audio=audio_to_bytes(str(ref_audio)),
+                    enable_reference_audio=True,
+                )
+                for ref_audio in ref_audios
+            ]
+            prompt_texts = [
+                read_ref_text(str(ref_audio.with_suffix(".lab")))
+                for ref_audio in ref_audios
+            ]
+            self.ref_by_id[id] = (prompt_tokens, prompt_texts)
+
+        else:
+            # Reuse already encoded references
+            logger.info("Use same references")
+            prompt_tokens, prompt_texts = self.ref_by_id[id]
+
+        return prompt_tokens, prompt_texts
+
+    def load_by_hash(
+        self,
+        references: list[ServeReferenceAudio],
+        use_cache: Literal["on", "off"],
+    ) -> Tuple:
+        # Load the references audio and text by hash
+        audio_hashes = [sha256(ref.audio).hexdigest() for ref in references]
+
+        cache_used = False
+        prompt_tokens, prompt_texts = [], []
+        for i, ref in enumerate(references):
+            if use_cache == "off" or audio_hashes[i] not in self.ref_by_hash:
+                # If the references are not already loaded, encode them
+                prompt_tokens.append(
+                    self.encode_reference(
+                        reference_audio=ref.audio,
+                        enable_reference_audio=True,
+                    )
+                )
+                prompt_texts.append(ref.text)
+                self.ref_by_hash[audio_hashes[i]] = (prompt_tokens[-1], ref.text)
+
+            else:
+                # Reuse already encoded references
+                cached_token, cached_text = self.ref_by_hash[audio_hashes[i]]
+                prompt_tokens.append(cached_token)
+                prompt_texts.append(cached_text)
+                cache_used = True
+
+        if cache_used:
+            logger.info("Use same references")
+
+        return prompt_tokens, prompt_texts
+
+    def load_audio(self, reference_audio: bytes | str, sr: int):
+        """
+        Load the audio data from a file or bytes.
+        """
+        if len(reference_audio) > 255 or not Path(reference_audio).exists():
+            audio_data = reference_audio
+            reference_audio = io.BytesIO(audio_data)
+
+        waveform, original_sr = torchaudio.load(reference_audio, backend=self.backend)
+
+        if waveform.shape[0] > 1:
+            waveform = torch.mean(waveform, dim=0, keepdim=True)
+
+        if original_sr != sr:
+            resampler = torchaudio.transforms.Resample(
+                orig_freq=original_sr, new_freq=sr
+            )
+            waveform = resampler(waveform)
+
+        audio = waveform.squeeze().numpy()
+        return audio
+
+    def list_reference_ids(self) -> list[str]:
+        """
+        List all valid reference IDs (subdirectory names containing valid audio and .lab files).
+
+        Returns:
+            list[str]: List of valid reference IDs
+        """
+        ref_base_path = Path("references")
+        if not ref_base_path.exists():
+            return []
+
+        valid_ids = []
+        for ref_dir in ref_base_path.iterdir():
+            if not ref_dir.is_dir():
+                continue
+
+            # Check if directory contains at least one audio file and corresponding .lab file
+            audio_files = list_files(
+                ref_dir, AUDIO_EXTENSIONS, recursive=False, sort=False
+            )
+            if not audio_files:
+                continue
+
+            # Check if corresponding .lab file exists for at least one audio file
+            has_valid_pair = False
+            for audio_file in audio_files:
+                lab_file = audio_file.with_suffix(".lab")
+                if lab_file.exists():
+                    has_valid_pair = True
+                    break
+
+            if has_valid_pair:
+                valid_ids.append(ref_dir.name)
+
+        return sorted(valid_ids)
+
+    def add_reference(self, id: str, wav_file_path: str, reference_text: str) -> None:
+        """
+        Add a new reference voice by creating a new directory and copying files.
+
+        Args:
+            id: Reference ID (directory name)
+            wav_file_path: Path to the audio file to copy
+            reference_text: Text content for the .lab file
+
+        Raises:
+            FileExistsError: If the reference ID already exists
+            FileNotFoundError: If the audio file doesn't exist
+            OSError: If file operations fail
+        """
+        self._validate_id(id)
+
+        # Check if reference already exists
+        ref_dir = Path("references") / id
+        if ref_dir.exists():
+            raise FileExistsError(f"Reference ID '{id}' already exists")
+
+        # Check if audio file exists
+        audio_path = Path(wav_file_path)
+        if not audio_path.exists():
+            raise FileNotFoundError(f"Audio file not found: {wav_file_path}")
+
+        # Validate audio file extension
+        if audio_path.suffix.lower() not in AUDIO_EXTENSIONS:
+            raise ValueError(
+                f"Unsupported audio format: {audio_path.suffix}. Supported formats: {', '.join(AUDIO_EXTENSIONS)}"
+            )
+
+        try:
+            # Create reference directory
+            ref_dir.mkdir(parents=True, exist_ok=False)
+
+            # Determine the target audio filename with original extension
+            target_audio_path = ref_dir / f"sample{audio_path.suffix}"
+
+            # Copy audio file
+            import shutil
+
+            shutil.copy2(audio_path, target_audio_path)
+
+            # Create .lab file
+            lab_path = ref_dir / "sample.lab"
+            with open(lab_path, "w", encoding="utf-8") as f:
+                f.write(reference_text)
+
+            # Clear cache for this ID if it exists
+            if id in self.ref_by_id:
+                del self.ref_by_id[id]
+
+            logger.info(f"Successfully added reference voice with ID: {id}")
+
+        except Exception as e:
+            # Clean up on failure
+            if ref_dir.exists():
+                import shutil
+
+                shutil.rmtree(ref_dir)
+            raise e
+
+    def delete_reference(self, id: str) -> None:
+        """
+        Delete a reference voice by removing its directory and files.
+
+        Args:
+            id: Reference ID (directory name) to delete
+
+        Raises:
+            FileNotFoundError: If the reference ID doesn't exist
+            OSError: If file operations fail
+        """
+        self._validate_id(id)
+
+        # Check if reference exists
+        ref_dir = Path("references") / id
+        if not ref_dir.exists():
+            raise FileNotFoundError(f"Reference ID '{id}' does not exist")
+
+        try:
+            # Remove the entire reference directory
+            import shutil
+
+            shutil.rmtree(ref_dir)
+
+            # Clear cache for this ID if it exists
+            if id in self.ref_by_id:
+                del self.ref_by_id[id]
+
+            logger.info(f"Successfully deleted reference voice with ID: {id}")
+
+        except Exception as e:
+            logger.error(f"Failed to delete reference '{id}': {e}")
+            raise OSError(f"Failed to delete reference '{id}': {e}")

--- a/xinference/thirdparty/fish_speech_s1/fish_speech/inference_engine/utils.py
+++ b/xinference/thirdparty/fish_speech_s1/fish_speech/inference_engine/utils.py
@@ -1,0 +1,29 @@
+import io
+import wave
+from dataclasses import dataclass
+from typing import Literal, Optional, Tuple
+
+import numpy as np
+
+
+@dataclass
+class InferenceResult:
+    code: Literal["header", "segment", "error", "final"]
+    audio: Optional[Tuple[int, np.ndarray]]
+    error: Optional[Exception]
+
+
+def wav_chunk_header(
+    sample_rate: int = 44100, bit_depth: int = 16, channels: int = 1
+) -> bytes:
+    buffer = io.BytesIO()
+
+    with wave.open(buffer, "wb") as wav_file:
+        wav_file.setnchannels(channels)
+        wav_file.setsampwidth(bit_depth // 8)
+        wav_file.setframerate(sample_rate)
+
+    wav_header_bytes = buffer.getvalue()
+    buffer.close()
+
+    return wav_header_bytes

--- a/xinference/thirdparty/fish_speech_s1/fish_speech/inference_engine/vq_manager.py
+++ b/xinference/thirdparty/fish_speech_s1/fish_speech/inference_engine/vq_manager.py
@@ -1,0 +1,59 @@
+from typing import Callable
+
+import torch
+from loguru import logger
+
+from xinference.thirdparty.fish_speech_s1.fish_speech.models.dac.modded_dac import DAC
+
+
+class VQManager:
+
+    def __init__(self):
+        # Make Pylance happy (attribut/method not defined...)
+        self.decoder_model: DAC
+        self.load_audio: Callable
+
+    def decode_vq_tokens(self, codes):
+        feature_lengths = torch.tensor(
+            [codes.shape[1]], device=self.decoder_model.device
+        )
+        logger.info(f"VQ features: {codes.shape}")
+
+        if isinstance(self.decoder_model, DAC):
+            return self.decoder_model.decode(
+                indices=codes[None],
+                feature_lengths=feature_lengths,
+            )[0].squeeze()
+
+        raise ValueError(f"Unknown model type: {type(self.decoder_model)}")
+
+    def encode_reference(self, reference_audio, enable_reference_audio):
+        if enable_reference_audio and reference_audio is not None:
+            # Load audios, and prepare basic info here
+            if hasattr(self.decoder_model, "spec_transform"):
+                sample_rate = self.decoder_model.spec_transform.sample_rate
+            else:
+                sample_rate = self.decoder_model.sample_rate
+            reference_audio_content = self.load_audio(reference_audio, sample_rate)
+
+            audios = torch.from_numpy(reference_audio_content).to(
+                self.decoder_model.device
+            )[None, None, :]
+            audio_lengths = torch.tensor(
+                [audios.shape[2]], device=self.decoder_model.device, dtype=torch.long
+            )
+            logger.info(
+                f"Loaded audio with {audios.shape[2] / sample_rate:.2f} seconds"
+            )
+
+            # VQ Encoder
+            if isinstance(self.decoder_model, DAC):
+                prompt_tokens = self.decoder_model.encode(audios, audio_lengths)[0][0]
+                logger.info(f"Encoded prompt: {prompt_tokens.shape}")
+            else:
+                raise ValueError(f"Unknown model type: {type(self.decoder_model)}")
+        else:
+            prompt_tokens = None
+            logger.info("No reference audio provided")
+
+        return prompt_tokens

--- a/xinference/thirdparty/fish_speech_s1/fish_speech/models/__init__.py
+++ b/xinference/thirdparty/fish_speech_s1/fish_speech/models/__init__.py
@@ -1,0 +1,1 @@
+"""Fish Audio S1 model implementations."""

--- a/xinference/thirdparty/fish_speech_s1/fish_speech/models/dac/inference.py
+++ b/xinference/thirdparty/fish_speech_s1/fish_speech/models/dac/inference.py
@@ -1,0 +1,121 @@
+from pathlib import Path
+
+import click
+import hydra
+import numpy as np
+import soundfile as sf
+import torch
+import torchaudio
+from hydra import compose, initialize_config_dir
+from hydra.utils import instantiate
+from loguru import logger
+from omegaconf import OmegaConf
+
+from xinference.thirdparty.fish_speech_s1.fish_speech.utils.file import AUDIO_EXTENSIONS
+
+# register eval resolver
+OmegaConf.register_new_resolver("eval", eval, replace=True)
+
+
+def load_model(config_name, checkpoint_path, device="cuda"):
+    hydra.core.global_hydra.GlobalHydra.instance().clear()
+    config_dir = str(Path(__file__).resolve().parents[2] / "configs")
+    with initialize_config_dir(version_base="1.3", config_dir=config_dir):
+        cfg = compose(config_name=config_name)
+
+    model = instantiate(cfg)
+    state_dict = torch.load(
+        checkpoint_path, map_location=device, mmap=True, weights_only=True
+    )
+    if "state_dict" in state_dict:
+        state_dict = state_dict["state_dict"]
+
+    if any("generator" in k for k in state_dict):
+        state_dict = {
+            k.replace("generator.", ""): v
+            for k, v in state_dict.items()
+            if "generator." in k
+        }
+
+    result = model.load_state_dict(state_dict, strict=False, assign=True)
+    model.eval()
+    model.to(device)
+
+    logger.info(f"Loaded model: {result}")
+    return model
+
+
+@torch.no_grad()
+@click.command()
+@click.option(
+    "--input-path",
+    "-i",
+    default="test.wav",
+    type=click.Path(exists=True, path_type=Path),
+)
+@click.option(
+    "--output-path", "-o", default="fake.wav", type=click.Path(path_type=Path)
+)
+@click.option("--config-name", default="modded_dac_vq")
+@click.option(
+    "--checkpoint-path",
+    default="checkpoints/openaudio-s1-mini/codec.pth",
+)
+@click.option(
+    "--device",
+    "-d",
+    default="cuda",
+)
+def main(input_path, output_path, config_name, checkpoint_path, device):
+    model = load_model(config_name, checkpoint_path, device=device)
+
+    if input_path.suffix in AUDIO_EXTENSIONS:
+        logger.info(f"Processing in-place reconstruction of {input_path}")
+
+        # Load audio
+        audio, sr = torchaudio.load(str(input_path))
+        if audio.shape[0] > 1:
+            audio = audio.mean(0, keepdim=True)
+        audio = torchaudio.functional.resample(audio, sr, model.sample_rate)
+
+        audios = audio[None].to(device)
+        logger.info(
+            f"Loaded audio with {audios.shape[2] / model.sample_rate:.2f} seconds"
+        )
+
+        # VQ Encoder
+        audio_lengths = torch.tensor([audios.shape[2]], device=device, dtype=torch.long)
+        indices, indices_lens = model.encode(audios, audio_lengths)
+
+        if indices.ndim == 3:
+            indices = indices[0]
+
+        logger.info(f"Generated indices of shape {indices.shape}")
+
+        # Save indices
+        np.save(output_path.with_suffix(".npy"), indices.cpu().numpy())
+    elif input_path.suffix == ".npy":
+        logger.info(f"Processing precomputed indices from {input_path}")
+        indices = np.load(input_path)
+        indices = torch.from_numpy(indices).to(device).long()
+        assert indices.ndim == 2, f"Expected 2D indices, got {indices.ndim}"
+        indices_lens = torch.tensor([indices.shape[1]], device=device, dtype=torch.long)
+    else:
+        raise ValueError(f"Unknown input type: {input_path}")
+
+    # Restore
+    fake_audios, audio_lengths = model.decode(indices, indices_lens)
+    audio_time = fake_audios.shape[-1] / model.sample_rate
+
+    logger.info(
+        f"Generated audio of shape {fake_audios.shape}, equivalent to {audio_time:.2f} seconds from {indices.shape[1]} features, features/second: {indices.shape[1] / audio_time:.2f}"
+    )
+
+    # Save audio
+    fake_audio = fake_audios[0, 0].float().cpu().numpy()
+    sf.write(output_path, fake_audio, model.sample_rate)
+    logger.info(f"Saved audio to {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/xinference/thirdparty/fish_speech_s1/fish_speech/models/dac/modded_dac.py
+++ b/xinference/thirdparty/fish_speech_s1/fish_speech/models/dac/modded_dac.py
@@ -1,0 +1,978 @@
+import math
+import typing as tp
+from dataclasses import dataclass
+from typing import List, Optional, Union
+
+import hydra
+import librosa
+import numpy as np
+import soundfile as sf
+import torch
+from audiotools import AudioSignal
+from audiotools.ml import BaseModel
+from dac.model.base import CodecMixin
+from dac.nn.layers import Snake1d, WNConv1d, WNConvTranspose1d
+from omegaconf import OmegaConf
+from torch import Tensor, nn
+from torch.nn import functional as F
+from torch.nn.utils.parametrizations import weight_norm
+from torch.nn.utils.parametrize import remove_parametrizations
+
+
+@dataclass
+class VQResult:
+    z: torch.Tensor
+    codes: torch.Tensor
+    latents: torch.Tensor
+    codebook_loss: torch.Tensor
+    commitment_loss: torch.Tensor
+    semantic_distill_z: torch.Tensor | None = None
+
+
+def find_multiple(n: int, k: int) -> int:
+    if n % k == 0:
+        return n
+    return n + k - (n % k)
+
+
+@dataclass
+class ModelArgs:
+    block_size: int = 2048
+    n_layer: int = 8
+    n_head: int = 8
+    dim: int = 512
+    intermediate_size: int = 1536
+    n_local_heads: int = -1
+    head_dim: int = 64
+    rope_base: float = 10000
+    norm_eps: float = 1e-5
+    dropout_rate: float = 0.1
+    attn_dropout_rate: float = 0.1
+    channels_first: bool = True  # to be compatible with conv1d input/output
+    pos_embed_type: str = "rope"  # can be "rope" or "conformer"
+    max_relative_position: int = 128  # for conformer-style relative position embedding
+
+    def __post_init__(self):
+        if self.n_local_heads == -1:
+            self.n_local_heads = self.n_head
+        if self.intermediate_size is None:
+            hidden_dim = 4 * self.dim
+            n_hidden = int(2 * hidden_dim / 3)
+            self.intermediate_size = find_multiple(n_hidden, 256)
+        assert self.pos_embed_type in [
+            "rope",
+            "conformer",
+        ], "pos_embed_type must be either 'rope' or 'conformer'"
+
+
+class KVCache(nn.Module):
+    def __init__(
+        self, max_batch_size, max_seq_length, n_heads, head_dim, dtype=torch.bfloat16
+    ):
+        super().__init__()
+        cache_shape = (max_batch_size, n_heads, max_seq_length, head_dim)
+        self.register_buffer("k_cache", torch.zeros(cache_shape, dtype=dtype))
+        self.register_buffer("v_cache", torch.zeros(cache_shape, dtype=dtype))
+
+    def update(self, input_pos, k_val, v_val):
+        # input_pos: [S], k_val: [B, H, S, D]
+        assert input_pos.shape[0] == k_val.shape[2]
+
+        k_out = self.k_cache
+        v_out = self.v_cache
+        k_out[:, :, input_pos] = k_val
+        v_out[:, :, input_pos] = v_val
+
+        return (
+            k_out[:, :, : input_pos.max() + 1, :],
+            v_out[:, :, : input_pos.max() + 1, :],
+        )
+
+    def clear_cache(self, prompt_len):
+        self.k_cache[:, :, prompt_len:, :].fill_(0)
+        self.v_cache[:, :, prompt_len:, :].fill_(0)
+
+
+class Transformer(nn.Module):
+    def __init__(self, config: ModelArgs) -> None:
+        super().__init__()
+        self.config = config
+
+        self.layers = nn.ModuleList(
+            TransformerBlock(config) for _ in range(config.n_layer)
+        )
+        self.norm = RMSNorm(config.dim, eps=config.norm_eps)
+
+        # Only compute RoPE frequencies if using RoPE
+        if config.pos_embed_type == "rope":
+            freqs_cis = precompute_freqs_cis(
+                self.config.block_size, self.config.head_dim, self.config.rope_base
+            )
+            self.register_buffer("freqs_cis", freqs_cis)
+        else:
+            self.register_buffer("freqs_cis", None)
+
+        causal_mask = torch.tril(
+            torch.ones(self.config.block_size, self.config.block_size, dtype=torch.bool)
+        )
+        self.register_buffer("causal_mask", causal_mask)
+
+        self.max_batch_size = -1
+        self.max_seq_length = -1
+        self.use_kv_cache = False
+
+    def setup_caches(self, max_batch_size, max_seq_length):
+        """
+        This method will only be called during inference when using KV cache.
+        """
+        head_dim = self.config.dim // self.config.n_head
+        max_seq_length = find_multiple(max_seq_length, 8)
+        self.max_seq_length = max_seq_length
+        self.max_batch_size = max_batch_size
+        dtype = self.norm.weight.dtype
+        device = self.norm.weight.device
+
+        for b in self.layers:
+            b.attention.kv_cache = KVCache(
+                max_batch_size,
+                max_seq_length,
+                self.config.n_local_heads,
+                head_dim,
+                dtype,
+            ).to(device)
+
+        self.use_kv_cache = True
+
+    def forward(
+        self,
+        x: Tensor,
+        input_pos: Optional[Tensor] = None,
+        mask: Optional[Tensor] = None,
+    ) -> Tensor:
+        if self.config.pos_embed_type == "rope":
+            assert (
+                self.freqs_cis is not None
+            ), "RoPE frequencies must be initialized for RoPE positional embedding"
+            freqs_cis = self.freqs_cis[input_pos]
+        else:
+            freqs_cis = None
+
+        if mask is None:  # in case of non-causal model
+            if not self.training and self.use_kv_cache:
+                mask = self.causal_mask[None, None, input_pos]
+                mask = mask[..., : input_pos.max() + 1]
+            else:
+                mask = self.causal_mask[None, None, input_pos]
+                mask = mask[..., input_pos]
+
+        for i, layer in enumerate(self.layers):
+            x = layer(x, input_pos, freqs_cis, mask)
+        x = self.norm(x)
+        return x
+
+
+class TransformerBlock(nn.Module):
+    def __init__(self, config: ModelArgs) -> None:
+        super().__init__()
+        self.attention = Attention(config)
+        self.feed_forward = FeedForward(config)
+        self.ffn_norm = RMSNorm(config.dim, eps=config.norm_eps)
+        self.attention_norm = RMSNorm(config.dim, eps=config.norm_eps)
+        self.attention_layer_scale = LayerScale(config.dim, inplace=True)
+        self.ffn_layer_scale = LayerScale(config.dim, inplace=True)
+
+    def forward(
+        self,
+        x: Tensor,
+        input_pos: Tensor,
+        freqs_cis: Tensor,
+        mask: Tensor,
+    ) -> Tensor:
+        h = x + self.attention_layer_scale(
+            self.attention(self.attention_norm(x), freqs_cis, mask, input_pos)
+        )
+        out = h + self.ffn_layer_scale(self.feed_forward(self.ffn_norm(h)))
+        return out
+
+
+class Attention(nn.Module):
+    def __init__(self, config: ModelArgs):
+        super().__init__()
+        assert config.dim % config.n_head == 0
+
+        total_head_dim = (config.n_head + 2 * config.n_local_heads) * config.head_dim
+        # key, query, value projections for all heads, but in a batch
+        self.wqkv = nn.Linear(config.dim, total_head_dim, bias=False)
+        self.wo = nn.Linear(config.head_dim * config.n_head, config.dim, bias=False)
+        self.kv_cache = None
+
+        self.n_head = config.n_head
+        self.head_dim = config.head_dim
+        self.n_local_heads = config.n_local_heads
+        self.dim = config.dim
+        self.attn_dropout_rate = config.attn_dropout_rate
+        self.pos_embed_type = config.pos_embed_type
+
+        # Add relative position embedding for conformer-style
+        if self.pos_embed_type == "conformer":
+            self.max_relative_position = config.max_relative_position
+            num_pos_embeddings = 2 * config.max_relative_position + 1
+            self.rel_pos_embeddings = nn.Parameter(
+                torch.zeros(num_pos_embeddings, self.head_dim)
+            )
+            nn.init.normal_(self.rel_pos_embeddings, mean=0.0, std=0.02)
+
+    def _compute_conformer_pos_scores(self, q: Tensor, seqlen: int) -> Tensor:
+        # q: [B, H, S, D]
+        # Returns: [B, H, S, S]
+        positions = torch.arange(seqlen, device=q.device)
+        relative_positions = positions.unsqueeze(1) - positions.unsqueeze(0)  # [S, S]
+        relative_positions = torch.clamp(
+            relative_positions + self.max_relative_position,
+            0,
+            2 * self.max_relative_position,
+        )
+        rel_embeddings = self.rel_pos_embeddings[relative_positions]  # [S, S, D]
+
+        # Compute attention scores with relative position embeddings
+        q = q.transpose(1, 2)  # [B, S, H, D]
+        rel_logits = torch.matmul(q, rel_embeddings.transpose(-2, -1))  # [B, S, H, S]
+        rel_logits = rel_logits.transpose(1, 2)  # [B, H, S, S]
+        return rel_logits
+
+    def forward(
+        self,
+        x: Tensor,
+        freqs_cis: Tensor,
+        mask: Tensor,
+        input_pos: Optional[Tensor] = None,
+    ) -> Tensor:
+        bsz, seqlen, _ = x.shape
+
+        kv_size = self.n_local_heads * self.head_dim
+        q, k, v = self.wqkv(x).split([kv_size, kv_size, kv_size], dim=-1)
+        context_seqlen = seqlen
+
+        q = q.view(bsz, seqlen, self.n_head, self.head_dim)
+        k = k.view(bsz, context_seqlen, self.n_local_heads, self.head_dim)
+        v = v.view(bsz, context_seqlen, self.n_local_heads, self.head_dim)
+
+        if self.pos_embed_type == "rope":
+            q = apply_rotary_emb(q, freqs_cis)
+            k = apply_rotary_emb(k, freqs_cis)
+
+        q, k, v = map(lambda x: x.transpose(1, 2), (q, k, v))
+
+        if self.kv_cache is not None:
+            k, v = self.kv_cache.update(input_pos, k, v)
+
+        k = k.repeat_interleave(self.n_head // self.n_local_heads, dim=1)
+        v = v.repeat_interleave(self.n_head // self.n_local_heads, dim=1)
+
+        if self.pos_embed_type == "conformer":
+            # Compute attention scores
+            scale = 1.0 / math.sqrt(self.head_dim)
+            scores = torch.matmul(q, k.transpose(-2, -1)) * scale
+
+            # Add relative position embeddings for conformer-style
+            rel_scores = self._compute_conformer_pos_scores(q, seqlen)
+            scores = scores + rel_scores
+
+            # Apply attention
+            if mask is not None:
+                scores = scores.masked_fill(~mask, float("-inf"))
+
+            attn = F.softmax(scores, dim=-1)
+            if self.attn_dropout_rate > 0 and self.training:
+                attn = F.dropout(attn, p=self.attn_dropout_rate)
+
+            y = torch.matmul(attn, v)
+        else:
+            y = F.scaled_dot_product_attention(
+                q,
+                k,
+                v,
+                dropout_p=self.attn_dropout_rate if self.training else 0.0,
+                attn_mask=mask,
+            )
+            # is_causal=True)
+        y = (
+            y.transpose(1, 2)
+            .contiguous()
+            .view(bsz, seqlen, self.head_dim * self.n_head)
+        )
+        y = self.wo(y)
+        return y
+
+
+class FeedForward(nn.Module):
+    def __init__(self, config: ModelArgs) -> None:
+        super().__init__()
+        self.w1 = nn.Linear(config.dim, config.intermediate_size, bias=False)
+        self.w3 = nn.Linear(config.dim, config.intermediate_size, bias=False)
+        self.w2 = nn.Linear(config.intermediate_size, config.dim, bias=False)
+        self.dropout = nn.Dropout(config.dropout_rate)
+
+    def forward(self, x: Tensor) -> Tensor:
+        return self.w2(self.dropout(F.silu(self.w1(x)) * self.w3(x)))
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim: int, eps: float = 1e-5):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(dim))
+
+    def _norm(self, x):
+        return x * torch.rsqrt(torch.mean(x * x, dim=-1, keepdim=True) + self.eps)
+
+    def forward(self, x: Tensor) -> Tensor:
+        output = self._norm(x.float()).type_as(x)
+        return output * self.weight
+
+
+class LayerScale(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        init_values: Union[float, Tensor] = 1e-2,
+        inplace: bool = False,
+    ) -> None:
+        super().__init__()
+        self.inplace = inplace
+        self.gamma = nn.Parameter(init_values * torch.ones(dim))
+
+    def forward(self, x: Tensor) -> Tensor:
+        return x.mul_(self.gamma) if self.inplace else x * self.gamma
+
+
+class WindowLimitedTransformer(Transformer):
+    """
+    Transformer with window limited attention, causal.
+    """
+
+    def __init__(
+        self,
+        config: ModelArgs,
+        input_dim: int = 512,
+        window_size: Optional[int] = None,
+        causal: bool = True,
+        look_ahead_conv: nn.Module = None,
+    ):
+        super().__init__(config)
+        self.window_size = window_size
+        self.causal = causal
+        self.channels_first = config.channels_first
+        self.look_ahead_conv = (
+            look_ahead_conv if look_ahead_conv is not None else nn.Identity()
+        )
+        self.input_proj = (
+            nn.Linear(input_dim, config.dim)
+            if input_dim != config.dim
+            else nn.Identity()
+        )
+        self.output_proj = (
+            nn.Linear(config.dim, input_dim)
+            if input_dim != config.dim
+            else nn.Identity()
+        )
+
+    def make_window_limited_mask(
+        self,
+        max_length: int,
+        x_lens: Optional[Tensor] = None,
+    ) -> Tensor:
+        """
+        Make mask to form window limited attention.
+        """
+        if self.causal:
+            mask = torch.tril(torch.ones(max_length, max_length))
+            row_indices = torch.arange(max_length).view(-1, 1)
+            window_size = self.window_size or max_length
+            valid_range = (row_indices - window_size + 1).clamp(min=0)
+            column_indices = torch.arange(max_length)
+            mask = (column_indices >= valid_range) & mask.bool()
+        else:
+            raise NotImplementedError
+        mask = mask.bool()[None, None]
+        return mask
+
+    def make_mask(
+        self,
+        max_length: int,
+        x_lens: Optional[Tensor] = None,
+    ) -> Tensor:
+        """
+        Make ordinary mask if window size is not specified.
+        """
+        if self.causal:
+            mask = torch.tril(torch.ones(max_length, max_length))
+        else:
+            mask = torch.ones(max_length, max_length)
+            mask = mask.bool()[None, None]
+            for i, x_len in enumerate(x_lens):
+                mask[:x_len, i] = 0
+        mask = mask.bool()[None, None]
+        return mask
+
+    def forward(
+        self,
+        x: Tensor,
+        x_lens: Optional[Tensor] = None,
+    ) -> Tensor:
+        if self.channels_first:
+            x = x.transpose(1, 2)
+        x = self.input_proj(x)  # (B, T, D)
+        x = self.look_ahead_conv(x)
+        input_pos = torch.arange(x.shape[1], device=x.device)
+        # construct mask to form window limited attention
+        max_length = x.shape[1]
+        if self.window_size is not None:
+            mask = self.make_window_limited_mask(max_length, x_lens)
+        else:
+            mask = self.make_mask(max_length, x_lens)
+        mask = mask.to(x.device)
+        x = super().forward(x, input_pos, mask)
+        x = self.output_proj(x)  # (B, T, D)
+        if self.channels_first:
+            x = x.transpose(1, 2)
+        return x
+
+
+def precompute_freqs_cis(
+    seq_len: int, n_elem: int, base: int = 10000, dtype: torch.dtype = torch.bfloat16
+) -> Tensor:
+    freqs = 1.0 / (
+        base ** (torch.arange(0, n_elem, 2)[: (n_elem // 2)].float() / n_elem)
+    )
+    t = torch.arange(seq_len, device=freqs.device)
+    freqs = torch.outer(t, freqs)
+    freqs_cis = torch.polar(torch.ones_like(freqs), freqs)
+    cache = torch.stack([freqs_cis.real, freqs_cis.imag], dim=-1)
+    return cache.to(dtype=dtype)
+
+
+def apply_rotary_emb(x: Tensor, freqs_cis: Tensor) -> Tensor:
+    xshaped = x.float().reshape(*x.shape[:-1], -1, 2)
+    freqs_cis = freqs_cis.view(1, xshaped.size(1), 1, xshaped.size(3), 2)
+    x_out2 = torch.stack(
+        [
+            xshaped[..., 0] * freqs_cis[..., 0] - xshaped[..., 1] * freqs_cis[..., 1],
+            xshaped[..., 1] * freqs_cis[..., 0] + xshaped[..., 0] * freqs_cis[..., 1],
+        ],
+        -1,
+    )
+
+    x_out2 = x_out2.flatten(3)
+    return x_out2.type_as(x)
+
+
+def init_weights(m):
+    if isinstance(m, nn.Conv1d):
+        nn.init.trunc_normal_(m.weight, std=0.02)
+        nn.init.constant_(m.bias, 0)
+
+
+def unpad1d(x: torch.Tensor, paddings: tp.Tuple[int, int]):
+    """Remove padding from x, handling properly zero padding. Only for 1d!"""
+    padding_left, padding_right = paddings
+    assert padding_left >= 0 and padding_right >= 0, (padding_left, padding_right)
+    assert (padding_left + padding_right) <= x.shape[-1]
+    end = x.shape[-1] - padding_right
+    return x[..., padding_left:end]
+
+
+def get_extra_padding_for_conv1d(
+    x: torch.Tensor, kernel_size: int, stride: int, padding_total: int = 0
+) -> int:
+    """See `pad_for_conv1d`."""
+    length = x.shape[-1]
+    n_frames = (length - kernel_size + padding_total) / stride + 1
+    ideal_length = (math.ceil(n_frames) - 1) * stride + (kernel_size - padding_total)
+    return ideal_length - length
+
+
+def pad1d(
+    x: torch.Tensor,
+    paddings: tp.Tuple[int, int],
+    mode: str = "zeros",
+    value: float = 0.0,
+):
+    """Tiny wrapper around F.pad, just to allow for reflect padding on small input.
+    If this is the case, we insert extra 0 padding to the right
+    before the reflection happen.
+    """
+    length = x.shape[-1]
+    padding_left, padding_right = paddings
+    assert padding_left >= 0 and padding_right >= 0, (padding_left, padding_right)
+    if mode == "reflect":
+        max_pad = max(padding_left, padding_right)
+        extra_pad = 0
+        if length <= max_pad:
+            extra_pad = max_pad - length + 1
+            x = F.pad(x, (0, extra_pad))
+        padded = F.pad(x, paddings, mode, value)
+        end = padded.shape[-1] - extra_pad
+        return padded[..., :end]
+    else:
+        return F.pad(x, paddings, mode, value)
+
+
+class CausalConvNet(nn.Module):
+    def __init__(
+        self,
+        in_channels,
+        out_channels,
+        kernel_size,
+        dilation=1,
+        stride=1,
+        groups=1,
+        padding=None,
+    ):
+        super(CausalConvNet, self).__init__()
+        self.conv = nn.Conv1d(
+            in_channels,
+            out_channels,
+            kernel_size,
+            stride=stride,
+            dilation=dilation,
+            groups=groups,
+        )
+        self.stride = stride
+        self.kernel_size = (kernel_size - 1) * dilation + 1
+        self.dilation = dilation
+        self.padding = self.kernel_size - self.stride
+
+    def forward(self, x):
+        pad = self.padding
+        extra_padding = get_extra_padding_for_conv1d(
+            x, self.kernel_size, self.stride, pad
+        )
+        x = pad1d(x, (pad, extra_padding), mode="constant", value=0)
+        return self.conv(x).contiguous()
+
+    def weight_norm(self, name="weight", dim=0):
+        self.conv = weight_norm(self.conv, name=name, dim=dim)
+        return self
+
+    def remove_weight_norm(self):
+        self.conv = remove_parametrizations(self.conv)
+        return self
+
+
+class CausalTransConvNet(nn.Module):
+    def __init__(
+        self, in_channels, out_channels, kernel_size, dilation=1, stride=1, padding=None
+    ):
+        super(CausalTransConvNet, self).__init__()
+        self.conv = nn.ConvTranspose1d(
+            in_channels, out_channels, kernel_size, stride=stride, dilation=dilation
+        )
+        self.stride = stride
+        self.kernel_size = kernel_size
+
+    def forward(self, x):
+        x = self.conv(x)
+        pad = self.kernel_size - self.stride
+        padding_right = math.ceil(pad)
+        padding_left = pad - padding_right
+        x = unpad1d(x, (padding_left, padding_right))
+        return x.contiguous()
+
+    def weight_norm(self, name="weight", dim=0):
+        self.conv = weight_norm(self.conv, name=name, dim=dim)
+        return self
+
+    def remove_weight_norm(self):
+        self.conv = remove_parametrizations(self.conv)
+        return self
+
+
+def CausalWNConv1d(*args, **kwargs):
+    return CausalConvNet(*args, **kwargs).weight_norm()
+
+
+def CausalWNConvTranspose1d(*args, **kwargs):
+    return CausalTransConvNet(*args, **kwargs).weight_norm()
+
+
+class ResidualUnit(nn.Module):
+    def __init__(self, dim: int = 16, dilation: int = 1, causal: bool = False):
+        super().__init__()
+        conv_class = CausalWNConv1d if causal else WNConv1d
+        pad = ((7 - 1) * dilation) // 2
+        self.block = nn.Sequential(
+            Snake1d(dim),
+            conv_class(dim, dim, kernel_size=7, dilation=dilation, padding=pad),
+            Snake1d(dim),
+            conv_class(dim, dim, kernel_size=1),
+        )
+        self.causal = causal
+
+    def forward(self, x):
+        y = self.block(x)
+        pad = x.shape[-1] - y.shape[-1]
+        if pad > 0:
+            if self.causal:
+                x = x[..., :-pad]
+            else:
+                x = x[..., pad // 2 : -pad // 2]
+        return x + y
+
+
+class EncoderBlock(nn.Module):
+    def __init__(
+        self,
+        dim: int = 16,
+        stride: int = 1,
+        causal: bool = False,
+        n_t_layer: int = 0,
+        transformer_general_config=None,
+    ):
+        super().__init__()
+        conv_class = CausalWNConv1d if causal else WNConv1d
+        transformer_module = (
+            nn.Identity()
+            if n_t_layer == 0
+            else (
+                WindowLimitedTransformer(
+                    causal=causal,
+                    input_dim=dim,
+                    window_size=512,
+                    config=transformer_general_config(
+                        n_layer=n_t_layer,
+                        n_head=dim // 64,
+                        dim=dim,
+                        intermediate_size=dim * 3,
+                    ),
+                )
+            )
+        )
+        self.block = nn.Sequential(
+            ResidualUnit(dim // 2, dilation=1, causal=causal),
+            ResidualUnit(dim // 2, dilation=3, causal=causal),
+            ResidualUnit(dim // 2, dilation=9, causal=causal),
+            Snake1d(dim // 2),
+            conv_class(
+                dim // 2,
+                dim,
+                kernel_size=2 * stride,
+                stride=stride,
+                padding=math.ceil(stride / 2),
+            ),
+            transformer_module,
+        )
+
+    def forward(self, x):
+        return self.block(x)
+
+
+class Encoder(nn.Module):
+    def __init__(
+        self,
+        d_model: int = 64,
+        strides: list = [2, 4, 8, 8],
+        d_latent: int = 64,
+        n_transformer_layers: list = [0, 0, 4, 4],
+        transformer_general_config: ModelArgs = None,
+        causal: bool = False,
+    ):
+        super().__init__()
+        conv_class = CausalWNConv1d if causal else WNConv1d
+        # Create first convolution
+        self.block = [conv_class(1, d_model, kernel_size=7, padding=3)]
+
+        # Create EncoderBlocks that double channels as they downsample by `stride`
+        for stride, n_t_layer in zip(strides, n_transformer_layers):
+            d_model *= 2
+            self.block += [
+                EncoderBlock(
+                    d_model,
+                    stride=stride,
+                    causal=causal,
+                    n_t_layer=n_t_layer,
+                    transformer_general_config=transformer_general_config,
+                )
+            ]
+
+        # Create last convolution
+        self.block += [
+            Snake1d(d_model),
+            conv_class(d_model, d_latent, kernel_size=3, padding=1),
+        ]
+
+        # Wrap black into nn.Sequential
+        self.block = nn.Sequential(*self.block)
+        self.enc_dim = d_model
+
+    def forward(self, x):
+        return self.block(x)
+
+
+class DecoderBlock(nn.Module):
+    def __init__(
+        self,
+        input_dim: int = 16,
+        output_dim: int = 8,
+        stride: int = 1,
+        causal: bool = False,
+        n_t_layer: int = 0,
+        transformer_general_config=None,
+    ):
+        super().__init__()
+        conv_trans_class = CausalWNConvTranspose1d if causal else WNConvTranspose1d
+        transformer_module = (
+            nn.Identity()
+            if n_t_layer == 0
+            else (
+                WindowLimitedTransformer(
+                    causal=causal,
+                    input_dim=input_dim,
+                    window_size=None,
+                    config=transformer_general_config(
+                        n_layer=n_t_layer,
+                        n_head=input_dim // 64,
+                        dim=input_dim,
+                        intermediate_size=input_dim * 3,
+                    ),
+                )
+            )
+        )
+        self.block = nn.Sequential(
+            # transformer_module,
+            Snake1d(input_dim),
+            conv_trans_class(
+                input_dim,
+                output_dim,
+                kernel_size=2 * stride,
+                stride=stride,
+                padding=math.ceil(stride / 2),
+            ),
+            ResidualUnit(output_dim, dilation=1, causal=causal),
+            ResidualUnit(output_dim, dilation=3, causal=causal),
+            ResidualUnit(output_dim, dilation=9, causal=causal),
+        )
+
+    def forward(self, x):
+        return self.block(x)
+
+
+class Decoder(nn.Module):
+    def __init__(
+        self,
+        input_channel,
+        channels,
+        rates,
+        d_out: int = 1,
+        causal: bool = False,
+        n_transformer_layers: list = [0, 0, 0, 0],
+        transformer_general_config=None,
+    ):
+        super().__init__()
+        conv_class = CausalWNConv1d if causal else WNConv1d
+        # Add first conv layer
+        layers = [conv_class(input_channel, channels, kernel_size=7, padding=3)]
+
+        # Add upsampling + MRF blocks
+        for i, (stride, n_t_layer) in enumerate(zip(rates, n_transformer_layers)):
+            input_dim = channels // 2**i
+            output_dim = channels // 2 ** (i + 1)
+            layers += [
+                DecoderBlock(
+                    input_dim,
+                    output_dim,
+                    stride,
+                    causal=causal,
+                    n_t_layer=n_t_layer,
+                    transformer_general_config=transformer_general_config,
+                )
+            ]
+
+        # Add final conv layer
+        layers += [
+            Snake1d(output_dim),
+            conv_class(output_dim, d_out, kernel_size=7, padding=3),
+            nn.Tanh(),
+        ]
+
+        self.model = nn.Sequential(*layers)
+
+    def forward(self, x):
+        return self.model(x)
+
+
+class DAC(BaseModel, CodecMixin):
+    def __init__(
+        self,
+        encoder_dim: int = 64,
+        encoder_rates: List[int] = [2, 4, 8, 8],
+        latent_dim: int = None,
+        decoder_dim: int = 1536,
+        decoder_rates: List[int] = [8, 8, 4, 2],
+        quantizer: torch.nn.Module = None,
+        sample_rate: int = 44100,
+        causal: bool = True,
+        encoder_transformer_layers: List[int] = [0, 0, 0, 0],
+        decoder_transformer_layers: List[int] = [0, 0, 0, 0],
+        transformer_general_config=None,
+    ):
+        super().__init__()
+
+        self.encoder_dim = encoder_dim
+        self.encoder_rates = encoder_rates
+        self.decoder_dim = decoder_dim
+        self.decoder_rates = decoder_rates
+        self.sample_rate = sample_rate
+
+        if latent_dim is None:
+            latent_dim = encoder_dim * (2 ** len(encoder_rates))
+
+        self.latent_dim = latent_dim
+
+        self.hop_length = np.prod(encoder_rates)
+        self.encoder = Encoder(
+            encoder_dim,
+            encoder_rates,
+            latent_dim,
+            causal=causal,
+            n_transformer_layers=encoder_transformer_layers,
+            transformer_general_config=transformer_general_config,
+        )
+
+        self.quantizer = quantizer
+
+        self.decoder = Decoder(
+            latent_dim,
+            decoder_dim,
+            decoder_rates,
+            causal=causal,
+            n_transformer_layers=decoder_transformer_layers,
+            transformer_general_config=transformer_general_config,
+        )
+        self.sample_rate = sample_rate
+        self.apply(init_weights)
+
+        self.delay = self.get_delay()
+
+        self.frame_length = self.hop_length * 4
+
+    def preprocess(self, audio_data, sample_rate):
+        if sample_rate is None:
+            sample_rate = self.sample_rate
+        assert sample_rate == self.sample_rate
+
+        length = audio_data.shape[-1]
+        right_pad = math.ceil(length / self.hop_length) * self.hop_length - length
+        audio_data = nn.functional.pad(audio_data, (0, right_pad))
+
+        return audio_data
+
+    def encode(
+        self,
+        audio_data: torch.Tensor,
+        audio_lengths: torch.Tensor = None,
+        n_quantizers: int = None,
+        **kwargs,
+    ):
+        """Encode given audio data and return quantized latent codes
+
+        Parameters
+        ----------
+        audio_data : Tensor[B x T]
+            Audio data to encode
+        n_quantizers : int, optional
+            Number of quantizers to use, by default None
+            If None, all quantizers are used.
+
+        Returns
+        -------
+        dict
+            A dictionary with the following keys:
+            "z" : Tensor[B x D x T]
+                Quantized continuous representation of input
+            "codes" : Tensor[B x N x T]
+                Codebook indices for each codebook
+                (quantized discrete representation of input)
+            "latents" : Tensor[B x N*D x T]
+                Projected latents (continuous representation of input before quantization)
+            "vq/commitment_loss" : Tensor[1]
+                Commitment loss to train encoder to predict vectors closer to codebook
+                entries
+            "vq/codebook_loss" : Tensor[1]
+                Codebook loss to update the codebook
+            "length" : int
+                Number of samples in input audio
+        """
+        # pad to multiple of self.frame_length
+        if audio_data.ndim == 2:
+            audio_data = audio_data.unsqueeze(1)
+        # print(audio_data.shape)
+        length = audio_data.shape[-1]
+        right_pad = math.ceil(length / self.frame_length) * self.frame_length - length
+        audio_data = nn.functional.pad(audio_data, (0, right_pad))
+        if audio_lengths is None:
+            audio_lengths = torch.LongTensor([length + right_pad]).to(audio_data.device)
+
+        z = self.encoder(audio_data)
+        vq_results = self.quantizer(z, n_quantizers, **kwargs)
+        indices = vq_results.codes
+        indices_lens = torch.ceil(audio_lengths / self.frame_length).long()
+        return indices, indices_lens
+
+    def decode(self, indices: torch.Tensor, feature_lengths):
+        if indices.ndim == 2:
+            indices = indices[None]
+
+        z = self.quantizer.decode(indices)
+        audio_lengths = feature_lengths * self.frame_length
+        return self.decoder(z), audio_lengths
+
+    def forward(
+        self,
+        audio_data: torch.Tensor,
+        template: torch.Tensor = None,
+        mask: torch.Tensor = None,
+        sample_rate: int = None,
+        n_quantizers: int = None,
+        **kwargs,
+    ):
+        """Model forward pass
+
+        Parameters
+        ----------
+        audio_data : Tensor[B x 1 x T]
+            Audio data to encode
+        sample_rate : int, optional
+            Sample rate of audio data in Hz, by default None
+            If None, defaults to `self.sample_rate`
+        n_quantizers : int, optional
+            Number of quantizers to use, by default None.
+            If None, all quantizers are used.
+
+        Returns
+        -------
+        dict
+            A dictionary with the following keys:
+            "z" : Tensor[B x D x T]
+                Quantized continuous representation of input
+            "codes" : Tensor[B x N x T]
+                Codebook indices for each codebook
+                (quantized discrete representation of input)
+            "latents" : Tensor[B x N*D x T]
+                Projected latents (continuous representation of input before quantization)
+            "vq/commitment_loss" : Tensor[1]
+                Commitment loss to train encoder to predict vectors closer to codebook
+                entries
+            "vq/codebook_loss" : Tensor[1]
+                Codebook loss to update the codebook
+            "length" : int
+                Number of samples in input audio
+            "audio" : Tensor[B x 1 x length]
+                Decoded audio data.
+        """
+        length = audio_data.shape[-1]
+        audio_data = self.preprocess(audio_data, sample_rate)
+        vq_results = self.encode(audio_data, n_quantizers, **kwargs)
+        z = vq_results[0] if isinstance(vq_results, tuple) else vq_results.z
+        x = self.decode(z)
+        return x[..., :length], vq_results

--- a/xinference/thirdparty/fish_speech_s1/fish_speech/models/dac/rvq.py
+++ b/xinference/thirdparty/fish_speech_s1/fish_speech/models/dac/rvq.py
@@ -1,0 +1,403 @@
+import math
+import typing as tp
+from dataclasses import dataclass
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from dac.nn.quantize import ResidualVectorQuantize
+from torch.nn.utils.parametrizations import weight_norm
+from torch.nn.utils.parametrize import remove_parametrizations
+
+
+def unpad1d(x: torch.Tensor, paddings: tp.Tuple[int, int]):
+    """Remove padding from x, handling properly zero padding. Only for 1d!"""
+    padding_left, padding_right = paddings
+    assert padding_left >= 0 and padding_right >= 0, (padding_left, padding_right)
+    assert (padding_left + padding_right) <= x.shape[-1]
+    end = x.shape[-1] - padding_right
+    return x[..., padding_left:end]
+
+
+def get_extra_padding_for_conv1d(
+    x: torch.Tensor, kernel_size: int, stride: int, padding_total: int = 0
+) -> int:
+    """See `pad_for_conv1d`."""
+    length = x.shape[-1]
+    n_frames = (length - kernel_size + padding_total) / stride + 1
+    ideal_length = (math.ceil(n_frames) - 1) * stride + (kernel_size - padding_total)
+    return ideal_length - length
+
+
+def pad1d(
+    x: torch.Tensor,
+    paddings: tp.Tuple[int, int],
+    mode: str = "zeros",
+    value: float = 0.0,
+):
+    """Tiny wrapper around F.pad, just to allow for reflect padding on small input.
+    If this is the case, we insert extra 0 padding to the right
+    before the reflection happen.
+    """
+    length = x.shape[-1]
+    padding_left, padding_right = paddings
+    assert padding_left >= 0 and padding_right >= 0, (padding_left, padding_right)
+    if mode == "reflect":
+        max_pad = max(padding_left, padding_right)
+        extra_pad = 0
+        if length <= max_pad:
+            extra_pad = max_pad - length + 1
+            x = F.pad(x, (0, extra_pad))
+        padded = F.pad(x, paddings, mode, value)
+        end = padded.shape[-1] - extra_pad
+        return padded[..., :end]
+    else:
+        return F.pad(x, paddings, mode, value)
+
+
+class CausalConvNet(nn.Module):
+    def __init__(
+        self,
+        in_channels,
+        out_channels,
+        kernel_size,
+        dilation=1,
+        stride=1,
+        groups=1,
+        padding=None,
+    ):
+        super(CausalConvNet, self).__init__()
+        self.conv = nn.Conv1d(
+            in_channels,
+            out_channels,
+            kernel_size,
+            stride=stride,
+            dilation=dilation,
+            groups=groups,
+        )
+        self.stride = stride
+        self.kernel_size = (kernel_size - 1) * dilation + 1
+        self.dilation = dilation
+        self.padding = self.kernel_size - self.stride
+
+    def forward(self, x):
+        pad = self.padding
+        extra_padding = get_extra_padding_for_conv1d(
+            x, self.kernel_size, self.stride, pad
+        )
+        x = pad1d(x, (pad, extra_padding), mode="constant", value=0)
+        return self.conv(x).contiguous()
+
+    def weight_norm(self, name="weight", dim=0):
+        self.conv = weight_norm(self.conv, name=name, dim=dim)
+        return self
+
+    def remove_weight_norm(self):
+        self.conv = remove_parametrizations(self.conv)
+        return self
+
+
+class CausalTransConvNet(nn.Module):
+    def __init__(
+        self, in_channels, out_channels, kernel_size, dilation=1, stride=1, padding=None
+    ):
+        super(CausalTransConvNet, self).__init__()
+        self.conv = nn.ConvTranspose1d(
+            in_channels, out_channels, kernel_size, stride=stride, dilation=dilation
+        )
+        self.stride = stride
+        self.kernel_size = kernel_size
+
+    def forward(self, x):
+        x = self.conv(x)
+        pad = self.kernel_size - self.stride
+        padding_right = math.ceil(pad)
+        padding_left = pad - padding_right
+        x = unpad1d(x, (padding_left, padding_right))
+        return x.contiguous()
+
+    def weight_norm(self, name="weight", dim=0):
+        self.conv = weight_norm(self.conv, name=name, dim=dim)
+        return self
+
+    def remove_weight_norm(self):
+        self.conv = remove_parametrizations(self.conv)
+        return self
+
+
+# ConvNeXt Block copied from https://github.com/fishaudio/fish-diffusion/blob/main/fish_diffusion/modules/convnext.py
+class ConvNeXtBlock(nn.Module):
+    r"""ConvNeXt Block. There are two equivalent implementations:
+    (1) DwConv -> LayerNorm (channels_first) -> 1x1 Conv -> GELU -> 1x1 Conv; all in (N, C, H, W)
+    (2) DwConv -> Permute to (N, H, W, C); LayerNorm (channels_last) -> Linear -> GELU -> Linear; Permute back
+    We use (2) as we find it slightly faster in PyTorch
+    Args:
+        dim (int): Number of input channels.
+        drop_path (float): Stochastic depth rate. Default: 0.0
+        layer_scale_init_value (float): Init value for Layer Scale. Default: 1e-6.
+        mlp_ratio (float): Ratio of mlp hidden dim to embedding dim. Default: 4.0.
+        kernel_size (int): Kernel size for depthwise conv. Default: 7.
+        dilation (int): Dilation for depthwise conv. Default: 1.
+    """  # noqa: E501
+
+    def __init__(
+        self,
+        dim: int,
+        layer_scale_init_value: float = 1e-6,
+        mlp_ratio: float = 4.0,
+        kernel_size: int = 7,
+        dilation: int = 1,
+    ):
+        super().__init__()
+        convnet_type = CausalConvNet
+        self.dwconv = convnet_type(
+            dim,
+            dim,
+            kernel_size=kernel_size,
+            # padding=int(dilation * (kernel_size - 1) / 2),
+            groups=dim,
+            dilation=dilation,
+        )  # depthwise conv
+        self.norm = nn.LayerNorm(dim, eps=1e-6)
+        self.pwconv1 = nn.Linear(
+            dim, int(mlp_ratio * dim)
+        )  # pointwise/1x1 convs, implemented with linear layers
+        self.act = nn.GELU()
+        self.pwconv2 = nn.Linear(int(mlp_ratio * dim), dim)
+        self.gamma = (
+            nn.Parameter(layer_scale_init_value * torch.ones((dim)), requires_grad=True)
+            if layer_scale_init_value > 0
+            else None
+        )
+
+    def forward(self, x, apply_residual: bool = True):
+        input = x
+
+        x = self.dwconv(x)
+        x = x.permute(0, 2, 1)  # (N, C, L) -> (N, L, C)
+        x = self.norm(x)
+        x = self.pwconv1(x)
+        x = self.act(x)
+        x = self.pwconv2(x)
+
+        if self.gamma is not None:
+            x = self.gamma * x
+
+        x = x.permute(0, 2, 1)  # (N, L, C) -> (N, C, L)
+
+        if apply_residual:
+            x = input + x
+
+        return x
+
+
+@dataclass
+class VQResult:
+    z: torch.Tensor
+    codes: torch.Tensor
+    latents: torch.Tensor
+    codebook_loss: torch.Tensor
+    commitment_loss: torch.Tensor
+    semantic_distill_z: torch.Tensor | None = None
+
+
+class DownsampleResidualVectorQuantize(nn.Module):
+    def __init__(
+        self,
+        input_dim: int = 1024,
+        n_codebooks: int = 9,
+        codebook_dim: int = 8,
+        quantizer_dropout: float = 0.5,
+        codebook_size: int = 1024,
+        semantic_codebook_size: int = 4096,
+        downsample_factor: tuple[int] = (2, 2),
+        downsample_dims: tuple[int] | None = None,
+        pre_module: nn.Module | None = None,
+        post_module: nn.Module | None = None,
+        semantic_predictor_module: nn.Module | None = None,
+    ):
+        super().__init__()
+
+        if downsample_dims is None:
+            downsample_dims = [input_dim for _ in range(len(downsample_factor))]
+
+        all_dims = (input_dim,) + tuple(downsample_dims)
+
+        self.semantic_quantizer = ResidualVectorQuantize(
+            input_dim=input_dim,
+            n_codebooks=1,
+            codebook_size=semantic_codebook_size,
+            codebook_dim=codebook_dim,
+            quantizer_dropout=0.0,
+        )
+
+        self.quantizer = ResidualVectorQuantize(
+            input_dim=input_dim,
+            n_codebooks=n_codebooks,
+            codebook_size=codebook_size,
+            codebook_dim=codebook_dim,
+            quantizer_dropout=quantizer_dropout,
+        )
+
+        self.downsample_factor = downsample_factor
+        self.downsample_dims = downsample_dims
+
+        convnet_type = CausalConvNet
+        transconvnet_type = CausalTransConvNet
+
+        self.downsample = nn.Sequential(
+            *[
+                nn.Sequential(
+                    convnet_type(
+                        all_dims[idx],
+                        all_dims[idx + 1],
+                        kernel_size=factor,
+                        stride=factor,
+                    ),
+                    ConvNeXtBlock(dim=all_dims[idx + 1]),
+                )
+                for idx, factor in enumerate(downsample_factor)
+            ]
+        )
+
+        self.upsample = nn.Sequential(
+            *[
+                nn.Sequential(
+                    transconvnet_type(
+                        all_dims[idx + 1],
+                        all_dims[idx],
+                        kernel_size=factor,
+                        stride=factor,
+                    ),
+                    ConvNeXtBlock(dim=all_dims[idx]),
+                )
+                for idx, factor in reversed(list(enumerate(downsample_factor)))
+            ]
+        )
+        self.apply(self._init_weights)
+        self.pre_module = (
+            pre_module if pre_module is not None else nn.Identity()
+        )  # leave for transformer, LSTM or Mamba or something else
+        self.post_module = post_module if post_module is not None else nn.Identity()
+        self.semantic_predictor_module = (
+            semantic_predictor_module
+            if semantic_predictor_module is not None
+            else nn.Identity()
+        )
+
+    def _init_weights(self, m):
+        if isinstance(m, (nn.Conv1d, nn.Linear)):
+            nn.init.trunc_normal_(m.weight, std=0.02)
+            nn.init.constant_(m.bias, 0)
+
+    def forward(
+        self, z, n_quantizers: int = None, semantic_len: torch.Tensor = None, **kwargs
+    ):
+        # z: (B, D, T)
+        original_shape = z.shape
+        if semantic_len is None:
+            semantic_len = torch.LongTensor([z.shape[-1]])
+        z = self.downsample(z)
+        z = self.pre_module(z)  # B, T, D
+        (
+            semantic_z,
+            semantic_codes,
+            semantic_latents,
+            semantic_commitment_loss,
+            semantic_codebook_loss,
+        ) = self.semantic_quantizer(z)
+        residual_z = z - semantic_z
+        residual_z, codes, latents, commitment_loss, codebook_loss = self.quantizer(
+            residual_z, n_quantizers=n_quantizers
+        )
+        z = semantic_z + residual_z
+        commitment_loss = commitment_loss + semantic_commitment_loss
+        codebook_loss = codebook_loss + semantic_codebook_loss
+        codes = torch.cat([semantic_codes, codes], dim=1)
+        latents = torch.cat([semantic_latents, latents], dim=1)
+        z = self.post_module(z)
+        z = self.upsample(z)
+        # z: (B, D, T)
+
+        # semantic distillation (disabled here since only used in training)
+        # semantic_distill_z = self.semantic_predictor_module(semantic_z, semantic_len).mT  # wav2vec target is B, T, D
+
+        # Pad or crop z to match original shape
+        diff = original_shape[-1] - z.shape[-1]
+        right = 0
+        left = abs(diff) - right
+
+        if diff > 0:
+            z = F.pad(z, (left, right))
+        elif diff < 0:
+            z = z[..., left:]
+
+        results = VQResult(
+            z=z,
+            codes=codes,
+            latents=latents,
+            commitment_loss=commitment_loss,
+            codebook_loss=codebook_loss,
+        )
+
+        return results
+
+    # def encode(self, z):
+    #     z = self.downsample(z)
+    #     z = self.pre_module(z)
+    #     _, indices, _, _, _ = self.quantizer(z.mT)
+    #     indices = rearrange(indices, "g b l r -> b (g r) l")
+    #     return indices
+    #
+    def decode(self, indices: torch.Tensor):
+        # indices = rearrange(indices, "b (g r) l -> g b l r", g=self.residual_fsq.groups)
+
+        # print(f"indices: {indices.shape}, semantic_quantizer.codebook_size: {self.semantic_quantizer.codebook_size}, quantizer.codebook_size: {self.quantizer.codebook_size}, semantic min: {indices[:, 0].min()}, max: {indices[:, 0].max()}, quantizer min: {indices[:, 1:].min()}, max: {indices[:, 1:].max()}")
+
+        new_indices = torch.zeros_like(indices)
+        new_indices[:, 0] = torch.clamp(
+            indices[:, 0], max=self.semantic_quantizer.codebook_size - 1
+        )
+        new_indices[:, 1:] = torch.clamp(
+            indices[:, 1:], max=self.quantizer.codebook_size - 1
+        )
+
+        z_q_semantic = self.semantic_quantizer.from_codes(new_indices[:, :1])[0]
+        z_q_residual = self.quantizer.from_codes(new_indices[:, 1:])[0]
+        z_q = z_q_semantic + z_q_residual
+        z_q = self.post_module(z_q)
+        z_q = self.upsample(z_q)
+        return z_q
+
+    # def from_latents(self, latents: torch.Tensor):
+    #     z_q, z_p, codes = super().from_latents(latents)
+    #     z_q = self.upsample(z_q)
+    #     return z_q, z_p, codes
+
+
+if __name__ == "__main__":
+    rvq = DownsampleResidualVectorQuantize(
+        input_dim=512,
+        n_codebooks=8,
+        codebook_dim=8,
+        codebook_size=1024,
+        quantizer_dropout=0.5,
+        downsample_factor=[2, 2],
+    )
+    rvq.eval()
+    x = torch.randn(2, 512, 442)
+
+    result = rvq(x)
+    print(rvq)
+    print(result.latents.shape, result.codes.shape, result.z.shape)
+
+    # y = rvq.from_codes(result.codes)
+    # print(y[0].shape)
+
+    # y = rvq.from_latents(
+
+    result1 = rvq(x[:, :, :40])
+    print(result1.latents.shape, result1.codes.shape, result1.z.shape)
+
+    assert torch.allclose(result.z[:, :, :40], result1.z, atol=1e-8)
+    print("Success")

--- a/xinference/thirdparty/fish_speech_s1/fish_speech/models/text2semantic/inference.py
+++ b/xinference/thirdparty/fish_speech_s1/fish_speech/models/text2semantic/inference.py
@@ -1,0 +1,706 @@
+import os
+import queue
+import threading
+import time
+import traceback
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Literal, Optional, Tuple, Union
+
+import click
+import numpy as np
+import torch
+import torch._inductor.config
+from loguru import logger
+from tqdm import tqdm
+from transformers import AutoTokenizer
+
+from xinference.thirdparty.fish_speech_s1.fish_speech.content_sequence import (
+    ContentSequence,
+    TextPart,
+    VQPart,
+)
+from xinference.thirdparty.fish_speech_s1.fish_speech.tokenizer import IM_END_TOKEN
+
+os.environ["TOKENIZERS_PARALLELISM"] = "false"
+torch._inductor.config.coordinate_descent_tuning = True
+torch._inductor.config.triton.unique_kernel_names = True
+
+if hasattr(torch._inductor.config, "fx_graph_cache"):
+    # Experimental feature to reduce compilation times, will be on by default in future
+    torch._inductor.config.fx_graph_cache = True
+
+
+from torch.nn.attention import SDPBackend, sdpa_kernel
+
+from xinference.thirdparty.fish_speech_s1.fish_speech.models.text2semantic.llama import (
+    BaseTransformer,
+    DualARTransformer,
+    NaiveTransformer,
+)
+
+
+def multinomial_sample_one_no_sync(
+    probs_sort,
+):  # Does multinomial sampling without a cuda synchronization
+    q = torch.empty_like(probs_sort).exponential_(1)
+    return torch.argmax(probs_sort / q, dim=-1, keepdim=True).to(dtype=torch.int)
+
+
+def logits_to_probs(
+    logits,
+    temperature: torch.Tensor,
+    top_p: torch.Tensor,
+    repetition_penalty: torch.Tensor,
+    previous_tokens: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    # Apply repetition penalty
+    if previous_tokens is not None:
+        previous_tokens = previous_tokens.long()
+        score = torch.gather(logits, dim=-1, index=previous_tokens)
+        score = torch.where(
+            score < 0, score * repetition_penalty, score / repetition_penalty
+        )
+        logits.scatter_(dim=-1, index=previous_tokens, src=score)
+
+    # Apply top-p sampling
+    sorted_logits, sorted_indices = torch.sort(logits, descending=True)
+    cum_probs = torch.cumsum(torch.nn.functional.softmax(sorted_logits, dim=-1), dim=-1)
+    sorted_indices_to_remove = cum_probs > top_p
+    sorted_indices_to_remove[0] = False  # keep at least one option
+    indices_to_remove = sorted_indices_to_remove.scatter(
+        dim=-1, index=sorted_indices, src=sorted_indices_to_remove
+    )
+    logits = logits.masked_fill(indices_to_remove, -float("Inf"))
+    logits = logits / torch.clip(temperature, min=1e-5)
+
+    probs = torch.nn.functional.softmax(logits, dim=-1)
+    return probs
+
+
+def sample(
+    logits,
+    temperature: torch.Tensor,
+    top_p: torch.Tensor,
+    repetition_penalty: torch.Tensor,
+    previous_tokens: Optional[torch.Tensor] = None,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    probs = logits_to_probs(
+        logits=logits[0, -1],
+        temperature=temperature,
+        top_p=top_p,
+        repetition_penalty=repetition_penalty,
+        previous_tokens=previous_tokens,
+    )
+    idx_next = multinomial_sample_one_no_sync(probs)
+    return idx_next, probs
+
+
+def decode_one_token_ar(
+    model: DualARTransformer,
+    x: torch.Tensor,
+    input_pos: torch.Tensor,
+    temperature: torch.Tensor,
+    top_p: torch.Tensor,
+    repetition_penalty: torch.Tensor,
+    audio_masks: torch.Tensor,
+    audio_parts: torch.Tensor,
+    previous_tokens: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    # print(x, torch.count_nonzero(vq_masks))
+    forward_result = model.forward_generate(
+        x,
+        input_pos,
+        audio_masks=audio_masks,
+        audio_parts=audio_parts,
+    )
+    logits = forward_result.logits  # [:, -1:]
+    hidden_states = forward_result.hidden_states  # [:, -1:]
+
+    codebooks = [
+        sample(
+            logits,
+            temperature=temperature,
+            top_p=top_p,
+            repetition_penalty=repetition_penalty,
+            previous_tokens=(
+                previous_tokens[:, 0] if previous_tokens is not None else None
+            ),
+        )[0]
+    ]
+
+    # Only clear cache for fast_layers, avoid clearing main model cache
+    for layer in model.fast_layers:
+        if hasattr(layer, "attention") and hasattr(layer.attention, "kv_cache"):
+            layer.attention.kv_cache.k_cache.fill_(0)
+            layer.attention.kv_cache.v_cache.fill_(0)
+
+    input_pos = torch.tensor([0], device=hidden_states.device, dtype=torch.long)
+    model.forward_generate_fast(hidden_states, input_pos)
+    a = codebooks[0] - model.tokenizer.semantic_begin_id
+    a[a < 0] = 0
+    hidden_states = model.fast_embeddings(a)
+    codebooks.append(a)
+
+    for codebook_idx in range(1, model.config.num_codebooks):
+        input_pos = torch.tensor(
+            [codebook_idx], device=hidden_states.device, dtype=torch.long
+        )
+        logits = model.forward_generate_fast(hidden_states, input_pos)
+
+        short_logits = logits[:, :, :1024]
+
+        # Convert logits to probs
+        a = sample(
+            short_logits,
+            temperature=temperature,
+            top_p=top_p,
+            repetition_penalty=repetition_penalty,
+            previous_tokens=(
+                previous_tokens[codebook_idx + 1]
+                if previous_tokens is not None
+                else None
+            ),
+        )[0]
+
+        hidden_states = model.fast_embeddings(a)
+        codebooks.append(a)
+
+    codebooks = torch.stack(codebooks, dim=1)
+
+    # Only delete references, let Python GC handle cleanup
+    del logits, hidden_states, forward_result
+
+    return codebooks.T
+
+
+def decode_n_tokens(
+    model: DualARTransformer,
+    cur_token: torch.Tensor,
+    input_pos: torch.Tensor,
+    num_new_tokens: int,
+    temperature: torch.Tensor,
+    top_p: torch.Tensor,
+    repetition_penalty: torch.Tensor,
+    audio_masks: torch.Tensor,
+    audio_parts: torch.Tensor,
+    decode_one_token=decode_one_token_ar,
+):
+    previous_tokens = torch.zeros(
+        (model.config.num_codebooks + 1, model.config.max_seq_len),
+        dtype=torch.int,
+        device=cur_token.device,
+    )
+
+    for i in tqdm(range(num_new_tokens)):
+        # We need to get windowed repeat penalty
+        win_size = 16
+        if i < win_size:
+            window = previous_tokens[:, :win_size]
+        else:
+            window = previous_tokens[:, i - win_size : i]
+
+        with sdpa_kernel(
+            SDPBackend.MATH
+        ):  # Actually better for Inductor to codegen attention here
+            next_token = decode_one_token(
+                model=model,
+                x=cur_token,
+                input_pos=input_pos,
+                previous_tokens=window,
+                temperature=temperature,
+                top_p=top_p,
+                repetition_penalty=repetition_penalty,
+                audio_masks=audio_masks,
+                audio_parts=audio_parts,
+            ).clone()
+
+        input_pos += 1
+        cur_token = next_token.view(1, model.config.num_codebooks + 1, -1)
+        previous_tokens[:, i : i + 1] = next_token.view(
+            model.config.num_codebooks + 1, -1
+        )
+
+        if cur_token[0, 0, -1] == model.tokenizer.get_token_id(IM_END_TOKEN):
+            break
+
+    # Only clean up the large tensor
+    del cur_token
+
+    return previous_tokens[:, : i + 1]
+
+
+@torch.no_grad()
+@torch.inference_mode()
+def generate(
+    *,
+    model: DualARTransformer,
+    prompt: torch.Tensor,
+    max_new_tokens: int,
+    audio_masks: torch.Tensor,
+    audio_parts: torch.Tensor,
+    decode_one_token=decode_one_token_ar,
+    num_samples: int = 1,
+    **sampling_kwargs,
+):
+    """
+    Takes a conditioning sequence (prompt) as input and continues to generate as many tokens as requested.
+    """
+
+    # create an empty tensor of the expected final shape and fill in the current tokens
+    T = prompt.size(1)
+    prompt = prompt[None].repeat(num_samples, 1, 1)
+
+    if T >= model.config.max_seq_len:
+        raise ValueError(
+            f"Input sequence length {T} exceeds max_seq_len {model.config.max_seq_len}"
+        )
+
+    if max_new_tokens:
+        if T + max_new_tokens > model.config.max_seq_len:
+            max_new_tokens = model.config.max_seq_len - T
+
+        T_new = T + max_new_tokens
+    else:
+        T_new = model.config.max_seq_len
+        max_new_tokens = T_new - T
+
+    device, dtype = prompt.device, prompt.dtype
+
+    # Critical fix: Only set up cache on first run or when necessary
+    if not hasattr(model, "_cache_setup_done") or not model._cache_setup_done:
+        with torch.device(device):
+            model.setup_caches(
+                max_batch_size=1,  # Fixed to 1, avoid dynamic changes
+                max_seq_len=model.config.max_seq_len,
+                dtype=next(model.parameters()).dtype,
+            )
+        model._cache_setup_done = True
+
+    codebook_dim = 1 + model.config.num_codebooks
+
+    # Create new tensor each time, but try to reuse memory
+    input_pos = torch.arange(0, T, device=device, dtype=torch.long)
+    empty = torch.empty(
+        (codebook_dim, model.config.max_seq_len), dtype=dtype, device=device
+    )
+    empty[:, :T] = prompt
+    seq = empty
+
+    # Use pre-created fixed parameter tensors
+    temperature = getattr(
+        model, "fixed_temperature", torch.tensor(0.8, device=device, dtype=torch.float)
+    )
+    top_p = getattr(
+        model, "fixed_top_p", torch.tensor(0.8, device=device, dtype=torch.float)
+    )
+    repetition_penalty = getattr(
+        model,
+        "fixed_repetition_penalty",
+        torch.tensor(1.1, device=device, dtype=torch.float),
+    )
+
+    # If different parameter values are needed, directly modify existing tensors
+    temp_val = sampling_kwargs.get("temperature", 0.7)
+    top_p_val = sampling_kwargs.get("top_p", 0.7)
+    rep_val = sampling_kwargs.get("repetition_penalty", 1.5)
+
+    if abs(temperature.item() - temp_val) > 1e-6:
+        temperature.fill_(temp_val)
+    if abs(top_p.item() - top_p_val) > 1e-6:
+        top_p.fill_(top_p_val)
+    if abs(repetition_penalty.item() - rep_val) > 1e-6:
+        repetition_penalty.fill_(rep_val)
+
+    prefill_decode = decode_one_token_ar
+
+    first_token = prefill_decode(
+        model,
+        prompt.view(1, codebook_dim, -1),
+        input_pos,
+        temperature,
+        top_p,
+        repetition_penalty,
+        audio_masks,
+        audio_parts,
+    )
+    seq[:, T : T + 1] = first_token
+
+    # Recreate input_pos
+    input_pos = torch.tensor([T], device=device, dtype=torch.int)
+
+    x = decode_n_tokens(
+        model,
+        first_token.view(1, codebook_dim, -1),
+        input_pos,
+        max_new_tokens - 1,
+        temperature=temperature,
+        top_p=top_p,
+        repetition_penalty=repetition_penalty,
+        audio_masks=audio_masks,
+        audio_parts=audio_parts,
+        decode_one_token=decode_one_token,
+    )
+    seq = seq[:, : T + 1 + x.size(1)]
+    seq[:, T + 1 :] = x
+
+    # Clean up temporary variables
+    del first_token, x, prompt, empty, input_pos
+
+    return seq
+
+
+def init_model(checkpoint_path, device, precision, compile=False):
+    model = DualARTransformer.from_pretrained(checkpoint_path, load_weights=True)
+
+    model = model.to(device=device, dtype=precision)
+    logger.info(f"Restored model from checkpoint")
+
+    if isinstance(model, DualARTransformer):
+        decode_one_token = decode_one_token_ar
+        prefill_n_tokens = decode_one_token_ar
+        logger.info("Using DualARTransformer")
+    else:
+        raise ValueError("Unsupported model type")
+
+    # Pre-create fixed parameter tensors to avoid runtime creation
+    model.fixed_temperature = torch.tensor(0.7, device=device, dtype=torch.float)
+    model.fixed_top_p = torch.tensor(0.7, device=device, dtype=torch.float)
+    model.fixed_repetition_penalty = torch.tensor(1.5, device=device, dtype=torch.float)
+
+    # Mark whether cache has been initialized
+    model._cache_setup_done = False
+
+    if compile:
+        logger.info("Compiling function...")
+        decode_one_token = torch.compile(
+            decode_one_token,
+            backend="inductor" if torch.cuda.is_available() else "aot_eager",
+            mode="reduce-overhead" if torch.cuda.is_available() else None,
+            fullgraph=True,
+        )
+
+    return model.eval(), decode_one_token
+
+
+@dataclass
+class GenerateResponse:
+    action: Literal["sample", "next"]
+    codes: Optional[torch.Tensor] = None
+    text: Optional[str] = None
+
+
+def generate_long(
+    *,
+    model,
+    device: Union[str, torch.device],
+    decode_one_token: Callable,
+    text: str,
+    num_samples: int = 1,
+    max_new_tokens: int = 0,
+    top_p: float = 0.8,
+    repetition_penalty: float = 1.1,
+    temperature: float = 0.8,
+    compile: bool = False,
+    iterative_prompt: bool = True,
+    chunk_length: int = 512,
+    prompt_text: Optional[Union[str, list[str]]] = None,
+    prompt_tokens: Optional[Union[torch.Tensor, list[torch.Tensor]]] = None,
+):
+    assert 0 < top_p <= 1, "top_p must be in (0, 1]"
+    assert 0 < repetition_penalty < 2, "repetition_penalty must be in (0, 2)"
+    assert 0 < temperature < 2, "temperature must be in (0, 2)"
+
+    use_prompt = prompt_text is not None and prompt_tokens is not None
+    if use_prompt and isinstance(prompt_text, str):
+        prompt_text = [prompt_text]
+        prompt_tokens = [prompt_tokens]
+
+    if use_prompt:
+        assert len(prompt_text) == len(
+            prompt_tokens
+        ), "Prompt text and tokens must have the same length"
+
+    if prompt_tokens:
+        prompt_tokens = [i.cpu() for i in prompt_tokens]
+
+    model_size = sum(p.numel() for p in model.parameters() if p.requires_grad)
+    tokenizer = model.tokenizer
+    base_content_sequence = ContentSequence(modality="interleave")
+
+    max_length = model.config.max_seq_len
+    if use_prompt:
+        for t, c in zip(prompt_text, prompt_tokens):
+            base_content_sequence.append(
+                [
+                    TextPart(text=t),
+                    VQPart(codes=c),
+                ],
+                add_end=True,
+                speaker=0,
+            )
+    base_content_sequence.append(
+        [
+            TextPart(text=text),
+        ],
+        add_end=False,
+        speaker=0,
+    )
+
+    encoded, audio_masks, audio_parts = base_content_sequence.encode_for_inference(
+        tokenizer, num_codebooks=model.config.num_codebooks
+    )
+    if encoded.size(1) > max_length - 2048:
+        raise ValueError(f"Prompt is too long: {encoded.size(1)} > {max_length - 2048}")
+
+    encoded = encoded.to(device=device)
+    logger.info(f"Encoded text: {text}")
+
+    for sample_idx in range(num_samples):
+        if torch.cuda.is_available():
+            torch.cuda.synchronize()
+
+        global_encoded = []
+        seg_idx = 0
+        prompt_length = encoded.size(1)
+
+        t0 = time.perf_counter()
+
+        y = generate(
+            model=model,
+            prompt=encoded,
+            max_new_tokens=max_new_tokens,
+            audio_masks=audio_masks,
+            audio_parts=audio_parts,
+            decode_one_token=decode_one_token,
+            temperature=temperature,
+            top_p=top_p,
+            repetition_penalty=repetition_penalty,
+        )
+
+        if sample_idx == 0 and seg_idx == 0 and compile:
+            logger.info(f"Compilation time: {time.perf_counter() - t0:.2f} seconds")
+
+        if torch.cuda.is_available():
+            torch.cuda.synchronize()
+
+        t = time.perf_counter() - t0
+
+        tokens_generated = y.size(1) - prompt_length
+        tokens_sec = tokens_generated / t
+        logger.info(
+            f"Generated {tokens_generated} tokens in {t:.02f} seconds, {tokens_sec:.02f} tokens/sec"
+        )
+        logger.info(f"Bandwidth achieved: {model_size * tokens_sec / 1e9:.02f} GB/s")
+
+        if torch.cuda.is_available():
+            logger.info(
+                f"GPU Memory used: {torch.cuda.max_memory_reserved() / 1e9:.02f} GB"
+            )
+
+        # Put the generated tokens
+        codes = y[1:, prompt_length:-1].clone()
+        assert (codes >= 0).all(), f"Negative code found"
+
+        decoded = y[:, prompt_length:].clone()
+        global_encoded.append(decoded.cpu())
+        assert (codes >= 0).all(), f"Negative code found: {codes}"
+
+        yield GenerateResponse(action="sample", codes=codes, text=text)
+        seg_idx += 1
+
+        # Force GPU memory cleanup
+        del y, decoded, codes
+
+        yield GenerateResponse(action="next")
+
+
+@dataclass
+class WrappedGenerateResponse:
+    status: Literal["success", "error"]
+    response: Optional[Union[GenerateResponse, Exception]] = None
+
+
+@dataclass
+class GenerateRequest:
+    request: dict
+    response_queue: queue.Queue
+
+
+def launch_thread_safe_queue(
+    checkpoint_path,
+    device,
+    precision,
+    compile: bool = False,
+):
+    input_queue = queue.Queue()
+    init_event = threading.Event()
+
+    def worker():
+        model, decode_one_token = init_model(
+            checkpoint_path, device, precision, compile=compile
+        )
+        with torch.device(device):
+            model.setup_caches(
+                max_batch_size=1,
+                max_seq_len=model.config.max_seq_len,
+                dtype=next(model.parameters()).dtype,
+            )
+        init_event.set()
+
+        while True:
+            item: GenerateRequest | None = input_queue.get()
+            if item is None:
+                break
+
+            kwargs = item.request
+            response_queue = item.response_queue
+
+            try:
+                for chunk in generate_long(
+                    model=model, decode_one_token=decode_one_token, **kwargs
+                ):
+                    response_queue.put(
+                        WrappedGenerateResponse(status="success", response=chunk)
+                    )
+
+                # Only clear cache after complete request batch
+                if torch.cuda.is_available():
+                    torch.cuda.empty_cache()
+
+            except Exception as e:
+                logger.error(traceback.format_exc())
+                response_queue.put(WrappedGenerateResponse(status="error", response=e))
+                # Clear cache on error
+                if torch.cuda.is_available():
+                    torch.cuda.empty_cache()
+
+    threading.Thread(target=worker, daemon=True).start()
+    init_event.wait()
+
+    return input_queue
+
+
+@click.command()
+@click.option(
+    "--text",
+    type=str,
+    default="你说的对, 但是原神是一款由米哈游自主研发的开放世界手游.",
+)
+@click.option("--prompt-text", type=str, default=None, multiple=True)
+@click.option(
+    "--prompt-tokens",
+    type=click.Path(path_type=Path, exists=True),
+    default=None,
+    multiple=True,
+)
+@click.option("--num-samples", type=int, default=1)
+@click.option("--max-new-tokens", type=int, default=0)
+@click.option("--top-p", type=float, default=0.8)
+@click.option("--repetition-penalty", type=float, default=1.1)
+@click.option("--temperature", type=float, default=0.8)
+@click.option(
+    "--checkpoint-path",
+    type=click.Path(path_type=Path, exists=True),
+    default="checkpoints/openaudio-s1-mini",
+)
+@click.option("--device", type=str, default="cuda")
+@click.option("--compile/--no-compile", default=False)
+@click.option("--seed", type=int, default=42)
+@click.option("--half/--no-half", default=False)
+@click.option("--iterative-prompt/--no-iterative-prompt", default=True)
+@click.option("--chunk-length", type=int, default=300)
+@click.option("--output-dir", type=Path, default="temp")
+def main(
+    text: str,
+    prompt_text: Optional[tuple[str, ...]],
+    prompt_tokens: Optional[tuple[Path, ...]],
+    num_samples: int,
+    max_new_tokens: int,
+    top_p: int,
+    repetition_penalty: float,
+    temperature: float,
+    checkpoint_path: Path,
+    device: str,
+    compile: bool,
+    seed: int,
+    half: bool,
+    iterative_prompt: bool,
+    chunk_length: int,
+    output_dir: Path,
+) -> None:
+    os.makedirs(output_dir, exist_ok=True)
+    precision = torch.half if half else torch.bfloat16
+
+    if (
+        prompt_text is not None
+        and prompt_tokens is not None
+        and len(prompt_text) != len(prompt_tokens)
+    ):
+        raise ValueError(
+            f"Number of prompt text ({len(prompt_text)}) and prompt tokens ({len(prompt_tokens)}) should be the same"
+        )
+
+    logger.info("Loading model ...")
+    t0 = time.time()
+    model, decode_one_token = init_model(
+        checkpoint_path, device, precision, compile=compile
+    )
+    with torch.device(device):
+        model.setup_caches(
+            max_batch_size=1,
+            max_seq_len=model.config.max_seq_len,
+            dtype=next(model.parameters()).dtype,
+        )
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+
+    logger.info(f"Time to load model: {time.time() - t0:.02f} seconds")
+
+    prompt_tokens_list = None
+    if prompt_tokens is not None:
+        prompt_tokens_list = [torch.from_numpy(np.load(p)) for p in prompt_tokens]
+
+    torch.manual_seed(seed)
+
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed(seed)
+
+    generator = generate_long(
+        model=model,
+        device=device,
+        decode_one_token=decode_one_token,
+        text=text,
+        num_samples=num_samples,
+        max_new_tokens=max_new_tokens,
+        top_p=top_p,
+        repetition_penalty=repetition_penalty,
+        temperature=temperature,
+        compile=compile,
+        iterative_prompt=iterative_prompt,
+        chunk_length=chunk_length,
+        prompt_text=list(prompt_text) if prompt_text else None,
+        prompt_tokens=prompt_tokens_list,
+    )
+
+    idx = 0
+    codes = []
+
+    for response in generator:
+        if response.action == "sample":
+            codes.append(response.codes)
+            logger.info(f"Sampled text: {response.text}")
+        elif response.action == "next":
+            if codes:
+                codes_npy_path = os.path.join(output_dir, f"codes_{idx}.npy")
+                np.save(codes_npy_path, torch.cat(codes, dim=1).cpu().numpy())
+                logger.info(f"Saved codes to {codes_npy_path}")
+            logger.info(f"Next sample")
+            codes = []
+            idx += 1
+        else:
+            logger.error(f"Error: {response}")
+
+
+if __name__ == "__main__":
+    main()

--- a/xinference/thirdparty/fish_speech_s1/fish_speech/models/text2semantic/llama.py
+++ b/xinference/thirdparty/fish_speech_s1/fish_speech/models/text2semantic/llama.py
@@ -1,0 +1,940 @@
+import dataclasses
+import json
+import math
+from collections import OrderedDict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import torch
+import torch.nn as nn
+from einops import rearrange
+from loguru import logger
+from torch import Tensor
+from torch.nn import functional as F
+from torch.nn.attention import SDPBackend, sdpa_kernel
+from torch.utils.checkpoint import checkpoint
+from transformers import AutoTokenizer
+
+from xinference.thirdparty.fish_speech_s1.fish_speech.models.text2semantic.lora import LoraConfig, setup_lora
+from xinference.thirdparty.fish_speech_s1.fish_speech.tokenizer import SEMANTIC_TOKENS, FishTokenizer
+
+
+def find_multiple(n: int, k: int) -> int:
+    if n % k == 0:
+        return n
+    return n + k - (n % k)
+
+
+@dataclass
+class BaseModelArgs:
+    model_type: str = "base"
+
+    vocab_size: int = 32000
+    n_layer: int = 32
+    n_head: int = 32
+    dim: int = 4096
+    intermediate_size: int = None
+    n_local_heads: int = -1
+    head_dim: int = 64
+    rope_base: float = 10000
+    norm_eps: float = 1e-5
+    max_seq_len: int = 2048
+    dropout: float = 0.0
+    tie_word_embeddings: bool = True
+    attention_qkv_bias: bool = False
+    attention_o_bias: bool = False
+    attention_qk_norm: bool = False
+
+    # Codebook configs
+    codebook_size: int = 160
+    num_codebooks: int = 4
+
+    # Gradient checkpointing
+    use_gradient_checkpointing: bool = True
+
+    # Initialize the model
+    initializer_range: float = 0.02
+
+    # Dummy vars
+    is_reward_model: bool = False
+    scale_codebook_embeddings: bool = False
+
+    def __post_init__(self):
+        if self.n_local_heads == -1:
+            self.n_local_heads = self.n_head
+        if self.intermediate_size is None:
+            hidden_dim = 4 * self.dim
+            n_hidden = int(2 * hidden_dim / 3)
+            self.intermediate_size = find_multiple(n_hidden, 256)
+        if self.head_dim is None:
+            self.head_dim = self.dim // self.n_head
+
+    @staticmethod
+    def from_pretrained(path: str):
+        path = Path(path)
+
+        if path.is_dir():
+            path = path / "config.json"
+
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+
+        match data["model_type"]:
+            case "naive":
+                cls = NaiveModelArgs
+            case "dual_ar":
+                cls = DualARModelArgs
+            case _:
+                raise ValueError(f"Unknown model type: {data['model_type']}")
+
+        return cls(**data)
+
+    def save(self, path: str):
+        with open(path, "w") as f:
+            json.dump(self.__dict__, f, indent=4, sort_keys=True, ensure_ascii=False)
+
+
+@dataclass
+class NaiveModelArgs(BaseModelArgs):
+    model_type: str = "naive"
+
+
+@dataclass
+class DualARModelArgs(BaseModelArgs):
+    model_type: str = "dual_ar"
+    n_fast_layer: int = 4
+    fast_dim: int | None = None
+    fast_n_head: int | None = None
+    fast_n_local_heads: int | None = None
+    fast_head_dim: int | None = None
+    fast_intermediate_size: int | None = None
+    fast_attention_qkv_bias: bool | None = None
+    fast_attention_qk_norm: bool | None = None
+    fast_attention_o_bias: bool | None = None
+
+    def __post_init__(self):
+        super().__post_init__()
+
+        self.fast_dim = self.fast_dim or self.dim
+        self.fast_n_head = self.fast_n_head or self.n_head
+        self.fast_n_local_heads = self.fast_n_local_heads or self.n_local_heads
+        self.fast_head_dim = self.fast_head_dim or self.head_dim
+        self.fast_intermediate_size = (
+            self.fast_intermediate_size or self.intermediate_size
+        )
+        self.fast_attention_qkv_bias = (
+            self.fast_attention_qkv_bias
+            if self.fast_attention_qkv_bias is not None
+            else self.attention_qkv_bias
+        )
+        self.fast_attention_qk_norm = (
+            self.fast_attention_qk_norm
+            if self.fast_attention_qk_norm is not None
+            else self.attention_qk_norm
+        )
+        self.fast_attention_o_bias = (
+            self.fast_attention_o_bias
+            if self.fast_attention_o_bias is not None
+            else self.attention_o_bias
+        )
+
+
+class KVCache(nn.Module):
+    def __init__(
+        self, max_batch_size, max_seq_len, n_heads, head_dim, dtype=torch.bfloat16
+    ):
+        super().__init__()
+        cache_shape = (max_batch_size, n_heads, max_seq_len, head_dim)
+        self.register_buffer("k_cache", torch.zeros(cache_shape, dtype=dtype))
+        self.register_buffer("v_cache", torch.zeros(cache_shape, dtype=dtype))
+
+    def update(self, input_pos, k_val, v_val):
+        # input_pos: [S], k_val: [B, H, S, D]
+        assert input_pos.shape[0] == k_val.shape[2]
+
+        k_out = self.k_cache
+        v_out = self.v_cache
+        k_out[:, :, input_pos] = k_val
+        v_out[:, :, input_pos] = v_val
+
+        return k_out, v_out
+
+
+@dataclass
+class TransformerForwardResult:
+    token_logits: Tensor
+    codebook_logits: Tensor
+
+
+@dataclass
+class BaseTransformerForwardResult:
+    logits: Tensor
+    hidden_states: Tensor
+
+
+class BaseTransformer(nn.Module):
+    def __init__(
+        self,
+        config: BaseModelArgs,
+        tokenizer: FishTokenizer,
+        init_weights: bool = True,
+    ) -> None:
+        super().__init__()
+        self.config = config
+        self.tokenizer = tokenizer
+        self.semantic_token_ids = list(tokenizer.semantic_id_to_token_id.values())
+
+        # Slow transformer
+        self.embeddings = nn.Embedding(
+            config.vocab_size,
+            config.dim,
+        )
+        self.codebook_embeddings = nn.Embedding(
+            config.codebook_size * config.num_codebooks,
+            config.dim,
+        )
+        self.layers = nn.ModuleList(
+            TransformerBlock(config, use_sdpa=True) for _ in range(config.n_layer)
+        )
+        self.norm = RMSNorm(config.dim, eps=config.norm_eps)
+
+        if self.config.tie_word_embeddings is False:
+            self.output = nn.Linear(
+                config.dim,
+                config.vocab_size,
+                bias=False,
+            )
+
+        self.register_buffer(
+            "freqs_cis",
+            precompute_freqs_cis(
+                config.max_seq_len,
+                config.head_dim,
+                config.rope_base,
+            ),
+            persistent=False,
+        )
+        self.register_buffer(
+            "causal_mask",
+            torch.tril(
+                torch.ones(
+                    config.max_seq_len,
+                    config.max_seq_len,
+                    dtype=torch.bool,
+                )
+            ),
+            persistent=False,
+        )
+
+        # For kv cache
+        self.max_batch_size = -1
+        self.max_seq_len = -1
+
+        if init_weights:
+            self.apply(self._init_weights)
+
+    def setup_caches(
+        self, max_batch_size: int, max_seq_len: int, dtype: torch.dtype = torch.bfloat16
+    ):
+        if self.max_seq_len >= max_seq_len and self.max_batch_size >= max_batch_size:
+            return
+
+        max_seq_len = find_multiple(max_seq_len, 8)
+        self.max_seq_len = max_seq_len
+        self.max_batch_size = max_batch_size
+
+        for b in self.layers:
+            b.attention.kv_cache = KVCache(
+                max_batch_size,
+                max_seq_len,
+                self.config.n_local_heads,
+                self.config.head_dim,
+                dtype=dtype,
+            )
+
+    def embed(self, inp: Tensor) -> Tensor:
+        embeds = []
+        semantic_token_ids_tensor = torch.tensor(
+            self.semantic_token_ids, device=inp.device, dtype=inp.dtype
+        )
+
+        for i in range(self.config.num_codebooks):
+            emb = self.codebook_embeddings(
+                inp[:, i + 1] + i * self.config.codebook_size
+            )
+            embeds.append(emb)
+
+        vq_embeds_sum = torch.stack(embeds, dim=1).sum(dim=1)
+        vq_embeds_sum[~torch.isin(inp[:, 0], semantic_token_ids_tensor)] = 0
+        x = self.embeddings(inp[:, 0]) + vq_embeds_sum
+
+        return x
+
+    def forward(
+        self,
+        inp: Tensor,
+        key_padding_mask: Optional[Tensor] = None,
+    ) -> BaseTransformerForwardResult:
+        seq_len = inp.size(2)
+
+        # Here we want to merge the embeddings of the codebooks
+        x = self.embed(inp)
+
+        freqs_cis = self.freqs_cis[:seq_len]
+
+        # Not that the causal mask here follows the definition of scaled_dot_product_attention
+        # That is, FALSE means masked out
+        # To maintain consistency, key_padding_mask use TRUE to mask out
+        mask = None
+        if key_padding_mask is not None:
+            causal = self.causal_mask[:seq_len, :seq_len]
+            causal = rearrange(causal, "q k -> 1 1 q k")
+
+            atten_mask = rearrange(key_padding_mask, "b s -> b 1 1 s")
+            atten_mask = atten_mask.logical_not()
+            mask = causal & atten_mask
+
+        # return freqs_cis, mask
+
+        for layer in self.layers:
+            if self.config.use_gradient_checkpointing and self.training:
+                x = checkpoint(layer, x, freqs_cis, mask, use_reentrant=True)
+            else:
+                x = layer(x, freqs_cis, mask)
+
+        # We got slow_out here
+        slow_out = self.norm(x)
+
+        if self.config.tie_word_embeddings:
+            token_logits = F.linear(slow_out, self.embeddings.weight)
+        else:
+            token_logits = self.output(slow_out)
+
+        return BaseTransformerForwardResult(
+            logits=token_logits,
+            hidden_states=x,
+        )
+
+    def forward_generate(
+        self,
+        inp: Tensor,
+        input_pos: Optional[Tensor] = None,
+        audio_masks: Optional[Tensor] = None,
+        audio_parts: Optional[Tensor] = None,
+        return_all: bool = False,
+    ) -> BaseTransformerForwardResult:
+        # This is used for generation, optimized for torch compile
+        # assert (
+        #     self.max_seq_len != -1 and self.max_batch_size != -1
+        # ), "Please call setup_caches before forward_generate"
+
+        embeds = []
+        for i in range(self.config.num_codebooks):
+            emb = self.codebook_embeddings(
+                inp[:, i + 1] + i * self.config.codebook_size
+            )
+            embeds.append(emb)
+
+        vq_embeds_sum = torch.stack(embeds, dim=1).sum(dim=1)
+
+        vq_masks = (inp[:, 0] >= self.tokenizer.semantic_begin_id) & (
+            inp[:, 0] <= self.tokenizer.semantic_end_id
+        )
+
+        vq_embeds_sum[~vq_masks] = 0
+        x = self.embeddings(inp[:, 0]) + vq_embeds_sum
+
+        if self.config.scale_codebook_embeddings:
+            # Expand vq_masks to match x's shape
+            vq_masks_expanded = vq_masks.unsqueeze(-1).expand_as(x)
+            x = torch.where(
+                vq_masks_expanded, x / math.sqrt(self.config.num_codebooks + 1), x
+            )
+
+        # Audio embeddings
+        if audio_parts is not None:
+            audio_embeds = self.audio_projector(audio_parts)
+            if self.config.scale_codebook_embeddings:
+                x[audio_masks] = audio_embeds / math.sqrt(2)
+            else:
+                x[audio_masks] = audio_embeds
+
+        if input_pos is None:
+            input_pos = torch.arange(inp.shape[-1], device=x.device)
+            max_seq_len = inp.shape[-1]
+        else:
+            max_seq_len = self.max_seq_len
+
+        mask = self.causal_mask[None, None, input_pos, :max_seq_len]  # (B, N, Q, K)
+        freqs_cis = self.freqs_cis[input_pos]
+
+        for layer in self.layers:
+            x = layer(x, freqs_cis, mask, input_pos=input_pos)
+
+        # If prefill, we only calculate the logits of last token
+        if x.size(1) > 1 and not return_all:
+            x = x[:, -1:]
+
+        # We got slow_out here
+        slow_out = self.norm(x)
+
+        if self.config.is_reward_model:
+            token_logits = self.score_output(slow_out)
+        elif self.config.tie_word_embeddings:
+            token_logits = F.linear(slow_out, self.embeddings.weight)
+        else:
+            token_logits = self.output(slow_out)
+
+        return BaseTransformerForwardResult(
+            logits=token_logits,
+            hidden_states=x,
+        )
+
+    def _init_weights(self, module):
+        std = self.config.initializer_range
+        if isinstance(module, nn.Linear):
+            module.weight.data.normal_(mean=0.0, std=std)
+            if module.bias is not None:
+                module.bias.data.zero_()
+        elif isinstance(module, nn.Embedding):
+            module.weight.data.normal_(mean=0.0, std=std)
+            if module.padding_idx is not None:
+                module.weight.data[module.padding_idx].zero_()
+
+    @staticmethod
+    def from_pretrained(
+        path: str,
+        load_weights: bool = False,
+        max_length: int | None = None,
+        lora_config: LoraConfig | None = None,
+        rope_base: int | None = None,
+    ) -> "BaseTransformer":
+        config = BaseModelArgs.from_pretrained(str(path))
+        if max_length is not None:
+            config.max_seq_len = max_length
+            logger.info(f"Override max_seq_len to {max_length}")
+
+        if rope_base is not None:
+            config.rope_base = rope_base
+            logger.info(f"Override rope_base to {rope_base}")
+
+        match config.model_type:
+            case "naive":
+                model_cls = NaiveTransformer
+            case "dual_ar":
+                model_cls = DualARTransformer
+            case _:
+                raise ValueError(f"Unknown model type: {config.model_type}")
+
+        tokenizer = FishTokenizer.from_pretrained(path)
+
+        logger.info(f"Loading model from {path}, config: {config}")
+        model = model_cls(config, tokenizer=tokenizer)
+
+        if load_weights is False:
+            logger.info("Randomly initialized model")
+        else:
+
+            if "int8" in str(Path(path)):
+                logger.info("Using int8 weight-only quantization!")
+                from tools.llama.quantize import WeightOnlyInt8QuantHandler
+
+                simple_quantizer = WeightOnlyInt8QuantHandler(model)
+                model = simple_quantizer.convert_for_runtime()
+
+            if "int4" in str(Path(path)):
+                logger.info("Using int4 quantization!")
+                path_comps = path.name.split("-")
+                assert path_comps[-2].startswith("g")
+                groupsize = int(path_comps[-2][1:])
+                from tools.llama.quantize import WeightOnlyInt4QuantHandler
+
+                simple_quantizer = WeightOnlyInt4QuantHandler(model, groupsize)
+                model = simple_quantizer.convert_for_runtime()
+
+            weights = torch.load(
+                Path(path) / "model.pth",
+                map_location="cpu",
+                mmap=True,
+                weights_only=True,
+            )
+
+            if "state_dict" in weights:
+                logger.warning(
+                    "Using a TextToSemantic LightningModule checkpoint, "
+                    "please make sure it is a full model, not a LoRA model."
+                )
+                weights = weights["state_dict"]
+
+            if next(iter(weights.keys())).startswith("model."):
+                logger.info(
+                    f"Remove prefix 'model.' created by TextToSemantic LightningModule from keys"
+                )
+                new_weights = OrderedDict()
+                for k, v in weights.items():
+                    new_weights[k.replace("model.", "")] = v
+                weights = new_weights
+
+            # Remove audio related weights
+            for k in list(weights.keys()):
+                if "audio_" in k:
+                    weights.pop(k)
+
+            # Verify the name and shape of parameters since strict=False in load_state_dict.
+            for k, v in model.named_parameters():
+                if k not in weights:
+                    logger.warning(f"No weight for {k}")
+                elif v.shape != weights[k].shape:
+                    logger.warning(
+                        f"Shape mismatch for {k}: {v.shape} vs {weights[k].shape}"
+                    )
+
+            err = model.load_state_dict(weights, strict=False, assign=True)
+            logger.info(f"Model weights loaded - Status: {err}")
+
+        if lora_config is not None:
+            setup_lora(model, lora_config)
+            logger.info(f"LoRA setup: {lora_config}")
+
+        return model
+
+    def save_pretrained(self, path: str, drop_lora: bool = False):
+        path = Path(path)
+        path.mkdir(parents=True, exist_ok=True)
+
+        self.config.save(path / "config.json")
+        state_dict = self.state_dict()
+
+        if drop_lora:
+            for key in list(state_dict.keys()):
+                if "lora" not in key:
+                    continue
+
+                state_dict.pop(key)
+                logger.info(f"Drop LoRA parameter: {key}")
+
+        torch.save(state_dict, path / "model.pth")
+        self.tokenizer.save_pretrained(path)
+
+
+class NaiveTransformer(BaseTransformer):
+    def __init__(self, config: NaiveModelArgs, tokenizer: FishTokenizer) -> None:
+        super().__init__(config, init_weights=False, tokenizer=tokenizer)
+
+        self.codebook_norm = RMSNorm(config.dim, eps=config.norm_eps)
+        self.codebook_output = nn.Linear(
+            config.dim,
+            config.codebook_size * config.num_codebooks,
+            bias=False,
+        )
+
+        self.apply(self._init_weights)
+
+    def decode(self, result: BaseTransformerForwardResult) -> TransformerForwardResult:
+        token_logits = result.logits
+        x = result.hidden_states
+
+        # Codebook
+        codebook_logits = self.codebook_output(self.codebook_norm(x))
+        codebook_logits = rearrange(
+            codebook_logits, "b n (c d) -> b n c d", c=self.config.num_codebooks
+        )
+
+        return TransformerForwardResult(
+            token_logits=token_logits,
+            codebook_logits=codebook_logits,
+        )
+
+    def forward(
+        self,
+        inp: Tensor,
+        key_padding_mask: Optional[Tensor] = None,
+    ) -> TransformerForwardResult:
+        result = super().forward(
+            inp=inp,
+            key_padding_mask=key_padding_mask,
+        )
+        return self.decode(result)
+
+    def forward_generate(
+        self, x: Tensor, input_pos: Optional[Tensor] = None
+    ) -> TransformerForwardResult:
+        result = super().forward_generate(x, input_pos)
+        return self.decode(result)
+
+
+class DualARTransformer(BaseTransformer):
+    def __init__(self, config: NaiveModelArgs, tokenizer: FishTokenizer) -> None:
+        super().__init__(config, init_weights=False, tokenizer=tokenizer)
+
+        # Project to fast dim if needed
+        if config.fast_dim is not None and config.fast_dim != config.dim:
+            self.fast_project_in = nn.Linear(config.dim, config.fast_dim)
+        else:
+            self.fast_project_in = nn.Identity()
+
+        # Fast transformer
+        self.fast_embeddings = nn.Embedding(config.codebook_size, config.fast_dim)
+
+        # The equivalent bs is so large that sdpa doesn't work
+        override_config = dataclasses.replace(
+            config,
+            dim=config.fast_dim,
+            n_head=config.fast_n_head,
+            n_local_heads=config.fast_n_local_heads,
+            head_dim=config.fast_head_dim,
+            intermediate_size=config.fast_intermediate_size,
+            attention_qkv_bias=config.fast_attention_qkv_bias,
+            attention_qk_norm=config.fast_attention_qk_norm,
+            attention_o_bias=config.fast_attention_o_bias,
+        )
+
+        self.fast_layers = nn.ModuleList(
+            TransformerBlock(override_config, use_sdpa=False)
+            for _ in range(config.n_fast_layer)
+        )
+        self.fast_norm = RMSNorm(config.fast_dim, eps=config.norm_eps)
+        self.fast_output = nn.Linear(
+            config.fast_dim,
+            config.codebook_size,
+            bias=False,
+        )
+
+        self.register_buffer(
+            "fast_freqs_cis",
+            precompute_freqs_cis(
+                config.num_codebooks,
+                config.fast_head_dim,
+                config.rope_base,
+            ),
+            persistent=False,
+        )
+        self.apply(self._init_weights)
+
+    def setup_caches(
+        self, max_batch_size: int, max_seq_len: int, dtype: torch.dtype = torch.bfloat16
+    ):
+        super().setup_caches(max_batch_size, max_seq_len, dtype)
+
+        # Fast transformer
+        # The max seq len here is the number of codebooks
+        for b in self.fast_layers:
+            b.attention.kv_cache = KVCache(
+                max_batch_size,
+                self.config.num_codebooks,
+                self.config.fast_n_local_heads,
+                self.config.fast_head_dim,
+                dtype=dtype,
+            )
+
+    def forward(
+        self,
+        inp: Tensor,
+        labels: Optional[Tensor] = None,
+        key_padding_mask: Optional[Tensor] = None,
+        vq_parts: Optional[Tensor] = None,
+        vq_masks: Optional[Tensor] = None,
+        vq_require_losses: Optional[Tensor] = None,
+        mel_parts: Optional[Tensor] = None,
+        mel_masks: Optional[Tensor] = None,
+    ) -> TransformerForwardResult:
+        parent_result = super().forward(
+            inp=inp,
+            key_padding_mask=key_padding_mask,
+        )
+        token_logits = parent_result.logits
+        x = parent_result.hidden_states
+
+        # Fast transformer
+        fast_seq_len = self.config.num_codebooks
+        fast_mask = self.causal_mask[
+            None, None, :fast_seq_len, :fast_seq_len
+        ]  # (B, N, Q, K)
+        fast_freqs_cis = self.fast_freqs_cis[:fast_seq_len]
+
+        # Extract corresponding parts with labels
+        token_labels = labels[:, 0]
+        codebook_mask = (token_labels >= self.tokenizer.semantic_begin_id) & (
+            token_labels <= self.tokenizer.semantic_end_id
+        )
+        # This gives where input token is <|semantic|>
+        x = x[codebook_mask]
+
+        if x.shape[0] == 0:
+            # Use dummy input when no vq is required
+            x = torch.zeros(
+                (4, self.config.dim),
+                device=x.device,
+                dtype=x.dtype,
+            )
+            codebooks = torch.zeros(
+                (x.shape[0], self.config.num_codebooks - 1),
+                device=x.device,
+                dtype=torch.int,
+            )
+        else:
+            all_codebooks = labels[:, 1:, :]
+            all_codebooks_permuted = all_codebooks.permute(0, 2, 1)
+            semantic_codebooks = all_codebooks_permuted[codebook_mask]
+            codebooks = semantic_codebooks[:, :-1]
+
+        x = self.fast_project_in(x)
+        codebook_embeddings = self.fast_embeddings(codebooks)
+        x = torch.cat([x[:, None], codebook_embeddings], dim=1)
+
+        for layer in self.fast_layers:
+            if self.config.use_gradient_checkpointing and self.training:
+                x = checkpoint(layer, x, fast_freqs_cis, fast_mask, use_reentrant=True)
+            else:
+                x = layer(x, fast_freqs_cis, fast_mask)
+
+        # unflatten the batch and num_codebooks
+        fast_out = self.fast_norm(x)
+        codebook_logits = self.fast_output(fast_out)
+
+        assert codebook_logits.shape[1] == self.config.num_codebooks
+
+        return TransformerForwardResult(
+            token_logits=token_logits,
+            codebook_logits=codebook_logits,
+        )
+
+    def forward_generate_fast(
+        self, x: Tensor, input_pos: Optional[Tensor] = None
+    ) -> Tensor:
+        # Fast transformer
+        x = x.view(x.shape[0], 1, -1)
+
+        fast_mask = self.causal_mask[
+            None, None, input_pos, : self.config.num_codebooks
+        ]  # (B, N, Q, K)
+        fast_freqs_cis = self.fast_freqs_cis[input_pos]
+
+        for layer in self.fast_layers:
+            x = layer(x, fast_freqs_cis, fast_mask, input_pos=input_pos)
+
+        # unflatten the batch and num_codebooks
+        fast_out = self.fast_norm(x)  # only take the last token
+        codebook_logits = self.fast_output(fast_out)
+
+        return codebook_logits
+
+    def forward_generate(
+        self,
+        x: Tensor,
+        input_pos: Optional[Tensor] = None,
+        audio_masks: Optional[Tensor] = None,
+        audio_parts: Optional[Tensor] = None,
+    ) -> TransformerForwardResult:
+        x = super().forward_generate(x, input_pos, audio_masks, audio_parts)
+        x.hidden_states = self.fast_project_in(x.hidden_states)
+        return x
+
+
+class TransformerBlock(nn.Module):
+    def __init__(self, config: BaseModelArgs, use_sdpa: bool = True) -> None:
+        super().__init__()
+        self.attention = Attention(config, use_sdpa=use_sdpa)
+        self.feed_forward = FeedForward(config)
+        self.ffn_norm = RMSNorm(config.dim, config.norm_eps)
+        self.attention_norm = RMSNorm(config.dim, config.norm_eps)
+
+    def forward(
+        self, x: Tensor, freqs_cis: Tensor, mask: Tensor, input_pos: Tensor = None
+    ) -> Tensor:
+        h = x + self.attention(self.attention_norm(x), freqs_cis, mask, input_pos)
+        out = h + self.feed_forward(self.ffn_norm(h))
+        return out
+
+
+class Attention(nn.Module):
+    def __init__(self, config: BaseModelArgs, use_sdpa: bool = True):
+        super().__init__()
+        assert config.dim % config.n_head == 0
+
+        total_head_dim = (config.n_head + 2 * config.n_local_heads) * config.head_dim
+        # key, query, value projections for all heads, but in a batch
+        self.wqkv = nn.Linear(
+            config.dim, total_head_dim, bias=config.attention_qkv_bias
+        )
+        self.wo = nn.Linear(
+            config.n_head * config.head_dim, config.dim, bias=config.attention_o_bias
+        )
+        self.kv_cache = None
+
+        if config.attention_qk_norm:
+            self.q_norm = nn.RMSNorm(config.head_dim, config.norm_eps)
+            self.k_norm = nn.RMSNorm(config.head_dim, config.norm_eps)
+
+        self.dropout = config.dropout
+        self.n_head = config.n_head
+        self.head_dim = config.head_dim
+        self.n_local_heads = config.n_local_heads
+        self.dim = config.dim
+        self.use_sdpa = use_sdpa
+        self.attention_qk_norm = config.attention_qk_norm
+        self.config = config
+
+        self._register_load_state_dict_pre_hook(self.load_hook)
+
+    def load_hook(self, state_dict, prefix, *args):
+        if prefix + "wq.weight" in state_dict:
+            wq = state_dict.pop(prefix + "wq.weight")
+            wk = state_dict.pop(prefix + "wk.weight")
+            wv = state_dict.pop(prefix + "wv.weight")
+            state_dict[prefix + "wqkv.weight"] = torch.cat([wq, wk, wv])
+
+    def forward(
+        self,
+        x: Tensor,
+        freqs_cis: Tensor,
+        mask: Tensor,
+        input_pos: Optional[Tensor] = None,
+    ) -> Tensor:
+        bsz, seqlen, _ = x.shape
+
+        q_size = self.n_head * self.head_dim
+        kv_size = self.n_local_heads * self.head_dim
+        q, k, v = self.wqkv(x).split([q_size, kv_size, kv_size], dim=-1)
+
+        q = q.view(bsz, seqlen, self.n_head, self.head_dim)
+        k = k.view(bsz, seqlen, self.n_local_heads, self.head_dim)
+        v = v.view(bsz, seqlen, self.n_local_heads, self.head_dim)
+
+        if self.attention_qk_norm:
+            q = self.q_norm(q)
+            k = self.k_norm(k)
+
+        q = apply_rotary_emb(q, freqs_cis)
+        k = apply_rotary_emb(k, freqs_cis)
+
+        q, k, v = map(lambda x: x.transpose(1, 2), (q, k, v))
+
+        if self.kv_cache is not None:
+            k, v = self.kv_cache.update(input_pos, k, v)
+
+        k = k.repeat_interleave(self.n_head // self.n_local_heads, dim=1)
+        v = v.repeat_interleave(self.n_head // self.n_local_heads, dim=1)
+
+        if self.use_sdpa:
+            if mask is None:
+                with sdpa_kernel(SDPBackend.FLASH_ATTENTION):
+                    y = F.scaled_dot_product_attention(
+                        q,
+                        k,
+                        v,
+                        dropout_p=self.dropout if self.training else 0.0,
+                        is_causal=True,
+                        # No third party attn_mask here to use flash_attention
+                    )
+            else:
+                y = F.scaled_dot_product_attention(
+                    q,
+                    k,
+                    v,
+                    attn_mask=mask,
+                    dropout_p=self.dropout if self.training else 0.0,
+                )
+        else:
+            y = self.eq_scaled_dot_product_attention(
+                q,
+                k,
+                v,
+                attn_mask=mask,
+                dropout_p=self.dropout if self.training else 0.0,
+            )
+
+        y = y.transpose(1, 2).contiguous().view(bsz, seqlen, q_size)
+
+        return self.wo(y)
+
+    def eq_scaled_dot_product_attention(
+        self,
+        query,
+        key,
+        value,
+        attn_mask=None,
+        dropout_p=0.0,
+    ) -> torch.Tensor:
+        # This is a standard scaled dot product attention
+        # It's low efficient, but it doesn't raise cuda error
+
+        L, S = query.size(-2), key.size(-2)
+        scale_factor = 1 / math.sqrt(query.size(-1))
+        attn_bias = torch.zeros(1, 1, L, S, dtype=query.dtype, device=query.device)
+
+        if attn_mask is not None:
+            if attn_mask.dtype == torch.bool:
+                attn_bias.masked_fill_(attn_mask.logical_not(), float("-inf"))
+            else:
+                attn_bias += attn_mask
+
+        attn_weight = query @ key.transpose(-2, -1) * scale_factor
+        attn_weight += attn_bias
+        attn_weight = torch.softmax(attn_weight, dim=-1)
+        attn_weight = torch.dropout(attn_weight, dropout_p, train=True)
+
+        return attn_weight @ value
+
+
+class FeedForward(nn.Module):
+    def __init__(self, config: BaseModelArgs) -> None:
+        super().__init__()
+        self.w1 = nn.Linear(config.dim, config.intermediate_size, bias=False)
+        self.w3 = nn.Linear(config.dim, config.intermediate_size, bias=False)
+        self.w2 = nn.Linear(config.intermediate_size, config.dim, bias=False)
+
+    def forward(self, x: Tensor) -> Tensor:
+        return self.w2(F.silu(self.w1(x)) * self.w3(x))
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim: int, eps: float = 1e-5):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(dim))
+
+    def _norm(self, x):
+        return x * torch.rsqrt(torch.mean(x * x, dim=-1, keepdim=True) + self.eps)
+
+    def forward(self, x: Tensor) -> Tensor:
+        output = self._norm(x.float()).type_as(x)
+        return output * self.weight
+
+
+def precompute_freqs_cis(seq_len: int, n_elem: int, base: int = 10000) -> Tensor:
+    """
+    Precomputes frequency tensors for complex exponentials (cis)
+
+    Args:
+        seq_len: Length of the sequence for which positional embeddings are needed.
+        n_elem: Number of elements in the frequency tensor.
+        base: Base value for the frequency scaling (default: 10000).
+
+    Returns:
+        A tensor containing the precomputed frequencies in real and imaginary parts (bfloat16).
+    """
+    freqs = 1.0 / (
+        base ** (torch.arange(0, n_elem, 2)[: (n_elem // 2)].float() / n_elem)
+    )
+    t = torch.arange(seq_len, device=freqs.device)
+    freqs = torch.outer(t, freqs)
+    freqs_cis = torch.polar(torch.ones_like(freqs), freqs)
+    cache = torch.stack([freqs_cis.real, freqs_cis.imag], dim=-1)
+    return cache.to(dtype=torch.bfloat16)
+
+
+def apply_rotary_emb(x: Tensor, freqs_cis: Tensor) -> Tensor:
+    xshaped = x.float().reshape(*x.shape[:-1], -1, 2)
+    freqs_cis = freqs_cis.view(1, xshaped.size(1), 1, xshaped.size(3), 2)
+    x_out2 = torch.stack(
+        [
+            xshaped[..., 0] * freqs_cis[..., 0] - xshaped[..., 1] * freqs_cis[..., 1],
+            xshaped[..., 1] * freqs_cis[..., 0] + xshaped[..., 0] * freqs_cis[..., 1],
+        ],
+        -1,
+    )
+
+    x_out2 = x_out2.flatten(3)
+    return x_out2.type_as(x)

--- a/xinference/thirdparty/fish_speech_s1/fish_speech/models/text2semantic/lora.py
+++ b/xinference/thirdparty/fish_speech_s1/fish_speech/models/text2semantic/lora.py
@@ -1,0 +1,92 @@
+from dataclasses import dataclass
+
+import loralib as lora
+
+
+@dataclass
+class LoraConfig:
+    r: int
+    lora_alpha: float
+    lora_dropout: float = 0.0
+
+
+def setup_lora(model, lora_config):
+    # Replace the embedding layer with a LoRA layer
+    model.embeddings = lora.Embedding(
+        num_embeddings=model.embeddings.num_embeddings,
+        embedding_dim=model.embeddings.embedding_dim,
+        padding_idx=model.embeddings.padding_idx,
+        r=lora_config.r,
+        lora_alpha=lora_config.lora_alpha,
+    )
+
+    model.codebook_embeddings = lora.Embedding(
+        num_embeddings=model.codebook_embeddings.num_embeddings,
+        embedding_dim=model.codebook_embeddings.embedding_dim,
+        padding_idx=model.codebook_embeddings.padding_idx,
+        r=lora_config.r,
+        lora_alpha=lora_config.lora_alpha,
+    )
+
+    # Replace output layer with a LoRA layer
+    linears = [(model, "output")]
+
+    # Replace all linear layers with LoRA layers
+    for layer in model.layers:
+        linears.extend([(layer.attention, "wqkv"), (layer.attention, "wo")])
+        linears.extend(
+            [
+                (layer.feed_forward, "w1"),
+                (layer.feed_forward, "w2"),
+                (layer.feed_forward, "w3"),
+            ]
+        )
+
+    if hasattr(model, "fast_layers"):
+        model.fast_embeddings = lora.Embedding(
+            num_embeddings=model.fast_embeddings.num_embeddings,
+            embedding_dim=model.fast_embeddings.embedding_dim,
+            padding_idx=model.fast_embeddings.padding_idx,
+            r=lora_config.r,
+            lora_alpha=lora_config.lora_alpha,
+        )
+
+        # Dual-AR model
+        linears.append((model, "fast_output"))
+
+        for layer in model.fast_layers:
+            linears.extend([(layer.attention, "wqkv"), (layer.attention, "wo")])
+            linears.extend(
+                [
+                    (layer.feed_forward, "w1"),
+                    (layer.feed_forward, "w2"),
+                    (layer.feed_forward, "w3"),
+                ]
+            )
+
+    for module, layer in linears:
+        updated_linear = lora.Linear(
+            in_features=getattr(module, layer).in_features,
+            out_features=getattr(module, layer).out_features,
+            bias=getattr(module, layer).bias,
+            r=lora_config.r,
+            lora_alpha=lora_config.lora_alpha,
+            lora_dropout=lora_config.lora_dropout,
+        )
+        setattr(module, layer, updated_linear)
+
+    # Mark only the LoRA layers as trainable
+    lora.mark_only_lora_as_trainable(model, bias="none")
+
+
+def get_merged_state_dict(model):
+    # This line will merge the state dict of the model and the LoRA parameters
+    model.eval()
+
+    # Then we need to remove the LoRA parameters from the state dict
+    state_dict = model.state_dict()
+    for name in list(state_dict.keys()):
+        if "lora" in name:
+            state_dict.pop(name)
+
+    return state_dict

--- a/xinference/thirdparty/fish_speech_s1/fish_speech/tokenizer.py
+++ b/xinference/thirdparty/fish_speech_s1/fish_speech/tokenizer.py
@@ -1,0 +1,179 @@
+import base64
+import json
+import logging
+import re
+from pathlib import Path
+
+import tiktoken
+
+logger = logging.getLogger(__name__)
+
+# This is a modified version of the default pattern from GPT-4o, that better handles punctuations.
+FISH_TIKTOKEN_PATTERN = "|".join(
+    [
+        r"(?i:'s|'t|'re|'ve|'m|'ll|'d)",
+        r"\p{P}",
+        r"[^\r\n\p{L}\p{N}]?\p{L}+",
+        r"\p{N}",
+        r" ?[^\s\p{L}\p{N}]+[\r\n]*",
+        r"\s*[\r\n]+",
+        r"\s+(\?!\S)",
+        r"\s+",
+    ]
+)
+TIKTOKEN_MAX_ENCODE_CHARS = 400_000
+
+BOS_TOKEN = "<|begin_of_text|>"
+EOS_TOKEN = "<|end_of_text|>"
+PAD_TOKEN = "<|pad|>"
+IM_START_TOKEN = "<|im_start|>"
+IM_END_TOKEN = "<|im_end|>"
+PHONEME_START_TOKEN = "<|phoneme_start|>"
+PHONEME_END_TOKEN = "<|phoneme_end|>"
+TOOL_CALL_START_TOKEN = "<|tool_call_start|>"
+TOOL_CALL_END_TOKEN = "<|tool_call_end|>"
+
+MODALITY_TEXT_TOKEN = "<|text|>"
+MODALITY_VOICE_TOKEN = "<|voice|>"
+MODALITY_INTERLEAVE_TOKEN = "<|interleave|>"
+AUDIO_START_TOKEN = "<|audio_start|>"
+AUDIO_END_TOKEN = "<|audio_end|>"
+AUDIO_EMBED_TOKEN = "<|audio|>"
+MODALITY_TOKENS = {
+    "text": MODALITY_TEXT_TOKEN,
+    "voice": MODALITY_VOICE_TOKEN,
+    "interleave": MODALITY_INTERLEAVE_TOKEN,
+}
+
+SEMANTIC_TOKEN_TEMPLATE = "<|semantic:{i}|>"
+SEMANTIC_TOKENS = [SEMANTIC_TOKEN_TEMPLATE.format(i=i) for i in range(4096)]
+
+# Warning: when you add a new special token, you should only add it to the end of the list.
+ALL_SPECIAL_TOKENS = [
+    BOS_TOKEN,
+    EOS_TOKEN,
+    PAD_TOKEN,
+    IM_START_TOKEN,
+    IM_END_TOKEN,
+    PHONEME_START_TOKEN,
+    PHONEME_END_TOKEN,
+    TOOL_CALL_START_TOKEN,
+    TOOL_CALL_END_TOKEN,
+    MODALITY_TEXT_TOKEN,
+    MODALITY_VOICE_TOKEN,
+    MODALITY_INTERLEAVE_TOKEN,
+    AUDIO_START_TOKEN,
+    AUDIO_END_TOKEN,
+    AUDIO_EMBED_TOKEN,
+    *SEMANTIC_TOKENS,
+]
+
+
+class FishTokenizer:
+    def __init__(
+        self, model_path: str, special_tokens: list[str] = ALL_SPECIAL_TOKENS
+    ) -> None:
+        mergeable_ranks = self.load_tiktoken_bpe(model_path)
+        special_token_begin = len(mergeable_ranks)
+        self.all_special_tokens_with_ids = {
+            token: special_token_begin + i for i, token in enumerate(special_tokens)
+        }
+
+        self.semantic_id_to_token_id = {}
+        end_idx = 0
+        for token in special_tokens:
+            if token.startswith("<|semantic:"):
+                idx = int(re.match(r"<\|semantic:(\d+)\|>", token).group(1))
+                self.semantic_id_to_token_id[idx] = self.all_special_tokens_with_ids[
+                    token
+                ]
+
+                if idx > end_idx:
+                    end_idx = idx
+
+        self.semantic_begin_id = self.semantic_id_to_token_id[0]
+        self.semantic_end_id = self.semantic_id_to_token_id[end_idx]
+
+        self.tkt_model = tiktoken.core.Encoding(
+            name=Path(model_path).stem,
+            pat_str=FISH_TIKTOKEN_PATTERN,
+            mergeable_ranks=mergeable_ranks,
+            special_tokens=self.all_special_tokens_with_ids,
+        )
+
+    @property
+    def vocab_size(self):
+        return len(self.tkt_model._mergeable_ranks)
+
+    @property
+    def num_special_tokens(self):
+        return len(self.all_special_tokens_with_ids)
+
+    @staticmethod
+    def load_tiktoken_bpe(tiktoken_bpe_file: str) -> dict[bytes, int]:
+        data = {}
+        for line in open(tiktoken_bpe_file).read().splitlines():
+            if not line:
+                continue
+            token, rank = line.split()
+            if token == "=":
+                continue
+            data[base64.b64decode(token)] = int(rank)
+        return data
+
+    def get_token_id(self, token: str) -> int:
+        return self.all_special_tokens_with_ids[token]
+
+    def encode(self, s: str, allowed_special: bool | set[str] = True) -> list[int]:
+        assert isinstance(s, str)
+
+        subs = []
+        for i in range(0, len(s), TIKTOKEN_MAX_ENCODE_CHARS):
+            subs.append(s[i : i + TIKTOKEN_MAX_ENCODE_CHARS])
+
+        if allowed_special is True:
+            allowed_special = self.tkt_model.special_tokens_set
+        elif allowed_special is False:
+            allowed_special = set()
+
+        return sum(
+            self.tkt_model.encode_batch(
+                subs, allowed_special=allowed_special, disallowed_special=set()
+            ),
+            start=[],
+        )
+
+    def decode(self, tokens: list[int]) -> str:
+        return self.tkt_model.decode(tokens)
+
+    def save_pretrained(self, path: str):
+        path = Path(path)
+        path.mkdir(parents=True, exist_ok=True)
+
+        with open(path / "tokenizer.tiktoken", "w") as f:
+            for token, rank in self.tkt_model._mergeable_ranks.items():
+                a = base64.b64encode(token).decode()
+                if a == "":
+                    a = "="
+                f.write(f"{a} {rank}\n")
+
+        with open(path / "special_tokens.json", "w") as f:
+            json.dump(
+                self.all_special_tokens_with_ids,
+                f,
+                indent=2,
+                ensure_ascii=False,
+            )
+
+    @staticmethod
+    def from_pretrained(path: str):
+        special_tokens_path = Path(path) / "special_tokens.json"
+        if special_tokens_path.exists():
+            with open(special_tokens_path) as f:
+                all_special_tokens_with_ids = json.load(f)
+        else:
+            all_special_tokens_with_ids = ALL_SPECIAL_TOKENS
+
+        return FishTokenizer(
+            Path(path) / "tokenizer.tiktoken", all_special_tokens_with_ids
+        )

--- a/xinference/thirdparty/fish_speech_s1/fish_speech/tokenizer.py
+++ b/xinference/thirdparty/fish_speech_s1/fish_speech/tokenizer.py
@@ -112,7 +112,7 @@ class FishTokenizer:
     @staticmethod
     def load_tiktoken_bpe(tiktoken_bpe_file: str) -> dict[bytes, int]:
         data = {}
-        for line in open(tiktoken_bpe_file).read().splitlines():
+        for line in open(tiktoken_bpe_file, encoding="utf-8").read().splitlines():
             if not line:
                 continue
             token, rank = line.split()

--- a/xinference/thirdparty/fish_speech_s1/fish_speech/utils/__init__.py
+++ b/xinference/thirdparty/fish_speech_s1/fish_speech/utils/__init__.py
@@ -1,0 +1,28 @@
+import random
+
+import numpy as np
+import torch
+
+from .context import autocast_exclude_mps
+
+
+def set_seed(seed: int):
+    if seed < 0:
+        seed = -seed
+    if seed > (1 << 31):
+        seed = 1 << 31
+
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed(seed)
+        torch.cuda.manual_seed_all(seed)
+
+    if torch.backends.cudnn.is_available():
+        torch.backends.cudnn.deterministic = True
+        torch.backends.cudnn.benchmark = False
+
+
+__all__ = ["autocast_exclude_mps", "set_seed"]

--- a/xinference/thirdparty/fish_speech_s1/fish_speech/utils/context.py
+++ b/xinference/thirdparty/fish_speech_s1/fish_speech/utils/context.py
@@ -1,0 +1,13 @@
+from contextlib import nullcontext
+
+import torch
+
+
+def autocast_exclude_mps(
+    device_type: str, dtype: torch.dtype
+) -> nullcontext | torch.autocast:
+    return (
+        nullcontext()
+        if torch.backends.mps.is_available()
+        else torch.autocast(device_type, dtype)
+    )

--- a/xinference/thirdparty/fish_speech_s1/fish_speech/utils/file.py
+++ b/xinference/thirdparty/fish_speech_s1/fish_speech/utils/file.py
@@ -1,0 +1,139 @@
+import os
+from pathlib import Path
+from typing import Union
+
+from loguru import logger
+from natsort import natsorted
+
+AUDIO_EXTENSIONS = {
+    ".mp3",
+    ".wav",
+    ".flac",
+    ".ogg",
+    ".m4a",
+    ".wma",
+    ".aac",
+    ".aiff",
+    ".aif",
+    ".aifc",
+}
+
+VIDEO_EXTENSIONS = {
+    ".mp4",
+    ".avi",
+}
+
+
+def get_latest_checkpoint(path: Path | str) -> Path | None:
+    # Find the latest checkpoint
+    ckpt_dir = Path(path)
+
+    if ckpt_dir.exists() is False:
+        return None
+
+    ckpts = sorted(ckpt_dir.glob("*.ckpt"), key=os.path.getmtime)
+    if len(ckpts) == 0:
+        return None
+
+    return ckpts[-1]
+
+
+def audio_to_bytes(file_path):
+    if not file_path or not Path(file_path).exists():
+        return None
+    with open(file_path, "rb") as wav_file:
+        wav = wav_file.read()
+    return wav
+
+
+def read_ref_text(ref_text):
+    path = Path(ref_text)
+    if path.exists() and path.is_file():
+        with path.open("r", encoding="utf-8") as file:
+            return file.read()
+    return ref_text
+
+
+def list_files(
+    path: Union[Path, str],
+    extensions: set[str] = set(),
+    recursive: bool = False,
+    sort: bool = True,
+) -> list[Path]:
+    """List files in a directory.
+
+    Args:
+        path (Path): Path to the directory.
+        extensions (set, optional): Extensions to filter. Defaults to None.
+        recursive (bool, optional): Whether to search recursively. Defaults to False.
+        sort (bool, optional): Whether to sort the files. Defaults to True.
+
+    Returns:
+        list: List of files.
+    """
+
+    if isinstance(path, str):
+        path = Path(path)
+
+    if not path.exists():
+        raise FileNotFoundError(f"Directory {path} does not exist.")
+
+    files = [file for ext in extensions for file in path.rglob(f"*{ext}")]
+
+    if sort:
+        files = natsorted(files)
+
+    return files
+
+
+def load_filelist(path: Path | str) -> list[tuple[Path, str, str, str]]:
+    """
+    Load a Bert-VITS2 style filelist.
+    """
+
+    files = set()
+    results = []
+    count_duplicated, count_not_found = 0, 0
+
+    LANGUAGE_TO_LANGUAGES = {
+        "zh": ["zh", "en"],
+        "jp": ["jp", "en"],
+        "en": ["en"],
+    }
+
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f.readlines():
+            splits = line.strip().split("|", maxsplit=3)
+            if len(splits) != 4:
+                logger.warning(f"Invalid line: {line}")
+                continue
+
+            filename, speaker, language, text = splits
+            file = Path(filename)
+            language = language.strip().lower()
+
+            if language == "ja":
+                language = "jp"
+
+            assert language in ["zh", "jp", "en"], f"Invalid language {language}"
+            languages = LANGUAGE_TO_LANGUAGES[language]
+
+            if file in files:
+                logger.warning(f"Duplicated file: {file}")
+                count_duplicated += 1
+                continue
+
+            if not file.exists():
+                logger.warning(f"File not found: {file}")
+                count_not_found += 1
+                continue
+
+            results.append((file, speaker, languages, text))
+
+    if count_duplicated > 0:
+        logger.warning(f"Total duplicated files: {count_duplicated}")
+
+    if count_not_found > 0:
+        logger.warning(f"Total files not found: {count_not_found}")
+
+    return results

--- a/xinference/thirdparty/fish_speech_s1/fish_speech/utils/schema.py
+++ b/xinference/thirdparty/fish_speech_s1/fish_speech/utils/schema.py
@@ -1,0 +1,136 @@
+import base64
+import os
+import queue
+from dataclasses import dataclass
+from typing import Literal
+
+import torch
+from pydantic import BaseModel, Field, conint, model_validator
+from pydantic.functional_validators import SkipValidation
+from typing_extensions import Annotated
+
+from xinference.thirdparty.fish_speech_s1.fish_speech.content_sequence import TextPart, VQPart
+
+
+class ServeVQPart(BaseModel):
+    type: Literal["vq"] = "vq"
+    codes: SkipValidation[list[list[int]]]
+
+
+class ServeTextPart(BaseModel):
+    type: Literal["text"] = "text"
+    text: str
+
+
+class ServeAudioPart(BaseModel):
+    type: Literal["audio"] = "audio"
+    audio: bytes
+
+
+class ServeRequest(BaseModel):
+    # Raw content sequence dict that we can use with ContentSequence(**content)
+    content: dict
+    max_new_tokens: int = 600
+    top_p: float = 0.7
+    repetition_penalty: float = 1.2
+    temperature: float = 0.7
+    streaming: bool = False
+    num_samples: int = 1
+    early_stop_threshold: float = 1.0
+
+
+class ServeVQGANEncodeRequest(BaseModel):
+    # The audio here should be in wav, mp3, etc
+    audios: list[bytes]
+
+
+class ServeVQGANEncodeResponse(BaseModel):
+    tokens: SkipValidation[list[list[list[int]]]]
+
+
+class ServeVQGANDecodeRequest(BaseModel):
+    tokens: SkipValidation[list[list[list[int]]]]
+
+
+class ServeVQGANDecodeResponse(BaseModel):
+    # The audio here should be in PCM float16 format
+    audios: list[bytes]
+
+
+class ServeReferenceAudio(BaseModel):
+    audio: bytes
+    text: str
+
+    @model_validator(mode="before")
+    def decode_audio(cls, values):
+        audio = values.get("audio")
+        if (
+            isinstance(audio, str) and len(audio) > 255
+        ):  # Check if audio is a string (Base64)
+            try:
+                values["audio"] = base64.b64decode(audio)
+            except Exception:
+                # If the audio is not a valid base64 string, we will just ignore it and let the server handle it
+                pass
+        return values
+
+    def __repr__(self) -> str:
+        return f"ServeReferenceAudio(text={self.text!r}, audio_size={len(self.audio)})"
+
+
+class ServeTTSRequest(BaseModel):
+    text: str
+    chunk_length: Annotated[int, conint(ge=100, le=300, strict=True)] = 200
+    # Audio format
+    format: Literal["wav", "pcm", "mp3"] = "wav"
+    # References audios for in-context learning
+    references: list[ServeReferenceAudio] = []
+    # Reference id
+    # For example, if you want use https://fish.audio/m/7f92f8afb8ec43bf81429cc1c9199cb1/
+    # Just pass 7f92f8afb8ec43bf81429cc1c9199cb1
+    reference_id: str | None = None
+    seed: int | None = None
+    use_memory_cache: Literal["on", "off"] = "off"
+    # Normalize text for en & zh, this increase stability for numbers
+    normalize: bool = True
+    # not usually used below
+    streaming: bool = False
+    max_new_tokens: int = 1024
+    top_p: Annotated[float, Field(ge=0.1, le=1.0, strict=True)] = 0.8
+    repetition_penalty: Annotated[float, Field(ge=0.9, le=2.0, strict=True)] = 1.1
+    temperature: Annotated[float, Field(ge=0.1, le=1.0, strict=True)] = 0.8
+
+    class Config:
+        # Allow arbitrary types for pytorch related types
+        arbitrary_types_allowed = True
+
+
+class AddReferenceRequest(BaseModel):
+    id: str = Field(..., min_length=1, max_length=255, pattern=r"^[a-zA-Z0-9\-_ ]+$")
+    audio: bytes
+    text: str = Field(..., min_length=1)
+
+
+class AddReferenceResponse(BaseModel):
+    success: bool
+    message: str
+    reference_id: str
+
+
+class ListReferencesResponse(BaseModel):
+    success: bool
+    reference_ids: list[str]
+    message: str = "Success"
+
+
+class DeleteReferenceResponse(BaseModel):
+    success: bool
+    message: str
+    reference_id: str
+
+
+class UpdateReferenceResponse(BaseModel):
+    success: bool
+    message: str
+    old_reference_id: str
+    new_reference_id: str

--- a/xinference/thirdparty/fish_speech_s2/LICENSE
+++ b/xinference/thirdparty/fish_speech_s2/LICENSE
@@ -1,0 +1,94 @@
+# FISH AUDIO RESEARCH LICENSE AGREEMENT
+
+**Last Updated: March 7, 2026**
+
+## I. INTRODUCTION
+
+This Agreement applies to any individual person or entity ("You", "Your" or "Licensee") that uses or distributes any portion or element of the Fish Audio Materials or Derivative Works thereof for any Research, Non-Commercial, or Commercial purpose. Capitalized terms not otherwise defined herein are defined in Section V below.
+
+This Agreement is intended to allow research and non-commercial uses of the Materials free of charge. Any Commercial use of the Materials requires a separate license from Fish Audio.
+
+By clicking "I Accept" or by using, distributing, or accessing any portion or element of the Fish Audio Materials or Derivative Works, You agree that You have read, understood and are bound by the terms of this Agreement. If You are acting on behalf of a company, organization or other entity, then "You" includes you and that entity, and You agree that You: (i) are an authorized representative of such entity with the authority to bind such entity to this Agreement, and (ii) You agree to the terms of this Agreement on that entity's behalf.
+
+## II. RESEARCH & NON-COMMERCIAL USE LICENSE
+
+Subject to the terms of this Agreement, Fish Audio grants You a non-exclusive, worldwide, non-transferable, non-sublicensable, revocable and royalty-free limited license under Fish Audio's intellectual property or other rights owned by Fish Audio embodied in the Fish Audio Materials to use, reproduce, distribute, and create Derivative Works of, and make modifications to, the Fish Audio Materials for any Research or Non-Commercial Purpose.
+
+"Research Purpose" means academic or scientific advancement, and in each case, is not primarily intended for commercial advantage or monetary compensation to You or others.
+
+"Non-Commercial Purpose" means any purpose other than a Research Purpose that is not primarily intended for commercial advantage or monetary compensation to You or others, such as personal use (i.e., hobbyist) or evaluation and testing.
+
+## III. COMMERCIAL USE
+
+**Any use of the Fish Audio Materials or Derivative Works for a Commercial Purpose requires a separate written license agreement from Fish Audio.** No commercial rights are granted under this Agreement.
+
+"Commercial Purpose" means any purpose other than a Research Purpose or Non-Commercial Purpose that is primarily intended for or directed toward commercial advantage or monetary compensation to You or others, including but not limited to: (i) creating, modifying, or distributing Your product or service, including via a hosted service or application programming interface, (ii) Your business's or organization's internal operations, and (iii) any use in connection with a product or service for which You charge a fee or generate revenue, whether directly or indirectly.
+
+To obtain a commercial license, please contact Fish Audio at:
+
+- **Website:** [https://fish.audio](https://fish.audio)
+- **Email:** business@fish.audio
+
+## IV. GENERAL TERMS
+
+Your Research and Non-Commercial License under this Agreement is subject to the following terms.
+
+### a. Distribution & Attribution
+
+If You distribute or make available the Fish Audio Materials or a Derivative Work to a third party, or a product or service that uses any portion of them, You shall: (i) provide a copy of this Agreement to that third party, (ii) retain the following attribution notice within a "Notice" text file distributed as a part of such copies: "This model is licensed under the Fish Audio Research License, Copyright © 39 AI, INC. All Rights Reserved.", and (iii) prominently display "Built with Fish Audio" on a related website, user interface, blogpost, about page, or product documentation.
+
+If You create a Derivative Work, You may add your own attribution notice(s) to the "Notice" text file included with that Derivative Work, provided that You clearly indicate which attributions apply to the Fish Audio Materials and state in the "Notice" text file that You changed the Fish Audio Materials and how it was modified.
+
+### b. Use Restrictions
+
+Your use of the Fish Audio Materials and Derivative Works, including any output or results of the Fish Audio Materials or Derivative Works, must comply with applicable laws and regulations (including Trade Control Laws and equivalent regulations) and adhere to Fish Audio's Acceptable Use Policy, which is hereby incorporated by reference.
+
+Furthermore, You will not use the Fish Audio Materials or Derivative Works, or any output or results of the Fish Audio Materials or Derivative Works, to create or improve any foundational generative AI model (excluding the Models or Derivative Works).
+
+### c. Intellectual Property
+
+**(i) Trademark License.** No trademark licenses are granted under this Agreement, and in connection with the Fish Audio Materials or Derivative Works, You may not use any name or mark owned by or associated with Fish Audio or any of its Affiliates, except as required under Section IV(a) herein.
+
+**(ii) Ownership of Derivative Works.** As between You and Fish Audio, You are the owner of Derivative Works You create, subject to Fish Audio's ownership of the Fish Audio Materials and any Derivative Works made by or for Fish Audio.
+
+**(iii) Ownership of Outputs.** As between You and Fish Audio, You own any outputs generated from the Models or Derivative Works to the extent permitted by applicable law.
+
+**(iv) Disputes.** If You or Your Affiliate(s) institute litigation or other proceedings against Fish Audio (including a cross-claim or counterclaim in a lawsuit) alleging that the Fish Audio Materials, Derivative Works or associated outputs or results, or any portion of any of the foregoing, constitutes infringement of intellectual property or other rights owned or licensable by You, then any licenses granted to You under this Agreement shall terminate as of the date such litigation or claim is filed or instituted. You will indemnify and hold harmless Fish Audio from and against any claim by any third party arising out of or related to Your use or distribution of the Fish Audio Materials or Derivative Works in violation of this Agreement.
+
+**(v) Feedback.** From time to time, You may provide Fish Audio with verbal and/or written suggestions, comments or other feedback related to Fish Audio's existing or prospective technology, products or services (collectively, "Feedback"). You are not obligated to provide Fish Audio with Feedback, but to the extent that You do, You hereby grant Fish Audio a perpetual, irrevocable, royalty-free, fully-paid, sub-licensable, transferable, non-exclusive, worldwide right and license to exploit the Feedback in any manner without restriction. Your Feedback is provided "AS IS" and You make no warranties whatsoever about any Feedback.
+
+### d. Disclaimer of Warranty
+
+UNLESS REQUIRED BY APPLICABLE LAW, THE FISH AUDIO MATERIALS AND ANY OUTPUT AND RESULTS THEREFROM ARE PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE. YOU ARE SOLELY RESPONSIBLE FOR DETERMINING THE APPROPRIATENESS OR LAWFULNESS OF USING OR REDISTRIBUTING THE FISH AUDIO MATERIALS, DERIVATIVE WORKS OR ANY OUTPUT OR RESULTS AND ASSUME ANY RISKS ASSOCIATED WITH YOUR USE OF THE FISH AUDIO MATERIALS, DERIVATIVE WORKS AND ANY OUTPUT AND RESULTS.
+
+### e. Limitation of Liability
+
+IN NO EVENT WILL FISH AUDIO OR ITS AFFILIATES BE LIABLE UNDER ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, TORT, NEGLIGENCE, PRODUCTS LIABILITY, OR OTHERWISE, ARISING OUT OF THIS AGREEMENT, FOR ANY LOST PROFITS OR ANY DIRECT, INDIRECT, SPECIAL, CONSEQUENTIAL, INCIDENTAL, EXEMPLARY OR PUNITIVE DAMAGES, EVEN IF FISH AUDIO OR ITS AFFILIATES HAVE BEEN ADVISED OF THE POSSIBILITY OF ANY OF THE FOREGOING.
+
+### f. Term and Termination
+
+The term of this Agreement will commence upon Your acceptance of this Agreement or access to the Fish Audio Materials and will continue in full force and effect until terminated in accordance with the terms and conditions herein. Fish Audio may terminate this Agreement if You are in breach of any term or condition of this Agreement. Upon termination of this Agreement, You shall delete and cease use of any Fish Audio Materials or Derivative Works. Sections IV(d), (e), and (g) shall survive the termination of this Agreement.
+
+### g. Governing Law
+
+This Agreement will be governed by and construed in accordance with the laws of the United States and the State of California without regard to choice of law principles, and the UN Convention on Contracts for International Sale of Goods does not apply to this Agreement.
+
+## V. DEFINITIONS
+
+**"Affiliate(s)"** means any entity that directly or indirectly controls, is controlled by, or is under common control with the subject entity; for purposes of this definition, "control" means direct or indirect ownership or control of more than 50% of the voting interests of the subject entity.
+
+**"Agreement"** means this Fish Audio Research License Agreement.
+
+**"Derivative Work(s)"** means (a) any derivative work of the Fish Audio Materials as recognized by U.S. copyright laws and (b) any modifications to a Model, and any other model created which is based on or derived from the Model or the Model's output, including "fine tune" and "low-rank adaptation" models derived from a Model or a Model's output, but do not include the output of any Model.
+
+**"Documentation"** means any specifications, manuals, documentation, and other written information provided by Fish Audio related to the Software or Models.
+
+**"Fish Audio"** or **"we"** means 39 AI, INC. and its Affiliates.
+
+**"Model(s)"** means, collectively, Fish Audio's proprietary models and algorithms, including machine-learning models, trained model weights and other elements of the foregoing.
+
+**"Software"** means Fish Audio's proprietary software made available under this Agreement now or in the future.
+
+**"Fish Audio Materials"** means, collectively, Fish Audio's proprietary Models, Software and Documentation (and any portion or combination thereof) made available under this Agreement.
+
+**"Trade Control Laws"** means any applicable U.S. and non-U.S. export control and trade sanctions laws and regulations.

--- a/xinference/thirdparty/fish_speech_s2/NOTICE
+++ b/xinference/thirdparty/fish_speech_s2/NOTICE
@@ -3,4 +3,5 @@ This model is licensed under the Fish Audio Research License, Copyright © 39 AI
 Xinference Holdings Pte. Ltd changed the Fish Audio Materials by retaining the
 inference-only Python subset, package-qualifying imports, trimming training-only
 utility initialization, and resolving the Hydra codec config relative to the
-vendored package.
+vendored package. It also fixes audio-feature placeholder encoding in content
+sequences.

--- a/xinference/thirdparty/fish_speech_s2/NOTICE
+++ b/xinference/thirdparty/fish_speech_s2/NOTICE
@@ -1,0 +1,6 @@
+This model is licensed under the Fish Audio Research License, Copyright © 39 AI, INC. All Rights Reserved.
+
+Xinference Holdings Pte. Ltd changed the Fish Audio Materials by retaining the
+inference-only Python subset, package-qualifying imports, trimming training-only
+utility initialization, and resolving the Hydra codec config relative to the
+vendored package.

--- a/xinference/thirdparty/fish_speech_s2/README.md
+++ b/xinference/thirdparty/fish_speech_s2/README.md
@@ -1,0 +1,20 @@
+# Fish Audio S2 inference runtime
+
+Built with Fish Audio.
+
+This directory contains the inference subset vendored from
+[fishaudio/fish-speech](https://github.com/fishaudio/fish-speech) at commit
+`befe4001745417f8c42131739d862b8a6fdbd15a`. The upstream software is licensed
+under the Fish Audio Research License. Research and non-commercial use are
+permitted under that license; commercial use requires a separate license from
+Fish Audio.
+
+Only the tokenizer, conversation format, text-to-semantic runtime, ModifiedDAC
+codec, inference engine, schemas, and supporting utilities needed by Xinference
+are included. Model weights are not vendored and remain governed by their model
+repository license.
+
+Xinference changes upstream imports to package-qualified imports, trims the
+training-only utility initializer, and resolves the bundled Hydra codec config
+relative to this package. See `NOTICE` for the required attribution and change
+notice.

--- a/xinference/thirdparty/fish_speech_s2/__init__.py
+++ b/xinference/thirdparty/fish_speech_s2/__init__.py
@@ -1,0 +1,1 @@
+"""Vendored Fish Audio S2 inference runtime."""

--- a/xinference/thirdparty/fish_speech_s2/fish_speech/__init__.py
+++ b/xinference/thirdparty/fish_speech_s2/fish_speech/__init__.py
@@ -1,0 +1,1 @@
+"""Fish Audio S2 inference subset."""

--- a/xinference/thirdparty/fish_speech_s2/fish_speech/configs/modded_dac_vq.yaml
+++ b/xinference/thirdparty/fish_speech_s2/fish_speech/configs/modded_dac_vq.yaml
@@ -1,0 +1,50 @@
+_target_: xinference.thirdparty.fish_speech_s2.fish_speech.models.dac.modded_dac.DAC
+# Model setup
+sample_rate: 44100
+encoder_dim: 64
+encoder_rates: [2, 4, 8, 8]
+decoder_dim: 1536
+decoder_rates: [8, 8, 4, 2]
+encoder_transformer_layers: [0, 0, 0, 4]
+decoder_transformer_layers: [4, 0, 0, 0]
+transformer_general_config:
+  _target_: xinference.thirdparty.fish_speech_s2.fish_speech.models.dac.modded_dac.ModelArgs
+  _partial_: true
+  block_size: 8192
+  n_local_heads: -1
+  head_dim: 64
+  rope_base: 10000
+  norm_eps: 1e-5
+  dropout_rate: 0.1
+  attn_dropout_rate: 0.1
+  channels_first: true
+# Quantization
+quantizer:
+  _target_: xinference.thirdparty.fish_speech_s2.fish_speech.models.dac.rvq.DownsampleResidualVectorQuantize
+  input_dim: 1024
+  n_codebooks: 9
+  codebook_size: 1024
+  codebook_dim: 8
+  quantizer_dropout: 0.5
+  downsample_factor: [2, 2]
+  post_module: &transformer_module
+    _target_: xinference.thirdparty.fish_speech_s2.fish_speech.models.dac.modded_dac.WindowLimitedTransformer
+    causal: true
+    window_size: 128  # empirically this does not seem to matter
+    input_dim: 1024
+    config: &transformer_config
+      _target_: xinference.thirdparty.fish_speech_s2.fish_speech.models.dac.modded_dac.ModelArgs
+      block_size: 2048
+      n_layer: 8
+      n_head: 16
+      dim: 1024
+      intermediate_size: 3072
+      n_local_heads: -1
+      head_dim: 64
+      rope_base: 10000
+      norm_eps: 1e-5
+      dropout_rate: 0.1
+      attn_dropout_rate: 0.1
+      channels_first: true
+  pre_module: *transformer_module
+  semantic_codebook_size: 4096

--- a/xinference/thirdparty/fish_speech_s2/fish_speech/content_sequence.py
+++ b/xinference/thirdparty/fish_speech_s2/fish_speech/content_sequence.py
@@ -5,6 +5,9 @@ import numpy as np
 import torch
 
 from xinference.thirdparty.fish_speech_s2.fish_speech.tokenizer import (
+    AUDIO_EMBED_TOKEN,
+    AUDIO_END_TOKEN,
+    AUDIO_START_TOKEN,
     IM_END_TOKEN,
     MODALITY_TOKENS,
     FishTokenizer,
@@ -210,6 +213,15 @@ class ContentSequence:
 
                 vq_parts.append(curr_codes)
                 vq_require_losses.append(part.cal_loss)
+            elif isinstance(part, AudioPart):
+                audio_parts.append(part.features)
+                tokens = torch.tensor(
+                    [tokenizer.get_token_id(AUDIO_START_TOKEN)]
+                    + [tokenizer.get_token_id(AUDIO_EMBED_TOKEN)]
+                    * part.features.shape[0]
+                    + [tokenizer.get_token_id(AUDIO_END_TOKEN)],
+                    dtype=torch.long,
+                )
             else:
                 raise ValueError(f"Unsupported part type: {type(part)}")
 

--- a/xinference/thirdparty/fish_speech_s2/fish_speech/content_sequence.py
+++ b/xinference/thirdparty/fish_speech_s2/fish_speech/content_sequence.py
@@ -1,0 +1,403 @@
+from dataclasses import dataclass, field
+from typing import List, Literal, Union
+
+import numpy as np
+import torch
+
+from xinference.thirdparty.fish_speech_s2.fish_speech.tokenizer import (
+    IM_END_TOKEN,
+    MODALITY_TOKENS,
+    FishTokenizer,
+)
+
+
+def restore_ndarray(obj, to_tensor: bool = False):
+    if isinstance(obj, dict) and "__ndarray__" in obj:
+        obj = np.frombuffer(obj["data"], dtype=obj["dtype"]).reshape(obj["shape"])
+
+    if to_tensor and isinstance(obj, np.ndarray):
+        obj = torch.from_numpy(obj.copy())
+
+    return obj
+
+
+@dataclass
+class BasePart:
+    type: Literal["text", "vq", "audio"] | None = None
+    cal_loss: bool = False
+
+
+@dataclass(kw_only=True)
+class VQPart(BasePart):
+    type = "vq"
+    codes: torch.Tensor
+
+    def __post_init__(self: "VQPart"):
+        self.type = "vq"
+        self.codes = restore_ndarray(self.codes, to_tensor=True)
+
+
+@dataclass(kw_only=True)
+class TextPart(BasePart):
+    type = "text"
+    text: str | None = None
+    tokens: list[int] | None = None
+
+    def __post_init__(self: "TextPart"):
+        self.type = "text"
+        if self.text is None and self.tokens is None:
+            raise ValueError("Either text or tokens must be provided")
+
+
+@dataclass(kw_only=True)
+class AudioPart(BasePart):
+    type = "audio"
+    features: torch.Tensor
+
+    def __post_init__(self: "AudioPart"):
+        self.type = "audio"
+        self.features = restore_ndarray(self.features, to_tensor=True)
+
+
+@dataclass(kw_only=True)
+class EncodedMessage:
+    tokens: torch.Tensor
+    labels: torch.Tensor
+    vq_mask_tokens: torch.Tensor | None = None
+    vq_mask_labels: torch.Tensor | None = None
+    vq_parts: list[torch.Tensor]
+    vq_require_losses: torch.Tensor | None = None
+    audio_parts: list[torch.Tensor]
+    audio_masks: torch.Tensor | None = None
+    metadata: dict | None = None
+
+
+@dataclass
+class ContentSequence:
+    """
+    Flexible sequence of content parts that supports interleaved multimodal format.
+    Example format: <|interleave|><|speaker:1|> TEXT AUDIO <|im_end|><|speaker:2|> TEXT AUDIO <|im_end|>
+    """
+
+    parts: list[BasePart] = field(default_factory=list)
+    modality: Literal["text", "voice", "interleave"] | None = None
+    metadata: dict | None = None
+
+    def __init__(
+        self: "ContentSequence",
+        parts: list[BasePart | dict] | None = None,
+        modality: Literal["text", "voice", "interleave"] | None = None,
+        metadata: dict | None = None,
+    ):
+        self.modality = modality
+        self.metadata = metadata or {}
+
+        fixed_parts = []
+        for part in parts or []:
+            if isinstance(part, dict):
+                if part["type"] == "vq":
+                    part = VQPart(**part)
+                elif part["type"] == "audio":
+                    part = AudioPart(**part)
+                elif part["type"] == "text":
+                    part = TextPart(**part)
+                else:
+                    raise ValueError(f"Unsupported part type: {part['type']}")
+            fixed_parts.append(part)
+
+        self.parts = fixed_parts
+
+        # If modality is specified, add it at the beginning if it's not already there
+        if self.modality and not (
+            len(self.parts) > 0
+            and isinstance(self.parts[0], dict) is False
+            and isinstance(self.parts[0], TextPart)
+            and self.parts[0].text is not None
+            and self.parts[0].text.startswith(MODALITY_TOKENS[self.modality])
+        ):
+            modality_token = MODALITY_TOKENS[self.modality]
+            self.parts.insert(0, TextPart(text=modality_token))
+
+    def append(
+        self: "ContentSequence",
+        part_or_parts: Union[BasePart, List[BasePart]],
+        add_end: bool = False,
+        speaker: Union[str, int] | None = None,
+    ):
+        """
+        Append a part or list of parts to the sequence.
+
+        Args:
+            part_or_parts: A single part or list of parts to add
+            add_end: Whether to add the IM_END_TOKEN after these parts
+            speaker: Optional speaker identifier (name or ID) to add before the parts
+        """
+        # Convert single part to list
+        parts_to_add = (
+            [part_or_parts] if not isinstance(part_or_parts, list) else part_or_parts
+        )
+
+        # Add speaker token if specified
+        if speaker is not None:
+            speaker_token = f"<|speaker:{speaker}|>"
+            self.parts.append(TextPart(text=speaker_token))
+
+        # Add all the parts
+        self.parts.extend(parts_to_add)
+
+        # Add end token if requested
+        if add_end:
+            self.parts.append(
+                TextPart(text=IM_END_TOKEN, cal_loss=self.parts[-1].cal_loss)
+            )
+
+    def encode(
+        self: "ContentSequence",
+        tokenizer: FishTokenizer,
+        add_shift: bool = True,
+        ignore_loss_tokens: list[str] = [],
+    ) -> EncodedMessage:
+        """
+        Encode the sequence parts into tokens for the model.
+
+        Args:
+            tokenizer: The tokenizer to use
+            add_shift: Whether to shift tokens for next-token prediction
+            ignore_loss_tokens: List of token strings to ignore when calculating loss
+
+        Returns:
+            EncodedMessage with tensors ready for the model
+        """
+        all_tokens = []
+        all_labels = []
+
+        # Multi-modal elements
+        vq_parts = []
+        vq_masks = []
+        vq_require_losses = []
+
+        audio_parts = []
+        audio_masks = []
+
+        # Optimization: Batch conversion for ignore tokens
+        ignore_loss_token_ids = []
+        if ignore_loss_tokens:
+            # Use the wrapper method which uses convert_tokens_to_ids
+            ignore_loss_token_ids = [
+                tokenizer.get_token_id(i) for i in ignore_loss_tokens
+            ]
+
+        for part in self.parts:
+            if isinstance(part, TextPart):
+                if part.tokens is None:
+                    assert part.text is not None
+                    # Optimization: Explicitly disable special tokens (BOS/EOS)
+                    # because we are constructing the sequence manually
+                    tokens = tokenizer.encode(part.text, add_special_tokens=False)
+                else:
+                    tokens = part.tokens
+
+                tokens = torch.tensor(tokens, dtype=torch.long)
+            elif isinstance(part, VQPart):
+                # Critical Optimization: Vectorized mapping
+                # Instead of loop lookup: [tokenizer.semantic_id_to_token_id[i] for i in codes]
+                # We use arithmetic offset: code + semantic_begin_id
+                # This assumes semantic tokens are contiguous in the vocab (DualAR requirement)
+                curr_codes = part.codes.clone().to(torch.int)
+
+                # Use int64 (long) for token IDs to avoid overflow or type mismatch in embedding
+                tokens = (curr_codes[0] + tokenizer.semantic_begin_id).to(torch.long)
+
+                vq_parts.append(curr_codes)
+                vq_require_losses.append(part.cal_loss)
+            else:
+                raise ValueError(f"Unsupported part type: {type(part)}")
+
+            all_tokens.append(tokens)
+
+            # Set masks for different part types
+            if isinstance(part, VQPart):
+                vq_masks.append(torch.ones_like(tokens, dtype=torch.bool))
+                audio_masks.append(torch.zeros_like(tokens, dtype=torch.bool))
+            elif isinstance(part, AudioPart):
+                vq_masks.append(torch.zeros_like(tokens, dtype=torch.bool))
+                audio_mask = torch.ones_like(tokens, dtype=torch.bool)
+                audio_mask[0] = False  # Skip start token
+                audio_mask[-1] = False  # Skip end token
+                audio_masks.append(audio_mask)
+            else:
+                vq_masks.append(torch.zeros_like(tokens, dtype=torch.bool))
+                audio_masks.append(torch.zeros_like(tokens, dtype=torch.bool))
+
+            # Set labels based on whether we want to calculate loss for this part
+            if part.cal_loss and not isinstance(part, AudioPart):
+                all_labels.append(tokens.clone())
+            else:
+                all_labels.append(torch.full_like(tokens, -100))
+
+        # Concatenate all tensors
+        if not all_tokens:
+            # Handle empty case safely
+            tokens = torch.empty(0, dtype=torch.long)
+            labels = torch.empty(0, dtype=torch.long)
+            vq_masks = torch.empty(0, dtype=torch.bool)
+            audio_masks = torch.empty(0, dtype=torch.bool)
+        else:
+            tokens = torch.cat(all_tokens, dim=0)
+            labels = torch.cat(all_labels, dim=0)
+            vq_masks = torch.cat(vq_masks, dim=0)
+            audio_masks = torch.cat(audio_masks, dim=0)
+
+        vq_require_losses = torch.tensor(vq_require_losses, dtype=torch.bool)
+
+        # Apply shift if needed for next-token prediction
+        vq_mask_tokens = vq_masks
+        vq_mask_labels = vq_masks
+
+        if add_shift and len(tokens) > 0:
+            tokens = tokens[:-1]
+            labels = labels[1:]
+            vq_masks = vq_masks[:-1]
+            vq_mask_tokens = vq_mask_tokens[:-1]
+            vq_mask_labels = vq_mask_labels[1:]
+            audio_masks = audio_masks[:-1]
+
+        # Ignore specified tokens
+        for i in ignore_loss_token_ids:
+            if i is not None:
+                labels[labels == i] = -100
+
+        return EncodedMessage(
+            tokens=tokens,
+            labels=labels,
+            vq_parts=vq_parts,
+            vq_mask_tokens=vq_mask_tokens,
+            vq_mask_labels=vq_mask_labels,
+            vq_require_losses=vq_require_losses,
+            audio_parts=audio_parts,
+            audio_masks=audio_masks,
+            metadata=self.metadata,
+        )
+
+    def encode_for_inference(
+        self: "ContentSequence",
+        tokenizer: FishTokenizer,
+        num_codebooks: int,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        encoded = self.encode(tokenizer, add_shift=False)
+        tokens = encoded.tokens
+        # Use int32 for prompt cache to save memory, convert to model dtype later if needed
+        # Or keep as input_ids (long)
+        values = torch.zeros((num_codebooks + 1, len(tokens)), dtype=torch.long)
+        values[0] = tokens
+
+        if (encoded.vq_parts is None or len(encoded.vq_parts) == 0) and (
+            encoded.audio_parts is None or len(encoded.audio_parts) == 0
+        ):
+            return values, None, None
+
+        audio_parts = None
+        audio_masks = None
+
+        if encoded.vq_parts is not None and len(encoded.vq_parts) > 0:
+            vq_parts = encoded.vq_parts
+            # List[Tensor(1, T)] -> Tensor(1, Total_T) -> Tensor(1, Total_T)
+            # Ensure we are handling the list concatenation correctly
+            if len(vq_parts) > 1:
+                # We need to be careful here: vq_parts is a list of tensors from different VQPart segments
+                # They correspond to encoded.vq_mask_tokens
+                # Since we just want to fill the 'values' tensor at the right positions:
+                all_vq_codes = torch.cat(
+                    vq_parts, dim=1
+                )  # Shape: (C, Total_Semantic_Tokens)
+            else:
+                all_vq_codes = vq_parts[0]
+
+            # Values[0] is already the Main Token ID (Semantic Begin + Code)
+            # Values[1:] should be the codes themselves
+            values[1:, encoded.vq_mask_tokens] = all_vq_codes.to(dtype=torch.long)
+
+        if encoded.audio_parts is not None and len(encoded.audio_parts) > 0:
+            audio_parts = torch.cat(encoded.audio_parts, dim=0)
+            audio_masks = encoded.audio_masks[None, :]
+
+        return values, audio_masks, audio_parts
+
+    def visualize(
+        self: "ContentSequence",
+        tokenizer: FishTokenizer,
+        ignore_loss_tokens: list[str] = [],
+        merge_semantic_tokens: bool = False,
+    ):
+        """
+        Visualize the encoded sequence with color-coded tokens.
+        Blue/cyan tokens contribute to loss, green tokens do not.
+        """
+        encoded = self.encode(
+            tokenizer, add_shift=False, ignore_loss_tokens=ignore_loss_tokens
+        )
+
+        # Colors for alternating tokens
+        colors = {
+            "blue": "\033[94m",  # Light blue
+            "cyan": "\033[96m",  # Cyan
+            "green": "\033[92m",  # Light green
+            "dark_green": "\033[32m",  # Dark green
+        }
+        blue_idx = 0
+        green_idx = 0
+
+        def print_in_blue(x):
+            nonlocal blue_idx
+            color = colors["blue"] if blue_idx % 2 == 0 else colors["cyan"]
+            print(f"{color}{x}\033[0m", end="")
+            blue_idx += 1
+
+        def print_in_green(x):
+            nonlocal green_idx
+            color = colors["green"] if green_idx % 2 == 0 else colors["dark_green"]
+            print(f"{color}{x}\033[0m", end="")
+            green_idx += 1
+
+        def print_semantic_token(x, count):
+            val = f"[<|semantic|>x{count}]"
+            if x == -100:
+                print_in_green(val)
+            else:
+                print_in_blue(val)
+
+        count_semantic_tokens = 0
+        semantic_label = None
+
+        for tok, lab in zip(encoded.tokens, encoded.labels):
+            token_id = int(tok.item())
+
+            if merge_semantic_tokens:
+                if (
+                    tokenizer.semantic_begin_id <= token_id <= tokenizer.semantic_end_id
+                    and (semantic_label is None or semantic_label == lab)
+                ):
+                    count_semantic_tokens += 1
+                    semantic_label = lab
+                    continue
+                elif count_semantic_tokens > 0:
+                    print_semantic_token(semantic_label, count_semantic_tokens)
+                    count_semantic_tokens = 0
+                    semantic_label = None
+
+            # Use HF decode
+            val = tokenizer.decode([token_id])
+
+            # Simple fallback for visualization if decode returns empty or weird stuff for special tokens
+            if not val:
+                val = f"<{token_id}>"
+
+            if lab == -100:
+                print_in_green(val)
+            else:
+                print_in_blue(val)
+
+        if merge_semantic_tokens and count_semantic_tokens > 0:
+            print_semantic_token(semantic_label, count_semantic_tokens)
+
+        print()

--- a/xinference/thirdparty/fish_speech_s2/fish_speech/conversation.py
+++ b/xinference/thirdparty/fish_speech_s2/fish_speech/conversation.py
@@ -1,0 +1,174 @@
+from copy import deepcopy
+from dataclasses import dataclass, field
+from typing import Literal
+
+import torch
+from transformers import PreTrainedTokenizerFast
+
+from xinference.thirdparty.fish_speech_s2.fish_speech.content_sequence import (
+    AudioPart,
+    BasePart,
+    ContentSequence,
+    EncodedMessage,
+    TextPart,
+    VQPart,
+)
+from xinference.thirdparty.fish_speech_s2.fish_speech.tokenizer import IM_END_TOKEN, IM_START_TOKEN, MODALITY_TOKENS
+
+
+@dataclass(kw_only=True)
+class Message:
+    role: Literal["system", "user", "assistant"]
+    parts: list[BasePart] = field(default_factory=list)
+    add_im_start: bool = True
+    add_im_end: bool = True
+    cal_loss: bool = False
+    modality: Literal["text", "voice", "interleave"] | None = None
+
+    # By default, ignore the loss of the auto-generated im_start token
+    ignore_im_start_loss: bool = True
+
+
+@dataclass
+class Conversation:
+    messages: list[Message]
+
+    def __init__(self: "Conversation", messages: list[Message] | None = None):
+        self.messages = messages or []
+
+    def _build_content_sequence(
+        self: "Conversation",
+        metadata: dict | None = None,
+    ) -> ContentSequence:
+        """
+        Build a ContentSequence from all messages.
+        Handles cal_loss inheritance from message to part level.
+        """
+        all_parts = []
+        for message in self.messages:
+            # Add im_start
+            if message.add_im_start:
+                modality_token = (
+                    MODALITY_TOKENS[message.modality] if message.modality else ""
+                )
+                all_parts.append(
+                    TextPart(
+                        text=f"{IM_START_TOKEN}{message.role}\n{modality_token}",
+                        cal_loss=not message.ignore_im_start_loss,
+                    )
+                )
+
+            # Add message parts
+            for part in message.parts:
+                # Inherit cal_loss from message if not set at part level
+                if not hasattr(part, "cal_loss") or part.cal_loss is False:
+                    new_part = deepcopy(part)
+                    new_part.cal_loss = message.cal_loss
+                    all_parts.append(new_part)
+                else:
+                    all_parts.append(part)
+
+            # Add im_end
+            if message.add_im_end:
+                all_parts.append(
+                    TextPart(text=IM_END_TOKEN + "\n", cal_loss=message.cal_loss)
+                )
+
+        return ContentSequence(parts=all_parts, modality=None, metadata=metadata)
+
+    def encode(
+        self: "Conversation",
+        tokenizer: any,
+        add_shift: bool = True,
+        ignore_loss_tokens: list[str] = [],
+        metadata: dict | None = None,
+        max_length: int | None = None,
+    ) -> EncodedMessage:
+        # Build ContentSequence from messages
+        content_seq = self._build_content_sequence(metadata=metadata)
+        return content_seq.encode(
+            tokenizer,
+            add_shift=add_shift,
+            ignore_loss_tokens=ignore_loss_tokens,
+            max_length=max_length,
+        )
+
+    def encode_for_inference(
+        self: "Conversation",
+        tokenizer: any,
+        num_codebooks: int,
+        metadata: dict | None = None,
+    ):
+        content_seq = self._build_content_sequence(metadata=metadata)
+        return content_seq.encode_for_inference(tokenizer, num_codebooks=num_codebooks)
+
+    def visualize(
+        self: "Conversation",
+        tokenizer: PreTrainedTokenizerFast,
+        ignore_loss_tokens: list[str] = [],
+        merge_semantic_tokens: bool = False,
+        merge_audio_tokens: bool = False,
+        use_color: bool = True,
+    ):
+        """
+        Visualize the encoded sequence with color-coded tokens.
+        Blue/cyan tokens contribute to loss, green tokens do not.
+        """
+        # Build ContentSequence from messages and use its visualize method
+        content_seq = self._build_content_sequence()
+        content_seq.visualize(
+            tokenizer,
+            ignore_loss_tokens=ignore_loss_tokens,
+            merge_semantic_tokens=merge_semantic_tokens,
+        )
+
+    def append(self: "Conversation", message: Message):
+        self.messages.append(message)
+
+    def to_content_sequence(
+        self: "Conversation",
+        metadata: dict | None = None,
+    ) -> ContentSequence:
+        """
+        Convert the Conversation to a ContentSequence.
+
+        This method builds a ContentSequence from all messages,
+        handling cal_loss inheritance from message to part level.
+
+        Args:
+            metadata: Optional metadata to include in the ContentSequence
+
+        Returns:
+            ContentSequence with all messages converted to parts
+        """
+        return self._build_content_sequence(metadata=metadata)
+
+
+if __name__ == "__main__":
+    # Test the new implementation with the same API
+    message0 = Message(
+        role="user",
+        parts=[
+            TextPart(text="Hello, how are you?"),
+            VQPart(codes=torch.zeros((4, 10))),
+        ],
+        cal_loss=False,
+    )
+
+    message1 = Message(
+        role="assistant",
+        parts=[TextPart(text="I'm fine, thank you.")],
+        cal_loss=True,
+    )
+    conversation = Conversation([message0, message1])
+    tokenizer = PreTrainedTokenizerFast.from_pretrained("checkpoints/agent-0.6b-debug")
+
+    # Test with enhanced visualization from ContentSequence
+    print("Basic visualization:")
+    conversation.visualize(tokenizer)
+
+    print("\nWith merged semantic tokens:")
+    conversation.visualize(tokenizer, merge_semantic_tokens=True)
+
+    print("\nWithout colors:")
+    conversation.visualize(tokenizer, use_color=False)

--- a/xinference/thirdparty/fish_speech_s2/fish_speech/inference_engine/__init__.py
+++ b/xinference/thirdparty/fish_speech_s2/fish_speech/inference_engine/__init__.py
@@ -1,0 +1,192 @@
+import gc
+import queue
+from typing import Generator
+
+import numpy as np
+import torch
+from loguru import logger
+
+from xinference.thirdparty.fish_speech_s2.fish_speech.inference_engine.reference_loader import ReferenceLoader
+from xinference.thirdparty.fish_speech_s2.fish_speech.inference_engine.utils import InferenceResult, wav_chunk_header
+from xinference.thirdparty.fish_speech_s2.fish_speech.inference_engine.vq_manager import VQManager
+from xinference.thirdparty.fish_speech_s2.fish_speech.models.dac.modded_dac import DAC
+from xinference.thirdparty.fish_speech_s2.fish_speech.models.text2semantic.inference import (
+    GenerateRequest,
+    GenerateResponse,
+    WrappedGenerateResponse,
+)
+from xinference.thirdparty.fish_speech_s2.fish_speech.utils import autocast_exclude_mps, set_seed
+from xinference.thirdparty.fish_speech_s2.fish_speech.utils.schema import ServeTTSRequest
+
+
+class TTSInferenceEngine(ReferenceLoader, VQManager):
+
+    def __init__(
+        self,
+        llama_queue: queue.Queue,
+        decoder_model: DAC,
+        precision: torch.dtype,
+        compile: bool,
+    ) -> None:
+
+        super().__init__()
+
+        self.llama_queue = llama_queue
+        self.decoder_model = decoder_model
+        self.precision = precision
+        self.compile = compile
+
+    @torch.inference_mode()
+    def inference(self, req: ServeTTSRequest) -> Generator[InferenceResult, None, None]:
+        """
+        Main inference function:
+        - Loads the reference audio and text.
+        - Calls the LLAMA model for inference.
+        - Decodes the VQ tokens to audio.
+        """
+
+        ref_id: str | None = req.reference_id
+        prompt_tokens, prompt_texts = [], []
+        # Load the reference audio and text based on id or hash
+        if ref_id is not None:
+            prompt_tokens, prompt_texts = self.load_by_id(ref_id, req.use_memory_cache)
+
+        elif req.references:
+            prompt_tokens, prompt_texts = self.load_by_hash(
+                req.references, req.use_memory_cache
+            )
+
+        # Set the random seed if provided
+        if req.seed is not None:
+            set_seed(req.seed)
+            logger.warning(f"set seed: {req.seed}")
+
+        # Get the symbolic tokens from the LLAMA model
+        response_queue = self.send_Llama_request(req, prompt_tokens, prompt_texts)
+
+        # Get the sample rate from the decoder model
+        if hasattr(self.decoder_model, "spec_transform"):
+            sample_rate = self.decoder_model.spec_transform.sample_rate
+        else:
+            sample_rate = self.decoder_model.sample_rate
+
+        # If streaming, send the header
+        if req.streaming:
+            yield InferenceResult(
+                code="header",
+                audio=(
+                    sample_rate,
+                    np.array(wav_chunk_header(sample_rate=sample_rate)),
+                ),
+                error=None,
+            )
+
+        segments = []
+
+        while True:
+            # Get the response from the LLAMA model
+            wrapped_result: WrappedGenerateResponse = response_queue.get()
+            if wrapped_result.status == "error":
+                yield InferenceResult(
+                    code="error",
+                    audio=None,
+                    error=(
+                        wrapped_result.response
+                        if isinstance(wrapped_result.response, Exception)
+                        else Exception("Unknown error")
+                    ),
+                )
+                break
+
+            # Check the response type
+            if not isinstance(wrapped_result.response, GenerateResponse):
+                raise TypeError(
+                    f"Expected GenerateResponse, got {type(wrapped_result.response).__name__}"
+                )
+
+            result: GenerateResponse = wrapped_result.response
+            if result.action != "next":
+                segment = self.get_audio_segment(result)
+
+                if req.streaming:  # Used only by the API server
+                    yield InferenceResult(
+                        code="segment",
+                        audio=(sample_rate, segment),
+                        error=None,
+                    )
+                segments.append(segment)
+            else:
+                break
+
+        # Clean up the memory
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+            gc.collect()
+
+        # Edge case: no audio generated
+        if len(segments) == 0:
+            yield InferenceResult(
+                code="error",
+                audio=None,
+                error=RuntimeError("No audio generated, please check the input text."),
+            )
+        else:
+            # Streaming or not, return the final audio
+            audio = np.concatenate(segments, axis=0)
+            yield InferenceResult(
+                code="final",
+                audio=(sample_rate, audio),
+                error=None,
+            )
+
+        return None
+
+    def send_Llama_request(
+        self, req: ServeTTSRequest, prompt_tokens: list, prompt_texts: list
+    ) -> queue.Queue:
+        """
+        Send a request to the LLAMA model to generate the symbolic tokens.
+        """
+
+        # Prepare the request
+        request = dict(
+            device=self.decoder_model.device,
+            max_new_tokens=req.max_new_tokens,
+            text=req.text,
+            top_p=req.top_p,
+            repetition_penalty=req.repetition_penalty,
+            temperature=req.temperature,
+            compile=self.compile,
+            iterative_prompt=req.chunk_length > 0,
+            chunk_length=req.chunk_length,
+            prompt_tokens=prompt_tokens,
+            prompt_text=prompt_texts,
+        )
+
+        # Create a queue to get the response
+        response_queue = queue.Queue()
+
+        # Send the request to the LLAMA model
+        self.llama_queue.put(
+            GenerateRequest(
+                request=request,
+                response_queue=response_queue,
+            )
+        )
+
+        return response_queue
+
+    def get_audio_segment(self, result: GenerateResponse) -> np.ndarray:
+        """
+        Decode the VQ tokens to audio.
+        """
+
+        # Don't use autocast on MPS devices
+        with autocast_exclude_mps(
+            device_type=self.decoder_model.device.type, dtype=self.precision
+        ):
+            # Decode the symbolic tokens to audio
+            segment = self.decode_vq_tokens(codes=result.codes)
+
+        # Convert the audio to numpy
+        return segment.float().cpu().numpy()

--- a/xinference/thirdparty/fish_speech_s2/fish_speech/inference_engine/reference_loader.py
+++ b/xinference/thirdparty/fish_speech_s2/fish_speech/inference_engine/reference_loader.py
@@ -1,0 +1,284 @@
+import io
+import re
+from hashlib import sha256
+from pathlib import Path
+from typing import Callable, Literal, Tuple
+
+import torch
+import torchaudio
+from loguru import logger
+
+from xinference.thirdparty.fish_speech_s2.fish_speech.models.dac.modded_dac import DAC
+from xinference.thirdparty.fish_speech_s2.fish_speech.utils.file import (
+    AUDIO_EXTENSIONS,
+    audio_to_bytes,
+    list_files,
+    read_ref_text,
+)
+from xinference.thirdparty.fish_speech_s2.fish_speech.utils.schema import ServeReferenceAudio
+
+_ID_PATTERN = re.compile(r"^[a-zA-Z0-9\-_ ]+$")
+
+
+class ReferenceLoader:
+    def __init__(self) -> None:
+        """
+        Component of the TTSInferenceEngine class.
+        Loads and manages the cache for the reference audio and text.
+        """
+        self.ref_by_id: dict = {}
+        self.ref_by_hash: dict = {}
+
+        # Make Pylance happy (attribut/method not defined...)
+        self.decoder_model: DAC
+        self.encode_reference: Callable
+
+        # Define the torchaudio backend
+        # list_audio_backends() was removed in torchaudio 2.9
+        try:
+            backends = torchaudio.list_audio_backends()
+            if "ffmpeg" in backends:
+                self.backend = "ffmpeg"
+            else:
+                self.backend = "soundfile"
+        except AttributeError:
+            # torchaudio 2.9+ removed list_audio_backends()
+            # Try ffmpeg first, fallback to soundfile
+            try:
+                __import__("torchaudio.io._load_audio_fileobj")
+
+                self.backend = "ffmpeg"
+            except (ImportError, ModuleNotFoundError):
+                self.backend = "soundfile"
+
+    @staticmethod
+    def _validate_id(id: str) -> None:
+        if not _ID_PATTERN.match(id) or len(id) > 255:
+            raise ValueError(
+                "Reference ID contains invalid characters or is too long. "
+                "Only alphanumeric, hyphens, underscores, and spaces are allowed."
+            )
+
+    def load_by_id(
+        self,
+        id: str,
+        use_cache: Literal["on", "off"],
+    ) -> Tuple:
+        self._validate_id(id)
+
+        # Load the references audio and text by id
+        ref_folder = Path("references") / id
+        ref_folder.mkdir(parents=True, exist_ok=True)
+        ref_audios = list_files(
+            ref_folder, AUDIO_EXTENSIONS, recursive=True, sort=False
+        )
+
+        if use_cache == "off" or id not in self.ref_by_id:
+            # If the references are not already loaded, encode them
+            prompt_tokens = [
+                self.encode_reference(
+                    # decoder_model=self.decoder_model,
+                    reference_audio=audio_to_bytes(str(ref_audio)),
+                    enable_reference_audio=True,
+                )
+                for ref_audio in ref_audios
+            ]
+            prompt_texts = [
+                read_ref_text(str(ref_audio.with_suffix(".lab")))
+                for ref_audio in ref_audios
+            ]
+            self.ref_by_id[id] = (prompt_tokens, prompt_texts)
+
+        else:
+            # Reuse already encoded references
+            logger.info("Use same references")
+            prompt_tokens, prompt_texts = self.ref_by_id[id]
+
+        return prompt_tokens, prompt_texts
+
+    def load_by_hash(
+        self,
+        references: list[ServeReferenceAudio],
+        use_cache: Literal["on", "off"],
+    ) -> Tuple:
+        # Load the references audio and text by hash
+        audio_hashes = [sha256(ref.audio).hexdigest() for ref in references]
+
+        cache_used = False
+        prompt_tokens, prompt_texts = [], []
+        for i, ref in enumerate(references):
+            if use_cache == "off" or audio_hashes[i] not in self.ref_by_hash:
+                # If the references are not already loaded, encode them
+                prompt_tokens.append(
+                    self.encode_reference(
+                        reference_audio=ref.audio,
+                        enable_reference_audio=True,
+                    )
+                )
+                prompt_texts.append(ref.text)
+                self.ref_by_hash[audio_hashes[i]] = (prompt_tokens[-1], ref.text)
+
+            else:
+                # Reuse already encoded references
+                cached_token, cached_text = self.ref_by_hash[audio_hashes[i]]
+                prompt_tokens.append(cached_token)
+                prompt_texts.append(cached_text)
+                cache_used = True
+
+        if cache_used:
+            logger.info("Use same references")
+
+        return prompt_tokens, prompt_texts
+
+    def load_audio(self, reference_audio: bytes | str, sr: int):
+        """
+        Load the audio data from a file or bytes.
+        """
+        if isinstance(reference_audio, bytes):
+            reference_audio = io.BytesIO(reference_audio)
+
+        waveform, original_sr = torchaudio.load(reference_audio, backend=self.backend)
+
+        if waveform.shape[0] > 1:
+            waveform = torch.mean(waveform, dim=0, keepdim=True)
+
+        if original_sr != sr:
+            resampler = torchaudio.transforms.Resample(
+                orig_freq=original_sr, new_freq=sr
+            )
+            waveform = resampler(waveform)
+
+        audio = waveform.squeeze().numpy()
+        return audio
+
+    def list_reference_ids(self) -> list[str]:
+        """
+        List all valid reference IDs (subdirectory names containing valid audio and .lab files).
+
+        Returns:
+            list[str]: List of valid reference IDs
+        """
+        ref_base_path = Path("references")
+        if not ref_base_path.exists():
+            return []
+
+        valid_ids = []
+        for ref_dir in ref_base_path.iterdir():
+            if not ref_dir.is_dir():
+                continue
+
+            # Check if directory contains at least one audio file and corresponding .lab file
+            audio_files = list_files(
+                ref_dir, AUDIO_EXTENSIONS, recursive=False, sort=False
+            )
+            if not audio_files:
+                continue
+
+            # Check if corresponding .lab file exists for at least one audio file
+            has_valid_pair = False
+            for audio_file in audio_files:
+                lab_file = audio_file.with_suffix(".lab")
+                if lab_file.exists():
+                    has_valid_pair = True
+                    break
+
+            if has_valid_pair:
+                valid_ids.append(ref_dir.name)
+
+        return sorted(valid_ids)
+
+    def add_reference(self, id: str, wav_file_path: str, reference_text: str) -> None:
+        """
+        Add a new reference voice by creating a new directory and copying files.
+
+        Args:
+            id: Reference ID (directory name)
+            wav_file_path: Path to the audio file to copy
+            reference_text: Text content for the .lab file
+
+        Raises:
+            FileExistsError: If the reference ID already exists
+            FileNotFoundError: If the audio file doesn't exist
+            OSError: If file operations fail
+        """
+        self._validate_id(id)
+
+        # Check if reference already exists
+        ref_dir = Path("references") / id
+        if ref_dir.exists():
+            raise FileExistsError(f"Reference ID '{id}' already exists")
+
+        # Check if audio file exists
+        audio_path = Path(wav_file_path)
+        if not audio_path.exists():
+            raise FileNotFoundError(f"Audio file not found: {wav_file_path}")
+
+        # Validate audio file extension
+        if audio_path.suffix.lower() not in AUDIO_EXTENSIONS:
+            raise ValueError(
+                f"Unsupported audio format: {audio_path.suffix}. Supported formats: {', '.join(AUDIO_EXTENSIONS)}"
+            )
+
+        try:
+            # Create reference directory
+            ref_dir.mkdir(parents=True, exist_ok=False)
+
+            # Determine the target audio filename with original extension
+            target_audio_path = ref_dir / f"sample{audio_path.suffix}"
+
+            # Copy audio file
+            import shutil
+
+            shutil.copy2(audio_path, target_audio_path)
+
+            # Create .lab file
+            lab_path = ref_dir / "sample.lab"
+            with open(lab_path, "w", encoding="utf-8") as f:
+                f.write(reference_text)
+
+            # Clear cache for this ID if it exists
+            if id in self.ref_by_id:
+                del self.ref_by_id[id]
+
+            logger.info(f"Successfully added reference voice with ID: {id}")
+
+        except Exception as e:
+            # Clean up on failure
+            if ref_dir.exists():
+                import shutil
+
+                shutil.rmtree(ref_dir)
+            raise e
+
+    def delete_reference(self, id: str) -> None:
+        """
+        Delete a reference voice by removing its directory and files.
+
+        Args:
+            id: Reference ID (directory name) to delete
+
+        Raises:
+            FileNotFoundError: If the reference ID doesn't exist
+            OSError: If file operations fail
+        """
+        self._validate_id(id)
+
+        ref_dir = Path("references") / id
+        if not ref_dir.exists():
+            raise FileNotFoundError(f"Reference ID '{id}' does not exist")
+
+        try:
+            # Remove the entire reference directory
+            import shutil
+
+            shutil.rmtree(ref_dir)
+
+            # Clear cache for this ID if it exists
+            if id in self.ref_by_id:
+                del self.ref_by_id[id]
+
+            logger.info(f"Successfully deleted reference voice with ID: {id}")
+
+        except Exception as e:
+            logger.error(f"Failed to delete reference '{id}': {e}")
+            raise OSError(f"Failed to delete reference '{id}': {e}")

--- a/xinference/thirdparty/fish_speech_s2/fish_speech/inference_engine/utils.py
+++ b/xinference/thirdparty/fish_speech_s2/fish_speech/inference_engine/utils.py
@@ -1,0 +1,29 @@
+import io
+import wave
+from dataclasses import dataclass
+from typing import Literal, Optional, Tuple
+
+import numpy as np
+
+
+@dataclass
+class InferenceResult:
+    code: Literal["header", "segment", "error", "final"]
+    audio: Optional[Tuple[int, np.ndarray]]
+    error: Optional[Exception]
+
+
+def wav_chunk_header(
+    sample_rate: int = 44100, bit_depth: int = 16, channels: int = 1
+) -> bytes:
+    buffer = io.BytesIO()
+
+    with wave.open(buffer, "wb") as wav_file:
+        wav_file.setnchannels(channels)
+        wav_file.setsampwidth(bit_depth // 8)
+        wav_file.setframerate(sample_rate)
+
+    wav_header_bytes = buffer.getvalue()
+    buffer.close()
+
+    return wav_header_bytes

--- a/xinference/thirdparty/fish_speech_s2/fish_speech/inference_engine/vq_manager.py
+++ b/xinference/thirdparty/fish_speech_s2/fish_speech/inference_engine/vq_manager.py
@@ -1,0 +1,53 @@
+from typing import Callable
+
+import torch
+from loguru import logger
+
+from xinference.thirdparty.fish_speech_s2.fish_speech.models.dac.modded_dac import DAC
+
+
+class VQManager:
+
+    def __init__(self):
+        # Make Pylance happy (attribut/method not defined...)
+        self.decoder_model: DAC
+        self.load_audio: Callable
+
+    def decode_vq_tokens(self, codes):
+        logger.info(f"VQ features: {codes.shape}")
+
+        if isinstance(self.decoder_model, DAC):
+            return self.decoder_model.from_indices(codes[None])[0].squeeze()
+
+        raise ValueError(f"Unknown model type: {type(self.decoder_model)}")
+
+    def encode_reference(self, reference_audio, enable_reference_audio):
+        if enable_reference_audio and reference_audio is not None:
+            # Load audios, and prepare basic info here
+            if hasattr(self.decoder_model, "spec_transform"):
+                sample_rate = self.decoder_model.spec_transform.sample_rate
+            else:
+                sample_rate = self.decoder_model.sample_rate
+            reference_audio_content = self.load_audio(reference_audio, sample_rate)
+
+            audios = torch.from_numpy(reference_audio_content).to(
+                self.decoder_model.device
+            )[None, None, :]
+            audio_lengths = torch.tensor(
+                [audios.shape[2]], device=self.decoder_model.device, dtype=torch.long
+            )
+            logger.info(
+                f"Loaded audio with {audios.shape[2] / sample_rate:.2f} seconds"
+            )
+
+            # VQ Encoder
+            if isinstance(self.decoder_model, DAC):
+                prompt_tokens = self.decoder_model.encode(audios, audio_lengths)[0][0]
+                logger.info(f"Encoded prompt: {prompt_tokens.shape}")
+            else:
+                raise ValueError(f"Unknown model type: {type(self.decoder_model)}")
+        else:
+            prompt_tokens = None
+            logger.info("No reference audio provided")
+
+        return prompt_tokens

--- a/xinference/thirdparty/fish_speech_s2/fish_speech/models/__init__.py
+++ b/xinference/thirdparty/fish_speech_s2/fish_speech/models/__init__.py
@@ -1,0 +1,1 @@
+"""Fish Audio S2 model implementations."""

--- a/xinference/thirdparty/fish_speech_s2/fish_speech/models/dac/inference.py
+++ b/xinference/thirdparty/fish_speech_s2/fish_speech/models/dac/inference.py
@@ -1,0 +1,125 @@
+from pathlib import Path
+
+import click
+import hydra
+import numpy as np
+import soundfile as sf
+import torch
+import torchaudio
+from hydra import compose, initialize_config_dir
+from hydra.utils import instantiate
+from loguru import logger
+from omegaconf import OmegaConf
+
+from xinference.thirdparty.fish_speech_s2.fish_speech.utils.file import AUDIO_EXTENSIONS
+
+# register eval resolver
+OmegaConf.register_new_resolver("eval", eval, replace=True)
+
+
+def load_model(config_name, checkpoint_path, device="cuda"):
+    hydra.core.global_hydra.GlobalHydra.instance().clear()
+    config_dir = str(Path(__file__).resolve().parents[2] / "configs")
+    with initialize_config_dir(version_base="1.3", config_dir=config_dir):
+        cfg = compose(config_name=config_name)
+
+    model = instantiate(cfg)
+    state_dict = torch.load(
+        checkpoint_path, map_location=device, mmap=True, weights_only=True
+    )
+    if "state_dict" in state_dict:
+        state_dict = state_dict["state_dict"]
+
+    if any("generator" in k for k in state_dict):
+        state_dict = {
+            k.replace("generator.", ""): v
+            for k, v in state_dict.items()
+            if "generator." in k
+        }
+
+    result = model.load_state_dict(state_dict, strict=False, assign=True)
+    model.eval()
+    model.to(device)
+
+    logger.info(f"Loaded model: {result}")
+    return model
+
+
+@torch.no_grad()
+@click.command()
+@click.option(
+    "--input-path",
+    "-i",
+    default="test.wav",
+    type=click.Path(exists=True, path_type=Path),
+)
+@click.option(
+    "--output-path", "-o", default="fake.wav", type=click.Path(path_type=Path)
+)
+@click.option("--config-name", default="modded_dac_vq")
+@click.option(
+    "--checkpoint-path",
+    default="checkpoints/openaudio-s1-mini/codec.pth",
+)
+@click.option(
+    "--device",
+    "-d",
+    default="cuda",
+)
+def main(input_path, output_path, config_name, checkpoint_path, device):
+    model = load_model(config_name, checkpoint_path, device=device)
+
+    suffix = input_path.suffix.lower()
+    if suffix in AUDIO_EXTENSIONS:
+        logger.info(f"Processing in-place reconstruction of {input_path}")
+
+        # Load audio
+        audio, sr = torchaudio.load(str(input_path))
+        if audio.shape[0] > 1:
+            audio = audio.mean(0, keepdim=True)
+        audio = torchaudio.functional.resample(audio, sr, model.sample_rate)
+
+        audios = audio[None].to(device)
+        logger.info(
+            f"Loaded audio with {audios.shape[2] / model.sample_rate:.2f} seconds"
+        )
+
+        # VQ Encoder
+        audio_lengths = torch.tensor([audios.shape[2]], device=device, dtype=torch.long)
+        indices, _ = model.encode(audios, audio_lengths)
+
+        if indices.ndim == 3:
+            indices = indices[0]
+
+        logger.info(f"Generated indices of shape {indices.shape}")
+
+        # Save indices
+        np.save(output_path.with_suffix(".npy"), indices.cpu().numpy())
+    elif suffix == ".npy":
+        logger.info(f"Processing precomputed indices from {input_path}")
+        indices = np.load(input_path)
+        indices = torch.from_numpy(indices).to(device).long()
+        assert indices.ndim == 2, f"Expected 2D indices, got {indices.ndim}"
+        # indices_lens = torch.tensor([indices.shape[1]], device=device, dtype=torch.long)
+    else:
+        raise ValueError(f"Unknown input type: {input_path}")
+
+    # Restore
+    if indices.ndim == 2:
+        indices = indices.unsqueeze(0)
+
+    fake_audios = model.from_indices(indices)
+    audio_time = fake_audios.shape[-1] / model.sample_rate
+
+    logger.info(
+        f"Generated audio of shape {fake_audios.shape}, equivalent to {audio_time:.2f} seconds from {indices.shape[1]} features, features/second: {indices.shape[1] / audio_time:.2f}"
+    )
+
+    # Save audio
+    fake_audio = fake_audios[0, 0].float().cpu().numpy()
+    sf.write(output_path, fake_audio, model.sample_rate)
+    logger.info(f"Saved audio to {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/xinference/thirdparty/fish_speech_s2/fish_speech/models/dac/modded_dac.py
+++ b/xinference/thirdparty/fish_speech_s2/fish_speech/models/dac/modded_dac.py
@@ -1,0 +1,1045 @@
+import math
+import typing as tp
+from dataclasses import dataclass
+from typing import List, Optional, Union
+
+import numpy as np
+import torch
+from audiotools import AudioSignal
+from audiotools.ml import BaseModel
+from dac.model.base import CodecMixin
+from dac.nn.layers import Snake1d, WNConv1d, WNConvTranspose1d
+from torch import Tensor, nn
+from torch.nn import functional as F
+from torch.nn.utils.parametrizations import weight_norm
+from torch.nn.utils.parametrize import remove_parametrizations
+
+
+@dataclass
+class VQResult:
+    z: torch.Tensor
+    codes: torch.Tensor
+    latents: torch.Tensor
+    codebook_loss: torch.Tensor
+    commitment_loss: torch.Tensor
+    semantic_distill_z: torch.Tensor | None = None
+
+
+def find_multiple(n: int, k: int) -> int:
+    if n % k == 0:
+        return n
+    return n + k - (n % k)
+
+
+@dataclass
+class ModelArgs:
+    block_size: int = 2048
+    n_layer: int = 8
+    n_head: int = 8
+    dim: int = 512
+    intermediate_size: int = 1536
+    n_local_heads: int = -1
+    head_dim: int = 64
+    rope_base: float = 10000
+    norm_eps: float = 1e-5
+    dropout_rate: float = 0.1
+    attn_dropout_rate: float = 0.1
+    channels_first: bool = True  # to be compatible with conv1d input/output
+    pos_embed_type: str = "rope"  # can be "rope" or "conformer"
+    max_relative_position: int = 128  # for conformer-style relative position embedding
+    window_size: int = 512  # for window limited attention
+
+    def __post_init__(self):
+        if self.n_local_heads == -1:
+            self.n_local_heads = self.n_head
+        if self.intermediate_size is None:
+            hidden_dim = 4 * self.dim
+            n_hidden = int(2 * hidden_dim / 3)
+            self.intermediate_size = find_multiple(n_hidden, 256)
+        assert self.pos_embed_type in [
+            "rope",
+            "conformer",
+        ], "pos_embed_type must be either 'rope' or 'conformer'"
+
+
+class KVCache(nn.Module):
+    def __init__(
+        self, max_batch_size, max_seq_length, n_heads, head_dim, dtype=torch.bfloat16
+    ):
+        super().__init__()
+        cache_shape = (max_batch_size, n_heads, max_seq_length, head_dim)
+        self.register_buffer("k_cache", torch.zeros(cache_shape, dtype=dtype))
+        self.register_buffer("v_cache", torch.zeros(cache_shape, dtype=dtype))
+
+    def update(self, input_pos, k_val, v_val):
+        # input_pos: [S], k_val: [B, H, S, D]
+        assert input_pos.shape[0] == k_val.shape[2]
+
+        k_out = self.k_cache
+        v_out = self.v_cache
+        k_out[:, :, input_pos] = k_val
+        v_out[:, :, input_pos] = v_val
+
+        return (
+            k_out[:, :, : input_pos.max() + 1, :],
+            v_out[:, :, : input_pos.max() + 1, :],
+        )
+
+    def clear_cache(self, prompt_len):
+        self.k_cache[:, :, prompt_len:, :] = torch.zeros_like(
+            self.k_cache[:, :, prompt_len:, :]
+        )
+        self.v_cache[:, :, prompt_len:, :] = torch.zeros_like(
+            self.v_cache[:, :, prompt_len:, :]
+        )
+
+
+class Transformer(nn.Module):
+    def __init__(self, config: ModelArgs) -> None:
+        super().__init__()
+        self.config = config
+
+        self.layers = nn.ModuleList(
+            TransformerBlock(config) for _ in range(config.n_layer)
+        )
+        self.norm = RMSNorm(config.dim, eps=config.norm_eps)
+
+        # Only compute RoPE frequencies if using RoPE
+        if config.pos_embed_type == "rope":
+            freqs_cis = precompute_freqs_cis(
+                327680, self.config.head_dim, self.config.rope_base
+            )
+            self.register_buffer("freqs_cis", freqs_cis, persistent=False)
+        else:
+            self.register_buffer("freqs_cis", None)
+
+        causal_mask = torch.tril(torch.ones(32768, 32768, dtype=torch.bool))
+        self.register_buffer("causal_mask", causal_mask, persistent=False)
+
+        self.max_batch_size = -1
+        self.max_seq_length = -1
+        self.use_kv_cache = False
+
+    def setup_caches(self, max_batch_size, max_seq_length):
+        """
+        This method will only be called during inference when using KV cache.
+        """
+        head_dim = self.config.dim // self.config.n_head
+        max_seq_length = find_multiple(max_seq_length, 8)
+        self.max_seq_length = max_seq_length
+        self.max_batch_size = max_batch_size
+        dtype = self.norm.weight.dtype
+        device = self.norm.weight.device
+
+        for b in self.layers:
+            b.attention.kv_cache = KVCache(
+                max_batch_size,
+                max_seq_length,
+                self.config.n_local_heads,
+                head_dim,
+                dtype,
+            ).to(device)
+
+        self.use_kv_cache = True
+
+    def forward(
+        self,
+        x: Tensor,
+        input_pos: Optional[Tensor] = None,
+        mask: Optional[Tensor] = None,
+    ) -> Tensor:
+        if self.config.pos_embed_type == "rope":
+            assert (
+                self.freqs_cis is not None
+            ), "RoPE frequencies must be initialized for RoPE positional embedding"
+            # print("MAX", input_pos.max())
+            freqs_cis = self.freqs_cis[input_pos]
+        else:
+            freqs_cis = None
+
+        if mask is None:  # in case of non-causal model
+            if not self.training and self.use_kv_cache:
+                mask = self.causal_mask[None, None, input_pos]
+                mask = mask[..., : input_pos.max() + 1]
+            else:
+                mask = self.causal_mask[None, None, input_pos]
+                mask = mask[..., input_pos]
+
+        for i, layer in enumerate(self.layers):
+            x = layer(x, input_pos, freqs_cis, mask)
+        x = self.norm(x)
+        return x
+
+
+class TransformerBlock(nn.Module):
+    def __init__(self, config: ModelArgs) -> None:
+        super().__init__()
+        self.attention = Attention(config)
+        self.feed_forward = FeedForward(config)
+        self.ffn_norm = RMSNorm(config.dim, eps=config.norm_eps)
+        self.attention_norm = RMSNorm(config.dim, eps=config.norm_eps)
+        self.attention_layer_scale = LayerScale(config.dim, inplace=True)
+        self.ffn_layer_scale = LayerScale(config.dim, inplace=True)
+
+    def forward(
+        self,
+        x: Tensor,
+        input_pos: Tensor,
+        freqs_cis: Tensor,
+        mask: Tensor,
+    ) -> Tensor:
+        h = x + self.attention_layer_scale(
+            self.attention(self.attention_norm(x), freqs_cis, mask, input_pos)
+        )
+        out = h + self.ffn_layer_scale(self.feed_forward(self.ffn_norm(h)))
+        return out
+
+
+class Attention(nn.Module):
+    def __init__(self, config: ModelArgs):
+        super().__init__()
+        assert config.dim % config.n_head == 0
+
+        total_head_dim = (config.n_head + 2 * config.n_local_heads) * config.head_dim
+        # key, query, value projections for all heads, but in a batch
+        self.wqkv = nn.Linear(config.dim, total_head_dim, bias=False)
+        self.wo = nn.Linear(config.head_dim * config.n_head, config.dim, bias=False)
+        self.kv_cache = None
+
+        self.n_head = config.n_head
+        self.head_dim = config.head_dim
+        self.n_local_heads = config.n_local_heads
+        self.dim = config.dim
+        self.attn_dropout_rate = config.attn_dropout_rate
+        self.pos_embed_type = config.pos_embed_type
+
+        # Add relative position embedding for conformer-style
+        if self.pos_embed_type == "conformer":
+            self.max_relative_position = config.max_relative_position
+            num_pos_embeddings = 2 * config.max_relative_position + 1
+            self.rel_pos_embeddings = nn.Parameter(
+                torch.zeros(num_pos_embeddings, self.head_dim)
+            )
+            nn.init.normal_(self.rel_pos_embeddings, mean=0.0, std=0.02)
+
+    def _compute_conformer_pos_scores(self, q: Tensor, seqlen: int) -> Tensor:
+        # q: [B, H, S, D]
+        # Returns: [B, H, S, S]
+        positions = torch.arange(seqlen, device=q.device)
+        relative_positions = positions.unsqueeze(1) - positions.unsqueeze(0)  # [S, S]
+        relative_positions = torch.clamp(
+            relative_positions + self.max_relative_position,
+            0,
+            2 * self.max_relative_position,
+        )
+        rel_embeddings = self.rel_pos_embeddings[relative_positions]  # [S, S, D]
+
+        # Compute attention scores with relative position embeddings
+        q = q.transpose(1, 2)  # [B, S, H, D]
+        rel_logits = torch.matmul(q, rel_embeddings.transpose(-2, -1))  # [B, S, H, S]
+        rel_logits = rel_logits.transpose(1, 2)  # [B, H, S, S]
+        return rel_logits
+
+    def forward(
+        self,
+        x: Tensor,
+        freqs_cis: Tensor,
+        mask: Tensor,
+        input_pos: Optional[Tensor] = None,
+    ) -> Tensor:
+        bsz, seqlen, _ = x.shape
+
+        kv_size = self.n_local_heads * self.head_dim
+        q, k, v = self.wqkv(x).split([kv_size, kv_size, kv_size], dim=-1)
+        context_seqlen = seqlen
+
+        q = q.view(bsz, seqlen, self.n_head, self.head_dim)
+        k = k.view(bsz, context_seqlen, self.n_local_heads, self.head_dim)
+        v = v.view(bsz, context_seqlen, self.n_local_heads, self.head_dim)
+
+        if self.pos_embed_type == "rope":
+            q = apply_rotary_emb(q, freqs_cis)
+            k = apply_rotary_emb(k, freqs_cis)
+
+        q, k, v = map(lambda x: x.transpose(1, 2), (q, k, v))
+
+        if self.kv_cache is not None:
+            k, v = self.kv_cache.update(input_pos, k, v)
+
+        k = k.repeat_interleave(self.n_head // self.n_local_heads, dim=1)
+        v = v.repeat_interleave(self.n_head // self.n_local_heads, dim=1)
+
+        if self.pos_embed_type == "conformer":
+            # Compute attention scores
+            scale = 1.0 / math.sqrt(self.head_dim)
+            scores = torch.matmul(q, k.transpose(-2, -1)) * scale
+
+            # Add relative position embeddings for conformer-style
+            rel_scores = self._compute_conformer_pos_scores(q, seqlen)
+            scores = scores + rel_scores
+
+            # Apply attention
+            if mask is not None:
+                scores = scores.masked_fill(~mask, float("-inf"))
+
+            attn = F.softmax(scores, dim=-1)
+            if self.attn_dropout_rate > 0 and self.training:
+                attn = F.dropout(attn, p=self.attn_dropout_rate)
+
+            y = torch.matmul(attn, v)
+        else:
+            y = F.scaled_dot_product_attention(
+                q,
+                k,
+                v,
+                dropout_p=self.attn_dropout_rate if self.training else 0.0,
+                attn_mask=mask,
+            )
+            # is_causal=True)
+        y = (
+            y.transpose(1, 2)
+            .contiguous()
+            .view(bsz, seqlen, self.head_dim * self.n_head)
+        )
+        y = self.wo(y)
+        return y
+
+
+class FeedForward(nn.Module):
+    def __init__(self, config: ModelArgs) -> None:
+        super().__init__()
+        self.w1 = nn.Linear(config.dim, config.intermediate_size, bias=False)
+        self.w3 = nn.Linear(config.dim, config.intermediate_size, bias=False)
+        self.w2 = nn.Linear(config.intermediate_size, config.dim, bias=False)
+        self.dropout = nn.Dropout(config.dropout_rate)
+
+    def forward(self, x: Tensor) -> Tensor:
+        return self.w2(self.dropout(F.silu(self.w1(x)) * self.w3(x)))
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim: int, eps: float = 1e-5):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(dim))
+
+    def _norm(self, x):
+        return x * torch.rsqrt(torch.mean(x * x, dim=-1, keepdim=True) + self.eps)
+
+    def forward(self, x: Tensor) -> Tensor:
+        output = self._norm(x.float()).type_as(x)
+        return output * self.weight
+
+
+class LayerScale(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        init_values: Union[float, Tensor] = 1e-2,
+        inplace: bool = False,
+    ) -> None:
+        super().__init__()
+        self.inplace = inplace
+        self.gamma = nn.Parameter(init_values * torch.ones(dim))
+
+    def forward(self, x: Tensor) -> Tensor:
+        return x.mul_(self.gamma) if self.inplace else x * self.gamma
+
+
+class WindowLimitedTransformer(Transformer):
+    """
+    Transformer with window limited attention, causal.
+    """
+
+    def __init__(
+        self,
+        config: ModelArgs,
+        input_dim: int = 512,
+        window_size: Optional[int] = None,
+        causal: bool = True,
+        look_ahead_conv: nn.Module = None,
+    ):
+        super().__init__(config)
+        self.window_size = window_size
+        self.causal = causal
+        self.channels_first = config.channels_first
+        self.look_ahead_conv = (
+            look_ahead_conv if look_ahead_conv is not None else nn.Identity()
+        )
+        self.input_proj = (
+            nn.Linear(input_dim, config.dim)
+            if input_dim != config.dim
+            else nn.Identity()
+        )
+        self.output_proj = (
+            nn.Linear(config.dim, input_dim)
+            if input_dim != config.dim
+            else nn.Identity()
+        )
+
+    def make_window_limited_mask(
+        self,
+        max_length: int,
+        x_lens: Optional[Tensor] = None,
+    ) -> Tensor:
+        """
+        Make mask to form window limited attention.
+        """
+        if self.causal:
+            mask = torch.tril(torch.ones(max_length, max_length))
+            row_indices = torch.arange(max_length).view(-1, 1)
+            window_size = self.window_size or max_length
+            valid_range = (row_indices - window_size + 1).clamp(min=0)
+            column_indices = torch.arange(max_length)
+            mask = (column_indices >= valid_range) & mask.bool()
+        else:
+            raise NotImplementedError
+        mask = mask.bool()[None, None]
+        return mask
+
+    def make_mask(
+        self,
+        max_length: int,
+        x_lens: Optional[Tensor] = None,
+    ) -> Tensor:
+        """
+        Make ordinary mask if window size is not specified.
+        """
+        if self.causal:
+            mask = torch.tril(torch.ones(max_length, max_length))
+        else:
+            mask = torch.ones(max_length, max_length)
+            mask = mask.bool()[None, None]
+            for i, x_len in enumerate(x_lens):
+                mask[:x_len, i] = 0
+        mask = mask.bool()[None, None]
+        return mask
+
+    def forward(
+        self,
+        x: Tensor,
+        x_lens: Optional[Tensor] = None,
+    ) -> Tensor:
+        if self.channels_first:
+            x = x.transpose(1, 2)
+        x = self.input_proj(x)  # (B, T, D)
+        x = self.look_ahead_conv(x)
+        input_pos = torch.arange(x.shape[1], device=x.device)
+        # construct mask to form window limited attention
+        max_length = x.shape[1]
+        if self.window_size is not None:
+            mask = self.make_window_limited_mask(max_length, x_lens)
+        else:
+            mask = self.make_mask(max_length, x_lens)
+        mask = mask.to(x.device)
+        x = super().forward(x, input_pos, mask)
+        x = self.output_proj(x)  # (B, T, D)
+        if self.channels_first:
+            x = x.transpose(1, 2)
+        return x
+
+
+def precompute_freqs_cis(
+    seq_len: int, n_elem: int, base: int = 10000, dtype: torch.dtype = torch.bfloat16
+) -> Tensor:
+    freqs = 1.0 / (
+        base ** (torch.arange(0, n_elem, 2)[: (n_elem // 2)].float() / n_elem)
+    )
+    t = torch.arange(seq_len, device=freqs.device)
+    freqs = torch.outer(t, freqs)
+    freqs_cis = torch.polar(torch.ones_like(freqs), freqs)
+    cache = torch.stack([freqs_cis.real, freqs_cis.imag], dim=-1)
+    return cache.to(dtype=dtype)
+
+
+def apply_rotary_emb(x: Tensor, freqs_cis: Tensor) -> Tensor:
+    xshaped = x.float().reshape(*x.shape[:-1], -1, 2)
+    freqs_cis = freqs_cis.view(1, xshaped.size(1), 1, xshaped.size(3), 2)
+    x_out2 = torch.stack(
+        [
+            xshaped[..., 0] * freqs_cis[..., 0] - xshaped[..., 1] * freqs_cis[..., 1],
+            xshaped[..., 1] * freqs_cis[..., 0] + xshaped[..., 0] * freqs_cis[..., 1],
+        ],
+        -1,
+    )
+
+    x_out2 = x_out2.flatten(3)
+    return x_out2.type_as(x)
+
+
+def init_weights(m):
+    if isinstance(m, nn.Conv1d):
+        nn.init.trunc_normal_(m.weight, std=0.02)
+        nn.init.constant_(m.bias, 0)
+
+
+def unpad1d(x: torch.Tensor, paddings: tp.Tuple[int, int]):
+    """Remove padding from x, handling properly zero padding. Only for 1d!"""
+    padding_left, padding_right = paddings
+    assert padding_left >= 0 and padding_right >= 0, (padding_left, padding_right)
+    assert (padding_left + padding_right) <= x.shape[-1]
+    end = x.shape[-1] - padding_right
+    return x[..., padding_left:end]
+
+
+def get_extra_padding_for_conv1d(
+    x: torch.Tensor, kernel_size: int, stride: int, padding_total: int = 0
+) -> int:
+    """See `pad_for_conv1d`."""
+    length = x.shape[-1]
+    n_frames = (length - kernel_size + padding_total) / stride + 1
+    ideal_length = (math.ceil(n_frames) - 1) * stride + (kernel_size - padding_total)
+    return ideal_length - length
+
+
+def pad1d(
+    x: torch.Tensor,
+    paddings: tp.Tuple[int, int],
+    mode: str = "zeros",
+    value: float = 0.0,
+):
+    """Tiny wrapper around F.pad, just to allow for reflect padding on small input.
+    If this is the case, we insert extra 0 padding to the right
+    before the reflection happen.
+    """
+    length = x.shape[-1]
+    padding_left, padding_right = paddings
+    assert padding_left >= 0 and padding_right >= 0, (padding_left, padding_right)
+    if mode == "reflect":
+        max_pad = max(padding_left, padding_right)
+        extra_pad = 0
+        if length <= max_pad:
+            extra_pad = max_pad - length + 1
+            x = F.pad(x, (0, extra_pad))
+        padded = F.pad(x, paddings, mode, value)
+        end = padded.shape[-1] - extra_pad
+        return padded[..., :end]
+    else:
+        return F.pad(x, paddings, mode, value)
+
+
+class CausalConvNet(nn.Module):
+    def __init__(
+        self,
+        in_channels,
+        out_channels,
+        kernel_size,
+        dilation=1,
+        stride=1,
+        groups=1,
+        padding=None,
+    ):
+        super(CausalConvNet, self).__init__()
+        self.conv = nn.Conv1d(
+            in_channels,
+            out_channels,
+            kernel_size,
+            stride=stride,
+            dilation=dilation,
+            groups=groups,
+        )
+        self.stride = stride
+        self.kernel_size = (kernel_size - 1) * dilation + 1
+        self.dilation = dilation
+        self.padding = self.kernel_size - self.stride
+
+    def forward(self, x):
+        pad = self.padding
+        extra_padding = get_extra_padding_for_conv1d(
+            x, self.kernel_size, self.stride, pad
+        )
+        x = pad1d(x, (pad, extra_padding), mode="constant", value=0)
+        return self.conv(x).contiguous()
+
+    def weight_norm(self, name="weight", dim=0):
+        self.conv = weight_norm(self.conv, name=name, dim=dim)
+        return self
+
+    def remove_weight_norm(self):
+        self.conv = remove_parametrizations(self.conv)
+        return self
+
+
+class CausalTransConvNet(nn.Module):
+    def __init__(
+        self, in_channels, out_channels, kernel_size, dilation=1, stride=1, padding=None
+    ):
+        super(CausalTransConvNet, self).__init__()
+        self.conv = nn.ConvTranspose1d(
+            in_channels, out_channels, kernel_size, stride=stride, dilation=dilation
+        )
+        self.stride = stride
+        self.kernel_size = kernel_size
+
+    def forward(self, x):
+        x = self.conv(x)
+        pad = self.kernel_size - self.stride
+        padding_right = math.ceil(pad)
+        padding_left = pad - padding_right
+        x = unpad1d(x, (padding_left, padding_right))
+        return x.contiguous()
+
+    def weight_norm(self, name="weight", dim=0):
+        self.conv = weight_norm(self.conv, name=name, dim=dim)
+        return self
+
+    def remove_weight_norm(self):
+        self.conv = remove_parametrizations(self.conv)
+        return self
+
+
+def CausalWNConv1d(*args, **kwargs):
+    return CausalConvNet(*args, **kwargs).weight_norm()
+
+
+def CausalWNConvTranspose1d(*args, **kwargs):
+    return CausalTransConvNet(*args, **kwargs).weight_norm()
+
+
+class ResidualUnit(nn.Module):
+    def __init__(self, dim: int = 16, dilation: int = 1, causal: bool = False):
+        super().__init__()
+        conv_class = CausalWNConv1d if causal else WNConv1d
+        pad = ((7 - 1) * dilation) // 2
+        self.block = nn.Sequential(
+            Snake1d(dim),
+            conv_class(dim, dim, kernel_size=7, dilation=dilation, padding=pad),
+            Snake1d(dim),
+            conv_class(dim, dim, kernel_size=1),
+        )
+        self.causal = causal
+
+    def forward(self, x):
+        y = self.block(x)
+        pad = x.shape[-1] - y.shape[-1]
+        if pad > 0:
+            if self.causal:
+                x = x[..., :-pad]
+            else:
+                x = x[..., pad // 2 : -pad // 2]
+        return x + y
+
+
+class EncoderBlock(nn.Module):
+    def __init__(
+        self,
+        dim: int = 16,
+        stride: int = 1,
+        causal: bool = False,
+        n_t_layer: int = 0,
+        transformer_general_config=None,
+    ):
+        super().__init__()
+        conv_class = CausalWNConv1d if causal else WNConv1d
+        transformer_module = (
+            nn.Identity()
+            if n_t_layer == 0
+            else (
+                WindowLimitedTransformer(
+                    causal=causal,
+                    input_dim=dim,
+                    window_size=getattr(transformer_general_config, "window_size", 512),
+                    config=transformer_general_config(
+                        n_layer=n_t_layer,
+                        n_head=dim // 64,
+                        dim=dim,
+                        intermediate_size=dim * 3,
+                    ),
+                )
+            )
+        )
+        self.block = nn.Sequential(
+            ResidualUnit(dim // 2, dilation=1, causal=causal),
+            ResidualUnit(dim // 2, dilation=3, causal=causal),
+            ResidualUnit(dim // 2, dilation=9, causal=causal),
+            Snake1d(dim // 2),
+            conv_class(
+                dim // 2,
+                dim,
+                kernel_size=2 * stride,
+                stride=stride,
+                padding=math.ceil(stride / 2),
+            ),
+            transformer_module,
+        )
+
+    def forward(self, x):
+        return self.block(x)
+
+
+class Encoder(nn.Module):
+    def __init__(
+        self,
+        d_model: int = 64,
+        strides: list = [2, 4, 8, 8],
+        d_latent: int = 64,
+        n_transformer_layers: list = [0, 0, 4, 4],
+        transformer_general_config: ModelArgs = None,
+        causal: bool = False,
+    ):
+        super().__init__()
+        conv_class = CausalWNConv1d if causal else WNConv1d
+        # Create first convolution
+        self.block = [conv_class(1, d_model, kernel_size=7, padding=3)]
+
+        # Create EncoderBlocks that double channels as they downsample by `stride`
+        for stride, n_t_layer in zip(strides, n_transformer_layers):
+            d_model *= 2
+            self.block += [
+                EncoderBlock(
+                    d_model,
+                    stride=stride,
+                    causal=causal,
+                    n_t_layer=n_t_layer,
+                    transformer_general_config=transformer_general_config,
+                )
+            ]
+
+        # Create last convolution
+        self.block += [
+            Snake1d(d_model),
+            conv_class(d_model, d_latent, kernel_size=3, padding=1),
+        ]
+
+        # Wrap black into nn.Sequential
+        self.block = nn.Sequential(*self.block)
+        self.enc_dim = d_model
+
+    def forward(self, x):
+        return self.block(x)
+
+
+class DecoderBlock(nn.Module):
+    def __init__(
+        self,
+        input_dim: int = 16,
+        output_dim: int = 8,
+        stride: int = 1,
+        causal: bool = False,
+        n_t_layer: int = 0,
+        transformer_general_config=None,
+    ):
+        super().__init__()
+        conv_trans_class = CausalWNConvTranspose1d if causal else WNConvTranspose1d
+        transformer_module = (
+            nn.Identity()
+            if n_t_layer == 0
+            else (
+                WindowLimitedTransformer(
+                    causal=causal,
+                    input_dim=input_dim,
+                    window_size=None,
+                    config=transformer_general_config(
+                        n_layer=n_t_layer,
+                        n_head=input_dim // 64,
+                        dim=input_dim,
+                        intermediate_size=input_dim * 3,
+                    ),
+                )
+            )
+        )
+        self.block = nn.Sequential(
+            # transformer_module,
+            Snake1d(input_dim),
+            conv_trans_class(
+                input_dim,
+                output_dim,
+                kernel_size=2 * stride,
+                stride=stride,
+                padding=math.ceil(stride / 2),
+            ),
+            ResidualUnit(output_dim, dilation=1, causal=causal),
+            ResidualUnit(output_dim, dilation=3, causal=causal),
+            ResidualUnit(output_dim, dilation=9, causal=causal),
+        )
+
+    def forward(self, x):
+        return self.block(x)
+
+
+class Decoder(nn.Module):
+    def __init__(
+        self,
+        input_channel,
+        channels,
+        rates,
+        d_out: int = 1,
+        causal: bool = False,
+        n_transformer_layers: list = [0, 0, 0, 0],
+        transformer_general_config=None,
+    ):
+        super().__init__()
+        conv_class = CausalWNConv1d if causal else WNConv1d
+        # Add first conv layer
+        layers = [conv_class(input_channel, channels, kernel_size=7, padding=3)]
+
+        # Add upsampling + MRF blocks
+        for i, (stride, n_t_layer) in enumerate(zip(rates, n_transformer_layers)):
+            input_dim = channels // 2**i
+            output_dim = channels // 2 ** (i + 1)
+            layers += [
+                DecoderBlock(
+                    input_dim,
+                    output_dim,
+                    stride,
+                    causal=causal,
+                    n_t_layer=n_t_layer,
+                    transformer_general_config=transformer_general_config,
+                )
+            ]
+
+        # Add final conv layer
+        layers += [
+            Snake1d(output_dim),
+            conv_class(output_dim, d_out, kernel_size=7, padding=3),
+            nn.Tanh(),
+        ]
+
+        self.model = nn.Sequential(*layers)
+
+    def forward(self, x):
+        return self.model(x)
+
+
+class DAC(BaseModel, CodecMixin):
+    def __init__(
+        self,
+        encoder_dim: int = 64,
+        encoder_rates: List[int] = [2, 4, 8, 8],
+        latent_dim: int = None,
+        decoder_dim: int = 1536,
+        decoder_rates: List[int] = [8, 8, 4, 2],
+        quantizer: torch.nn.Module = None,
+        sample_rate: int = 44100,
+        causal: bool = True,
+        encoder_transformer_layers: List[int] = [0, 0, 0, 0],
+        decoder_transformer_layers: List[int] = [0, 0, 0, 0],
+        overwrite_decoder: torch.nn.Module = None,
+        transformer_general_config=None,
+    ):
+        super().__init__()
+
+        self.encoder_dim = encoder_dim
+        self.encoder_rates = encoder_rates
+        self.decoder_dim = decoder_dim
+        self.decoder_rates = decoder_rates
+        self.sample_rate = sample_rate
+
+        if latent_dim is None:
+            latent_dim = encoder_dim * (2 ** len(encoder_rates))
+
+        self.latent_dim = latent_dim
+
+        self.hop_length = np.prod(encoder_rates)
+        self.encoder = Encoder(
+            encoder_dim,
+            encoder_rates,
+            latent_dim,
+            causal=causal,
+            n_transformer_layers=encoder_transformer_layers,
+            transformer_general_config=transformer_general_config,
+        )
+
+        self.quantizer = quantizer
+
+        if overwrite_decoder is not None:
+            self.decoder = overwrite_decoder
+        else:
+            self.decoder = Decoder(
+                latent_dim,
+                decoder_dim,
+                decoder_rates,
+                causal=causal,
+                n_transformer_layers=decoder_transformer_layers,
+                transformer_general_config=transformer_general_config,
+            )
+        self.sample_rate = sample_rate
+        self.apply(init_weights)
+
+        self.delay = self.get_delay()
+
+        self.frame_length = self.hop_length * 4
+
+    def preprocess(self, audio_data, sample_rate):
+        if sample_rate is None:
+            sample_rate = self.sample_rate
+        assert sample_rate == self.sample_rate
+
+        length = audio_data.shape[-1]
+        right_pad = math.ceil(length / self.hop_length) * self.hop_length - length
+        audio_data = nn.functional.pad(audio_data, (0, right_pad))
+
+        return audio_data
+
+    def encode(
+        self,
+        audio_data: torch.Tensor,
+        audio_lengths: torch.Tensor = None,
+        n_quantizers: int = None,
+        **kwargs,
+    ):
+        """Encode given audio data and return quantized latent codes
+
+        Parameters
+        ----------
+        audio_data : Tensor[B x T]
+            Audio data to encode
+        n_quantizers : int, optional
+            Number of quantizers to use, by default None
+            If None, all quantizers are used.
+
+        Returns
+        -------
+        dict
+            A dictionary with the following keys:
+            "z" : Tensor[B x D x T]
+                Quantized continuous representation of input
+            "codes" : Tensor[B x N x T]
+                Codebook indices for each codebook
+                (quantized discrete representation of input)
+            "latents" : Tensor[B x N*D x T]
+                Projected latents (continuous representation of input before quantization)
+            "vq/commitment_loss" : Tensor[1]
+                Commitment loss to train encoder to predict vectors closer to codebook
+                entries
+            "vq/codebook_loss" : Tensor[1]
+                Codebook loss to update the codebook
+            "length" : int
+                Number of samples in input audio
+        """
+        # pad to multiple of self.frame_length
+        if audio_data.ndim == 2:
+            audio_data = audio_data.unsqueeze(1)
+        length = audio_data.shape[-1]
+        right_pad = math.ceil(length / self.frame_length) * self.frame_length - length
+        audio_data = nn.functional.pad(audio_data, (0, right_pad))
+        if audio_lengths is None:
+            audio_lengths = torch.LongTensor([length + right_pad]).to(audio_data.device)
+
+        z = self.encoder(audio_data)
+        vq_results = self.quantizer(z, n_quantizers, **kwargs)
+        indices = vq_results.codes
+        indices_lens = torch.ceil(audio_lengths / self.frame_length).long()
+        return indices, indices_lens
+
+    def from_indices(self, indices: torch.Tensor):
+        z = self.quantizer.decode(indices)
+        return self.decoder(z)
+
+    def decode(self, z: torch.Tensor):
+        """Decode given latent codes and return audio data
+
+        Parameters
+        ----------
+        z : Tensor[B x D x T]
+            Quantized continuous representation of input
+        length : int, optional
+            Number of samples in output audio, by default None
+
+        Returns
+        -------
+        dict
+            A dictionary with the following keys:
+            "audio" : Tensor[B x 1 x length]
+                Decoded audio data.
+        """
+        return self.decoder(z)
+
+    def forward(
+        self,
+        audio_data: torch.Tensor,
+        template: torch.Tensor = None,
+        mask: torch.Tensor = None,
+        sample_rate: int = None,
+        n_quantizers: int = None,
+        **kwargs,
+    ):
+        """Model forward pass
+
+        Parameters
+        ----------
+        audio_data : Tensor[B x 1 x T]
+            Audio data to encode
+        sample_rate : int, optional
+            Sample rate of audio data in Hz, by default None
+            If None, defaults to `self.sample_rate`
+        n_quantizers : int, optional
+            Number of quantizers to use, by default None.
+            If None, all quantizers are used.
+
+        Returns
+        -------
+        dict
+            A dictionary with the following keys:
+            "z" : Tensor[B x D x T]
+                Quantized continuous representation of input
+            "codes" : Tensor[B x N x T]
+                Codebook indices for each codebook
+                (quantized discrete representation of input)
+            "latents" : Tensor[B x N*D x T]
+                Projected latents (continuous representation of input before quantization)
+            "vq/commitment_loss" : Tensor[1]
+                Commitment loss to train encoder to predict vectors closer to codebook
+                entries
+            "vq/codebook_loss" : Tensor[1]
+                Codebook loss to update the codebook
+            "length" : int
+                Number of samples in input audio
+            "audio" : Tensor[B x 1 x length]
+                Decoded audio data.
+        """
+        length = audio_data.shape[-1]
+        audio_data = self.preprocess(audio_data, sample_rate)
+        vq_results = self.encode(audio_data, n_quantizers, **kwargs)
+        z = vq_results[0] if isinstance(vq_results, tuple) else vq_results.z
+        x = self.decode(z)
+        return x[..., :length], vq_results
+
+
+if __name__ == "__main__":
+    import hydra
+    import numpy as np
+    import soundfile as sf
+    import torch
+    from omegaconf import OmegaConf
+
+    # 配置路径
+    config_path = "fish_speech/configs/modded_dac_vq.yaml"
+    checkpoint_path = "checkpoints/s2-pro/codec.pth"
+    codes_path = "./output/codes_0.npy"  # 你的 codes 文件路径
+    output_path = "reconstructed_from_codes.wav"
+    sample_rate = 44100  # 请确保采样率与模型训练时一致
+
+    with torch.inference_mode():
+        # 1. 初始化模型
+        model = hydra.utils.instantiate(OmegaConf.load(config_path))
+        new_sd = torch.load(checkpoint_path, map_location="cpu")
+        model.load_state_dict(new_sd, strict=False)
+        model.cuda()
+        model.eval()
+
+        # 2. 加载外部 codes (.npy)
+        # 预期 shape 通常为 [num_codebooks, seq_len] 或 [1, num_codebooks, seq_len]
+        codes_np = np.load(codes_path)
+        codes_tensor = torch.from_numpy(codes_np).to(torch.long).cuda()
+
+        # 如果 codes 没有 batch 维度，增加一个维度 [1, num_codebooks, seq_len]
+        if len(codes_tensor.shape) == 2:
+            codes_tensor = codes_tensor.unsqueeze(0)
+
+        print(f"Loaded codes shape: {codes_tensor.shape}")
+
+        # 3. 直接从 codes 重建音频 (Decoding)
+        # 注意：fish_speech 的 model.from_indices 通常接受的输入是 LongTensor
+        fake_audio = model.from_indices(codes_tensor)
+
+        # 4. 后处理与保存
+        # fake_audio 形状通常为 [B, C, T]
+        audio_np = fake_audio.squeeze().cpu().numpy()
+
+        # 如果是多声道，转置为 soundfile 要求的 (samples, channels)
+        if len(audio_np.shape) == 2:
+            audio_np = audio_np.T
+
+        sf.write(output_path, audio_np, sample_rate)
+        print(f"重建完成。音频已保存至: {output_path}")

--- a/xinference/thirdparty/fish_speech_s2/fish_speech/models/dac/rvq.py
+++ b/xinference/thirdparty/fish_speech_s2/fish_speech/models/dac/rvq.py
@@ -1,0 +1,399 @@
+import math
+import typing as tp
+from dataclasses import dataclass
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from dac.nn.quantize import ResidualVectorQuantize
+from torch.nn.utils.parametrizations import weight_norm
+from torch.nn.utils.parametrize import remove_parametrizations
+
+
+def unpad1d(x: torch.Tensor, paddings: tp.Tuple[int, int]):
+    """Remove padding from x, handling properly zero padding. Only for 1d!"""
+    padding_left, padding_right = paddings
+    assert padding_left >= 0 and padding_right >= 0, (padding_left, padding_right)
+    assert (padding_left + padding_right) <= x.shape[-1]
+    end = x.shape[-1] - padding_right
+    return x[..., padding_left:end]
+
+
+def get_extra_padding_for_conv1d(
+    x: torch.Tensor, kernel_size: int, stride: int, padding_total: int = 0
+) -> int:
+    """See `pad_for_conv1d`."""
+    length = x.shape[-1]
+    n_frames = (length - kernel_size + padding_total) / stride + 1
+    ideal_length = (math.ceil(n_frames) - 1) * stride + (kernel_size - padding_total)
+    return ideal_length - length
+
+
+def pad1d(
+    x: torch.Tensor,
+    paddings: tp.Tuple[int, int],
+    mode: str = "zeros",
+    value: float = 0.0,
+):
+    """Tiny wrapper around F.pad, just to allow for reflect padding on small input.
+    If this is the case, we insert extra 0 padding to the right
+    before the reflection happen.
+    """
+    length = x.shape[-1]
+    padding_left, padding_right = paddings
+    assert padding_left >= 0 and padding_right >= 0, (padding_left, padding_right)
+    if mode == "reflect":
+        max_pad = max(padding_left, padding_right)
+        extra_pad = 0
+        if length <= max_pad:
+            extra_pad = max_pad - length + 1
+            x = F.pad(x, (0, extra_pad))
+        padded = F.pad(x, paddings, mode, value)
+        end = padded.shape[-1] - extra_pad
+        return padded[..., :end]
+    else:
+        return F.pad(x, paddings, mode, value)
+
+
+class CausalConvNet(nn.Module):
+    def __init__(
+        self,
+        in_channels,
+        out_channels,
+        kernel_size,
+        dilation=1,
+        stride=1,
+        groups=1,
+        padding=None,
+    ):
+        super(CausalConvNet, self).__init__()
+        self.conv = nn.Conv1d(
+            in_channels,
+            out_channels,
+            kernel_size,
+            stride=stride,
+            dilation=dilation,
+            groups=groups,
+        )
+        self.stride = stride
+        self.kernel_size = (kernel_size - 1) * dilation + 1
+        self.dilation = dilation
+        self.padding = self.kernel_size - self.stride
+
+    def forward(self, x):
+        pad = self.padding
+        extra_padding = get_extra_padding_for_conv1d(
+            x, self.kernel_size, self.stride, pad
+        )
+        x = pad1d(x, (pad, extra_padding), mode="constant", value=0)
+        return self.conv(x).contiguous()
+
+    def weight_norm(self, name="weight", dim=0):
+        self.conv = weight_norm(self.conv, name=name, dim=dim)
+        return self
+
+    def remove_weight_norm(self):
+        self.conv = remove_parametrizations(self.conv)
+        return self
+
+
+class CausalTransConvNet(nn.Module):
+    def __init__(
+        self, in_channels, out_channels, kernel_size, dilation=1, stride=1, padding=None
+    ):
+        super(CausalTransConvNet, self).__init__()
+        self.conv = nn.ConvTranspose1d(
+            in_channels, out_channels, kernel_size, stride=stride, dilation=dilation
+        )
+        self.stride = stride
+        self.kernel_size = kernel_size
+
+    def forward(self, x):
+        x = self.conv(x)
+        pad = self.kernel_size - self.stride
+        padding_right = math.ceil(pad)
+        padding_left = pad - padding_right
+        x = unpad1d(x, (padding_left, padding_right))
+        return x.contiguous()
+
+    def weight_norm(self, name="weight", dim=0):
+        self.conv = weight_norm(self.conv, name=name, dim=dim)
+        return self
+
+    def remove_weight_norm(self):
+        self.conv = remove_parametrizations(self.conv)
+        return self
+
+
+# ConvNeXt Block copied from https://github.com/fishaudio/fish-diffusion/blob/main/fish_diffusion/modules/convnext.py
+class ConvNeXtBlock(nn.Module):
+    r"""ConvNeXt Block. There are two equivalent implementations:
+    (1) DwConv -> LayerNorm (channels_first) -> 1x1 Conv -> GELU -> 1x1 Conv; all in (N, C, H, W)
+    (2) DwConv -> Permute to (N, H, W, C); LayerNorm (channels_last) -> Linear -> GELU -> Linear; Permute back
+    We use (2) as we find it slightly faster in PyTorch
+    Args:
+        dim (int): Number of input channels.
+        drop_path (float): Stochastic depth rate. Default: 0.0
+        layer_scale_init_value (float): Init value for Layer Scale. Default: 1e-6.
+        mlp_ratio (float): Ratio of mlp hidden dim to embedding dim. Default: 4.0.
+        kernel_size (int): Kernel size for depthwise conv. Default: 7.
+        dilation (int): Dilation for depthwise conv. Default: 1.
+    """  # noqa: E501
+
+    def __init__(
+        self,
+        dim: int,
+        layer_scale_init_value: float = 1e-6,
+        mlp_ratio: float = 4.0,
+        kernel_size: int = 7,
+        dilation: int = 1,
+    ):
+        super().__init__()
+        convnet_type = CausalConvNet
+        self.dwconv = convnet_type(
+            dim,
+            dim,
+            kernel_size=kernel_size,
+            # padding=int(dilation * (kernel_size - 1) / 2),
+            groups=dim,
+            dilation=dilation,
+        )  # depthwise conv
+        self.norm = nn.LayerNorm(dim, eps=1e-6)
+        self.pwconv1 = nn.Linear(
+            dim, int(mlp_ratio * dim)
+        )  # pointwise/1x1 convs, implemented with linear layers
+        self.act = nn.GELU()
+        self.pwconv2 = nn.Linear(int(mlp_ratio * dim), dim)
+        self.gamma = (
+            nn.Parameter(layer_scale_init_value * torch.ones((dim)), requires_grad=True)
+            if layer_scale_init_value > 0
+            else None
+        )
+
+    def forward(self, x, apply_residual: bool = True):
+        input = x
+
+        x = self.dwconv(x)
+        x = x.permute(0, 2, 1)  # (N, C, L) -> (N, L, C)
+        x = self.norm(x)
+        x = self.pwconv1(x)
+        x = self.act(x)
+        x = self.pwconv2(x)
+
+        if self.gamma is not None:
+            x = self.gamma * x
+
+        x = x.permute(0, 2, 1)  # (N, L, C) -> (N, C, L)
+
+        if apply_residual:
+            x = input + x
+
+        return x
+
+
+@dataclass
+class VQResult:
+    z: torch.Tensor
+    codes: torch.Tensor
+    latents: torch.Tensor
+    codebook_loss: torch.Tensor
+    commitment_loss: torch.Tensor
+    semantic_distill_z: torch.Tensor | None = None
+
+
+class DownsampleResidualVectorQuantize(nn.Module):
+    def __init__(
+        self,
+        input_dim: int = 1024,
+        n_codebooks: int = 9,
+        codebook_dim: int = 8,
+        quantizer_dropout: float = 0.5,
+        codebook_size: int = 1024,
+        semantic_codebook_size: int = 4096,
+        downsample_factor: tuple[int] = (2, 2),
+        downsample_dims: tuple[int] | None = None,
+        pre_module: nn.Module | None = None,
+        post_module: nn.Module | None = None,
+        semantic_predictor_module: nn.Module | None = None,
+    ):
+        super().__init__()
+
+        if downsample_dims is None:
+            downsample_dims = [input_dim for _ in range(len(downsample_factor))]
+
+        all_dims = (input_dim,) + tuple(downsample_dims)
+
+        self.semantic_quantizer = ResidualVectorQuantize(
+            input_dim=input_dim,
+            n_codebooks=1,
+            codebook_size=semantic_codebook_size,
+            codebook_dim=codebook_dim,
+            quantizer_dropout=0.0,
+        )
+
+        self.quantizer = ResidualVectorQuantize(
+            input_dim=input_dim,
+            n_codebooks=n_codebooks,
+            codebook_size=codebook_size,
+            codebook_dim=codebook_dim,
+            quantizer_dropout=quantizer_dropout,
+        )
+
+        self.downsample_factor = downsample_factor
+        self.downsample_dims = downsample_dims
+
+        convnet_type = CausalConvNet
+        transconvnet_type = CausalTransConvNet
+
+        self.downsample = nn.Sequential(
+            *[
+                nn.Sequential(
+                    convnet_type(
+                        all_dims[idx],
+                        all_dims[idx + 1],
+                        kernel_size=factor,
+                        stride=factor,
+                    ),
+                    ConvNeXtBlock(dim=all_dims[idx + 1]),
+                )
+                for idx, factor in enumerate(downsample_factor)
+            ]
+        )
+
+        self.upsample = nn.Sequential(
+            *[
+                nn.Sequential(
+                    transconvnet_type(
+                        all_dims[idx + 1],
+                        all_dims[idx],
+                        kernel_size=factor,
+                        stride=factor,
+                    ),
+                    ConvNeXtBlock(dim=all_dims[idx]),
+                )
+                for idx, factor in reversed(list(enumerate(downsample_factor)))
+            ]
+        )
+        self.apply(self._init_weights)
+        self.pre_module = (
+            pre_module if pre_module is not None else nn.Identity()
+        )  # leave for transformer, LSTM or Mamba or something else
+        self.post_module = post_module if post_module is not None else nn.Identity()
+        self.semantic_predictor_module = (
+            semantic_predictor_module
+            if semantic_predictor_module is not None
+            else nn.Identity()
+        )
+
+    def _init_weights(self, m):
+        if isinstance(m, (nn.Conv1d, nn.Linear)):
+            nn.init.trunc_normal_(m.weight, std=0.02)
+            nn.init.constant_(m.bias, 0)
+
+    def forward(
+        self, z, n_quantizers: int = None, semantic_len: torch.Tensor = None, **kwargs
+    ):
+        # z: (B, D, T)
+        original_shape = z.shape
+        if semantic_len is None:
+            semantic_len = torch.LongTensor([z.shape[-1]])
+        z = self.downsample(z)
+        z = self.pre_module(z)  # B, T, D
+        (
+            semantic_z,
+            semantic_codes,
+            semantic_latents,
+            semantic_commitment_loss,
+            semantic_codebook_loss,
+        ) = self.semantic_quantizer(z)
+        residual_z = z - semantic_z
+        residual_z, codes, latents, commitment_loss, codebook_loss = self.quantizer(
+            residual_z, n_quantizers=n_quantizers
+        )
+        z = semantic_z + residual_z
+        commitment_loss = commitment_loss + semantic_commitment_loss
+        codebook_loss = codebook_loss + semantic_codebook_loss
+        codes = torch.cat([semantic_codes, codes], dim=1)
+        latents = torch.cat([semantic_latents, latents], dim=1)
+        z = self.post_module(z)
+        z = self.upsample(z)
+        # z: (B, D, T)
+
+        # semantic distillation (disabled here since only used in training)
+        # semantic_distill_z = self.semantic_predictor_module(semantic_z, semantic_len).mT  # wav2vec target is B, T, D
+
+        # Pad or crop z to match original shape
+        diff = original_shape[-1] - z.shape[-1]
+        right = 0
+        left = abs(diff) - right
+
+        if diff > 0:
+            z = F.pad(z, (left, right))
+        elif diff < 0:
+            z = z[..., left:]
+
+        results = VQResult(
+            z=z,
+            codes=codes,
+            latents=latents,
+            commitment_loss=commitment_loss,
+            codebook_loss=codebook_loss,
+        )
+
+        return results
+
+    # def encode(self, z):
+    #     z = self.downsample(z)
+    #     z = self.pre_module(z)
+    #     _, indices, _, _, _ = self.quantizer(z.mT)
+    #     indices = rearrange(indices, "g b l r -> b (g r) l")
+    #     return indices
+    #
+    def decode(self, indices: torch.Tensor):
+        # indices = rearrange(indices, "b (g r) l -> g b l r", g=self.residual_fsq.groups)
+        indices[:, 0] = torch.clamp(
+            indices[:, 0], max=self.semantic_quantizer.codebook_size - 1
+        )
+        indices[:, 1:] = torch.clamp(
+            indices[:, 1:], max=self.quantizer.codebook_size - 1
+        )
+
+        z_q_semantic = self.semantic_quantizer.from_codes(indices[:, :1])[0]
+        z_q_residual = self.quantizer.from_codes(indices[:, 1:])[0]
+        z_q = z_q_semantic + z_q_residual
+        z_q = self.post_module(z_q)
+        z_q = self.upsample(z_q)
+        return z_q
+
+    # def from_latents(self, latents: torch.Tensor):
+    #     z_q, z_p, codes = super().from_latents(latents)
+    #     z_q = self.upsample(z_q)
+    #     return z_q, z_p, codes
+
+
+if __name__ == "__main__":
+    rvq = DownsampleResidualVectorQuantize(
+        input_dim=512,
+        n_codebooks=8,
+        codebook_dim=8,
+        codebook_size=1024,
+        quantizer_dropout=0.5,
+        downsample_factor=[2, 2],
+    )
+    rvq.eval()
+    x = torch.randn(2, 512, 442)
+
+    result = rvq(x)
+    print(rvq)
+    print(result.latents.shape, result.codes.shape, result.z.shape)
+
+    # y = rvq.from_codes(result.codes)
+    # print(y[0].shape)
+
+    # y = rvq.from_latents(
+
+    result1 = rvq(x[:, :, :40])
+    print(result1.latents.shape, result1.codes.shape, result1.z.shape)
+
+    assert torch.allclose(result.z[:, :, :40], result1.z, atol=1e-8)
+    print("Success")

--- a/xinference/thirdparty/fish_speech_s2/fish_speech/models/text2semantic/inference.py
+++ b/xinference/thirdparty/fish_speech_s2/fish_speech/models/text2semantic/inference.py
@@ -1,0 +1,966 @@
+import os
+import queue
+import re
+import threading
+import time
+import traceback
+from copy import deepcopy
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Literal, Optional, Tuple, Union
+
+import click
+import numpy as np
+import torch
+import torch._inductor.config
+from loguru import logger
+from tqdm import tqdm
+
+from xinference.thirdparty.fish_speech_s2.fish_speech.content_sequence import (
+    TextPart,
+    VQPart,
+)
+from xinference.thirdparty.fish_speech_s2.fish_speech.conversation import Conversation, Message
+from xinference.thirdparty.fish_speech_s2.fish_speech.tokenizer import IM_END_TOKEN
+
+os.environ["TOKENIZERS_PARALLELISM"] = "false"
+torch._inductor.config.coordinate_descent_tuning = True
+torch._inductor.config.triton.unique_kernel_names = True
+
+if hasattr(torch._inductor.config, "fx_graph_cache"):
+    torch._inductor.config.fx_graph_cache = True
+
+
+from torch.nn.attention import SDPBackend, sdpa_kernel
+
+from xinference.thirdparty.fish_speech_s2.fish_speech.models.text2semantic.llama import (
+    BaseTransformer,
+    DualARTransformer,
+    NaiveTransformer,
+)
+
+
+def multinomial_sample_one_no_sync(probs_sort):
+    q = torch.rand_like(probs_sort)
+    q = -torch.log(q)
+    return torch.argmax(probs_sort / q, dim=-1, keepdim=True).to(dtype=torch.int)
+
+
+RAS_WIN_SIZE = 10  # window for Repetition Aware Sampling
+RAS_HIGH_TEMP = 1.0
+RAS_HIGH_TOP_P = 0.9
+
+
+def logits_to_probs(
+    logits,
+    temperature: torch.Tensor,
+    top_p: torch.Tensor,
+    top_k: int,  # 注意: 我看到你传进来的是 int，这很关键
+) -> torch.Tensor:
+    sorted_logits, sorted_indices = torch.sort(logits, descending=True)
+    cum_probs = torch.cumsum(torch.nn.functional.softmax(sorted_logits, dim=-1), dim=-1)
+
+    indices = torch.arange(sorted_logits.shape[-1], device=sorted_logits.device)
+    top_k_mask = indices >= top_k
+    sorted_indices_to_remove = (cum_probs > top_p) | top_k_mask
+    sorted_indices_to_remove[..., 0] = False  # keep the top-1 token, per row
+
+    indices_to_remove = sorted_indices_to_remove.scatter(
+        dim=-1, index=sorted_indices, src=sorted_indices_to_remove
+    )
+    logits = torch.where(
+        indices_to_remove, float("-Inf"), logits
+    )  # 同样替换 masked_fill_ 为 torch.where
+    logits = logits / torch.clip(temperature, min=1e-5)
+
+    probs = torch.nn.functional.softmax(logits, dim=-1)
+    return probs
+
+
+def sample(
+    logits,
+    temperature: torch.Tensor,
+    top_p: torch.Tensor,
+    top_k: int,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    probs = logits_to_probs(
+        logits=logits[0, -1],
+        temperature=temperature,
+        top_p=top_p,
+        top_k=top_k,
+    )
+    idx_next = multinomial_sample_one_no_sync(probs)
+    return idx_next, probs
+
+
+def decode_one_token_ar(
+    model: DualARTransformer,
+    x: torch.Tensor,
+    input_pos: torch.Tensor,
+    temperature: torch.Tensor,
+    top_p: torch.Tensor,
+    top_k: int,
+    semantic_logit_bias: torch.Tensor,
+    audio_masks: torch.Tensor,
+    audio_parts: torch.Tensor,
+    previous_tokens: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    forward_result = model.forward_generate(
+        x,
+        input_pos,
+        audio_masks=audio_masks,
+        audio_parts=audio_parts,
+    )
+    logits = forward_result.logits  # (1, 1, vocab_size)
+    hidden_states = forward_result.hidden_states
+
+    # Apply constrained decoding: only allow semantic tokens + im_end
+    biased_logits = logits + semantic_logit_bias
+
+    # Normal sample
+    main_token_normal = sample(
+        biased_logits, temperature=temperature, top_p=top_p, top_k=top_k
+    )[0]
+
+    # RAS: also sample with high temp to use as fallback if token repeats
+    high_temp = torch.tensor(
+        RAS_HIGH_TEMP, device=temperature.device, dtype=temperature.dtype
+    )
+    high_top_p = torch.tensor(RAS_HIGH_TOP_P, device=top_p.device, dtype=top_p.dtype)
+    main_token_high = sample(
+        biased_logits, temperature=high_temp, top_p=high_top_p, top_k=top_k
+    )[0]
+
+    # Use high-temp sample if: token is semantic AND token is in previous window
+    if previous_tokens is not None:
+        in_window = (previous_tokens[0] == main_token_normal).any()
+        # Use tensor ops (&, torch.where) instead of Python (and, if) — torch.compile requires no data-dependent branching
+        is_semantic = (main_token_normal >= model.config.semantic_begin_id) & (
+            main_token_normal <= model.config.semantic_end_id
+        )
+        should_use_high = in_window & is_semantic
+        main_token_normal = torch.where(
+            should_use_high, main_token_high, main_token_normal
+        )
+
+    codebooks = [main_token_normal]
+
+    input_pos = torch.tensor([0], device=hidden_states.device, dtype=torch.long)
+    model.forward_generate_fast(hidden_states, input_pos)
+
+    a = codebooks[0] - model.config.semantic_begin_id
+    a = torch.clamp(a, min=0, max=model.config.codebook_size - 1)
+
+    hidden_states = model.fast_embeddings(a)
+    codebooks.append(a)
+
+    for codebook_idx in range(1, model.config.num_codebooks):
+        input_pos = torch.tensor(
+            [codebook_idx], device=hidden_states.device, dtype=torch.long
+        )
+        logits = model.forward_generate_fast(hidden_states, input_pos)
+
+        short_logits = logits  # DualAR predicts config.codebook_size number of tokens
+
+        # Convert logits to probs (no constrain for fast codebooks)
+        a = sample(
+            short_logits,
+            temperature=temperature,
+            top_p=top_p,
+            top_k=top_k,
+        )[0]
+
+        hidden_states = model.fast_embeddings(a)
+        codebooks.append(a)
+
+    codebooks = torch.stack(codebooks, dim=1)
+
+    # Only delete references, let Python GC handle cleanup
+    del logits, hidden_states, forward_result
+
+    return codebooks.T
+
+
+def decode_n_tokens(
+    model: DualARTransformer,
+    cur_token: torch.Tensor,
+    input_pos: torch.Tensor,
+    num_new_tokens: int,
+    temperature: torch.Tensor,
+    top_p: torch.Tensor,
+    top_k: int,
+    semantic_logit_bias: torch.Tensor,
+    audio_masks: torch.Tensor,
+    audio_parts: torch.Tensor,
+    decode_one_token=decode_one_token_ar,
+):
+    # Rolling window for RAS (Repetition Aware Sampling)
+    previous_tokens = torch.zeros(
+        (model.config.num_codebooks + 1, RAS_WIN_SIZE),
+        dtype=torch.int,
+        device=cur_token.device,
+    )
+    # Accumulate all generated tokens (the actual output)
+    new_tokens = []
+
+    # [MODIFIED] Pre-fetch ID for efficiency loop
+    im_end_id = model.tokenizer.get_token_id(IM_END_TOKEN)
+
+    for i in tqdm(range(num_new_tokens)):
+        with sdpa_kernel(SDPBackend.MATH):
+            next_token = decode_one_token(
+                model=model,
+                x=cur_token,
+                input_pos=input_pos,
+                previous_tokens=previous_tokens,
+                temperature=temperature,
+                top_p=top_p,
+                top_k=top_k,
+                semantic_logit_bias=semantic_logit_bias,
+                audio_masks=audio_masks,
+                audio_parts=audio_parts,
+            ).clone()
+
+        input_pos += 1
+        cur_token = next_token.view(1, model.config.num_codebooks + 1, -1)
+        # Roll RAS window left and insert new token at end
+        previous_tokens = previous_tokens.roll(-1, dims=1)
+        previous_tokens[:, -1] = next_token.view(model.config.num_codebooks + 1, -1)[
+            :, 0
+        ]
+        new_tokens.append(next_token)
+
+        if cur_token[0, 0, -1] == im_end_id:
+            break
+
+    del cur_token
+
+    return torch.cat(new_tokens, dim=1)
+
+
+@torch.no_grad()
+@torch.inference_mode()
+def generate(
+    *,
+    model: DualARTransformer,
+    prompt: torch.Tensor,
+    max_new_tokens: int,
+    audio_masks: torch.Tensor,
+    audio_parts: torch.Tensor,
+    decode_one_token=decode_one_token_ar,
+    num_samples: int = 1,
+    **sampling_kwargs,
+):
+    """
+    Takes a conditioning sequence (prompt) as input and continues to generate as many tokens as requested.
+    """
+
+    # create an empty tensor of the expected final shape and fill in the current tokens
+    T = prompt.size(1)
+    prompt = prompt[None].repeat(num_samples, 1, 1)
+
+    if T >= model.config.max_seq_len:
+        raise ValueError(
+            f"Input sequence length {T} exceeds max_seq_len {model.config.max_seq_len}"
+        )
+
+    if max_new_tokens:
+        if T + max_new_tokens > model.config.max_seq_len:
+            max_new_tokens = model.config.max_seq_len - T
+
+        T_new = T + max_new_tokens
+    else:
+        T_new = model.config.max_seq_len
+        max_new_tokens = T_new - T
+
+    device = prompt.device
+    dtype = next(
+        model.parameters()
+    ).dtype  # model weight dtype (bfloat16), NOT prompt dtype (int32)
+
+    # Critical fix: Only set up cache on first run or when necessary
+    if not hasattr(model, "_cache_setup_done") or not model._cache_setup_done:
+        with torch.device(device):
+            model.setup_caches(
+                max_batch_size=1,  # Fixed to 1, avoid dynamic changes
+                max_seq_len=model.config.max_seq_len,
+                dtype=next(model.parameters()).dtype,
+            )
+        model._cache_setup_done = True
+
+    codebook_dim = 1 + model.config.num_codebooks
+
+    # Create new tensor each time, but try to reuse memory
+    input_pos = torch.arange(0, T, device=device, dtype=torch.long)
+    empty = torch.empty(
+        (codebook_dim, model.config.max_seq_len), dtype=prompt.dtype, device=device
+    )
+    empty[:, :T] = prompt
+    seq = empty
+
+    temp_val = sampling_kwargs.get("temperature", 1.0)
+    top_p_val = sampling_kwargs.get("top_p", 0.9)
+    top_k_val = sampling_kwargs.get("top_k", 30)
+
+    temperature = torch.tensor(temp_val, device=device, dtype=dtype)
+    top_p = torch.tensor(top_p_val, device=device, dtype=dtype)
+
+    # Build semantic logit bias: 0 for semantic tokens + im_end, -inf for all others
+    vocab_size = model.config.vocab_size
+    semantic_logit_bias = torch.full(
+        (1, 1, vocab_size), float("-inf"), device=device, dtype=dtype
+    )
+
+    # [MODIFIED] Use config for semantic range
+    semantic_logit_bias[
+        0, 0, model.config.semantic_begin_id : model.config.semantic_end_id + 1
+    ] = 0.0
+
+    # [MODIFIED] Use tokenizer.get_token_id (Wrapper method)
+    semantic_logit_bias[0, 0, model.tokenizer.get_token_id(IM_END_TOKEN)] = 0.0
+
+    prefill_decode = decode_one_token_ar
+
+    first_token = prefill_decode(
+        model,
+        prompt.view(1, codebook_dim, -1),
+        input_pos,
+        temperature,
+        top_p,
+        top_k_val,
+        semantic_logit_bias,
+        audio_masks,
+        audio_parts,
+    )
+    seq[:, T : T + 1] = first_token
+
+    # Recreate input_pos
+    input_pos = torch.tensor([T], device=device, dtype=torch.int)
+
+    x = decode_n_tokens(
+        model,
+        first_token.view(1, codebook_dim, -1),
+        input_pos,
+        max_new_tokens - 1,
+        temperature=temperature,
+        top_p=top_p,
+        top_k=top_k_val,
+        semantic_logit_bias=semantic_logit_bias,
+        audio_masks=audio_masks,
+        audio_parts=audio_parts,
+        decode_one_token=decode_one_token,
+    )
+    seq = seq[:, : T + 1 + x.size(1)]
+    seq[:, T + 1 :] = x
+
+    # Clean up temporary variables
+    del first_token, x, prompt, empty, input_pos
+
+    return seq
+
+
+def init_model(checkpoint_path, device, precision, compile=False):
+    model = DualARTransformer.from_pretrained(checkpoint_path, load_weights=True)
+
+    model = model.to(device=device, dtype=precision)
+    logger.info(f"Restored model from checkpoint")
+
+    if isinstance(model, DualARTransformer):
+        decode_one_token = decode_one_token_ar
+        # prefill_n_tokens = decode_one_token_ar
+        logger.info("Using DualARTransformer")
+    else:
+        raise ValueError("Unsupported model type")
+
+    # Pre-create fixed parameter tensors to avoid runtime creation
+    model.fixed_temperature = torch.tensor(0.7, device=device, dtype=torch.float)
+    model.fixed_top_p = torch.tensor(0.7, device=device, dtype=torch.float)
+    model.fixed_repetition_penalty = torch.tensor(1.5, device=device, dtype=torch.float)
+
+    # Mark whether cache has been initialized
+    model._cache_setup_done = False
+
+    if compile:
+        logger.info("Compiling function...")
+        decode_one_token = torch.compile(
+            decode_one_token,
+            backend="inductor" if torch.cuda.is_available() else "aot_eager",
+            mode="default" if torch.cuda.is_available() else None,
+            fullgraph=True,
+        )
+
+    return model.eval(), decode_one_token
+
+
+@torch.inference_mode()
+def load_codec_model(codec_checkpoint_path, device, precision=torch.bfloat16):
+    """Load the DAC codec model for audio encoding/decoding."""
+    from hydra.utils import instantiate
+    from omegaconf import OmegaConf
+
+    config_path = Path(__file__).parent.parent.parent / "configs" / "modded_dac_vq.yaml"
+    cfg = OmegaConf.load(str(config_path))
+    codec = instantiate(cfg)
+
+    state_dict = torch.load(codec_checkpoint_path, map_location="cpu")
+    if "state_dict" in state_dict:
+        state_dict = state_dict["state_dict"]
+    if any("generator" in k for k in state_dict):
+        state_dict = {
+            k.replace("generator.", ""): v
+            for k, v in state_dict.items()
+            if "generator." in k
+        }
+    codec.load_state_dict(state_dict, strict=False)
+    codec.eval()
+    codec.to(device=device, dtype=precision)
+    return codec
+
+
+@torch.inference_mode()
+def encode_audio(audio_path, codec, device):
+    """Encode an audio file to VQ codes."""
+    import torchaudio
+
+    wav, sr = torchaudio.load(str(audio_path))
+    if wav.shape[0] > 1:
+        wav = wav.mean(dim=0, keepdim=True)
+    wav = torchaudio.functional.resample(wav.to(device), sr, codec.sample_rate)[0]
+
+    # Match codec model dtype (e.g. bfloat16)
+    model_dtype = next(codec.parameters()).dtype
+    audios = wav[None, None].to(dtype=model_dtype)  # (1, 1, T)
+    audio_lengths = torch.tensor([len(wav)], device=device, dtype=torch.long)
+
+    indices, feature_lengths = codec.encode(audios, audio_lengths)
+    return indices[0, :, : feature_lengths[0]]  # (num_codebooks, T)
+
+
+@torch.inference_mode()
+def decode_to_audio(codes, codec):
+    """Decode VQ codes to audio waveform."""
+    # codes: (num_codebooks, T) -> (1, num_codebooks, T)
+    audio = codec.from_indices(codes[None])
+    return audio[0, 0]  # (T,) mono waveform
+
+
+@dataclass
+class GenerateResponse:
+    action: Literal["sample", "next"]
+    codes: Optional[torch.Tensor] = None
+    text: Optional[str] = None
+
+
+def split_text_by_speaker(text: str) -> list[str]:
+    """
+    Split text into turns based on <|speaker:X|> tags.
+
+    Args:
+        text: The full text with speaker tags
+
+    Returns:
+        List of speaker turns, each starting with <|speaker:X|>
+    """
+    pattern = r"(<\|speaker:\d+\|>)"
+    parts = re.split(pattern, text)
+
+    turns = []
+    i = 0
+    while i < len(parts):
+        part = parts[i].strip()
+        if re.match(pattern, part):
+            if i + 1 < len(parts):
+                turn = part + parts[i + 1]
+                turns.append(turn.strip())
+                i += 2
+            else:
+                turns.append(part)
+                i += 1
+        else:
+            i += 1
+
+    return turns
+
+
+def group_turns_into_batches(
+    turns: list[str], max_speakers: int = 3, max_bytes: int = 300
+) -> list[str]:
+    """
+    Group turns into batches based on speaker count or byte limit.
+
+    Args:
+        turns: List of speaker turns
+        max_speakers: Maximum number of speakers per batch (default 3)
+        max_bytes: Maximum UTF-8 bytes per batch (default 300)
+
+    Returns:
+        List of batched text strings
+    """
+    batches = []
+    current_batch = []
+    current_bytes = 0
+
+    for turn in turns:
+        turn_bytes = len(turn.encode("utf-8"))
+
+        would_exceed_speakers = len(current_batch) >= max_speakers
+        would_exceed_bytes = current_bytes + turn_bytes > max_bytes and current_batch
+
+        if would_exceed_speakers or would_exceed_bytes:
+            batches.append("\n".join(current_batch))
+            current_batch = [turn]
+            current_bytes = turn_bytes
+        else:
+            current_batch.append(turn)
+            current_bytes += turn_bytes
+
+    if current_batch:
+        batches.append("\n".join(current_batch))
+
+    return batches
+
+
+def generate_long(
+    *,
+    model,
+    device: Union[str, torch.device],
+    decode_one_token: Callable,
+    text: str,
+    num_samples: int = 1,
+    max_new_tokens: int = 0,
+    top_p: float = 0.9,
+    top_k: int = 30,
+    repetition_penalty: float = 1.1,
+    temperature: float = 1.0,
+    compile: bool = False,
+    iterative_prompt: bool = True,
+    chunk_length: int = 512,
+    prompt_text: Optional[Union[str, list[str]]] = None,
+    prompt_tokens: Optional[Union[torch.Tensor, list[torch.Tensor]]] = None,
+):
+    assert 0 < top_p <= 1, "top_p must be in (0, 1]"
+    assert 0 < temperature < 2, "temperature must be in (0, 2)"
+
+    use_prompt = bool(prompt_text) and bool(prompt_tokens)
+    if use_prompt and isinstance(prompt_text, str):
+        prompt_text = [prompt_text]
+        prompt_tokens = [prompt_tokens]
+
+    if use_prompt:
+        assert len(prompt_text) == len(
+            prompt_tokens
+        ), "Prompt text and tokens must have the same length"
+
+    if prompt_tokens:
+        prompt_tokens = [i.cpu() for i in prompt_tokens]
+
+    model_size = sum(p.numel() for p in model.parameters() if p.requires_grad)
+    tokenizer = model.tokenizer
+    max_length = model.config.max_seq_len
+
+    # Build base conversation with system message
+    base_conversation = Conversation()
+
+    if use_prompt:
+        # Auto-add speaker tags to prompt texts that don't have them
+        tagged_prompt_text = []
+        for i, t in enumerate(prompt_text):
+            if not re.search(r"<\|speaker:\d+\|>", t):
+                tagged_prompt_text.append(f"<|speaker:{i}|>{t}")
+            else:
+                tagged_prompt_text.append(t)
+
+        system_parts = [
+            TextPart(
+                text="convert the provided text to speech reference to the following:\n\nText:\n",
+                cal_loss=False,
+            ),
+        ]
+        reference_text = "\n".join(tagged_prompt_text)
+        system_parts.append(TextPart(text=reference_text, cal_loss=False))
+        system_parts.append(TextPart(text="\n\nSpeech:\n", cal_loss=False))
+        all_codes = torch.cat([c for c in prompt_tokens], dim=1)
+        system_parts.append(VQPart(codes=all_codes, cal_loss=False))
+        # torch.save(all_codes, "debug_vq_codes.pt")
+    else:
+        system_parts = [
+            TextPart(text="convert the provided text to speech", cal_loss=False)
+        ]
+
+    base_conversation.append(
+        Message(
+            role="system",
+            parts=system_parts,
+            cal_loss=False,
+            add_im_start=True,
+            add_im_end=True,
+        )
+    )
+
+    # Split text by speaker and group into batches
+    turns = split_text_by_speaker(text)
+    if turns:
+        batches = group_turns_into_batches(
+            turns, max_speakers=5, max_bytes=chunk_length
+        )
+    else:
+        batches = [text]
+
+    logger.info(f"Split into {len(turns)} turns, grouped into {len(batches)} batches")
+
+    for sample_idx in range(num_samples):
+        if torch.cuda.is_available():
+            torch.cuda.synchronize()
+
+        t0 = time.perf_counter()
+
+        # Deep copy base conversation for this sample
+        conversation = deepcopy(base_conversation)
+
+        for batch_idx, batch_text in enumerate(batches):
+            logger.info(
+                f"--- Sample {sample_idx}, Batch {batch_idx} "
+                f"({len(batch_text.encode('utf-8'))} bytes) ---"
+            )
+            logger.info(f"Batch text: {batch_text}")
+
+            # Add user message
+            conversation.append(
+                Message(
+                    role="user",
+                    parts=[TextPart(text=batch_text, cal_loss=False)],
+                    cal_loss=False,
+                    add_im_start=True,
+                    add_im_end=True,
+                )
+            )
+
+            # Deep copy for generation (don't pollute original conversation)
+            conversation_gen = deepcopy(conversation)
+            conversation_gen.append(
+                Message(
+                    role="assistant",
+                    parts=[],
+                    cal_loss=False,
+                    modality="voice",
+                    add_im_start=True,
+                    add_im_end=False,
+                )
+            )
+
+            logger.info("Visualizing prompt structure:")
+            conversation_gen.visualize(
+                tokenizer,
+                merge_audio_tokens=True,
+                merge_semantic_tokens=True,
+            )
+
+            encoded, audio_masks, audio_parts = conversation_gen.encode_for_inference(
+                tokenizer, num_codebooks=model.config.num_codebooks
+            )
+
+            logger.info(f"Encoded prompt shape: {encoded.shape}")
+            if audio_parts is not None:
+                logger.info(f"Audio parts shape: {audio_parts.shape}")
+            if audio_masks is not None:
+                logger.info(
+                    f"Audio masks non-zero count: {torch.count_nonzero(audio_masks)}"
+                )
+
+            if encoded.size(1) > max_length - 2048:
+                raise ValueError(
+                    f"Prompt is too long: {encoded.size(1)} > {max_length - 2048}"
+                )
+
+            encoded = encoded.to(device=device)
+            prompt_length = encoded.size(1)
+
+            y = generate(
+                model=model,
+                prompt=encoded,
+                max_new_tokens=max_new_tokens,
+                audio_masks=audio_masks,
+                audio_parts=audio_parts,
+                decode_one_token=decode_one_token,
+                temperature=temperature,
+                top_p=top_p,
+                top_k=top_k,
+            )
+
+            if sample_idx == 0 and batch_idx == 0 and compile:
+                logger.info(f"Compilation time: {time.perf_counter() - t0:.2f} seconds")
+
+            if torch.cuda.is_available():
+                torch.cuda.synchronize()
+
+            t_batch = time.perf_counter() - t0
+            tokens_generated = y.size(1) - prompt_length
+            tokens_sec = tokens_generated / t_batch if t_batch > 0 else 0
+            logger.info(
+                f"Batch {batch_idx}: Generated {tokens_generated} tokens in "
+                f"{t_batch:.02f} seconds, {tokens_sec:.02f} tokens/sec"
+            )
+            logger.info(
+                f"Bandwidth achieved: {model_size * tokens_sec / 1e9:.02f} GB/s"
+            )
+
+            # Extract generated codes
+            codes = y[1:, prompt_length:-1].clone()
+            assert (codes >= 0).all(), f"Negative code found: {codes}"
+
+            # Add assistant message with generated codes back to conversation
+            conversation.append(
+                Message(
+                    role="assistant",
+                    parts=[VQPart(codes=codes.cpu(), cal_loss=False)],
+                    cal_loss=False,
+                    modality="voice",
+                    add_im_start=True,
+                    add_im_end=True,
+                )
+            )
+
+            yield GenerateResponse(action="sample", codes=codes, text=batch_text)
+
+            # Cleanup
+            del y, encoded
+
+        if torch.cuda.is_available():
+            logger.info(
+                f"GPU Memory used: {torch.cuda.max_memory_reserved() / 1e9:.02f} GB"
+            )
+
+        yield GenerateResponse(action="next")
+
+
+@dataclass
+class WrappedGenerateResponse:
+    status: Literal["success", "error"]
+    response: Optional[Union[GenerateResponse, Exception]] = None
+
+
+@dataclass
+class GenerateRequest:
+    request: dict
+    response_queue: queue.Queue
+
+
+def launch_thread_safe_queue(
+    checkpoint_path,
+    device,
+    precision,
+    compile: bool = False,
+):
+    input_queue = queue.Queue()
+    init_event = threading.Event()
+
+    def worker():
+        model, decode_one_token = init_model(
+            checkpoint_path, device, precision, compile=compile
+        )
+        with torch.device(device):
+            model.setup_caches(
+                max_batch_size=1,
+                max_seq_len=model.config.max_seq_len,
+                dtype=next(model.parameters()).dtype,
+            )
+        init_event.set()
+
+        while True:
+            item: GenerateRequest | None = input_queue.get()
+            if item is None:
+                break
+
+            kwargs = item.request
+            response_queue = item.response_queue
+
+            try:
+                for chunk in generate_long(
+                    model=model, decode_one_token=decode_one_token, **kwargs
+                ):
+                    response_queue.put(
+                        WrappedGenerateResponse(status="success", response=chunk)
+                    )
+
+                # Only clear cache after complete request batch
+                if torch.cuda.is_available():
+                    torch.cuda.empty_cache()
+
+            except Exception as e:
+                logger.error(traceback.format_exc())
+                response_queue.put(WrappedGenerateResponse(status="error", response=e))
+                # Clear cache on error
+                if torch.cuda.is_available():
+                    torch.cuda.empty_cache()
+
+    threading.Thread(target=worker, daemon=True).start()
+    init_event.wait()
+
+    return input_queue
+
+
+@click.command()
+@click.option(
+    "--text",
+    type=str,
+    default="<|speaker:0|>你说的对, 但是原神是一款由米哈游自主研发的开放世界手游.",
+)
+@click.option("--prompt-text", type=str, default=None, multiple=True)
+@click.option(
+    "--prompt-tokens",
+    type=click.Path(path_type=Path, exists=True),
+    default=None,
+    multiple=True,
+)
+@click.option(
+    "--prompt-audio",
+    type=click.Path(path_type=Path, exists=True),
+    default=None,
+    multiple=True,
+)
+@click.option("--output", type=click.Path(path_type=Path), default=None)
+@click.option("--num-samples", type=int, default=1)
+@click.option("--max-new-tokens", type=int, default=0)
+@click.option("--top-p", type=float, default=0.9)
+@click.option("--top-k", type=int, default=30)
+@click.option("--temperature", type=float, default=1.0)
+@click.option(
+    "--checkpoint-path",
+    type=click.Path(path_type=Path, exists=True),
+    default="checkpoints/s2-pro",
+)
+@click.option("--device", type=str, default="cuda")
+@click.option("--compile/--no-compile", default=False)
+@click.option("--seed", type=int, default=42)
+@click.option("--half/--no-half", default=False)
+@click.option("--iterative-prompt/--no-iterative-prompt", default=True)
+@click.option("--chunk-length", type=int, default=300)
+@click.option("--output-dir", type=Path, default="output")
+def main(
+    text: str,
+    prompt_text: Optional[tuple[str, ...]],
+    prompt_tokens: Optional[tuple[Path, ...]],
+    prompt_audio: Optional[tuple[Path, ...]],
+    output: Optional[Path],
+    num_samples: int,
+    max_new_tokens: int,
+    top_p: float,
+    top_k: int,
+    temperature: float,
+    checkpoint_path: Path,
+    device: str,
+    compile: bool,
+    seed: int,
+    half: bool,
+    iterative_prompt: bool,
+    chunk_length: int,
+    output_dir: Path,
+) -> None:
+    os.makedirs(output_dir, exist_ok=True)
+    precision = torch.half if half else torch.bfloat16
+
+    if prompt_text and not prompt_audio and not prompt_tokens:
+        raise ValueError(
+            "--prompt-text requires either --prompt-audio or --prompt-tokens"
+        )
+    if prompt_text and prompt_tokens and len(prompt_text) != len(prompt_tokens):
+        raise ValueError(
+            f"Number of prompt text ({len(prompt_text)}) and prompt tokens ({len(prompt_tokens)}) should be the same"
+        )
+    if prompt_text and prompt_audio and len(prompt_text) != len(prompt_audio):
+        raise ValueError(
+            f"Number of prompt text ({len(prompt_text)}) and prompt audio ({len(prompt_audio)}) should be the same"
+        )
+
+    logger.info("Loading model ...")
+    t0 = time.time()
+    model, decode_one_token = init_model(
+        checkpoint_path, device, precision, compile=compile
+    )
+    with torch.device(device):
+        model.setup_caches(
+            max_batch_size=1,
+            max_seq_len=model.config.max_seq_len,
+            dtype=next(model.parameters()).dtype,
+        )
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+
+    logger.info(f"Time to load model: {time.time() - t0:.02f} seconds")
+
+    codec = None
+    codec_checkpoint = checkpoint_path / "codec.pth"
+
+    # Handle prompt: --prompt-audio takes priority over --prompt-tokens
+    prompt_tokens_list = None
+    if prompt_audio:
+        logger.info("Loading codec model for audio encoding...")
+        codec = load_codec_model(codec_checkpoint, device, precision)
+        prompt_tokens_list = [
+            encode_audio(p, codec, device).cpu() for p in prompt_audio
+        ]
+        logger.info(f"Encoded {len(prompt_audio)} audio file(s) to VQ codes")
+    elif prompt_tokens is not None:
+        prompt_tokens_list = [torch.from_numpy(np.load(p)) for p in prompt_tokens]
+
+    torch.manual_seed(seed)
+
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed(seed)
+
+    generator = generate_long(
+        model=model,
+        device=device,
+        decode_one_token=decode_one_token,
+        text=text,
+        num_samples=num_samples,
+        max_new_tokens=max_new_tokens,
+        top_p=top_p,
+        top_k=top_k,
+        temperature=temperature,
+        compile=compile,
+        iterative_prompt=iterative_prompt,
+        chunk_length=chunk_length,
+        prompt_text=list(prompt_text) if prompt_text else None,
+        prompt_tokens=prompt_tokens_list,
+    )
+
+    idx = 0
+    codes = []
+
+    for response in generator:
+        if response.action == "sample":
+            codes.append(response.codes)
+            logger.info(f"Sampled text: {response.text}")
+        elif response.action == "next":
+            if codes:
+                merged_codes = torch.cat(codes, dim=1)
+                codes_npy_path = os.path.join(output_dir, f"codes_{idx}.npy")
+                np.save(codes_npy_path, merged_codes.cpu().numpy())
+                logger.info(f"Saved codes to {codes_npy_path}")
+
+                # Decode to wav if --output is specified
+                if output:
+                    if codec is None:
+                        logger.info("Loading codec model for audio decoding...")
+                        codec = load_codec_model(codec_checkpoint, device, precision)
+                    audio = decode_to_audio(merged_codes.to(device), codec)
+                    import soundfile as sf
+
+                    out_path = (
+                        str(output)
+                        if num_samples == 1
+                        else str(output.with_stem(f"{output.stem}_{idx}"))
+                    )
+                    sf.write(out_path, audio.cpu().float().numpy(), codec.sample_rate)
+                    logger.info(f"Saved audio to {out_path}")
+
+            logger.info(f"Next sample")
+            codes = []
+            idx += 1
+        else:
+            logger.error(f"Error: {response}")
+
+
+if __name__ == "__main__":
+    main()

--- a/xinference/thirdparty/fish_speech_s2/fish_speech/models/text2semantic/llama.py
+++ b/xinference/thirdparty/fish_speech_s2/fish_speech/models/text2semantic/llama.py
@@ -1,0 +1,1038 @@
+import dataclasses
+import json
+import math
+from collections import OrderedDict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import torch
+import torch.nn as nn
+from einops import rearrange
+from loguru import logger
+from torch import Tensor
+from torch.nn import functional as F
+from torch.nn.attention import SDPBackend, sdpa_kernel
+from torch.utils.checkpoint import checkpoint
+
+from xinference.thirdparty.fish_speech_s2.fish_speech.models.text2semantic.lora import LoraConfig, setup_lora
+
+
+def find_multiple(n: int, k: int) -> int:
+    if n % k == 0:
+        return n
+    return n + k - (n % k)
+
+
+@dataclass
+class BaseModelArgs:
+    model_type: str = "base"
+
+    vocab_size: int = 32000
+    n_layer: int = 32
+    n_head: int = 32
+    dim: int = 4096
+    intermediate_size: int = None
+    n_local_heads: int = -1
+    head_dim: int = 64
+    rope_base: float = 10000
+    norm_eps: float = 1e-5
+    max_seq_len: int = 2048
+    dropout: float = 0.0
+    tie_word_embeddings: bool = True
+    attention_qkv_bias: bool = False
+    attention_o_bias: bool = False
+    attention_qk_norm: bool = False
+
+    # Codebook configs
+    codebook_size: int = 160
+    num_codebooks: int = 4
+
+    semantic_begin_id: int = 0
+    semantic_end_id: int = 0
+
+    # Gradient checkpointing
+    use_gradient_checkpointing: bool = True
+
+    # Initialize the model
+    initializer_range: float = 0.02
+
+    # Dummy vars
+    is_reward_model: bool = False
+    scale_codebook_embeddings: bool = False
+    audio_embed_dim: Optional[int] = None
+
+    def __post_init__(self):
+        if self.n_local_heads == -1:
+            self.n_local_heads = self.n_head
+        if self.intermediate_size is None:
+            hidden_dim = 4 * self.dim
+            n_hidden = int(2 * hidden_dim / 3)
+            self.intermediate_size = find_multiple(n_hidden, 256)
+        if self.head_dim is None:
+            self.head_dim = self.dim // self.n_head
+
+    @staticmethod
+    def from_pretrained(path: str):
+        path = Path(path)
+
+        if path.is_dir():
+            path = path / "config.json"
+
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+
+        match data["model_type"]:
+            case "naive":
+                cls = NaiveModelArgs
+            case "dual_ar":
+                cls = DualARModelArgs
+            case "fish_qwen3_omni":
+                return BaseModelArgs._from_fish_qwen3_omni(data)
+            case _:
+                raise ValueError(f"Unknown model type: {data['model_type']}")
+
+        # Filter out unexpected keyword arguments
+        valid_keys = {f.name for f in dataclasses.fields(cls)}
+        data = {k: v for k, v in data.items() if k in valid_keys}
+
+        return cls(**data)
+
+    @staticmethod
+    def _from_fish_qwen3_omni(data: dict) -> "DualARModelArgs":
+        tc = data["text_config"]
+        adc = data["audio_decoder_config"]
+        flat = dict(
+            model_type="dual_ar",
+            vocab_size=tc["vocab_size"],
+            n_layer=tc["n_layer"],
+            n_head=tc["n_head"],
+            n_local_heads=tc.get("n_local_heads", -1),
+            head_dim=tc.get("head_dim"),
+            dim=tc["dim"],
+            intermediate_size=tc.get("intermediate_size"),
+            rope_base=tc.get("rope_base", 10000),
+            norm_eps=tc.get("norm_eps", 1e-5),
+            max_seq_len=tc.get("max_seq_len", 2048),
+            dropout=tc.get("dropout", 0.0),
+            tie_word_embeddings=tc.get("tie_word_embeddings", True),
+            attention_qkv_bias=tc.get("attention_qkv_bias", False),
+            attention_o_bias=tc.get("attention_o_bias", False),
+            attention_qk_norm=tc.get("attention_qk_norm", False),
+            use_gradient_checkpointing=tc.get("use_gradient_checkpointing", True),
+            initializer_range=tc.get("initializer_range", 0.02),
+            semantic_begin_id=data.get("semantic_start_token_id", 0),
+            semantic_end_id=data.get("semantic_end_token_id", 0),
+            scale_codebook_embeddings=True,
+            norm_fastlayer_input=True,
+            audio_embed_dim=adc.get("text_dim", tc["dim"]),
+            codebook_size=adc["vocab_size"],
+            num_codebooks=adc["num_codebooks"],
+            n_fast_layer=adc["n_layer"],
+            fast_dim=adc.get("dim"),
+            fast_n_head=adc.get("n_head"),
+            fast_n_local_heads=adc.get("n_local_heads"),
+            fast_head_dim=adc.get("head_dim"),
+            fast_intermediate_size=adc.get("intermediate_size"),
+            fast_attention_qkv_bias=adc.get("attention_qkv_bias"),
+            fast_attention_qk_norm=adc.get("attention_qk_norm"),
+            fast_attention_o_bias=adc.get("attention_o_bias"),
+        )
+        valid_keys = {f.name for f in dataclasses.fields(DualARModelArgs)}
+        flat = {k: v for k, v in flat.items() if k in valid_keys and v is not None}
+        return DualARModelArgs(**flat)
+
+    def save(self, path: str):
+        with open(path, "w") as f:
+            json.dump(self.__dict__, f, indent=4, sort_keys=True, ensure_ascii=False)
+
+
+@dataclass
+class NaiveModelArgs(BaseModelArgs):
+    model_type: str = "naive"
+
+
+@dataclass
+class DualARModelArgs(BaseModelArgs):
+    model_type: str = "dual_ar"
+    n_fast_layer: int = 4
+    fast_dim: int | None = None
+    fast_n_head: int | None = None
+    fast_n_local_heads: int | None = None
+    fast_head_dim: int | None = None
+    fast_intermediate_size: int | None = None
+    fast_attention_qkv_bias: bool | None = None
+    fast_attention_qk_norm: bool | None = None
+    fast_attention_o_bias: bool | None = None
+    norm_fastlayer_input: bool = False
+
+    def __post_init__(self):
+        super().__post_init__()
+
+        self.fast_dim = self.fast_dim or self.dim
+        self.fast_n_head = self.fast_n_head or self.n_head
+        self.fast_n_local_heads = self.fast_n_local_heads or self.n_local_heads
+        self.fast_head_dim = self.fast_head_dim or self.head_dim
+        self.fast_intermediate_size = (
+            self.fast_intermediate_size or self.intermediate_size
+        )
+        self.fast_attention_qkv_bias = (
+            self.fast_attention_qkv_bias
+            if self.fast_attention_qkv_bias is not None
+            else self.attention_qkv_bias
+        )
+        self.fast_attention_qk_norm = (
+            self.fast_attention_qk_norm
+            if self.fast_attention_qk_norm is not None
+            else self.attention_qk_norm
+        )
+        self.fast_attention_o_bias = (
+            self.fast_attention_o_bias
+            if self.fast_attention_o_bias is not None
+            else self.attention_o_bias
+        )
+
+
+class KVCache(nn.Module):
+    def __init__(
+        self, max_batch_size, max_seq_len, n_heads, head_dim, dtype=torch.bfloat16
+    ):
+        super().__init__()
+        cache_shape = (max_batch_size, n_heads, max_seq_len, head_dim)
+        self.register_buffer("k_cache", torch.zeros(cache_shape, dtype=dtype))
+        self.register_buffer("v_cache", torch.zeros(cache_shape, dtype=dtype))
+
+    def update(self, input_pos, k_val, v_val):
+        # input_pos: [S], k_val: [B, H, S, D]
+        assert input_pos.shape[0] == k_val.shape[2]
+
+        k_out = self.k_cache
+        v_out = self.v_cache
+        k_out[:, :, input_pos] = k_val
+        v_out[:, :, input_pos] = v_val
+
+        return k_out, v_out
+
+
+@dataclass
+class TransformerForwardResult:
+    token_logits: Tensor
+    codebook_logits: Tensor
+
+
+@dataclass
+class BaseTransformerForwardResult:
+    logits: Tensor
+    hidden_states: Tensor
+
+
+def _remap_fish_qwen3_omni_keys(weights: OrderedDict) -> OrderedDict:
+    if not any(k.startswith(("text_model.", "audio_decoder.")) for k in weights):
+        return weights
+    new_weights = OrderedDict()
+    for k, v in weights.items():
+        if k.startswith("text_model.model."):
+            new_key = k[len("text_model.model.") :]
+        elif k.startswith("audio_decoder."):
+            suffix = k[len("audio_decoder.") :]
+            new_key = (
+                suffix
+                if suffix.startswith("codebook_embeddings.")
+                else "fast_" + suffix
+            )
+        else:
+            new_key = k
+        new_weights[new_key] = v
+    return new_weights
+
+
+class BaseTransformer(nn.Module):
+    def __init__(
+        self,
+        config: BaseModelArgs,
+        init_weights: bool = True,
+    ) -> None:
+        super().__init__()
+        self.config = config
+
+        # Slow transformer
+        self.embeddings = nn.Embedding(
+            config.vocab_size,
+            config.dim,
+        )
+        self.codebook_embeddings = nn.Embedding(
+            config.codebook_size * config.num_codebooks,
+            config.dim,
+        )
+        self.layers = nn.ModuleList(
+            TransformerBlock(config, use_sdpa=True) for _ in range(config.n_layer)
+        )
+        self.norm = RMSNorm(config.dim, eps=config.norm_eps)
+
+        if self.config.tie_word_embeddings is False:
+            self.output = nn.Linear(
+                config.dim,
+                config.vocab_size,
+                bias=False,
+            )
+
+        self.register_buffer(
+            "freqs_cis",
+            precompute_freqs_cis(
+                config.max_seq_len,
+                config.head_dim,
+                config.rope_base,
+            ),
+            persistent=False,
+        )
+        self.register_buffer(
+            "causal_mask",
+            torch.tril(
+                torch.ones(
+                    config.max_seq_len,
+                    config.max_seq_len,
+                    dtype=torch.bool,
+                )
+            ),
+            persistent=False,
+        )
+
+        # For kv cache
+        self.max_batch_size = -1
+        self.max_seq_len = -1
+
+        if init_weights:
+            self.apply(self._init_weights)
+
+    def setup_caches(
+        self, max_batch_size: int, max_seq_len: int, dtype: torch.dtype = torch.bfloat16
+    ):
+        if self.max_seq_len >= max_seq_len and self.max_batch_size >= max_batch_size:
+            return
+
+        max_seq_len = find_multiple(max_seq_len, 8)
+        self.max_seq_len = max_seq_len
+        self.max_batch_size = max_batch_size
+
+        for b in self.layers:
+            b.attention.kv_cache = KVCache(
+                max_batch_size,
+                max_seq_len,
+                self.config.n_local_heads,
+                self.config.head_dim,
+                dtype=dtype,
+            )
+
+    def embed(self, inp: Tensor) -> Tensor:
+        embeds = []
+
+        for i in range(self.config.num_codebooks):
+            emb = self.codebook_embeddings(
+                inp[:, i + 1] + i * self.config.codebook_size
+            )
+            embeds.append(emb)
+
+        vq_embeds_sum = torch.stack(embeds, dim=1).sum(dim=1)
+
+        is_semantic = (inp[:, 0] >= self.config.semantic_begin_id) & (
+            inp[:, 0] <= self.config.semantic_end_id
+        )
+
+        vq_embeds_sum[~is_semantic] = 0
+
+        x = self.embeddings(inp[:, 0]) + vq_embeds_sum
+
+        return x
+
+    def forward(
+        self,
+        inp: Tensor,
+        key_padding_mask: Optional[Tensor] = None,
+    ) -> BaseTransformerForwardResult:
+        seq_len = inp.size(2)
+
+        # Here we want to merge the embeddings of the codebooks
+        x = self.embed(inp)
+
+        freqs_cis = self.freqs_cis[:seq_len]
+
+        mask = None
+        if key_padding_mask is not None:
+            causal = self.causal_mask[:seq_len, :seq_len]
+            causal = rearrange(causal, "q k -> 1 1 q k")
+
+            atten_mask = rearrange(key_padding_mask, "b s -> b 1 1 s")
+            atten_mask = atten_mask.logical_not()
+            mask = causal & atten_mask
+
+        for layer in self.layers:
+            if self.config.use_gradient_checkpointing and self.training:
+                x = checkpoint(layer, x, freqs_cis, mask, use_reentrant=True)
+            else:
+                x = layer(x, freqs_cis, mask)
+
+        slow_out = self.norm(x)
+
+        if self.config.tie_word_embeddings:
+            token_logits = F.linear(slow_out, self.embeddings.weight)
+        else:
+            token_logits = self.output(slow_out)
+
+        hidden_out = (
+            slow_out if getattr(self.config, "norm_fastlayer_input", False) else x
+        )
+
+        return BaseTransformerForwardResult(
+            logits=token_logits,
+            hidden_states=hidden_out,
+        )
+
+    def forward_generate(
+        self,
+        inp: Tensor,
+        input_pos: Optional[Tensor] = None,
+        audio_masks: Optional[Tensor] = None,
+        audio_parts: Optional[Tensor] = None,
+        return_all: bool = False,
+    ) -> BaseTransformerForwardResult:
+
+        # Embedding logic replicated from embed() for compilation compatibility
+        embeds = []
+        for i in range(self.config.num_codebooks):
+            emb = self.codebook_embeddings(
+                inp[:, i + 1] + i * self.config.codebook_size
+            )
+            embeds.append(emb)
+
+        vq_embeds_sum = torch.stack(embeds, dim=1).sum(dim=1)
+
+        vq_masks = (inp[:, 0] >= self.config.semantic_begin_id) & (
+            inp[:, 0] <= self.config.semantic_end_id
+        )
+
+        vq_embeds_sum[~vq_masks] = 0
+        x = self.embeddings(inp[:, 0]) + vq_embeds_sum
+
+        if self.config.scale_codebook_embeddings:
+            vq_masks_expanded = vq_masks.unsqueeze(-1).expand_as(x)
+            x = torch.where(
+                vq_masks_expanded, x / math.sqrt(self.config.num_codebooks + 1), x
+            )
+
+        # Audio embeddings
+        if audio_parts is not None:
+            # Note: This assumes self.audio_projector exists if audio_parts is used
+            # It seems missing in init, but we keep existing logic
+            if hasattr(self, "audio_projector"):
+                audio_embeds = self.audio_projector(audio_parts)
+                if self.config.scale_codebook_embeddings:
+                    x[audio_masks] = audio_embeds / math.sqrt(2)
+                else:
+                    x[audio_masks] = audio_embeds
+            else:
+                logger.warning("audio_parts provided but model has no audio_projector")
+
+        if input_pos is None:
+            input_pos = torch.arange(inp.shape[-1], device=x.device)
+            max_seq_len = inp.shape[-1]
+        else:
+            max_seq_len = self.max_seq_len
+
+        mask = self.causal_mask[None, None, input_pos, :max_seq_len]  # (B, N, Q, K)
+        freqs_cis = self.freqs_cis[input_pos]
+
+        for layer in self.layers:
+            x = layer(x, freqs_cis, mask, input_pos=input_pos)
+
+        if x.size(1) > 1 and not return_all:
+            x = x[:, -1:]
+
+        slow_out = self.norm(x)
+
+        if self.config.is_reward_model:
+            token_logits = self.score_output(slow_out)
+        elif self.config.tie_word_embeddings:
+            token_logits = F.linear(slow_out, self.embeddings.weight)
+        else:
+            token_logits = self.output(slow_out)
+
+        hidden_out = (
+            slow_out if getattr(self.config, "norm_fastlayer_input", False) else x
+        )
+
+        return BaseTransformerForwardResult(
+            logits=token_logits,
+            hidden_states=hidden_out,
+        )
+
+    def _init_weights(self, module):
+        std = self.config.initializer_range
+        if isinstance(module, nn.Linear):
+            module.weight.data.normal_(mean=0.0, std=std)
+            if module.bias is not None:
+                module.bias.data.zero_()
+        elif isinstance(module, nn.Embedding):
+            module.weight.data.normal_(mean=0.0, std=std)
+            if module.padding_idx is not None:
+                module.weight.data[module.padding_idx].zero_()
+
+    @staticmethod
+    def from_pretrained(
+        path: str,
+        load_weights: bool = False,
+        max_length: int | None = None,
+        lora_config: LoraConfig | None = None,
+        rope_base: int | None = None,
+    ) -> "BaseTransformer":
+        # Import wrapper locally to avoid circular dependency or global import issues
+        from xinference.thirdparty.fish_speech_s2.fish_speech.tokenizer import FishTokenizer
+
+        config = BaseModelArgs.from_pretrained(str(path))
+        if max_length is not None:
+            config.max_seq_len = max_length
+            logger.info(f"Override max_seq_len to {max_length}")
+
+        if rope_base is not None:
+            config.rope_base = rope_base
+            logger.info(f"Override rope_base to {rope_base}")
+
+        tokenizer = None
+        try:
+            tokenizer = FishTokenizer.from_pretrained(path)
+            config.semantic_begin_id = tokenizer.semantic_begin_id
+            config.semantic_end_id = tokenizer.semantic_end_id
+            logger.info(
+                f"Injected Semantic IDs into Config: {config.semantic_begin_id}-{config.semantic_end_id}"
+            )
+        except Exception as e:
+            logger.warning(
+                f"Failed to load tokenizer for config injection: {e}. Semantic IDs might be 0."
+            )
+
+        match config.model_type:
+            case "naive":
+                model_cls = NaiveTransformer
+            case "dual_ar":
+                model_cls = DualARTransformer
+            case _:
+                raise ValueError(f"Unknown model type: {config.model_type}")
+
+        logger.info(f"Loading model from {path}, config: {config}")
+        # Initialize model without passing tokenizer explicitly to __init__
+        model = model_cls(config)
+        # Attach tokenizer to model instance for inference convenience (optional, but good for user scripts)
+        model.tokenizer = tokenizer
+
+        if load_weights is False:
+            logger.info("Randomly initialized model")
+        else:
+            if "int8" in str(Path(path)):
+                logger.info("Using int8 weight-only quantization!")
+                from tools.llama.quantize import WeightOnlyInt8QuantHandler
+
+                simple_quantizer = WeightOnlyInt8QuantHandler(model)
+                model = simple_quantizer.convert_for_runtime()
+
+            if "int4" in str(Path(path)):
+                logger.info("Using int4 quantization!")
+                path_comps = path.name.split("-")
+                assert path_comps[-2].startswith("g")
+                groupsize = int(path_comps[-2][1:])
+                from tools.llama.quantize import WeightOnlyInt4QuantHandler
+
+                simple_quantizer = WeightOnlyInt4QuantHandler(model, groupsize)
+                model = simple_quantizer.convert_for_runtime()
+
+            path_obj = Path(path)
+            index_json = path_obj / "model.safetensors.index.json"
+            single_st = path_obj / "model.safetensors"
+            pth_file = path_obj / "model.pth"
+
+            if index_json.exists():
+                logger.info("Loading sharded safetensors weights")
+                from safetensors.torch import load_file as st_load_file
+
+                with open(index_json) as f:
+                    st_index = json.load(f)
+                shard_files = sorted(set(st_index["weight_map"].values()))
+                weights = OrderedDict()
+                for shard in shard_files:
+                    weights.update(st_load_file(str(path_obj / shard), device="cpu"))
+                weights = _remap_fish_qwen3_omni_keys(weights)
+            elif single_st.exists():
+                logger.info("Loading single safetensors weights")
+                from safetensors.torch import load_file as st_load_file
+
+                weights = OrderedDict(st_load_file(str(single_st), device="cpu"))
+                weights = _remap_fish_qwen3_omni_keys(weights)
+            elif pth_file.exists():
+                weights = torch.load(
+                    pth_file,
+                    map_location="cpu",
+                    mmap=True,
+                    weights_only=True,
+                )
+                if "state_dict" in weights:
+                    weights = weights["state_dict"]
+                if weights and next(iter(weights.keys())).startswith("model."):
+                    weights = OrderedDict(
+                        (k.replace("model.", ""), v) for k, v in weights.items()
+                    )
+                for k in list(weights.keys()):
+                    if "audio_" in k:
+                        weights.pop(k)
+            else:
+                raise FileNotFoundError(f"No model weights found in {path_obj}")
+
+            err = model.load_state_dict(weights, strict=False, assign=True)
+            logger.info(f"Model weights loaded - Status: {err}")
+
+        if lora_config is not None:
+            setup_lora(model, lora_config)
+            logger.info(f"LoRA setup: {lora_config}")
+
+        return model
+
+    def save_pretrained(self, path: str, drop_lora: bool = False):
+        path = Path(path)
+        path.mkdir(parents=True, exist_ok=True)
+
+        self.config.save(path / "config.json")
+        state_dict = self.state_dict()
+
+        if drop_lora:
+            for key in list(state_dict.keys()):
+                if "lora" not in key:
+                    continue
+                state_dict.pop(key)
+
+        torch.save(state_dict, path / "model.pth")
+        if hasattr(self, "tokenizer"):
+            self.tokenizer.save_pretrained(path)
+
+
+class NaiveTransformer(BaseTransformer):
+    def __init__(self, config: NaiveModelArgs) -> None:
+        super().__init__(config, init_weights=False)
+
+        self.codebook_norm = RMSNorm(config.dim, eps=config.norm_eps)
+        self.codebook_output = nn.Linear(
+            config.dim,
+            config.codebook_size * config.num_codebooks,
+            bias=False,
+        )
+
+        self.apply(self._init_weights)
+
+    def decode(self, result: BaseTransformerForwardResult) -> TransformerForwardResult:
+        token_logits = result.logits
+        x = result.hidden_states
+
+        # Codebook
+        codebook_logits = self.codebook_output(self.codebook_norm(x))
+        codebook_logits = rearrange(
+            codebook_logits, "b n (c d) -> b n c d", c=self.config.num_codebooks
+        )
+
+        return TransformerForwardResult(
+            token_logits=token_logits,
+            codebook_logits=codebook_logits,
+        )
+
+    def forward(
+        self,
+        inp: Tensor,
+        key_padding_mask: Optional[Tensor] = None,
+    ) -> TransformerForwardResult:
+        result = super().forward(
+            inp=inp,
+            key_padding_mask=key_padding_mask,
+        )
+        return self.decode(result)
+
+    def forward_generate(
+        self, x: Tensor, input_pos: Optional[Tensor] = None
+    ) -> TransformerForwardResult:
+        result = super().forward_generate(x, input_pos)
+        return self.decode(result)
+
+
+class DualARTransformer(BaseTransformer):
+    def __init__(self, config: NaiveModelArgs) -> None:
+        super().__init__(config, init_weights=False)
+
+        # Project to fast dim if needed
+        if config.fast_dim is not None and config.fast_dim != config.dim:
+            self.fast_project_in = nn.Linear(config.dim, config.fast_dim)
+        else:
+            self.fast_project_in = nn.Identity()
+
+        # Fast transformer
+        self.fast_embeddings = nn.Embedding(config.codebook_size, config.fast_dim)
+
+        # The equivalent bs is so large that sdpa doesn't work
+        override_config = dataclasses.replace(
+            config,
+            dim=config.fast_dim,
+            n_head=config.fast_n_head,
+            n_local_heads=config.fast_n_local_heads,
+            head_dim=config.fast_head_dim,
+            intermediate_size=config.fast_intermediate_size,
+            attention_qkv_bias=config.fast_attention_qkv_bias,
+            attention_qk_norm=config.fast_attention_qk_norm,
+            attention_o_bias=config.fast_attention_o_bias,
+        )
+
+        self.fast_layers = nn.ModuleList(
+            TransformerBlock(override_config, use_sdpa=False)
+            for _ in range(config.n_fast_layer)
+        )
+        self.fast_norm = RMSNorm(config.fast_dim, eps=config.norm_eps)
+        self.fast_output = nn.Linear(
+            config.fast_dim,
+            config.codebook_size,
+            bias=False,
+        )
+
+        self.register_buffer(
+            "fast_freqs_cis",
+            precompute_freqs_cis(
+                config.num_codebooks,
+                config.fast_head_dim,
+                config.rope_base,
+            ),
+            persistent=False,
+        )
+        self.apply(self._init_weights)
+
+    def setup_caches(
+        self, max_batch_size: int, max_seq_len: int, dtype: torch.dtype = torch.bfloat16
+    ):
+        super().setup_caches(max_batch_size, max_seq_len, dtype)
+
+        # Fast transformer
+        # The max seq len here is the number of codebooks
+        for b in self.fast_layers:
+            b.attention.kv_cache = KVCache(
+                max_batch_size,
+                self.config.num_codebooks,
+                self.config.fast_n_local_heads,
+                self.config.fast_head_dim,
+                dtype=dtype,
+            )
+
+    def forward(
+        self,
+        inp: Tensor,
+        labels: Optional[Tensor] = None,
+        key_padding_mask: Optional[Tensor] = None,
+        vq_parts: Optional[Tensor] = None,
+        vq_masks: Optional[Tensor] = None,
+        vq_require_losses: Optional[Tensor] = None,
+        mel_parts: Optional[Tensor] = None,
+        mel_masks: Optional[Tensor] = None,
+    ) -> TransformerForwardResult:
+        parent_result = super().forward(
+            inp=inp,
+            key_padding_mask=key_padding_mask,
+        )
+        token_logits = parent_result.logits
+        x = parent_result.hidden_states
+
+        # Fast transformer
+        fast_seq_len = self.config.num_codebooks
+        fast_mask = self.causal_mask[
+            None, None, :fast_seq_len, :fast_seq_len
+        ]  # (B, N, Q, K)
+        fast_freqs_cis = self.fast_freqs_cis[:fast_seq_len]
+
+        # Extract corresponding parts with labels
+        token_labels = labels[:, 0]
+
+        # [MODIFIED] Use config instead of tokenizer
+        codebook_mask = (token_labels >= self.config.semantic_begin_id) & (
+            token_labels <= self.config.semantic_end_id
+        )
+
+        # This gives where input token is <|semantic|>
+        x = x[codebook_mask]
+
+        if x.shape[0] == 0:
+            # Use dummy input when no vq is required
+            x = torch.zeros(
+                (4, self.config.dim),
+                device=x.device,
+                dtype=x.dtype,
+            )
+            codebooks = torch.zeros(
+                (x.shape[0], self.config.num_codebooks - 1),
+                device=x.device,
+                dtype=torch.int,
+            )
+        else:
+            all_codebooks = labels[:, 1:, :]
+            all_codebooks_permuted = all_codebooks.permute(0, 2, 1)
+            semantic_codebooks = all_codebooks_permuted[codebook_mask]
+            codebooks = semantic_codebooks[:, :-1]
+
+        x = self.fast_project_in(x)
+        codebook_embeddings = self.fast_embeddings(codebooks)
+        x = torch.cat([x[:, None], codebook_embeddings], dim=1)
+
+        for layer in self.fast_layers:
+            if self.config.use_gradient_checkpointing and self.training:
+                x = checkpoint(layer, x, fast_freqs_cis, fast_mask, use_reentrant=True)
+            else:
+                x = layer(x, fast_freqs_cis, fast_mask)
+
+        # unflatten the batch and num_codebooks
+        fast_out = self.fast_norm(x)
+        codebook_logits = self.fast_output(fast_out)
+
+        assert codebook_logits.shape[1] == self.config.num_codebooks
+
+        return TransformerForwardResult(
+            token_logits=token_logits,
+            codebook_logits=codebook_logits,
+        )
+
+    def forward_generate_fast(
+        self, x: Tensor, input_pos: Optional[Tensor] = None
+    ) -> Tensor:
+        # Fast transformer
+        x = x.view(x.shape[0], 1, -1)
+
+        fast_mask = self.causal_mask[
+            None, None, input_pos, : self.config.num_codebooks
+        ]  # (B, N, Q, K)
+        fast_freqs_cis = self.fast_freqs_cis[input_pos]
+
+        for layer in self.fast_layers:
+            x = layer(x, fast_freqs_cis, fast_mask, input_pos=input_pos)
+
+        # unflatten the batch and num_codebooks
+        fast_out = self.fast_norm(x)  # only take the last token
+        codebook_logits = self.fast_output(fast_out)
+
+        return codebook_logits
+
+    def forward_generate(
+        self,
+        x: Tensor,
+        input_pos: Optional[Tensor] = None,
+        audio_masks: Optional[Tensor] = None,
+        audio_parts: Optional[Tensor] = None,
+    ) -> TransformerForwardResult:
+        x = super().forward_generate(x, input_pos, audio_masks, audio_parts)
+        x.hidden_states = self.fast_project_in(x.hidden_states)
+        return x
+
+
+class TransformerBlock(nn.Module):
+    def __init__(self, config: BaseModelArgs, use_sdpa: bool = True) -> None:
+        super().__init__()
+        self.attention = Attention(config, use_sdpa=use_sdpa)
+        self.feed_forward = FeedForward(config)
+        self.ffn_norm = RMSNorm(config.dim, config.norm_eps)
+        self.attention_norm = RMSNorm(config.dim, config.norm_eps)
+
+    def forward(
+        self, x: Tensor, freqs_cis: Tensor, mask: Tensor, input_pos: Tensor = None
+    ) -> Tensor:
+        h = x + self.attention(self.attention_norm(x), freqs_cis, mask, input_pos)
+        out = h + self.feed_forward(self.ffn_norm(h))
+        return out
+
+
+class Attention(nn.Module):
+    def __init__(self, config: BaseModelArgs, use_sdpa: bool = True):
+        super().__init__()
+        assert config.dim % config.n_head == 0
+
+        total_head_dim = (config.n_head + 2 * config.n_local_heads) * config.head_dim
+        # key, query, value projections for all heads, but in a batch
+        self.wqkv = nn.Linear(
+            config.dim, total_head_dim, bias=config.attention_qkv_bias
+        )
+        self.wo = nn.Linear(
+            config.n_head * config.head_dim, config.dim, bias=config.attention_o_bias
+        )
+        self.kv_cache = None
+
+        if config.attention_qk_norm:
+            self.q_norm = nn.RMSNorm(config.head_dim, config.norm_eps)
+            self.k_norm = nn.RMSNorm(config.head_dim, config.norm_eps)
+
+        self.dropout = config.dropout
+        self.n_head = config.n_head
+        self.head_dim = config.head_dim
+        self.n_local_heads = config.n_local_heads
+        self.dim = config.dim
+        self.use_sdpa = use_sdpa
+        self.attention_qk_norm = config.attention_qk_norm
+        self.config = config
+
+        self._register_load_state_dict_pre_hook(self.load_hook)
+
+    def load_hook(self, state_dict, prefix, *args):
+        if prefix + "wq.weight" in state_dict:
+            wq = state_dict.pop(prefix + "wq.weight")
+            wk = state_dict.pop(prefix + "wk.weight")
+            wv = state_dict.pop(prefix + "wv.weight")
+            state_dict[prefix + "wqkv.weight"] = torch.cat([wq, wk, wv])
+
+    def forward(
+        self,
+        x: Tensor,
+        freqs_cis: Tensor,
+        mask: Tensor,
+        input_pos: Optional[Tensor] = None,
+    ) -> Tensor:
+        bsz, seqlen, _ = x.shape
+
+        q_size = self.n_head * self.head_dim
+        kv_size = self.n_local_heads * self.head_dim
+        q, k, v = self.wqkv(x).split([q_size, kv_size, kv_size], dim=-1)
+
+        q = q.view(bsz, seqlen, self.n_head, self.head_dim)
+        k = k.view(bsz, seqlen, self.n_local_heads, self.head_dim)
+        v = v.view(bsz, seqlen, self.n_local_heads, self.head_dim)
+
+        if self.attention_qk_norm:
+            q = self.q_norm(q)
+            k = self.k_norm(k)
+
+        q = apply_rotary_emb(q, freqs_cis)
+        k = apply_rotary_emb(k, freqs_cis)
+
+        q, k, v = map(lambda x: x.transpose(1, 2), (q, k, v))
+
+        if self.kv_cache is not None:
+            k, v = self.kv_cache.update(input_pos, k, v)
+
+        k = k.repeat_interleave(self.n_head // self.n_local_heads, dim=1)
+        v = v.repeat_interleave(self.n_head // self.n_local_heads, dim=1)
+
+        if self.use_sdpa:
+            if mask is None:
+                with sdpa_kernel(SDPBackend.FLASH_ATTENTION):
+                    y = F.scaled_dot_product_attention(
+                        q,
+                        k,
+                        v,
+                        dropout_p=self.dropout if self.training else 0.0,
+                        is_causal=True,
+                        # No third party attn_mask here to use flash_attention
+                    )
+            else:
+                y = F.scaled_dot_product_attention(
+                    q,
+                    k,
+                    v,
+                    attn_mask=mask,
+                    dropout_p=self.dropout if self.training else 0.0,
+                )
+        else:
+            y = self.eq_scaled_dot_product_attention(
+                q,
+                k,
+                v,
+                attn_mask=mask,
+                dropout_p=self.dropout if self.training else 0.0,
+            )
+
+        y = y.transpose(1, 2).contiguous().view(bsz, seqlen, q_size)
+
+        return self.wo(y)
+
+    def eq_scaled_dot_product_attention(
+        self,
+        query,
+        key,
+        value,
+        attn_mask=None,
+        dropout_p=0.0,
+    ) -> torch.Tensor:
+        # This is a standard scaled dot product attention
+        # It's low efficient, but it doesn't raise cuda error
+
+        L, S = query.size(-2), key.size(-2)
+        scale_factor = 1 / math.sqrt(query.size(-1))
+        attn_bias = torch.zeros(1, 1, L, S, dtype=query.dtype, device=query.device)
+
+        if attn_mask is not None:
+            if attn_mask.dtype == torch.bool:
+                attn_bias = torch.where(
+                    attn_mask.logical_not(), float("-inf"), attn_bias
+                )
+            else:
+                attn_bias = attn_bias + attn_mask
+
+        attn_weight = query @ key.transpose(-2, -1) * scale_factor
+        attn_weight += attn_bias
+        attn_weight = torch.softmax(attn_weight, dim=-1)
+        attn_weight = torch.dropout(attn_weight, dropout_p, train=True)
+
+        return attn_weight @ value
+
+
+class FeedForward(nn.Module):
+    def __init__(self, config: BaseModelArgs) -> None:
+        super().__init__()
+        self.w1 = nn.Linear(config.dim, config.intermediate_size, bias=False)
+        self.w3 = nn.Linear(config.dim, config.intermediate_size, bias=False)
+        self.w2 = nn.Linear(config.intermediate_size, config.dim, bias=False)
+
+    def forward(self, x: Tensor) -> Tensor:
+        return self.w2(F.silu(self.w1(x)) * self.w3(x))
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim: int, eps: float = 1e-5):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(dim))
+
+    def _norm(self, x):
+        return x * torch.rsqrt(torch.mean(x * x, dim=-1, keepdim=True) + self.eps)
+
+    def forward(self, x: Tensor) -> Tensor:
+        output = self._norm(x.float()).type_as(x)
+        return output * self.weight
+
+
+def precompute_freqs_cis(seq_len: int, n_elem: int, base: int = 10000) -> Tensor:
+    """
+    Precomputes frequency tensors for complex exponentials (cis)
+
+    Args:
+        seq_len: Length of the sequence for which positional embeddings are needed.
+        n_elem: Number of elements in the frequency tensor.
+        base: Base value for the frequency scaling (default: 10000).
+
+    Returns:
+        A tensor containing the precomputed frequencies in real and imaginary parts (bfloat16).
+    """
+    freqs = 1.0 / (
+        base ** (torch.arange(0, n_elem, 2)[: (n_elem // 2)].float() / n_elem)
+    )
+    t = torch.arange(seq_len, device=freqs.device)
+    freqs = torch.outer(t, freqs)
+    freqs_cis = torch.polar(torch.ones_like(freqs), freqs)
+    cache = torch.stack([freqs_cis.real, freqs_cis.imag], dim=-1)
+    return cache.to(dtype=torch.bfloat16)
+
+
+def apply_rotary_emb(x: Tensor, freqs_cis: Tensor) -> Tensor:
+    xshaped = x.float().reshape(*x.shape[:-1], -1, 2)
+    freqs_cis = freqs_cis.view(1, xshaped.size(1), 1, xshaped.size(3), 2)
+    x_out2 = torch.stack(
+        [
+            xshaped[..., 0] * freqs_cis[..., 0] - xshaped[..., 1] * freqs_cis[..., 1],
+            xshaped[..., 1] * freqs_cis[..., 0] + xshaped[..., 0] * freqs_cis[..., 1],
+        ],
+        -1,
+    )
+
+    x_out2 = x_out2.flatten(3)
+    return x_out2.type_as(x)

--- a/xinference/thirdparty/fish_speech_s2/fish_speech/models/text2semantic/lora.py
+++ b/xinference/thirdparty/fish_speech_s2/fish_speech/models/text2semantic/lora.py
@@ -1,0 +1,118 @@
+from dataclasses import dataclass, field
+
+import loralib as lora
+
+
+@dataclass
+class LoraConfig:
+    r: int
+    lora_alpha: float
+    lora_dropout: float = 0.0
+    # Valid values: "attention", "mlp", "embeddings", "output",
+    #               "fast_attention", "fast_mlp", "fast_embeddings", "fast_output"
+    # Unprefixed names target the slow transformer (and fast too for backwards compat).
+    # "fast_*" names target only the fast transformer.
+    target_modules: list = field(
+        default_factory=lambda: ["attention", "mlp", "embeddings", "output"]
+    )
+
+
+def _replace_embedding(old_embed, lora_config):
+    new_embed = lora.Embedding(
+        num_embeddings=old_embed.num_embeddings,
+        embedding_dim=old_embed.embedding_dim,
+        padding_idx=old_embed.padding_idx,
+        r=lora_config.r,
+        lora_alpha=lora_config.lora_alpha,
+    )
+    new_embed.weight.data.copy_(old_embed.weight.data)
+    return new_embed
+
+
+def setup_lora(model, lora_config):
+    targets = set(lora_config.target_modules)
+    linears = []
+
+    # Slow transformer: targeted by unprefixed names (e.g. "attention")
+    slow_attention = "attention" in targets
+    slow_mlp = "mlp" in targets
+    slow_embeddings = "embeddings" in targets
+    slow_output = "output" in targets
+
+    # Fast transformer: targeted by unprefixed names (backwards compat) OR "fast_*"
+    fast_attention = slow_attention or "fast_attention" in targets
+    fast_mlp = slow_mlp or "fast_mlp" in targets
+    fast_embeddings = slow_embeddings or "fast_embeddings" in targets
+    fast_output = slow_output or "fast_output" in targets
+
+    if slow_embeddings:
+        model.embeddings = _replace_embedding(model.embeddings, lora_config)
+        model.codebook_embeddings = _replace_embedding(
+            model.codebook_embeddings, lora_config
+        )
+
+    if slow_output and hasattr(model, "output"):
+        linears.append((model, "output"))
+
+    for layer in model.layers:
+        if slow_attention:
+            linears.extend([(layer.attention, "wqkv"), (layer.attention, "wo")])
+        if slow_mlp:
+            linears.extend(
+                [
+                    (layer.feed_forward, "w1"),
+                    (layer.feed_forward, "w2"),
+                    (layer.feed_forward, "w3"),
+                ]
+            )
+
+    if hasattr(model, "fast_layers"):
+        if fast_embeddings:
+            model.fast_embeddings = _replace_embedding(
+                model.fast_embeddings, lora_config
+            )
+        if fast_output:
+            linears.append((model, "fast_output"))
+
+        for layer in model.fast_layers:
+            if fast_attention:
+                linears.extend([(layer.attention, "wqkv"), (layer.attention, "wo")])
+            if fast_mlp:
+                linears.extend(
+                    [
+                        (layer.feed_forward, "w1"),
+                        (layer.feed_forward, "w2"),
+                        (layer.feed_forward, "w3"),
+                    ]
+                )
+
+    for module, layer_name in linears:
+        old_linear = getattr(module, layer_name)
+        updated_linear = lora.Linear(
+            in_features=old_linear.in_features,
+            out_features=old_linear.out_features,
+            bias=old_linear.bias is not None,
+            r=lora_config.r,
+            lora_alpha=lora_config.lora_alpha,
+            lora_dropout=lora_config.lora_dropout,
+        )
+        updated_linear.weight.data.copy_(old_linear.weight.data)
+        if old_linear.bias is not None:
+            updated_linear.bias.data.copy_(old_linear.bias.data)
+        setattr(module, layer_name, updated_linear)
+
+    # Mark only the LoRA layers as trainable
+    lora.mark_only_lora_as_trainable(model, bias="none")
+
+
+def get_merged_state_dict(model):
+    # This line will merge the state dict of the model and the LoRA parameters
+    model.eval()
+
+    # Then we need to remove the LoRA parameters from the state dict
+    state_dict = model.state_dict()
+    for name in list(state_dict.keys()):
+        if "lora" in name:
+            state_dict.pop(name)
+
+    return state_dict

--- a/xinference/thirdparty/fish_speech_s2/fish_speech/tokenizer.py
+++ b/xinference/thirdparty/fish_speech_s2/fish_speech/tokenizer.py
@@ -1,0 +1,129 @@
+import json
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, List, Union
+
+import torch
+from transformers import AutoTokenizer
+
+if TYPE_CHECKING:
+    from transformers import PreTrainedTokenizerFast
+
+logger = logging.getLogger(__name__)
+
+# Constants definitions
+EOS_TOKEN = "<|endoftext|>"
+PAD_TOKEN = "<|pad|>"
+IM_START_TOKEN = "<|im_start|>"
+IM_END_TOKEN = "<|im_end|>"
+PHONEME_START_TOKEN = "<|phoneme_start|>"
+PHONEME_END_TOKEN = "<|phoneme_end|>"
+
+MODALITY_TEXT_TOKEN = "<|text|>"
+MODALITY_VOICE_TOKEN = "<|voice|>"
+MODALITY_INTERLEAVE_TOKEN = "<|interleave|>"
+AUDIO_START_TOKEN = "<|audio_start|>"
+AUDIO_END_TOKEN = "<|audio_end|>"
+AUDIO_EMBED_TOKEN = "<|audio_pad|>"
+
+MODALITY_TOKENS = {
+    "text": MODALITY_TEXT_TOKEN,
+    "voice": MODALITY_VOICE_TOKEN,
+    "interleave": MODALITY_INTERLEAVE_TOKEN,
+}
+
+SEMANTIC_TOKEN_TEMPLATE = "<|semantic:{i}|>"
+SEMANTIC_TOKENS = [SEMANTIC_TOKEN_TEMPLATE.format(i=i) for i in range(4096)]
+
+ALL_SPECIAL_TOKENS = [
+    EOS_TOKEN,
+    PAD_TOKEN,
+    IM_START_TOKEN,
+    IM_END_TOKEN,
+    PHONEME_START_TOKEN,
+    PHONEME_END_TOKEN,
+    MODALITY_TEXT_TOKEN,
+    MODALITY_VOICE_TOKEN,
+    MODALITY_INTERLEAVE_TOKEN,
+    AUDIO_START_TOKEN,
+    AUDIO_END_TOKEN,
+    AUDIO_EMBED_TOKEN,
+    *SEMANTIC_TOKENS,
+]
+
+
+class FishTokenizer:
+    def __init__(self, model_path: str):
+        self._tokenizer = AutoTokenizer.from_pretrained(model_path)
+        self.semantic_id_to_token_id = {}
+
+        vocab = self._tokenizer.get_vocab()
+        valid_ids = []
+
+        for code_idx in range(4096):
+            token = SEMANTIC_TOKEN_TEMPLATE.format(i=code_idx)
+            if token in vocab:
+                token_id = vocab[token]
+                self.semantic_id_to_token_id[code_idx] = token_id
+                valid_ids.append(token_id)
+
+        if not valid_ids:
+            logger.error(
+                "CRITICAL ERROR: No semantic tokens found in vocab! Audio cannot be synthesized."
+            )
+            self.semantic_begin_id = 0
+            self.semantic_end_id = 0
+            # Dummy tensor to prevent crash, though generation will fail
+            self.semantic_map_tensor = torch.zeros(4096, dtype=torch.long)
+        else:
+            self.semantic_begin_id = min(valid_ids)
+            self.semantic_end_id = max(valid_ids)
+            # Create a lookup tensor to handle potential gaps in token IDs safely
+            self.semantic_map_tensor = torch.zeros(4096, dtype=torch.long)
+            for k, v in self.semantic_id_to_token_id.items():
+                self.semantic_map_tensor[k] = v
+
+        logger.info(
+            f"Loaded Tokenizer. Semantic Range: {self.semantic_begin_id} -> {self.semantic_end_id}"
+        )
+
+    @property
+    def vocab_size(self):
+        return self._tokenizer.vocab_size
+
+    @property
+    def pad_token_id(self):
+        return self._tokenizer.pad_token_id
+
+    @property
+    def eos_token_id(self):
+        return self._tokenizer.eos_token_id
+
+    def get_token_id(self, token: str) -> int:
+        return self._tokenizer.convert_tokens_to_ids(token)
+
+    def encode(
+        self, text: str, add_special_tokens: bool = False, **kwargs
+    ) -> List[int]:
+        # [FIX] Force Qwen/Tiktoken backends to parse special tokens inline
+        import inspect
+
+        sig = inspect.signature(self._tokenizer.encode)
+        if "allowed_special" in sig.parameters and "allowed_special" not in kwargs:
+            kwargs["allowed_special"] = "all"
+        return self._tokenizer.encode(
+            text, add_special_tokens=add_special_tokens, **kwargs
+        )
+
+    def decode(self, tokens: Union[List[int], int], **kwargs) -> str:
+        return self._tokenizer.decode(tokens, **kwargs)
+
+    def save_pretrained(self, path: str):
+        self._tokenizer.save_pretrained(path)
+
+    @classmethod
+    def from_pretrained(cls, path: str):
+        return cls(path)
+
+    def __getattr__(self, name):
+        return getattr(self._tokenizer, name)

--- a/xinference/thirdparty/fish_speech_s2/fish_speech/utils/__init__.py
+++ b/xinference/thirdparty/fish_speech_s2/fish_speech/utils/__init__.py
@@ -1,0 +1,28 @@
+import random
+
+import numpy as np
+import torch
+
+from .context import autocast_exclude_mps
+
+
+def set_seed(seed: int):
+    if seed < 0:
+        seed = -seed
+    if seed > (1 << 31):
+        seed = 1 << 31
+
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed(seed)
+        torch.cuda.manual_seed_all(seed)
+
+    if torch.backends.cudnn.is_available():
+        torch.backends.cudnn.deterministic = True
+        torch.backends.cudnn.benchmark = False
+
+
+__all__ = ["autocast_exclude_mps", "set_seed"]

--- a/xinference/thirdparty/fish_speech_s2/fish_speech/utils/context.py
+++ b/xinference/thirdparty/fish_speech_s2/fish_speech/utils/context.py
@@ -1,0 +1,13 @@
+from contextlib import nullcontext
+
+import torch
+
+
+def autocast_exclude_mps(
+    device_type: str, dtype: torch.dtype
+) -> nullcontext | torch.autocast:
+    return (
+        nullcontext()
+        if torch.backends.mps.is_available()
+        else torch.autocast(device_type, dtype)
+    )

--- a/xinference/thirdparty/fish_speech_s2/fish_speech/utils/file.py
+++ b/xinference/thirdparty/fish_speech_s2/fish_speech/utils/file.py
@@ -1,0 +1,140 @@
+import os
+from pathlib import Path
+from typing import Union
+
+from loguru import logger
+from natsort import natsorted
+
+AUDIO_EXTENSIONS = {
+    ".mp3",
+    ".wav",
+    ".flac",
+    ".ogg",
+    ".m4a",
+    ".wma",
+    ".aac",
+    ".aiff",
+    ".aif",
+    ".aifc",
+}
+
+VIDEO_EXTENSIONS = {
+    ".mp4",
+    ".avi",
+}
+
+
+def get_latest_checkpoint(path: Path | str) -> Path | None:
+    # Find the latest checkpoint
+    ckpt_dir = Path(path)
+
+    if ckpt_dir.exists() is False:
+        return None
+
+    ckpts = sorted(ckpt_dir.glob("*.ckpt"), key=os.path.getmtime)
+    if len(ckpts) == 0:
+        return None
+
+    return ckpts[-1]
+
+
+def audio_to_bytes(file_path):
+    if not file_path or not Path(file_path).exists():
+        return None
+    with open(file_path, "rb") as wav_file:
+        wav = wav_file.read()
+    return wav
+
+
+def read_ref_text(ref_text):
+    path = Path(ref_text)
+    if path.exists() and path.is_file():
+        with path.open("r", encoding="utf-8") as file:
+            return file.read()
+    return ref_text
+
+
+def list_files(
+    path: Union[Path, str],
+    extensions: set[str] = set(),
+    recursive: bool = False,
+    sort: bool = True,
+) -> list[Path]:
+    """List files in a directory.
+
+    Args:
+        path (Path): Path to the directory.
+        extensions (set, optional): Extensions to filter. Defaults to None.
+        recursive (bool, optional): Whether to search recursively. Defaults to False.
+        sort (bool, optional): Whether to sort the files. Defaults to True.
+
+    Returns:
+        list: List of files.
+    """
+
+    if isinstance(path, str):
+        path = Path(path)
+
+    if not path.exists():
+        raise FileNotFoundError(f"Directory {path} does not exist.")
+
+    globber = path.rglob if recursive else path.glob
+    files = [file for ext in extensions for file in globber(f"*{ext}")]
+
+    if sort:
+        files = natsorted(files)
+
+    return files
+
+
+def load_filelist(path: Path | str) -> list[tuple[Path, str, str, str]]:
+    """
+    Load a Bert-VITS2 style filelist.
+    """
+
+    files = set()
+    results = []
+    count_duplicated, count_not_found = 0, 0
+
+    LANGUAGE_TO_LANGUAGES = {
+        "zh": ["zh", "en"],
+        "jp": ["jp", "en"],
+        "en": ["en"],
+    }
+
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f.readlines():
+            splits = line.strip().split("|", maxsplit=3)
+            if len(splits) != 4:
+                logger.warning(f"Invalid line: {line}")
+                continue
+
+            filename, speaker, language, text = splits
+            file = Path(filename)
+            language = language.strip().lower()
+
+            if language == "ja":
+                language = "jp"
+
+            assert language in ["zh", "jp", "en"], f"Invalid language {language}"
+            languages = LANGUAGE_TO_LANGUAGES[language]
+
+            if file in files:
+                logger.warning(f"Duplicated file: {file}")
+                count_duplicated += 1
+                continue
+
+            if not file.exists():
+                logger.warning(f"File not found: {file}")
+                count_not_found += 1
+                continue
+
+            results.append((file, speaker, languages, text))
+
+    if count_duplicated > 0:
+        logger.warning(f"Total duplicated files: {count_duplicated}")
+
+    if count_not_found > 0:
+        logger.warning(f"Total files not found: {count_not_found}")
+
+    return results

--- a/xinference/thirdparty/fish_speech_s2/fish_speech/utils/schema.py
+++ b/xinference/thirdparty/fish_speech_s2/fish_speech/utils/schema.py
@@ -1,0 +1,138 @@
+import base64
+import os
+import queue
+from dataclasses import dataclass
+from typing import Literal
+
+import torch
+from pydantic import BaseModel, Field, conint, model_validator
+from pydantic.functional_validators import SkipValidation
+from typing_extensions import Annotated
+
+from xinference.thirdparty.fish_speech_s2.fish_speech.content_sequence import TextPart, VQPart
+
+
+class ServeVQPart(BaseModel):
+    type: Literal["vq"] = "vq"
+    codes: SkipValidation[list[list[int]]]
+
+
+class ServeTextPart(BaseModel):
+    type: Literal["text"] = "text"
+    text: str
+
+
+class ServeAudioPart(BaseModel):
+    type: Literal["audio"] = "audio"
+    audio: bytes
+
+
+class ServeRequest(BaseModel):
+    # Raw content sequence dict that we can use with ContentSequence(**content)
+    content: dict
+    max_new_tokens: int = 600
+    top_p: float = 0.7
+    repetition_penalty: float = 1.2
+    temperature: float = 0.7
+    streaming: bool = False
+    num_samples: int = 1
+    early_stop_threshold: float = 1.0
+
+
+class ServeVQGANEncodeRequest(BaseModel):
+    # The audio here should be in wav, mp3, etc
+    audios: list[bytes]
+
+
+class ServeVQGANEncodeResponse(BaseModel):
+    tokens: SkipValidation[list[list[list[int]]]]
+
+
+class ServeVQGANDecodeRequest(BaseModel):
+    tokens: SkipValidation[list[list[list[int]]]]
+
+
+class ServeVQGANDecodeResponse(BaseModel):
+    # The audio here should be in PCM float16 format
+    audios: list[bytes]
+
+
+class ServeReferenceAudio(BaseModel):
+    audio: bytes
+    text: str
+
+    @model_validator(mode="before")
+    def decode_audio(cls, values):
+        audio = values.get("audio")
+        if (
+            isinstance(audio, str) and len(audio) > 255
+        ):  # Check if audio is a string (Base64)
+            try:
+                values["audio"] = base64.b64decode(audio)
+            except Exception:
+                # If the audio is not a valid base64 string, we will just ignore it and let the server handle it
+                pass
+        return values
+
+    def __repr__(self) -> str:
+        return f"ServeReferenceAudio(text={self.text!r}, audio_size={len(self.audio)})"
+
+
+class ServeTTSRequest(BaseModel):
+    text: str
+    chunk_length: Annotated[int, conint(ge=100, le=1000, strict=True)] = 200
+    # Audio format
+    format: Literal["wav", "pcm", "mp3", "opus"] = "wav"
+    # Latency mode (used by api.fish.audio; "normal" or "balanced")
+    latency: Literal["normal", "balanced"] = "normal"
+    # References audios for in-context learning
+    references: list[ServeReferenceAudio] = []
+    # Reference id
+    # For example, if you want use https://fish.audio/m/7f92f8afb8ec43bf81429cc1c9199cb1/
+    # Just pass 7f92f8afb8ec43bf81429cc1c9199cb1
+    reference_id: str | None = None
+    seed: int | None = None
+    use_memory_cache: Literal["on", "off"] = "off"
+    # Normalize text for en & zh, this increase stability for numbers
+    normalize: bool = True
+    # not usually used below
+    streaming: bool = False
+    max_new_tokens: int = 1024
+    top_p: Annotated[float, Field(ge=0.1, le=1.0, strict=True)] = 0.8
+    repetition_penalty: Annotated[float, Field(ge=0.9, le=2.0, strict=True)] = 1.1
+    temperature: Annotated[float, Field(ge=0.1, le=1.0, strict=True)] = 0.8
+
+    class Config:
+        # Allow arbitrary types for pytorch related types
+        arbitrary_types_allowed = True
+
+
+class AddReferenceRequest(BaseModel):
+    id: str = Field(..., min_length=1, max_length=255, pattern=r"^[a-zA-Z0-9\-_ ]+$")
+    audio: bytes
+    text: str = Field(..., min_length=1)
+
+
+class AddReferenceResponse(BaseModel):
+    success: bool
+    message: str
+    reference_id: str
+
+
+class ListReferencesResponse(BaseModel):
+    success: bool
+    reference_ids: list[str]
+    message: str = "Success"
+
+
+class DeleteReferenceResponse(BaseModel):
+    success: bool
+    message: str
+    reference_id: str
+
+
+class UpdateReferenceResponse(BaseModel):
+    success: bool
+    message: str
+    old_reference_id: str
+    new_reference_id: str


### PR DESCRIPTION
## What does this PR do?

Add built-in TTS support for:

- `FishAudio-S1-mini`
- `FishAudio-S2-Pro`

Both models support Hugging Face and ModelScope sources:

| Model | Hugging Face | Revision | ModelScope | Revision |
|---|---|---|---|---|
| FishAudio-S1-mini | `fishaudio/s1-mini` | `main` | `fishaudio/s1-mini` | `master` |
| FishAudio-S2-Pro | `fishaudio/s2-pro` | `main` | `fishaudio/s2-pro` | `master` |

## Changes

- Extend `FishSpeechModel` for the S1-mini and S2-Pro runtime APIs.
- Support text-to-speech, zero-shot synthesis, voice cloning, and streaming output.
- Vendor separate inference-only Fish Speech snapshots for S1 and S2 because their runtime APIs differ.
- Preserve existing `FishSpeech-1.5` behavior.
- Add virtual environment dependencies for both models.
- Avoid explicitly pinning `tqdm`; `transformers` provides it transitively. This prevents `uv` resolution failures when the PyTorch CUDA index lacks the host-pinned version.
- Add built-in model documentation and catalog entries.
- Add runtime dispatch, loading, request construction, streaming, and registry tests.
- Include upstream licenses and attribution notices.

## Notes

- S1-mini weights use `CC-BY-NC-SA-4.0` and require accepting the model repository terms.
- S2-Pro uses the Fish Audio Research License; commercial use requires a separate license.