### PR TITLE
feat(audio): add multilingual TTS language controls

### DIFF
--- a/frontend/src/components/pages/running-model-detail/capability-config.tsx
+++ b/frontend/src/components/pages/running-model-detail/capability-config.tsx
@@ -840,6 +840,7 @@ export const CAPABILITY_CONFIGS: Partial<Record<ModelAbility, CapabilityConfig>>
       seed: -1,
       prompt_speech: [],
       prompt_text: '',
+      language: '',
       instruct: '',
       use_emo_vector: false,
       emo_vector: [...EMPTY_INDEX_TTS_EMOTION_VECTOR],
@@ -855,6 +856,7 @@ export const CAPABILITY_CONFIGS: Partial<Record<ModelAbility, CapabilityConfig>>
       const promptSpeech = supportsVoiceCloning ? firstUpload(values, 'prompt_speech') : undefined;
       const kwargs: Record<string, unknown> = {};
       const promptText = stringValue(values.prompt_text).trim();
+      const language = stringValue(values.language).trim();
       const instruct = stringValue(values.instruct).trim();
       const seed = parseScalarSeed(values.seed);
       const responseFormat = stringValue(values.response_format).trim().toLowerCase() || 'mp3';
@@ -862,6 +864,10 @@ export const CAPABILITY_CONFIGS: Partial<Record<ModelAbility, CapabilityConfig>>
 
       if (seed !== undefined) {
         kwargs.seed = seed;
+      }
+
+      if (language) {
+        kwargs.language = language;
       }
 
       if (promptSpeech) {

--- a/frontend/src/components/pages/running-model-detail/panels/form-panels.tsx
+++ b/frontend/src/components/pages/running-model-detail/panels/form-panels.tsx
@@ -713,6 +713,7 @@ export function SpeechPanel({ form, model }: CapabilityFormProps) {
       : SPEECH_RESPONSE_FORMAT_OPTIONS;
   const supportsVoiceCloning = model.model_ability.includes(ModelAbility.Text2audioVoiceCloning);
   const supportsVoiceDesign = model.model_ability.includes(ModelAbility.Text2audioVoiceDesign);
+  const languageOptions = (model.model_lang ?? []).map((value) => ({ label: value, value }));
   const promptSpeech = useWatch('prompt_speech', form);
   const hasPromptSpeech =
     supportsVoiceCloning && Array.isArray(promptSpeech) && promptSpeech.length > 0;
@@ -746,6 +747,11 @@ export function SpeechPanel({ form, model }: CapabilityFormProps) {
           <FormField name="speed" label="Speed" normalize={normalizeNumberInput}>
             <Input type="number" min={0.5} max={2} step={0.1} />
           </FormField>
+          {languageOptions.length > 0 && (
+            <FormField name="language" label="Language">
+              <Select options={languageOptions} placeholder="Optional" />
+            </FormField>
+          )}
         </div>
       )}
       <div className="grid grid-cols-2 gap-3">

--- a/frontend/src/components/pages/running-model-detail/panels/form-panels.tsx
+++ b/frontend/src/components/pages/running-model-detail/panels/form-panels.tsx
@@ -714,10 +714,7 @@ export function SpeechPanel({ form, model }: CapabilityFormProps) {
   const supportsVoiceCloning = model.model_ability.includes(ModelAbility.Text2audioVoiceCloning);
   const supportsVoiceDesign = model.model_ability.includes(ModelAbility.Text2audioVoiceDesign);
   const supportedLanguages = model.model_lang ?? [];
-  const languageOptions = [
-    { label: '', value: '' },
-    ...supportedLanguages.map((value) => ({ label: value, value })),
-  ];
+  const languageOptions = supportedLanguages.map((value) => ({ label: value, value }));
   const promptSpeech = useWatch('prompt_speech', form);
   const hasPromptSpeech =
     supportsVoiceCloning && Array.isArray(promptSpeech) && promptSpeech.length > 0;
@@ -751,6 +748,16 @@ export function SpeechPanel({ form, model }: CapabilityFormProps) {
           <FormField name="speed" label="Speed" normalize={normalizeNumberInput}>
             <Input type="number" min={0.5} max={2} step={0.1} />
           </FormField>
+          <FormField
+            name="stream"
+            label="Streaming"
+            valuePropName="checked"
+            layout="horizontal"
+            className="flex h-full items-center"
+            tooltip="Play supported audio formats while they are generated."
+          >
+            <Switch />
+          </FormField>
           {supportedLanguages.length > 0 && (
             <FormField name="language" label="Language">
               <Select options={languageOptions} placeholder="Optional" />
@@ -773,17 +780,6 @@ export function SpeechPanel({ form, model }: CapabilityFormProps) {
       {isMusicGeneration && (
         <FormField name="response_format" label="Output Format">
           <Select options={MUSIC_RESPONSE_FORMAT_OPTIONS} allowClear={false} />
-        </FormField>
-      )}
-      {!isMusicGeneration && (
-        <FormField
-          name="stream"
-          label="Streaming"
-          valuePropName="checked"
-          layout="horizontal"
-          tooltip="Play supported audio formats while they are generated."
-        >
-          <Switch />
         </FormField>
       )}
       {showPromptSpeech && (

--- a/frontend/src/components/pages/running-model-detail/panels/form-panels.tsx
+++ b/frontend/src/components/pages/running-model-detail/panels/form-panels.tsx
@@ -713,7 +713,11 @@ export function SpeechPanel({ form, model }: CapabilityFormProps) {
       : SPEECH_RESPONSE_FORMAT_OPTIONS;
   const supportsVoiceCloning = model.model_ability.includes(ModelAbility.Text2audioVoiceCloning);
   const supportsVoiceDesign = model.model_ability.includes(ModelAbility.Text2audioVoiceDesign);
-  const languageOptions = (model.model_lang ?? []).map((value) => ({ label: value, value }));
+  const supportedLanguages = model.model_lang ?? [];
+  const languageOptions = [
+    { label: '', value: '' },
+    ...supportedLanguages.map((value) => ({ label: value, value })),
+  ];
   const promptSpeech = useWatch('prompt_speech', form);
   const hasPromptSpeech =
     supportsVoiceCloning && Array.isArray(promptSpeech) && promptSpeech.length > 0;
@@ -747,7 +751,7 @@ export function SpeechPanel({ form, model }: CapabilityFormProps) {
           <FormField name="speed" label="Speed" normalize={normalizeNumberInput}>
             <Input type="number" min={0.5} max={2} step={0.1} />
           </FormField>
-          {languageOptions.length > 0 && (
+          {supportedLanguages.length > 0 && (
             <FormField name="language" label="Language">
               <Select options={languageOptions} placeholder="Optional" />
             </FormField>

--- a/xinference/model/audio/core.py
+++ b/xinference/model/audio/core.py
@@ -77,6 +77,7 @@ class AudioModelFamilyV2(CacheableModelSpec, ModelInstanceInfoMixin):
     model_revision: Optional[str]
     multilingual: bool
     language: Optional[str]
+    model_lang: Optional[List[str]]
     model_ability: Optional[List[str]]
     default_model_config: Optional[Dict[str, Any]]
     default_transcription_config: Optional[Dict[str, Any]]
@@ -94,6 +95,7 @@ class AudioModelFamilyV2(CacheableModelSpec, ModelInstanceInfoMixin):
             "address": getattr(self, "address", None),
             "accelerators": getattr(self, "accelerators", None),
             "model_name": self.model_name,
+            "model_lang": self.model_lang or [],
             "model_family": self.model_family,
             "model_revision": self.model_revision,
             "model_ability": self.model_ability,

--- a/xinference/model/audio/model_spec.json
+++ b/xinference/model/audio/model_spec.json
@@ -2082,6 +2082,19 @@
     "model_name": "Qwen3-TTS-12Hz-0.6B-Base",
     "model_description": "This is a custom model description.",
     "multilingual": true,
+    "model_lang": [
+      "auto",
+      "chinese",
+      "english",
+      "french",
+      "german",
+      "italian",
+      "japanese",
+      "korean",
+      "portuguese",
+      "russian",
+      "spanish"
+    ],
     "model_ability": [
       "text2audio",
       "text2audio_voice_cloning"
@@ -2117,6 +2130,19 @@
     "cache_name": "Qwen3-TTS-12Hz-0.6B-Base-MLX",
     "model_description": "Qwen3-TTS Base 8-bit optimized for Apple Silicon with mlx-audio.",
     "multilingual": true,
+    "model_lang": [
+      "auto",
+      "chinese",
+      "english",
+      "french",
+      "german",
+      "italian",
+      "japanese",
+      "korean",
+      "portuguese",
+      "russian",
+      "spanish"
+    ],
     "model_ability": [
       "text2audio",
       "text2audio_voice_cloning"
@@ -2143,6 +2169,19 @@
     "model_name": "Qwen3-TTS-12Hz-1.7B-Base",
     "model_description": "This is a custom model description.",
     "multilingual": true,
+    "model_lang": [
+      "auto",
+      "chinese",
+      "english",
+      "french",
+      "german",
+      "italian",
+      "japanese",
+      "korean",
+      "portuguese",
+      "russian",
+      "spanish"
+    ],
     "model_ability": [
       "text2audio",
       "text2audio_voice_cloning"
@@ -2178,6 +2217,19 @@
     "cache_name": "Qwen3-TTS-12Hz-1.7B-Base-MLX",
     "model_description": "Qwen3-TTS Base 8-bit optimized for Apple Silicon with mlx-audio.",
     "multilingual": true,
+    "model_lang": [
+      "auto",
+      "chinese",
+      "english",
+      "french",
+      "german",
+      "italian",
+      "japanese",
+      "korean",
+      "portuguese",
+      "russian",
+      "spanish"
+    ],
     "model_ability": [
       "text2audio",
       "text2audio_voice_cloning"
@@ -2204,6 +2256,21 @@
     "model_name": "Qwen3-TTS-12Hz-0.6B-CustomVoice",
     "model_description": "This is a custom model description.",
     "multilingual": true,
+    "model_lang": [
+      "auto",
+      "chinese",
+      "english",
+      "french",
+      "german",
+      "italian",
+      "japanese",
+      "korean",
+      "portuguese",
+      "russian",
+      "spanish",
+      "beijing_dialect",
+      "sichuan_dialect"
+    ],
     "model_ability": [
       "text2audio"
     ],
@@ -2238,6 +2305,21 @@
     "cache_name": "Qwen3-TTS-12Hz-0.6B-CustomVoice-MLX",
     "model_description": "Qwen3-TTS CustomVoice 8-bit optimized for Apple Silicon with mlx-audio.",
     "multilingual": true,
+    "model_lang": [
+      "auto",
+      "chinese",
+      "english",
+      "french",
+      "german",
+      "italian",
+      "japanese",
+      "korean",
+      "portuguese",
+      "russian",
+      "spanish",
+      "beijing_dialect",
+      "sichuan_dialect"
+    ],
     "model_ability": [
       "text2audio"
     ],
@@ -2263,6 +2345,21 @@
     "model_name": "Qwen3-TTS-12Hz-1.7B-CustomVoice",
     "model_description": "This is a custom model description.",
     "multilingual": true,
+    "model_lang": [
+      "auto",
+      "chinese",
+      "english",
+      "french",
+      "german",
+      "italian",
+      "japanese",
+      "korean",
+      "portuguese",
+      "russian",
+      "spanish",
+      "beijing_dialect",
+      "sichuan_dialect"
+    ],
     "model_ability": [
       "text2audio"
     ],
@@ -2297,6 +2394,21 @@
     "cache_name": "Qwen3-TTS-12Hz-1.7B-CustomVoice-MLX",
     "model_description": "Qwen3-TTS CustomVoice 8-bit optimized for Apple Silicon with mlx-audio.",
     "multilingual": true,
+    "model_lang": [
+      "auto",
+      "chinese",
+      "english",
+      "french",
+      "german",
+      "italian",
+      "japanese",
+      "korean",
+      "portuguese",
+      "russian",
+      "spanish",
+      "beijing_dialect",
+      "sichuan_dialect"
+    ],
     "model_ability": [
       "text2audio"
     ],
@@ -2322,6 +2434,19 @@
     "model_name": "Qwen3-TTS-12Hz-1.7B-VoiceDesign",
     "model_description": "This is a custom model description.",
     "multilingual": true,
+    "model_lang": [
+      "auto",
+      "chinese",
+      "english",
+      "french",
+      "german",
+      "italian",
+      "japanese",
+      "korean",
+      "portuguese",
+      "russian",
+      "spanish"
+    ],
     "model_ability": [
       "text2audio",
       "text2audio_voice_design"
@@ -2357,6 +2482,19 @@
     "cache_name": "Qwen3-TTS-12Hz-1.7B-VoiceDesign-MLX",
     "model_description": "Qwen3-TTS VoiceDesign 8-bit optimized for Apple Silicon with mlx-audio.",
     "multilingual": true,
+    "model_lang": [
+      "auto",
+      "chinese",
+      "english",
+      "french",
+      "german",
+      "italian",
+      "japanese",
+      "korean",
+      "portuguese",
+      "russian",
+      "spanish"
+    ],
     "model_ability": [
       "text2audio",
       "text2audio_voice_design"
@@ -2545,6 +2683,13 @@
       "text2audio_emotion_control"
     ],
     "multilingual": true,
+    "model_lang": [
+      "ZH",
+      "EN",
+      "JA",
+      "ES",
+      "AR"
+    ],
     "virtualenv": {
       "packages": [
         "transformers==4.52.1",
@@ -2653,6 +2798,53 @@
       "text2audio_voice_cloning"
     ],
     "multilingual": true,
+    "model_lang": [
+      "Arabic",
+      "Cantonese",
+      "Chinese",
+      "Czech",
+      "Dutch",
+      "English",
+      "Finnish",
+      "French",
+      "German",
+      "Greek",
+      "Hindi",
+      "Indonesian",
+      "Italian",
+      "Japanese",
+      "Korean",
+      "Polish",
+      "Portuguese",
+      "Romanian",
+      "Russian",
+      "Spanish",
+      "Thai",
+      "Turkish",
+      "Ukrainian",
+      "Vietnamese",
+      "ZH_Anhui",
+      "ZH_Fujian",
+      "ZH_Gansu",
+      "ZH_Guizhou",
+      "ZH_Hebei",
+      "ZH_Henan",
+      "ZH_Hubei",
+      "ZH_Hunan",
+      "ZH_Jiangxi",
+      "ZH_Liaoning",
+      "ZH_Minnan",
+      "ZH_Ningxia",
+      "ZH_Shaanxi",
+      "ZH_Shandong",
+      "ZH_Shanghai",
+      "ZH_Shanxi",
+      "ZH_Sichuan",
+      "ZH_Tianjin",
+      "ZH_Wenzhou",
+      "ZH_Wu",
+      "ZH_Yunnan"
+    ],
     "virtualenv": {
       "packages": [
         "transformers==5.6.2",
@@ -2693,6 +2885,53 @@
       "text2audio_voice_cloning"
     ],
     "multilingual": true,
+    "model_lang": [
+      "Arabic",
+      "Cantonese",
+      "Chinese",
+      "Czech",
+      "Dutch",
+      "English",
+      "Finnish",
+      "French",
+      "German",
+      "Greek",
+      "Hindi",
+      "Indonesian",
+      "Italian",
+      "Japanese",
+      "Korean",
+      "Polish",
+      "Portuguese",
+      "Romanian",
+      "Russian",
+      "Spanish",
+      "Thai",
+      "Turkish",
+      "Ukrainian",
+      "Vietnamese",
+      "ZH_Anhui",
+      "ZH_Fujian",
+      "ZH_Gansu",
+      "ZH_Guizhou",
+      "ZH_Hebei",
+      "ZH_Henan",
+      "ZH_Hubei",
+      "ZH_Hunan",
+      "ZH_Jiangxi",
+      "ZH_Liaoning",
+      "ZH_Minnan",
+      "ZH_Ningxia",
+      "ZH_Shaanxi",
+      "ZH_Shandong",
+      "ZH_Shanghai",
+      "ZH_Shanxi",
+      "ZH_Sichuan",
+      "ZH_Tianjin",
+      "ZH_Wenzhou",
+      "ZH_Wu",
+      "ZH_Yunnan"
+    ],
     "virtualenv": {
       "packages": [
         "transformers==5.6.2",

--- a/xinference/model/audio/model_spec.json
+++ b/xinference/model/audio/model_spec.json
@@ -2267,9 +2267,7 @@
       "korean",
       "portuguese",
       "russian",
-      "spanish",
-      "beijing_dialect",
-      "sichuan_dialect"
+      "spanish"
     ],
     "model_ability": [
       "text2audio"
@@ -2356,9 +2354,7 @@
       "korean",
       "portuguese",
       "russian",
-      "spanish",
-      "beijing_dialect",
-      "sichuan_dialect"
+      "spanish"
     ],
     "model_ability": [
       "text2audio"

--- a/xinference/model/audio/tests/test_audio_engine.py
+++ b/xinference/model/audio/tests/test_audio_engine.py
@@ -125,6 +125,9 @@ class _FakeQwen3TTSBackend:
             "spanish",
         ]
 
+    def get_supported_speakers(self):
+        return []
+
     def generate_custom_voice(self, **kwargs):
         raise RuntimeError("generation reached")
 

--- a/xinference/model/audio/tests/test_audio_engine.py
+++ b/xinference/model/audio/tests/test_audio_engine.py
@@ -70,6 +70,46 @@ def _get_spec(model_name: str):
     return BUILTIN_AUDIO_MODELS[model_name][0]
 
 
+def test_tts_language_options_are_exposed_in_model_description():
+    qwen_languages = [
+        "auto",
+        "chinese",
+        "english",
+        "french",
+        "german",
+        "italian",
+        "japanese",
+        "korean",
+        "portuguese",
+        "russian",
+        "spanish",
+    ]
+
+    qwen_spec = _get_spec("Qwen3-TTS-12Hz-0.6B-Base")
+    assert qwen_spec.to_description()["model_lang"] == qwen_languages
+
+    custom_voice_spec = _get_spec("Qwen3-TTS-12Hz-0.6B-CustomVoice")
+    assert custom_voice_spec.to_description()["model_lang"] == qwen_languages + [
+        "beijing_dialect",
+        "sichuan_dialect",
+    ]
+
+    assert _get_spec("IndexTTS-2.5").to_description()["model_lang"] == [
+        "ZH",
+        "EN",
+        "JA",
+        "ES",
+        "AR",
+    ]
+
+    firered_languages = _get_spec("FireRedTTS3-Base").to_description()["model_lang"]
+    assert "Chinese" in firered_languages
+    assert "ZH_Sichuan" in firered_languages
+    assert "zh" not in firered_languages
+
+    assert _get_spec("CosyVoice2-0.5B").to_description()["model_lang"] == []
+
+
 def _register_all_engines():
     register_builtin_audio_engines()
     for model_specs in BUILTIN_AUDIO_MODELS.values():

--- a/xinference/model/audio/tests/test_audio_engine.py
+++ b/xinference/model/audio/tests/test_audio_engine.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 import json
+import sys
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -89,10 +91,7 @@ def test_tts_language_options_are_exposed_in_model_description():
     assert qwen_spec.to_description()["model_lang"] == qwen_languages
 
     custom_voice_spec = _get_spec("Qwen3-TTS-12Hz-0.6B-CustomVoice")
-    assert custom_voice_spec.to_description()["model_lang"] == qwen_languages + [
-        "beijing_dialect",
-        "sichuan_dialect",
-    ]
+    assert custom_voice_spec.to_description()["model_lang"] == qwen_languages
 
     assert _get_spec("IndexTTS-2.5").to_description()["model_lang"] == [
         "ZH",
@@ -108,6 +107,50 @@ def test_tts_language_options_are_exposed_in_model_description():
     assert "zh" not in firered_languages
 
     assert _get_spec("CosyVoice2-0.5B").to_description()["model_lang"] == []
+
+
+class _FakeQwen3TTSBackend:
+    def get_supported_languages(self):
+        return [
+            "auto",
+            "chinese",
+            "english",
+            "french",
+            "german",
+            "italian",
+            "japanese",
+            "korean",
+            "portuguese",
+            "russian",
+            "spanish",
+        ]
+
+    def generate_custom_voice(self, **kwargs):
+        raise RuntimeError("generation reached")
+
+
+@pytest.mark.parametrize(
+    "model_name",
+    [
+        "Qwen3-TTS-12Hz-0.6B-CustomVoice",
+        "Qwen3-TTS-12Hz-1.7B-CustomVoice",
+    ],
+)
+def test_qwen3_pytorch_custom_voice_languages_pass_backend_validation(
+    model_name, monkeypatch
+):
+    model_spec = next(
+        spec
+        for spec in BUILTIN_AUDIO_MODELS[model_name]
+        if spec.model_format == "pytorch"
+    )
+    model = PyTorchQwen3TTSAudioModel("uid", "/unused", model_spec)
+    model._model = _FakeQwen3TTSBackend()
+    monkeypatch.setitem(sys.modules, "soundfile", SimpleNamespace())
+
+    for language in model_spec.model_lang:
+        with pytest.raises(RuntimeError, match="generation reached"):
+            model.speech("test", voice="", language=language)
 
 
 def _register_all_engines():


### PR DESCRIPTION
## Summary
- Expose `model_lang` for TTS models that directly accept a language parameter.
- Render model-specific language options from the model spec in Web UI.
- Omit `kwargs.language` when no language is selected.
- Refine the Language and Streaming field layout.
- Add coverage for language capabilities in audio model descriptions.

<img width="400" height="491" alt="20c5255270677f1418076fa643a03a2d" src="https://github.com/user-attachments/assets/f7d822ce-33bf-40a5-b20a-a8567ec9136d" />
