### PR TITLE
feat(models): add embedding and rerank multimodal abilities

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -23,7 +23,7 @@ prune frontend/.npm-logs
 # into the sdist and wheel; trim the package payload back to code plus the
 # data declared above, and keep repository-only trees out of the sdist.
 recursive-exclude xinference *
-recursive-include xinference *.py *.json *.pyx *.pxd
+recursive-include xinference *.py *.json *.pyx *.pxd *.jinja
 recursive-exclude xinference/deploy/docker *.py
 graft xinference/thirdparty
 graft xinference/ui/web/dist

--- a/frontend/src/components/pages/launch-model/index.tsx
+++ b/frontend/src/components/pages/launch-model/index.tsx
@@ -70,9 +70,7 @@ const LaunchModel = ({ routeType, initialCustomType }: LaunchModelProps) => {
   const [deleteModel, setDeleteModel] = useState<CatalogModel>();
   const handledLaunchTargetRef = useRef('');
   const requestType = isCustomRoute ? customType : (routeType as RequestModelType);
-  const showAbilityFilter = ![ModelType.Embedding, ModelType.Rerank, ModelType.Custom].includes(
-    routeType
-  );
+  const showAbilityFilter = routeType !== ModelType.Custom;
   const showStatusFilter = !isCustomRoute;
 
   const statusOptions = [

--- a/frontend/src/constants/index.ts
+++ b/frontend/src/constants/index.ts
@@ -50,6 +50,7 @@ export enum ModelAbility {
   Tools = 'tools',
   Reasoning = 'reasoning',
   Audio = 'audio',
+  Video = 'video',
   Omni = 'omni',
   Hybrid = 'hybrid',
   Embed = 'embed',

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -497,6 +497,7 @@ const en = {
     reasoning: 'Reasoning',
     tools: 'Tool Use',
     audio: 'Audio Processing',
+    video: 'Video Processing',
     omni: 'Multimodal (Omni)',
     hybrid: 'Hybrid Capability',
     text2image: 'Text to Image',

--- a/frontend/src/i18n/locales/ja.ts
+++ b/frontend/src/i18n/locales/ja.ts
@@ -484,6 +484,7 @@ const ja = {
     reasoning: '推論',
     tools: 'ツール使用',
     audio: '音声処理',
+    video: '動画処理',
     omni: 'マルチモーダル (Omni)',
     hybrid: 'ハイブリッド機能',
     text2image: 'テキストから画像',

--- a/frontend/src/i18n/locales/ko.ts
+++ b/frontend/src/i18n/locales/ko.ts
@@ -483,6 +483,7 @@ const ko = {
     reasoning: '추론',
     tools: '도구 사용',
     audio: '오디오 처리',
+    video: '비디오 처리',
     omni: '멀티모달 (Omni)',
     hybrid: '하이브리드 기능',
     text2image: '텍스트에서 이미지',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -474,6 +474,7 @@ const zh = {
     reasoning: '推理能力',
     tools: '工具使用能力',
     audio: '音频处理',
+    video: '视频处理',
     omni: '全模态',
     hybrid: '混合能力',
     text2image: '文生图',

--- a/xinference/api/schemas/requests.py
+++ b/xinference/api/schemas/requests.py
@@ -50,8 +50,8 @@ class CreateEmbeddingRequest(BaseModel):
 
 class RerankRequest(BaseModel):
     model: str
-    query: str
-    documents: List[str]
+    query: Union[str, Dict[str, Any]]
+    documents: List[Union[str, Dict[str, Any]]]
     top_n: Optional[int] = None
     return_documents: Optional[bool] = False
     return_len: Optional[bool] = False

--- a/xinference/client/restful/async_restful_client.py
+++ b/xinference/client/restful/async_restful_client.py
@@ -194,8 +194,8 @@ class AsyncRESTfulEmbeddingModelHandle(AsyncRESTfulModelHandle):
 class AsyncRESTfulRerankModelHandle(AsyncRESTfulModelHandle):
     async def rerank(
         self,
-        documents: List[str],
-        query: str,
+        documents: List[Union[str, Dict[str, Any]]],
+        query: Union[str, Dict[str, Any]],
         top_n: Optional[int] = None,
         max_chunks_per_doc: Optional[int] = None,
         return_documents: Optional[bool] = None,
@@ -207,10 +207,10 @@ class AsyncRESTfulRerankModelHandle(AsyncRESTfulModelHandle):
 
         Parameters
         ----------
-        query: str
-            The search query
-        documents: List[str]
-            The documents to rerank
+        query: Union[str, Dict[str, Any]]
+            Text or multimodal query.
+        documents: List[Union[str, Dict[str, Any]]]
+            Text or multimodal documents to rerank.
         top_n: int
             The number of results to return, defaults to returning all results
         max_chunks_per_doc: int

--- a/xinference/client/restful/restful_client.py
+++ b/xinference/client/restful/restful_client.py
@@ -166,8 +166,8 @@ class RESTfulEmbeddingModelHandle(RESTfulModelHandle):
 class RESTfulRerankModelHandle(RESTfulModelHandle):
     def rerank(
         self,
-        documents: List[str],
-        query: str,
+        documents: List[Union[str, Dict[str, Any]]],
+        query: Union[str, Dict[str, Any]],
         top_n: Optional[int] = None,
         max_chunks_per_doc: Optional[int] = None,
         return_documents: Optional[bool] = None,
@@ -179,10 +179,10 @@ class RESTfulRerankModelHandle(RESTfulModelHandle):
 
         Parameters
         ----------
-        query: str
-            The search query
-        documents: List[str]
-            The documents to rerank
+        query: Union[str, Dict[str, Any]]
+            Text or multimodal query.
+        documents: List[Union[str, Dict[str, Any]]]
+            Text or multimodal documents to rerank.
         top_n: int
             The number of results to return, defaults to returning all results
         max_chunks_per_doc: int

--- a/xinference/core/tests/test_restful_api.py
+++ b/xinference/core/tests/test_restful_api.py
@@ -36,6 +36,42 @@ class _DummyRequest:
 
 
 @pytest.mark.asyncio
+async def test_rerank_multimodal_inputs_pass_through(monkeypatch):
+    from ...api.restful_api import RESTfulAPI
+
+    monkeypatch.setenv("XINFERENCE_AUTH_ADVANCED", "false")
+    api = RESTfulAPI("localhost", "localhost", 9997)
+    supervisor = AsyncMock()
+    api._get_supervisor_ref = AsyncMock(return_value=supervisor)
+
+    model = AsyncMock()
+    model.uid = "test-reranker"
+    model.rerank = AsyncMock(return_value="{}")
+    supervisor.get_model = AsyncMock(return_value=model)
+
+    query = {"image": "https://example.com/query.png"}
+    documents = [
+        {"text": "caption"},
+        {"video": "https://example.com/document.mp4"},
+    ]
+    response = await api.rerank(
+        _DummyRequest(
+            {"model": "test-reranker", "query": query, "documents": documents}
+        )
+    )
+
+    assert response.status_code == 200
+    model.rerank.assert_awaited_once_with(
+        documents,
+        query,
+        top_n=None,
+        max_chunks_per_doc=None,
+        return_documents=False,
+        return_len=False,
+    )
+
+
+@pytest.mark.asyncio
 async def test_restful_api(setup):
     endpoint, _ = setup
     url = f"{endpoint}/v1/models"

--- a/xinference/core/tests/test_worker.py
+++ b/xinference/core/tests/test_worker.py
@@ -4352,9 +4352,9 @@ async def test_update_cache_status_skips_when_cache_tracker_ref_is_none():
 
 @pytest.mark.asyncio
 async def test_get_model_ability_handles_missing_model_family_ability():
-    assert await WorkerActor._get_model_ability(None, SimpleNamespace(), "flexible") == [
-        "flexible"
-    ]
+    assert await WorkerActor._get_model_ability(
+        None, SimpleNamespace(), "flexible"
+    ) == ["flexible"]
     assert await WorkerActor._get_model_ability(
         None,
         SimpleNamespace(model_family=SimpleNamespace(model_ability=None)),

--- a/xinference/core/tests/test_worker.py
+++ b/xinference/core/tests/test_worker.py
@@ -4348,3 +4348,15 @@ async def test_update_cache_status_skips_when_cache_tracker_ref_is_none():
         "sdxl",
         [{"model_file_location": "/tmp/sdxl"}],
     )
+
+
+@pytest.mark.asyncio
+async def test_get_model_ability_handles_missing_model_family_ability():
+    assert await WorkerActor._get_model_ability(None, SimpleNamespace(), "flexible") == [
+        "flexible"
+    ]
+    assert await WorkerActor._get_model_ability(
+        None,
+        SimpleNamespace(model_family=SimpleNamespace(model_ability=None)),
+        "embedding",
+    ) == ["embed"]

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -3039,8 +3039,14 @@ class WorkerActor(xo.StatelessActor):
         from ..model.llm.core import LLM
 
         ability_map = {
-            "embedding": ["embed"],
-            "rerank": ["rerank"],
+            "embedding": [
+                "embed",
+                *getattr(model.model_family, "model_ability", []),
+            ],
+            "rerank": [
+                "rerank",
+                *getattr(model.model_family, "model_ability", []),
+            ],
             "flexible": ["flexible"],
         }
         if model_type in ability_map:

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -3038,14 +3038,16 @@ class WorkerActor(xo.StatelessActor):
     async def _get_model_ability(self, model: Any, model_type: str) -> List[str]:
         from ..model.llm.core import LLM
 
+        model_family = getattr(model, "model_family", None)
+        model_ability = getattr(model_family, "model_ability", None) or []
         ability_map = {
             "embedding": [
                 "embed",
-                *getattr(model.model_family, "model_ability", []),
+                *model_ability,
             ],
             "rerank": [
                 "rerank",
-                *getattr(model.model_family, "model_ability", []),
+                *model_ability,
             ],
             "flexible": ["flexible"],
         }

--- a/xinference/model/embedding/core.py
+++ b/xinference/model/embedding/core.py
@@ -94,6 +94,10 @@ class EmbeddingModelFamilyV2(BaseModel, ModelInstanceInfoMixin):
     dimensions: int
     max_tokens: int
     language: List[str]
+    # Extra accepted input modalities. Text is implicit for every embedding model.
+    model_ability: List[Literal["vision", "video", "audio"]] = Field(
+        default_factory=list
+    )
     model_specs: List["EmbeddingSpecV1"]
     cache_config: Optional[dict]
     virtualenv: Optional[VirtualEnvSettings]
@@ -115,6 +119,7 @@ class EmbeddingModelFamilyV2(BaseModel, ModelInstanceInfoMixin):
             "dimensions": self.dimensions,
             "max_tokens": self.max_tokens,
             "language": self.language,
+            "model_ability": ["embed", *self.model_ability],
             "model_hub": spec.model_hub,
             "model_revision": spec.model_revision,
             "quantization": spec.quantization,

--- a/xinference/model/embedding/model_spec.json
+++ b/xinference/model/embedding/model_spec.json
@@ -1470,6 +1470,9 @@
     "model_name": "jina-clip-v2",
     "dimensions": 1024,
     "max_tokens": 8192,
+    "model_ability": [
+      "vision"
+    ],
     "language": [
       "89 languages supported"
     ],
@@ -1510,6 +1513,9 @@
     "model_name": "jina-embeddings-v4",
     "dimensions": 2048,
     "max_tokens": 32768,
+    "model_ability": [
+      "vision"
+    ],
     "language": [
       "30+ languages supported"
     ],
@@ -1634,6 +1640,11 @@
     "model_name": "jina-embeddings-v5-omni-nano",
     "dimensions": 768,
     "max_tokens": 8192,
+    "model_ability": [
+      "vision",
+      "video",
+      "audio"
+    ],
     "language": [
       "multilingual"
     ],
@@ -1678,6 +1689,11 @@
     "model_name": "jina-embeddings-v5-omni-small",
     "dimensions": 1024,
     "max_tokens": 32768,
+    "model_ability": [
+      "vision",
+      "video",
+      "audio"
+    ],
     "language": [
       "multilingual"
     ],
@@ -1802,6 +1818,10 @@
     "model_name": "Qwen3-VL-Embedding-2B",
     "dimensions": 2048,
     "max_tokens": 8192,
+    "model_ability": [
+      "vision",
+      "video"
+    ],
     "language": [
       "zh",
       "en"
@@ -1843,6 +1863,10 @@
     "model_name": "Qwen3-VL-Embedding-8B",
     "dimensions": 4096,
     "max_tokens": 8192,
+    "model_ability": [
+      "vision",
+      "video"
+    ],
     "language": [
       "zh",
       "en"
@@ -1884,6 +1908,10 @@
     "model_name": "WeMM-Embedding-2B",
     "dimensions": 2048,
     "max_tokens": 262144,
+    "model_ability": [
+      "vision",
+      "video"
+    ],
     "language": [
       "zh",
       "en"
@@ -1928,6 +1956,10 @@
     "model_name": "WeMM-Embedding-4B",
     "dimensions": 2560,
     "max_tokens": 262144,
+    "model_ability": [
+      "vision",
+      "video"
+    ],
     "language": [
       "zh",
       "en"
@@ -1972,6 +2004,10 @@
     "model_name": "WeMM-Embedding-9B",
     "dimensions": 4096,
     "max_tokens": 262144,
+    "model_ability": [
+      "vision",
+      "video"
+    ],
     "language": [
       "zh",
       "en"

--- a/xinference/model/embedding/model_spec.json
+++ b/xinference/model/embedding/model_spec.json
@@ -1738,6 +1738,9 @@
     "model_name": "gme-Qwen2-VL-2B-Instruct",
     "dimensions": 1536,
     "max_tokens": 32768,
+    "model_ability": [
+      "vision"
+    ],
     "language": [
       "en",
       "zh"
@@ -1778,6 +1781,9 @@
     "model_name": "gme-Qwen2-VL-7B-Instruct",
     "dimensions": 3584,
     "max_tokens": 32768,
+    "model_ability": [
+      "vision"
+    ],
     "language": [
       "en",
       "zh"

--- a/xinference/model/embedding/tests/test_embedding_models.py
+++ b/xinference/model/embedding/tests/test_embedding_models.py
@@ -80,6 +80,33 @@ def test_engine_supported():
     assert "sentence_transformers" in EMBEDDING_ENGINES[model_name]
 
 
+def test_multimodal_model_abilities_are_exposed():
+    expected = {
+        "jina-clip-v2": ["vision"],
+        "jina-embeddings-v4": ["vision"],
+        "jina-embeddings-v5-omni-nano": [
+            "vision",
+            "video",
+            "audio",
+        ],
+        "jina-embeddings-v5-omni-small": [
+            "vision",
+            "video",
+            "audio",
+        ],
+        "Qwen3-VL-Embedding-2B": ["vision", "video"],
+        "Qwen3-VL-Embedding-8B": ["vision", "video"],
+        "WeMM-Embedding-2B": ["vision", "video"],
+        "WeMM-Embedding-4B": ["vision", "video"],
+        "WeMM-Embedding-9B": ["vision", "video"],
+    }
+
+    for model_name, abilities in expected.items():
+        family = BUILTIN_EMBEDDING_MODELS[model_name][0]
+        assert family.model_ability == abilities
+        assert family.to_description()["model_ability"] == ["embed", *abilities]
+
+
 def test_jina_v5_requires_transformers_5_compatible_sentence_transformers():
     from packaging.requirements import InvalidRequirement, Requirement
     from packaging.utils import canonicalize_name

--- a/xinference/model/embedding/tests/test_embedding_models.py
+++ b/xinference/model/embedding/tests/test_embedding_models.py
@@ -94,6 +94,8 @@ def test_multimodal_model_abilities_are_exposed():
             "video",
             "audio",
         ],
+        "gme-Qwen2-VL-2B-Instruct": ["vision"],
+        "gme-Qwen2-VL-7B-Instruct": ["vision"],
         "Qwen3-VL-Embedding-2B": ["vision", "video"],
         "Qwen3-VL-Embedding-8B": ["vision", "video"],
         "WeMM-Embedding-2B": ["vision", "video"],

--- a/xinference/model/rerank/core.py
+++ b/xinference/model/rerank/core.py
@@ -75,6 +75,10 @@ class RerankModelFamilyV2(BaseModel, ModelInstanceInfoMixin):
     model_name: str
     model_specs: List[RerankSpecV1]
     language: List[str]
+    # Extra accepted input modalities. Text is implicit for every rerank model.
+    model_ability: List[Literal["vision", "video", "audio"]] = Field(
+        default_factory=list
+    )
     type: Optional[str] = "unknown"
     max_tokens: Optional[int]
     cache_config: Optional[dict] = None
@@ -96,6 +100,7 @@ class RerankModelFamilyV2(BaseModel, ModelInstanceInfoMixin):
             "model_engine": getattr(self, "model_engine", None),
             "model_format": spec.model_format,
             "language": self.language,
+            "model_ability": ["rerank", *self.model_ability],
             "model_revision": spec.model_revision,
             "quantization": spec.quantization,
         }

--- a/xinference/model/rerank/core.py
+++ b/xinference/model/rerank/core.py
@@ -15,7 +15,7 @@ import logging
 import os
 from abc import abstractmethod
 from collections import defaultdict
-from typing import Annotated, Dict, List, Literal, Optional, Tuple, Union
+from typing import Annotated, Any, Dict, List, Literal, Optional, Tuple, Union
 
 from ..._compat import BaseModel, Field
 from ...constants import XINFERENCE_TRUST_REMOTE_CODE
@@ -216,8 +216,8 @@ class RerankModel:
     @abstractmethod
     def rerank(
         self,
-        documents: List[str],
-        query: str,
+        documents: List[Any],
+        query: Any,
         top_n: Optional[int],
         max_chunks_per_doc: Optional[int],
         return_documents: Optional[bool],

--- a/xinference/model/rerank/model_spec.json
+++ b/xinference/model/rerank/model_spec.json
@@ -709,6 +709,10 @@
     "version": 2,
     "model_name": "Qwen3-VL-Reranker-8B",
     "type": "normal",
+    "model_ability": [
+      "vision",
+      "video"
+    ],
     "language": [
       "en",
       "zh"
@@ -750,6 +754,10 @@
     "version": 2,
     "model_name": "Qwen3-VL-Reranker-2B",
     "type": "normal",
+    "model_ability": [
+      "vision",
+      "video"
+    ],
     "language": [
       "en",
       "zh"

--- a/xinference/model/rerank/model_spec.json
+++ b/xinference/model/rerank/model_spec.json
@@ -799,6 +799,9 @@
     "version": 2,
     "model_name": "jina-reranker-m0",
     "type": "normal",
+    "model_ability": [
+      "vision"
+    ],
     "language": [
       "en",
       "zh",

--- a/xinference/model/rerank/sentence_transformers/core.py
+++ b/xinference/model/rerank/sentence_transformers/core.py
@@ -374,7 +374,9 @@ class SentenceTransformerRerankModel(RerankModel, BatchMixin):
         # branch uses this to preserve per-request isolation.
         batch_offsets = kwargs.pop("_batch_offsets", None)
         if self._vl_reranker is not None:
-            return self._rerank_vl(documents, query, **kwargs)
+            return self._rerank_vl(
+                documents, query, batch_offsets=batch_offsets, **kwargs
+            )
         assert self._model is not None
         if max_chunks_per_doc is not None:
             raise ValueError("rerank hasn't support `max_chunks_per_doc` parameter.")
@@ -541,29 +543,42 @@ class SentenceTransformerRerankModel(RerankModel, BatchMixin):
             return {"text": val}
         raise ValueError("Unsupported input type for Qwen3-VL reranker.")
 
-    def _rerank_vl(self, documents: List[Any], query: List[Any], **kwargs) -> List[Any]:
+    def _rerank_vl(
+        self,
+        documents: List[Any],
+        query: List[Any],
+        batch_offsets: Optional[List[Tuple[int, int]]] = None,
+        **kwargs,
+    ) -> List[Any]:
         if self._vl_reranker is None:
             raise RuntimeError("Qwen3-VL reranker is not initialized.")
 
         if len(query) == 0 or len(documents) == 0:
             return []
 
-        query_obj = self._normalize_vl_text(query[0])
-        doc_objs = [self._normalize_vl_text(doc) for doc in documents]
+        def process_request(
+            request_query: Any, request_documents: List[Any]
+        ) -> List[Any]:
+            payload: Dict[str, Any] = {
+                "query": self._normalize_vl_text(request_query),
+                "documents": [
+                    self._normalize_vl_text(document) for document in request_documents
+                ],
+            }
+            for key in ("instruction", "fps", "max_frames"):
+                if key in kwargs:
+                    payload[key] = kwargs[key]
+            return [float(score) for score in self._vl_reranker.process(payload)]
 
-        payload: Dict[str, Any] = {
-            "query": query_obj,
-            "documents": doc_objs,
-        }
-        if "instruction" in kwargs:
-            payload["instruction"] = kwargs.get("instruction")
-        if "fps" in kwargs:
-            payload["fps"] = kwargs.get("fps")
-        if "max_frames" in kwargs:
-            payload["max_frames"] = kwargs.get("max_frames")
+        if batch_offsets is None:
+            return process_request(query[0], documents)
 
-        scores = self._vl_reranker.process(payload)
-        return [float(score) for score in scores]
+        scores = []
+        for offset, size in batch_offsets:
+            scores.extend(
+                process_request(query[offset], documents[offset : offset + size])
+            )
+        return scores
 
     @extensible
     def rerank(

--- a/xinference/model/rerank/sentence_transformers/core.py
+++ b/xinference/model/rerank/sentence_transformers/core.py
@@ -361,8 +361,8 @@ class SentenceTransformerRerankModel(RerankModel, BatchMixin):
 
     def _rerank(
         self,
-        documents: List[str],
-        query: List[str],
+        documents: List[Any],
+        query: List[Any],
         top_n: Optional[int],
         max_chunks_per_doc: Optional[int],
         return_documents: Optional[bool],
@@ -568,8 +568,8 @@ class SentenceTransformerRerankModel(RerankModel, BatchMixin):
     @extensible
     def rerank(
         self,
-        documents: List[str],
-        query: str,
+        documents: List[Any],
+        query: Any,
         top_n: Optional[int] = None,
         max_chunks_per_doc: Optional[int] = None,
         return_documents: Optional[bool] = True,

--- a/xinference/model/rerank/sentence_transformers/core.py
+++ b/xinference/model/rerank/sentence_transformers/core.py
@@ -575,6 +575,8 @@ class SentenceTransformerRerankModel(RerankModel, BatchMixin):
 
         scores = []
         for offset, size in batch_offsets:
+            if size == 0:
+                continue
             scores.extend(
                 process_request(query[offset], documents[offset : offset + size])
             )

--- a/xinference/model/rerank/sentence_transformers/tests/test_sentence_transformers.py
+++ b/xinference/model/rerank/sentence_transformers/tests/test_sentence_transformers.py
@@ -1,8 +1,11 @@
+import asyncio
+import contextlib
 import shutil
 from unittest.mock import MagicMock
 
 import pytest
 
+from ....batch import BatchMixin
 from ...cache_manager import RerankCacheManager
 from ...core import RerankModelFamilyV2, TransformersRerankSpecV1
 from ...rerank_family import BUILTIN_RERANK_MODELS
@@ -185,4 +188,30 @@ def test_qwen3_vl_batch_isolation():
             ),
             {},
         ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_qwen3_vl_batch_skips_empty_request():
+    model = SentenceTransformerRerankModel.__new__(SentenceTransformerRerankModel)
+    model._vl_reranker = MagicMock()
+    model._vl_reranker.process.return_value = [0.9]
+    model._counter = 0
+    model.batch_interval = 0.01
+    BatchMixin.__init__(model, model.rerank)
+
+    try:
+        normal, empty = await asyncio.gather(
+            model.rerank(["A"], "Q1", None, None, True, False),
+            model.rerank([], "Q2", None, None, True, False),
+        )
+    finally:
+        model._process_batch_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await model._process_batch_task
+
+    assert normal["results"][0]["document"]["text"] == "A"
+    assert empty["results"] == []
+    assert model._vl_reranker.process.call_args_list == [
+        (({"query": {"text": "Q1"}, "documents": [{"text": "A"}]},), {})
     ]

--- a/xinference/model/rerank/sentence_transformers/tests/test_sentence_transformers.py
+++ b/xinference/model/rerank/sentence_transformers/tests/test_sentence_transformers.py
@@ -25,10 +25,15 @@ TEST_MODEL_SPEC = RerankModelFamilyV2(
 
 
 def test_multimodal_model_abilities_are_exposed():
-    for model_name in ("Qwen3-VL-Reranker-2B", "Qwen3-VL-Reranker-8B"):
+    expected = {
+        "Qwen3-VL-Reranker-2B": ["vision", "video"],
+        "Qwen3-VL-Reranker-8B": ["vision", "video"],
+        "jina-reranker-m0": ["vision"],
+    }
+    for model_name, abilities in expected.items():
         family = BUILTIN_RERANK_MODELS[model_name][0]
-        assert family.model_ability == ["vision", "video"]
-        assert family.to_description()["model_ability"] == ["rerank", "vision", "video"]
+        assert family.model_ability == abilities
+        assert family.to_description()["model_ability"] == ["rerank", *abilities]
 
 
 async def test_model():

--- a/xinference/model/rerank/sentence_transformers/tests/test_sentence_transformers.py
+++ b/xinference/model/rerank/sentence_transformers/tests/test_sentence_transformers.py
@@ -5,6 +5,7 @@ import pytest
 
 from ...cache_manager import RerankCacheManager
 from ...core import RerankModelFamilyV2, TransformersRerankSpecV1
+from ...rerank_family import BUILTIN_RERANK_MODELS
 from ..core import SentenceTransformerRerankModel
 
 TEST_MODEL_SPEC = RerankModelFamilyV2(
@@ -21,6 +22,13 @@ TEST_MODEL_SPEC = RerankModelFamilyV2(
         )
     ],
 )
+
+
+def test_multimodal_model_abilities_are_exposed():
+    for model_name in ("Qwen3-VL-Reranker-2B", "Qwen3-VL-Reranker-8B"):
+        family = BUILTIN_RERANK_MODELS[model_name][0]
+        assert family.model_ability == ["vision", "video"]
+        assert family.to_description()["model_ability"] == ["rerank", "vision", "video"]
 
 
 async def test_model():

--- a/xinference/model/rerank/sentence_transformers/tests/test_sentence_transformers.py
+++ b/xinference/model/rerank/sentence_transformers/tests/test_sentence_transformers.py
@@ -148,3 +148,41 @@ def test_jina_reranker_v35_batch_isolation():
     assert scores[2] == pytest.approx(0.9)  # C
     assert scores[3] == pytest.approx(0.8)  # D
     assert scores[4] == pytest.approx(0.7)  # E
+
+
+def test_qwen3_vl_batch_isolation():
+    model = SentenceTransformerRerankModel.__new__(SentenceTransformerRerankModel)
+    model._vl_reranker = MagicMock()
+    model._vl_reranker.process.side_effect = [[0.9, 0.8], [0.7]]
+
+    scores = model._rerank(
+        documents=["A", "B", "C"],
+        query=["Q1", "Q1", "Q2"],
+        top_n=None,
+        max_chunks_per_doc=None,
+        return_documents=True,
+        return_len=False,
+        _batch_offsets=[(0, 2), (2, 1)],
+    )
+
+    assert scores == [0.9, 0.8, 0.7]
+    assert model._vl_reranker.process.call_args_list == [
+        (
+            (
+                {
+                    "query": {"text": "Q1"},
+                    "documents": [{"text": "A"}, {"text": "B"}],
+                },
+            ),
+            {},
+        ),
+        (
+            (
+                {
+                    "query": {"text": "Q2"},
+                    "documents": [{"text": "C"}],
+                },
+            ),
+            {},
+        ),
+    ]

--- a/xinference/model/rerank/vllm/core.py
+++ b/xinference/model/rerank/vllm/core.py
@@ -21,6 +21,9 @@ from ..core import (
 )
 
 QWEN3_RERANK_TEMPLATE = int(os.getenv("XINFERENCE_QWEN3_RERANK_TEMPLATE", "1"))
+QWEN3_VL_RERANK_TEMPLATE_PATH = os.path.join(
+    os.path.dirname(__file__), "qwen3_vl_reranker.jinja"
+)
 logger = logging.getLogger(__name__)
 SUPPORTED_MODELS_PREFIXES = ["bge", "gte", "text2vec", "m3e", "Qwen3"]
 
@@ -50,7 +53,9 @@ class VLLMRerankModel(RerankModel, BatchMixin):
         self._kwargs.pop("batch_size", None)
         self._kwargs.pop("batch_interval", None)
 
-        if self.model_family.model_name in {
+        model_name = self.model_family.model_name
+        is_qwen3_vl_reranker = model_name.startswith("Qwen3-VL-Reranker")
+        if model_name in {
             "Qwen3-Reranker-0.6B",
             "Qwen3-Reranker-4B",
             "Qwen3-Reranker-8B",
@@ -67,6 +72,23 @@ class VLLMRerankModel(RerankModel, BatchMixin):
                     classifier_from_token=["no", "yes"],
                     is_original_qwen3_reranker=True,
                 )
+
+        self._qwen3_vl_reranker_template = None
+        if is_qwen3_vl_reranker:
+            if Version(vllm_version) < Version("0.14.0"):
+                raise ValueError("Qwen3-VL reranker requires vLLM>=0.14.0")
+            hf_overrides = self._kwargs.get("hf_overrides", {})
+            if not isinstance(hf_overrides, dict):
+                raise ValueError("Qwen3-VL reranker hf_overrides must be a dictionary")
+            hf_overrides.update(
+                architectures=["Qwen3VLForSequenceClassification"],
+                classifier_from_token=["no", "yes"],
+                is_original_qwen3_reranker=True,
+            )
+            self._kwargs["hf_overrides"] = hf_overrides
+            self._kwargs["runner"] = "pooling"
+            with open(QWEN3_VL_RERANK_TEMPLATE_PATH, encoding="utf-8") as template:
+                self._qwen3_vl_reranker_template = template.read()
         if Version(vllm_version) >= Version("0.13.0"):
             self._model = LLM(model=self._model_path, **self._kwargs)
         else:
@@ -75,8 +97,8 @@ class VLLMRerankModel(RerankModel, BatchMixin):
 
     def _rerank(
         self,
-        documents: List[str],
-        query: Union[str, List[str]],
+        documents: List[Any],
+        query: Union[Any, List[Any]],
         top_n: Optional[int] = None,
         max_chunks_per_doc: Optional[int] = None,
         return_documents: Optional[bool] = None,
@@ -103,10 +125,10 @@ class VLLMRerankModel(RerankModel, BatchMixin):
         assert self._model is not None
 
         documents_size = len(documents)
-        if isinstance(query, str):
-            query_list = [query] * documents_size
-        else:
+        if isinstance(query, list):
             query_list = query
+        else:
+            query_list = [query] * documents_size
 
         if self.model_family.model_name in {
             "Qwen3-Reranker-0.6B",
@@ -137,11 +159,16 @@ class VLLMRerankModel(RerankModel, BatchMixin):
                 ]
                 query_list = processed_queries
                 documents = processed_documents
-        outputs = self._model.score(
-            query_list,
-            documents,
-            use_tqdm=False,
-        )
+        score_kwargs = {"use_tqdm": False}
+        if self.model_family.model_name.startswith("Qwen3-VL-Reranker"):
+            query_list = [
+                self._to_score_multimodal_param(query) for query in query_list
+            ]
+            documents = [
+                self._to_score_multimodal_param(document) for document in documents
+            ]
+            score_kwargs["chat_template"] = self._qwen3_vl_reranker_template
+        outputs = self._model.score(query_list, documents, **score_kwargs)
         # clear cache if possible
         self._counter += 1
         if self._counter % RERANK_EMPTY_CACHE_COUNT == 0:
@@ -150,11 +177,50 @@ class VLLMRerankModel(RerankModel, BatchMixin):
             empty_cache()
         return outputs
 
+    @staticmethod
+    def _to_score_multimodal_param(value: Any) -> Any:
+        """Translate Xinference multimodal rerank inputs for vLLM score."""
+        if isinstance(value, str):
+            return value
+        if not isinstance(value, dict):
+            raise ValueError(
+                "Qwen3-VL reranker inputs must be strings or multimodal dictionaries"
+            )
+        if "content" in value:
+            content = value["content"]
+            if not isinstance(content, list):
+                raise ValueError("Qwen3-VL reranker content must be a list")
+            return {"content": content}
+
+        content = []
+        if "text" in value:
+            content.append({"type": "text", "text": value["text"]})
+        for input_key, content_type, content_key in (
+            ("image", "image_url", "image_url"),
+            ("image_url", "image_url", "image_url"),
+            ("video", "video_url", "video_url"),
+            ("video_url", "video_url", "video_url"),
+        ):
+            if input_key not in value:
+                continue
+            media = value[input_key]
+            content.append(
+                {
+                    "type": content_type,
+                    content_key: media if isinstance(media, dict) else {"url": media},
+                }
+            )
+        if not content:
+            raise ValueError(
+                "Qwen3-VL reranker inputs must contain text, image, or video content"
+            )
+        return {"content": content}
+
     @extensible
     def rerank(
         self,
-        documents: List[str],
-        query: str,
+        documents: List[Any],
+        query: Any,
         top_n: Optional[int] = None,
         max_chunks_per_doc: Optional[int] = None,
         return_documents: Optional[bool] = None,

--- a/xinference/model/rerank/vllm/core.py
+++ b/xinference/model/rerank/vllm/core.py
@@ -168,7 +168,11 @@ class VLLMRerankModel(RerankModel, BatchMixin):
                 self._to_score_multimodal_param(document) for document in documents
             ]
             score_kwargs["chat_template"] = self._qwen3_vl_reranker_template
-        outputs = self._model.score(query_list, documents, **score_kwargs)
+            outputs = []
+            for query, document in zip(query_list, documents):
+                outputs.extend(self._model.score(query, document, **score_kwargs))
+        else:
+            outputs = self._model.score(query_list, documents, **score_kwargs)
         # clear cache if possible
         self._counter += 1
         if self._counter % RERANK_EMPTY_CACHE_COUNT == 0:

--- a/xinference/model/rerank/vllm/core.py
+++ b/xinference/model/rerank/vllm/core.py
@@ -167,10 +167,23 @@ class VLLMRerankModel(RerankModel, BatchMixin):
             documents = [
                 self._to_score_multimodal_param(document) for document in documents
             ]
+            if len(query_list) != len(documents):
+                raise ValueError(
+                    "Qwen3-VL reranker query and documents must have equal length"
+                )
             score_kwargs["chat_template"] = self._qwen3_vl_reranker_template
             outputs = []
             for query, document in zip(query_list, documents):
-                outputs.extend(self._model.score(query, document, **score_kwargs))
+                if self._is_vllm_media(query) and self._is_vllm_media(document):
+                    raise ValueError(
+                        "Qwen3-VL reranker with vLLM does not support media in both query and document"
+                    )
+                pair_outputs = self._model.score(query, document, **score_kwargs)
+                if len(pair_outputs) != 1:
+                    raise RuntimeError(
+                        "Qwen3-VL reranker with vLLM must return one score per document"
+                    )
+                outputs.extend(pair_outputs)
         else:
             outputs = self._model.score(query_list, documents, **score_kwargs)
         # clear cache if possible
@@ -194,31 +207,42 @@ class VLLMRerankModel(RerankModel, BatchMixin):
             content = value["content"]
             if not isinstance(content, list):
                 raise ValueError("Qwen3-VL reranker content must be a list")
-            return {"content": content}
-
-        content = []
-        if "text" in value:
-            content.append({"type": "text", "text": value["text"]})
-        for input_key, content_type, content_key in (
-            ("image", "image_url", "image_url"),
-            ("image_url", "image_url", "image_url"),
-            ("video", "video_url", "video_url"),
-            ("video_url", "video_url", "video_url"),
-        ):
-            if input_key not in value:
-                continue
-            media = value[input_key]
-            content.append(
-                {
-                    "type": content_type,
-                    content_key: media if isinstance(media, dict) else {"url": media},
-                }
-            )
-        if not content:
+        else:
+            content = []
+            if "text" in value:
+                content.append({"type": "text", "text": value["text"]})
+            for input_key, content_type, content_key in (
+                ("image", "image_url", "image_url"),
+                ("image_url", "image_url", "image_url"),
+                ("video", "video_url", "video_url"),
+                ("video_url", "video_url", "video_url"),
+            ):
+                if input_key not in value:
+                    continue
+                media = value[input_key]
+                content.append(
+                    {
+                        "type": content_type,
+                        content_key: (
+                            media if isinstance(media, dict) else {"url": media}
+                        ),
+                    }
+                )
+        if len(content) != 1:
             raise ValueError(
-                "Qwen3-VL reranker inputs must contain text, image, or video content"
+                "Qwen3-VL reranker with vLLM supports one content item per input"
             )
+        if not isinstance(content[0], dict) or content[0].get("type") not in {
+            "text",
+            "image_url",
+            "video_url",
+        }:
+            raise ValueError("Qwen3-VL reranker content type is not supported by vLLM")
         return {"content": content}
+
+    @staticmethod
+    def _is_vllm_media(value: Any) -> bool:
+        return isinstance(value, dict) and value["content"][0]["type"] != "text"
 
     @extensible
     def rerank(

--- a/xinference/model/rerank/vllm/qwen3_vl_reranker.jinja
+++ b/xinference/model/rerank/vllm/qwen3_vl_reranker.jinja
@@ -1,0 +1,16 @@
+<|im_start|>system
+Judge whether the Document meets the requirements based on the Query and the Instruct provided. Note that the answer can only be "yes" or "no".<|im_end|>
+<|im_start|>user
+<Instruct>: {{ instruction | default(instruct | default(messages | selectattr("role", "eq", "system") | map(attribute="content") | first | default("Given a search query, retrieve relevant candidates that answer the query.", true), true), true) }}<Query>:{{
+    messages
+    | selectattr("role", "eq", "query")
+    | map(attribute="content")
+    | first
+}}
+<Document>:{{
+    messages
+    | selectattr("role", "eq", "document")
+    | map(attribute="content")
+    | first
+}}<|im_end|>
+<|im_start|>assistant

--- a/xinference/model/rerank/vllm/tests/test_vllm.py
+++ b/xinference/model/rerank/vllm/tests/test_vllm.py
@@ -66,26 +66,15 @@ def test_qwen3_vl_rerank_converts_multimodal_inputs():
 
     outputs = model._rerank(
         documents=[
-            {"text": "document", "image": "https://example.com/image.jpg"},
+            {"image": "https://example.com/image.jpg"},
             {"video": "https://example.com/second-video.mp4"},
         ],
-        query={"video": "https://example.com/video.mp4"},
+        query="query",
     )
 
-    query = {
-        "content": [
-            {
-                "type": "video_url",
-                "video_url": {"url": "https://example.com/video.mp4"},
-            }
-        ]
-    }
+    query = "query"
     first_document = {
         "content": [
-            {
-                "type": "text",
-                "text": "document",
-            },
             {
                 "type": "image_url",
                 "image_url": {"url": "https://example.com/image.jpg"},
@@ -106,6 +95,26 @@ def test_qwen3_vl_rerank_converts_multimodal_inputs():
         call(query, second_document, **score_kwargs),
     ]
     assert outputs == [first_output, second_output]
+
+
+def test_qwen3_vl_rerank_rejects_unsupported_multimodal_pairs():
+    model = object.__new__(VLLMRerankModel)
+    model.model_family = SimpleNamespace(model_name="Qwen3-VL-Reranker-2B")
+    model._model = MagicMock()
+    model._counter = 0
+    model._qwen3_vl_reranker_template = "template"
+
+    with pytest.raises(ValueError, match="one content item"):
+        model._rerank(
+            documents=[{"text": "document", "image": "https://example.com/image.jpg"}],
+            query="query",
+        )
+
+    with pytest.raises(ValueError, match="media in both query and document"):
+        model._rerank(
+            documents=[{"image": "https://example.com/image.jpg"}],
+            query={"video": "https://example.com/video.mp4"},
+        )
 
 
 @pytest.mark.skipif(VLLMRerankModel.check_lib() != True, reason="vllm not installed")

--- a/xinference/model/rerank/vllm/tests/test_vllm.py
+++ b/xinference/model/rerank/vllm/tests/test_vllm.py
@@ -2,7 +2,7 @@ import shutil
 import sys
 import types
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 
 import pytest
 
@@ -61,38 +61,89 @@ def test_qwen3_vl_rerank_converts_multimodal_inputs():
     model._counter = 0
     model._qwen3_vl_reranker_template = "template"
 
-    model._rerank(
-        documents=[{"text": "document", "image": "https://example.com/image.jpg"}],
+    first_output, second_output = MagicMock(), MagicMock()
+    model._model.score.side_effect = [[first_output], [second_output]]
+
+    outputs = model._rerank(
+        documents=[
+            {"text": "document", "image": "https://example.com/image.jpg"},
+            {"video": "https://example.com/second-video.mp4"},
+        ],
         query={"video": "https://example.com/video.mp4"},
     )
 
-    assert model._model.score.call_args.args == (
-        [
+    query = {
+        "content": [
             {
-                "content": [
-                    {
-                        "type": "video_url",
-                        "video_url": {"url": "https://example.com/video.mp4"},
-                    }
-                ]
+                "type": "video_url",
+                "video_url": {"url": "https://example.com/video.mp4"},
             }
-        ],
-        [
-            {
-                "content": [
-                    {"type": "text", "text": "document"},
-                    {
-                        "type": "image_url",
-                        "image_url": {"url": "https://example.com/image.jpg"},
-                    },
-                ]
-            }
-        ],
-    )
-    assert model._model.score.call_args.kwargs == {
-        "use_tqdm": False,
-        "chat_template": "template",
+        ]
     }
+    first_document = {
+        "content": [
+            {
+                "type": "text",
+                "text": "document",
+            },
+            {
+                "type": "image_url",
+                "image_url": {"url": "https://example.com/image.jpg"},
+            },
+        ]
+    }
+    second_document = {
+        "content": [
+            {
+                "type": "video_url",
+                "video_url": {"url": "https://example.com/second-video.mp4"},
+            }
+        ]
+    }
+    score_kwargs = {"use_tqdm": False, "chat_template": "template"}
+    assert model._model.score.call_args_list == [
+        call(query, first_document, **score_kwargs),
+        call(query, second_document, **score_kwargs),
+    ]
+    assert outputs == [first_output, second_output]
+
+
+@pytest.mark.skipif(VLLMRerankModel.check_lib() != True, reason="vllm not installed")
+def test_qwen3_vl_score_wrapper_is_unwrapped_by_vllm(monkeypatch):
+    from vllm import LLM
+
+    query = {
+        "content": [
+            {
+                "type": "text",
+                "text": "query",
+            }
+        ]
+    }
+    document = {
+        "content": [
+            {
+                "type": "image_url",
+                "image_url": {"url": "https://example.com/image.jpg"},
+            }
+        ]
+    }
+    llm = object.__new__(LLM)
+    llm.model_config = SimpleNamespace(
+        runner_type="pooling",
+        is_cross_encoder=True,
+        hf_config=SimpleNamespace(num_labels=1),
+        is_multimodal_model=True,
+    )
+    llm.get_tokenizer = MagicMock()
+
+    def cross_encoding_score(_, __, data_1, data_2, *args, **kwargs):
+        assert data_1 == query["content"]
+        assert data_2 == document["content"]
+        return []
+
+    monkeypatch.setattr(LLM, "_cross_encoding_score", cross_encoding_score)
+    assert LLM.score(llm, query, document, use_tqdm=False) == []
 
 
 @pytest.mark.skipif(VLLMRerankModel.check_lib() != True, reason="vllm not installed")

--- a/xinference/model/rerank/vllm/tests/test_vllm.py
+++ b/xinference/model/rerank/vllm/tests/test_vllm.py
@@ -1,4 +1,8 @@
 import shutil
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -21,6 +25,74 @@ TEST_MODEL_SPEC = RerankModelFamilyV2(
         )
     ],
 )
+
+
+def test_qwen3_vl_load_configures_vllm(monkeypatch):
+    from .. import core
+
+    llm = MagicMock()
+    llm.return_value.get_tokenizer.return_value = MagicMock()
+    fake_vllm = types.ModuleType("vllm")
+    fake_vllm.LLM = llm
+    fake_vllm.__version__ = "0.14.0"
+    monkeypatch.setitem(sys.modules, "vllm", fake_vllm)
+    monkeypatch.setattr(core, "is_vacc_available", lambda: False)
+
+    model = object.__new__(VLLMRerankModel)
+    model._kwargs = {}
+    model._model_path = "/model"
+    model.model_family = SimpleNamespace(model_name="Qwen3-VL-Reranker-2B")
+    model.load()
+
+    kwargs = llm.call_args.kwargs
+    assert kwargs["runner"] == "pooling"
+    assert kwargs["hf_overrides"] == {
+        "architectures": ["Qwen3VLForSequenceClassification"],
+        "classifier_from_token": ["no", "yes"],
+        "is_original_qwen3_reranker": True,
+    }
+    assert "<|im_start|>system" in model._qwen3_vl_reranker_template
+
+
+def test_qwen3_vl_rerank_converts_multimodal_inputs():
+    model = object.__new__(VLLMRerankModel)
+    model.model_family = SimpleNamespace(model_name="Qwen3-VL-Reranker-2B")
+    model._model = MagicMock()
+    model._counter = 0
+    model._qwen3_vl_reranker_template = "template"
+
+    model._rerank(
+        documents=[{"text": "document", "image": "https://example.com/image.jpg"}],
+        query={"video": "https://example.com/video.mp4"},
+    )
+
+    assert model._model.score.call_args.args == (
+        [
+            {
+                "content": [
+                    {
+                        "type": "video_url",
+                        "video_url": {"url": "https://example.com/video.mp4"},
+                    }
+                ]
+            }
+        ],
+        [
+            {
+                "content": [
+                    {"type": "text", "text": "document"},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "https://example.com/image.jpg"},
+                    },
+                ]
+            }
+        ],
+    )
+    assert model._model.score.call_args.kwargs == {
+        "use_tqdm": False,
+        "chat_template": "template",
+    }
 
 
 @pytest.mark.skipif(VLLMRerankModel.check_lib() != True, reason="vllm not installed")


### PR DESCRIPTION
## Summary

- Add vision, video, and audio ability metadata for supported embedding and rerank models.
- Expose abilities in model descriptions and runtime status.
- Add model-ability filtering for embedding and rerank model lists.
- Add localized `video` ability labels.
