### PR TITLE
feat(ui): prefer system download source

### DIFF
--- a/frontend/src/components/pages/launch-model/launch-dialog/download-source-utils.mjs
+++ b/frontend/src/components/pages/launch-model/launch-dialog/download-source-utils.mjs
@@ -1,0 +1,9 @@
+export function shouldApplyPreferredDownloadSource(
+  preferredSource,
+  options,
+  userChangedDownloadHub
+) {
+  return (
+    !userChangedDownloadHub && options.some((option) => option.value === preferredSource)
+  );
+}

--- a/frontend/src/components/pages/launch-model/launch-dialog/download-source-utils.test.mjs
+++ b/frontend/src/components/pages/launch-model/launch-dialog/download-source-utils.test.mjs
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { shouldApplyPreferredDownloadSource } from './download-source-utils.mjs';
+
+const options = [{ value: 'auto' }, { value: 'huggingface' }, { value: 'modelscope' }];
+
+test('preserves a download hub selected before settings response resolves', async () => {
+  let resolvePreferredSource;
+  const preferredSource = new Promise((resolve) => {
+    resolvePreferredSource = resolve;
+  });
+  let userChangedDownloadHub = false;
+
+  userChangedDownloadHub = true;
+  resolvePreferredSource('modelscope');
+
+  assert.equal(
+    shouldApplyPreferredDownloadSource(
+      await preferredSource,
+      options,
+      userChangedDownloadHub
+    ),
+    false
+  );
+});
+
+test('applies a matching preferred source before user interaction', () => {
+  assert.equal(shouldApplyPreferredDownloadSource('modelscope', options, false), true);
+});
+
+test('does not apply an unavailable preferred source', () => {
+  assert.equal(shouldApplyPreferredDownloadSource('csghub', options, false), false);
+});

--- a/frontend/src/components/pages/launch-model/launch-dialog/launch-dialog.tsx
+++ b/frontend/src/components/pages/launch-model/launch-dialog/launch-dialog.tsx
@@ -87,6 +87,10 @@ interface LaunchProgressResponse {
   replicas?: LaunchProgressReplica[];
 }
 
+interface SystemSettingsResponse {
+  download_source: string;
+}
+
 const DOWNLOAD_TERMINAL_STAGES = new Set(['completed', 'failed', 'cancelled']);
 
 const DOWNLOAD_ONLY_EXCLUDED_FIELDS = new Set([
@@ -416,6 +420,11 @@ export default function LaunchDialog({
       value: item,
     }));
   }, [model?.download_hubs, model?.modelSpecs, modelEngineValue]);
+  const downloadHubOptionsRef = useRef(downloadHubOptions);
+
+  useEffect(() => {
+    downloadHubOptionsRef.current = downloadHubOptions;
+  }, [downloadHubOptions]);
 
   const workerIpFieldProps = useMemo(
     () => ({
@@ -1846,6 +1855,34 @@ export default function LaunchDialog({
     if (latestConfig) {
       form.setFieldsValue(transformFetchToForm(latestConfig.data));
     }
+  }, [form, isOpen, model?.model_name]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    let active = true;
+
+    const applyPreferredDownloadSource = async () => {
+      try {
+        const { download_source } = await request.get<SystemSettingsResponse>(
+          '/v1/cluster/system_settings'
+        );
+        if (
+          active &&
+          downloadHubOptionsRef.current.some((option) => option.value === download_source)
+        ) {
+          form.setFieldValue('download_hub', download_source);
+        }
+      } catch {
+        // Keep the current selection when settings are unavailable or unauthorized.
+      }
+    };
+
+    void applyPreferredDownloadSource();
+
+    return () => {
+      active = false;
+    };
   }, [form, isOpen, model?.model_name]);
 
   useEffect(() => {

--- a/frontend/src/components/pages/launch-model/launch-dialog/launch-dialog.tsx
+++ b/frontend/src/components/pages/launch-model/launch-dialog/launch-dialog.tsx
@@ -125,7 +125,7 @@ export default function LaunchDialog({
   const [form] = useForm();
   const { t } = useI18n();
   const { clusterAuth } = useGlobal();
-  const { isAdmin } = useMenuAuth();
+  const { isAdmin, hasSettingsRead } = useMenuAuth();
   const router = useRouter();
   const [loading, setLoading] = useState(false);
   const [isDownloading, setIsDownloading] = useState(false);
@@ -1858,7 +1858,7 @@ export default function LaunchDialog({
   }, [form, isOpen, model?.model_name]);
 
   useEffect(() => {
-    if (!isOpen) return;
+    if (!isOpen || (clusterAuth?.auth && !hasSettingsRead)) return;
 
     let active = true;
 
@@ -1883,7 +1883,7 @@ export default function LaunchDialog({
     return () => {
       active = false;
     };
-  }, [form, isOpen, model?.model_name]);
+  }, [clusterAuth?.auth, form, hasSettingsRead, isOpen, model?.model_name]);
 
   useEffect(() => {
     return () => {

--- a/frontend/src/components/pages/launch-model/launch-dialog/launch-dialog.tsx
+++ b/frontend/src/components/pages/launch-model/launch-dialog/launch-dialog.tsx
@@ -60,6 +60,7 @@ import CommandLine from './command-line';
 import DownloadProgressDetails, { type DownloadProgressFile } from './download-progress-details';
 import ReplicaPlacementConfig from './replica-placement-config';
 import { FormField } from '@/components/ui/form-field';
+import { shouldApplyPreferredDownloadSource } from './download-source-utils.mjs';
 
 interface LaunchDialogProps {
   model?: CatalogModel;
@@ -421,6 +422,16 @@ export default function LaunchDialog({
     }));
   }, [model?.download_hubs, model?.modelSpecs, modelEngineValue]);
   const downloadHubOptionsRef = useRef(downloadHubOptions);
+  const downloadHubTouchedRef = useRef(false);
+  const downloadHubFieldProps = useMemo(
+    () => ({
+      options: downloadHubOptions,
+      onChange: () => {
+        downloadHubTouchedRef.current = true;
+      },
+    }),
+    [downloadHubOptions]
+  );
 
   useEffect(() => {
     downloadHubOptionsRef.current = downloadHubOptions;
@@ -689,7 +700,7 @@ export default function LaunchDialog({
         type: 'select',
         label: t('launchModel.downloadHub'),
         placeholder: t('launchModel.downloadHubPlaceholder'),
-        fieldProps: { options: downloadHubOptions },
+        fieldProps: downloadHubFieldProps,
       },
       {
         name: 'enable_thinking',
@@ -803,7 +814,7 @@ export default function LaunchDialog({
         type: 'select',
         label: t('launchModel.downloadHub'),
         placeholder: t('launchModel.downloadHubPlaceholder'),
-        fieldProps: { options: downloadHubOptions },
+        fieldProps: downloadHubFieldProps,
       },
       {
         name: 'request_limits',
@@ -909,7 +920,7 @@ export default function LaunchDialog({
         type: 'select',
         label: t('launchModel.downloadHub'),
         placeholder: t('launchModel.downloadHubPlaceholder'),
-        fieldProps: { options: downloadHubOptions },
+        fieldProps: downloadHubFieldProps,
       },
       {
         name: 'gguf_quantization',
@@ -1030,7 +1041,7 @@ export default function LaunchDialog({
         type: 'select',
         label: t('launchModel.downloadHub'),
         placeholder: t('launchModel.downloadHubPlaceholder'),
-        fieldProps: { options: downloadHubOptions },
+        fieldProps: downloadHubFieldProps,
       },
       {
         name: 'request_limits',
@@ -1158,7 +1169,7 @@ export default function LaunchDialog({
         type: 'select',
         label: t('launchModel.downloadHub'),
         placeholder: t('launchModel.downloadHubPlaceholder'),
-        fieldProps: { options: downloadHubOptions },
+        fieldProps: downloadHubFieldProps,
       },
       {
         name: 'request_limits',
@@ -1263,7 +1274,7 @@ export default function LaunchDialog({
         type: 'select',
         label: t('launchModel.downloadHub'),
         placeholder: t('launchModel.downloadHubPlaceholder'),
-        fieldProps: { options: downloadHubOptions },
+        fieldProps: downloadHubFieldProps,
       },
       {
         name: 'request_limits',
@@ -1370,7 +1381,7 @@ export default function LaunchDialog({
         type: 'select',
         label: t('launchModel.downloadHub'),
         placeholder: t('launchModel.downloadHubPlaceholder'),
-        fieldProps: { options: downloadHubOptions },
+        fieldProps: downloadHubFieldProps,
       },
       {
         name: 'request_limits',
@@ -1848,6 +1859,7 @@ export default function LaunchDialog({
   useEffect(() => {
     if (!isOpen) return;
 
+    downloadHubTouchedRef.current = false;
     const latestConfig = getLatestModelConfigHistory(model?.model_name);
 
     form.resetFields();
@@ -1869,7 +1881,11 @@ export default function LaunchDialog({
         );
         if (
           active &&
-          downloadHubOptionsRef.current.some((option) => option.value === download_source)
+          shouldApplyPreferredDownloadSource(
+            download_source,
+            downloadHubOptionsRef.current,
+            downloadHubTouchedRef.current
+          )
         ) {
           form.setFieldValue('download_hub', download_source);
         }


### PR DESCRIPTION
## Summary

- Read system `download_source` when opening model launch dialog.
- Set `download_hub` only when source exists in current filtered hub options.
- Preserve current selection when source does not match, settings request fails, or caller lacks permission.
