### PR TITLE
feat(llm): add MiniCPM5-2B support

### DIFF
--- a/xinference/model/llm/__init__.py
+++ b/xinference/model/llm/__init__.py
@@ -55,6 +55,7 @@ from .utils import (
     GLM5_TOOL_CALL_FAMILY,
     KIMI_K3_TOOL_CALL_FAMILY,
     LLAMA3_TOOL_CALL_FAMILY,
+    MINICPM5_TOOL_CALL_FAMILY,
     QWEN_TOOL_CALL_FAMILY,
 )
 
@@ -227,6 +228,8 @@ def _register_model_family_metadata(model_spec: "LLMFamilyV2") -> None:
                 DEEPSEEK_TOOL_CALL_FAMILY.add(model_spec.model_name)
             elif tool_parser == "kimi-k3":
                 KIMI_K3_TOOL_CALL_FAMILY.add(model_spec.model_name)
+            elif tool_parser == "minicpm5":
+                MINICPM5_TOOL_CALL_FAMILY.add(model_spec.model_name)
             else:
                 warnings.warn(
                     f"Unknown tool parser {tool_parser} for model family "

--- a/xinference/model/llm/llm_family.json
+++ b/xinference/model/llm/llm_family.json
@@ -11091,6 +11091,130 @@
   },
   {
     "version": 2,
+    "context_length": 131072,
+    "model_name": "minicpm5-2b",
+    "model_lang": [
+      "en",
+      "zh"
+    ],
+    "model_ability": [
+      "chat",
+      "reasoning",
+      "hybrid",
+      "tools"
+    ],
+    "model_description": "MiniCPM5-2B is the second model in the MiniCPM5 series. It is a dense 2B Transformer built for on-device, local deployment, and resource-constrained scenarios. Supports hybrid thinking via enable_thinking and native XML-style tool calling (MCP-compatible).",
+    "model_specs": [
+      {
+        "model_format": "pytorch",
+        "model_size_in_billions": 2,
+        "model_src": {
+          "huggingface": {
+            "quantizations": [
+              "none"
+            ],
+            "model_id": "openbmb/MiniCPM5-2B"
+          },
+          "modelscope": {
+            "quantizations": [
+              "none"
+            ],
+            "model_id": "OpenBMB/MiniCPM5-2B"
+          }
+        }
+      },
+      {
+        "model_format": "ggufv2",
+        "model_size_in_billions": 2,
+        "model_src": {
+          "huggingface": {
+            "quantizations": [
+              "F16",
+              "Q4_K_M",
+              "Q8_0"
+            ],
+            "model_id": "openbmb/MiniCPM5-2B-GGUF",
+            "model_file_name_template": "MiniCPM5-2B-{quantization}.gguf"
+          },
+          "modelscope": {
+            "quantizations": [
+              "F16",
+              "Q4_K_M",
+              "Q8_0"
+            ],
+            "model_id": "OpenBMB/MiniCPM5-2B-GGUF",
+            "model_file_name_template": "MiniCPM5-2B-{quantization}.gguf"
+          }
+        }
+      },
+      {
+        "model_format": "mlx",
+        "model_size_in_billions": 2,
+        "model_src": {
+          "huggingface": {
+            "quantizations": [
+              "4bit"
+            ],
+            "model_id": "openbmb/MiniCPM5-2B-MLX"
+          },
+          "modelscope": {
+            "quantizations": [
+              "4bit"
+            ],
+            "model_id": "OpenBMB/MiniCPM5-2B-MLX"
+          }
+        }
+      },
+      {
+        "model_format": "awq",
+        "model_size_in_billions": 2,
+        "model_src": {
+          "huggingface": {
+            "quantizations": [
+              "Int4"
+            ],
+            "model_id": "openbmb/MiniCPM5-2B-GPTQ"
+          },
+          "modelscope": {
+            "quantizations": [
+              "Int4"
+            ],
+            "model_id": "OpenBMB/MiniCPM5-2B-GPTQ"
+          }
+        }
+      }
+    ],
+    "chat_template": "{{- bos_token }}{%- if tools %}\n    {%- set tool_definitions %}\n        {{- \"# Tools\\n\\nYou are provided with function signatures within <tools></tools> XML tags:\\n<tools>\" }}\n        {%- for tool in tools %}\n            {{- \"\\n\" }}\n            {{- tool | tojson(ensure_ascii=False) }}\n        {%- endfor %}\n        {{- '\\n</tools>\\n\\nTool usage guidelines:\\n- You may call zero or more functions. If no function calls are needed, just answer normally and do not include any <function ... </function>.\\n- When calling a function, return an XML object within <function ... </function> using:\\n<function name=\"function-name\"><param name=\"param-name\">param-value</param></function>\\n- param-value may be multi-line. If it contains <, & or newline characters, wrap it in a CDATA block: <param name=\"param-name\"><![CDATA[...multi-line value...]]></param>' }}\n    {%- endset %}\n    \n    {{- '<|im_start|>system\\n' }}\n    {%- if messages[0].role == 'system' %}\n        {%- if '<tool_def_sep>' in messages[0].content %}\n            {{- messages[0].content.replace('<tool_def_sep>', tool_definitions) }}\n        {%- else %}\n            {{- messages[0].content + '\\n\\n' + tool_definitions }}\n        {%- endif %}\n    {%- else %}\n        {{- tool_definitions.lstrip() }}\n    {%- endif %}\n    {{- '<|im_end|>\\n' }}\n{%- else %}\n    {%- if messages[0].role == 'system' %}\n        {{- '<|im_start|>system\\n' + messages[0].content + '<|im_end|>\\n' }}\n    {%- endif %}\n{%- endif %}\n{%- set ns = namespace(multi_step_tool=true, last_query_index=messages|length - 1) %}\n{%- for message in messages[::-1] %}\n    {%- set index = (messages|length - 1) - loop.index0 %}\n    {%- if ns.multi_step_tool and message.role == \"user\" and message.content is string and not(message.content.startswith('<tool_response>') and message.content.endswith('</tool_response>')) %}\n        {%- set ns.multi_step_tool = false %}\n        {%- set ns.last_query_index = index %}\n    {%- endif %}\n{%- endfor %}\n{%- for message in messages %}\n    {%- if message.content is string %}\n        {%- set content = message.content %}\n    {%- else %}\n        {%- set content = '' %}\n    {%- endif %}\n    {%- if (message.role == \"user\") or (message.role == \"system\" and not loop.first) %}\n        {{- '<|im_start|>' + message.role + '\\n' + content + '<|im_end|>' + '\\n' }}\n    {%- elif message.role == \"assistant\" %}\n        {%- set reasoning_content = '' %}\n        {%- if message.reasoning_content is string %}\n            {%- set reasoning_content = message.reasoning_content %}\n        {%- else %}\n            {%- if '</think>' in content %}\n                {%- set reasoning_content = content.split('</think>')[0].rstrip('\\n').split('<think>')[-1].lstrip('\\n') %}\n                {%- set content = content.split('</think>')[-1].lstrip('\\n') %}\n            {%- endif %}\n        {%- endif %}\n        \n        {%- if message.tool_calls %}\n            {%- set content_parts = content.split('<tool_sep>') %}\n            {%- set processed_content = content_parts[0] %}\n            {%- set tool_calls_count = message.tool_calls|length %}\n            {%- set tool_sep_count = content_parts|length - 1 %}\n            {%- set min_count = [tool_calls_count, tool_sep_count]|min %}\n            \n            {%- for i in range(1, content_parts|length) %}\n                {%- set tool_index = i - 1 %}\n                {%- if tool_index < tool_calls_count %}\n                    {%- set tool_call = message.tool_calls[tool_index] %}\n                    {%- if tool_call.function %}\n                        {%- set tool_call = tool_call.function %}\n                    {%- endif %}\n                    {%- set single_tool_xml %}\n                        {{- '<function name=\"' ~ tool_call.name ~ '\">' }}\n                        {%- if tool_call.arguments %}\n                            {%- set args_dict = tool_call.arguments %}\n                            {%- for param_name, param_value in args_dict.items() %}\n                                {{- '<param name=\"' ~ param_name ~ '\">' }}\n                                {%- if param_value is string and ('<' in param_value or '&' in param_value or '\\n' in param_value) %}\n                                    {{- '<![CDATA[' + param_value + ']]>' }}\n                                {%- else %}\n                                    {{- param_value }}\n                                {%- endif %}\n                                {{- '</param>' }}\n                            {%- endfor %}\n                        {%- endif %}\n                        {{- '</function>' }}\n                    {%- endset %}\n                    {%- set processed_content = processed_content + single_tool_xml + content_parts[i] %}\n                {%- else %}\n                    {%- set processed_content = processed_content + content_parts[i] %}\n                {%- endif %}\n            {%- endfor %}\n            \n            {%- if tool_calls_count > tool_sep_count %}\n                {%- for remaining_index in range(tool_sep_count, tool_calls_count) %}\n                    {%- set tool_call = message.tool_calls[remaining_index] %}\n                    {%- if tool_call.function %}\n                        {%- set tool_call = tool_call.function %}\n                    {%- endif %}\n                    {%- set remaining_tool_xml %}\n                        {{- '<function name=\"' ~ tool_call.name ~ '\">' }}\n                        {%- if tool_call.arguments %}\n                            {%- set args_dict = tool_call.arguments %}\n                            {%- for param_name, param_value in args_dict.items() %}\n                                {{- '<param name=\"' ~ param_name ~ '\">' }}\n                                {%- if param_value is string and ('<' in param_value or '&' in param_value or '\\n' in param_value) %}\n                                    {{- '<![CDATA[' + param_value + ']]>' }}\n                                {%- else %}\n                                    {{- param_value }}\n                                {%- endif %}\n                                {{- '</param>' }}\n                            {%- endfor %}\n                        {%- endif %}\n                        {{- '</function>' }}\n                    {%- endset %}\n                    {%- set processed_content = processed_content + remaining_tool_xml %}\n                {%- endfor %}\n            {%- endif %}\n            \n            {%- set content = processed_content %}\n        {%- endif %}\n        \n        {%- if reasoning_content %}\n            {{- '<|im_start|>' + message.role + '\\n<think>\\n' + reasoning_content.strip('\\n') + '\\n</think>\\n\\n' + content.lstrip('\\n') }}\n        {%- elif '<think>' not in content and '</think>' not in content %}\n            {{- '<|im_start|>' + message.role + '\\n<think>\\n\\n</think>\\n\\n' + content.lstrip('\\n') }}\n        {%- else %}\n            {{- '<|im_start|>' + message.role + '\\n' + content }}\n        {%- endif %}\n        \n        {%- if message.tool_calls and not has_tool_sep %}\n            {%- for tool_call in message.tool_calls %}\n                {%- if (loop.first and content) or (not loop.first) %}\n                    {{- '\\n' }}\n                {%- endif %}\n                {%- if tool_call.function %}\n                    {%- set tool_call = tool_call.function %}\n                {%- endif %}\n                {{- '<function name=\"' ~ tool_call.name ~ '\">' }}\n                {%- if tool_call.arguments %}\n                    {%- set args_dict = tool_call.arguments %}\n                    {%- for param_name, param_value in args_dict.items() %}\n                        {{- '<param name=\"' ~ param_name ~ '\">' }}\n                        {%- if param_value is string and ('<' in param_value or '&' in param_value or '\\n' in param_value) %}\n                            {{- '<![CDATA[' + param_value + ']]>' }}\n                        {%- else %}\n                            {{- param_value }}\n                        {%- endif %}\n                        {{- '</param>' }}\n                    {%- endfor %}\n                {%- endif %}\n                {{- '</function>' }}\n            {%- endfor %}\n        {%- endif %}\n        {{- '<|im_end|>\\n' }}\n    {%- elif message.role == \"tool\" %}\n        {%- if loop.first or (messages[loop.index0 - 1].role != \"tool\") %}\n            {{- '<|im_start|>user' }}\n        {%- endif %}\n        {{- '\\n<tool_response>\\n' }}\n        {%- if message.content is string %}\n            {{- content }}\n        {%- else %}\n            {{- message.content | tojson(ensure_ascii=False) }}\n        {%- endif %}\n        {{- '\\n</tool_response>' }}\n        {%- if loop.last or (messages[loop.index0 + 1].role != \"tool\") %}\n            {{- '<|im_end|>\\n' }}\n        {%- endif %}\n    {%- endif %}\n{%- endfor %}\n{%- if add_generation_prompt %}\n    {{- '<|im_start|>assistant\\n' }}\n    {%- if enable_thinking is defined %}\n        {%- if enable_thinking is false %}\n            {{- '<think>\\n\\n</think>\\n\\n' }}\n        {%- elif enable_thinking is true %}\n            {{- '<think>\\n' }}\n        {%- endif %}\n    {%- endif %}\n{%- endif %}\n",
+    "stop_token_ids": [
+      1,
+      130073
+    ],
+    "stop": [
+      "</s>",
+      "<|im_end|>"
+    ],
+    "reasoning_start_tag": "<think>",
+    "reasoning_end_tag": "</think>",
+    "updated_at": 1788843502,
+    "featured": false,
+    "architectures": [
+      "LlamaForCausalLM"
+    ],
+    "model_type": "llama",
+    "virtualenv": {
+      "packages": [
+        "transformers>=5.6 ; #engine# == \"Transformers\"",
+        "#mlx_dependencies# ; #engine# == \"MLX\"",
+        "vllm>=0.21 ; #engine# == \"vllm\"",
+        "#system_numpy# ; #engine# == \"vllm\"",
+        "#llama_cpp_dependencies# ; #engine# == \"llama.cpp\"",
+        "sglang>=0.5.16 ; #engine# == \"sglang\""
+      ]
+    },
+    "tool_parser": "minicpm5"
+  },
+  {
+    "version": 2,
     "context_length": 8192,
     "model_name": "mistral-instruct-v0.1",
     "model_lang": [

--- a/xinference/model/llm/mlx/core.py
+++ b/xinference/model/llm/mlx/core.py
@@ -58,6 +58,7 @@ from ..utils import (
     DEEPSEEK_TOOL_CALL_FAMILY,
     GEMMA_TOOL_CALL_FAMILY,
     GLM5_TOOL_CALL_FAMILY,
+    MINICPM5_TOOL_CALL_FAMILY,
     QWEN_TOOL_CALL_FAMILY,
     ChatModelMixin,
     generate_completion_chunk,
@@ -1521,6 +1522,7 @@ class MLXChatModel(MLXModel, ChatModelMixin):
                 or model_family in GEMMA_TOOL_CALL_FAMILY
                 or model_family in DEEPSEEK_TOOL_CALL_FAMILY
                 or model_family in GLM5_TOOL_CALL_FAMILY
+                or model_family in MINICPM5_TOOL_CALL_FAMILY
             ):
                 full_context_kwargs["tools"] = tools
         chat_template = self.model_family.chat_template
@@ -2167,6 +2169,7 @@ class MLXVisionModel(MLXModel, ChatModelMixin):
                 model_family in QWEN_TOOL_CALL_FAMILY
                 or model_family in GEMMA_TOOL_CALL_FAMILY
                 or model_family in GLM5_TOOL_CALL_FAMILY
+                or model_family in MINICPM5_TOOL_CALL_FAMILY
             ):
                 full_context_kwargs["tools"] = tools
             chat_template = self.model_family.chat_template

--- a/xinference/model/llm/sglang/core.py
+++ b/xinference/model/llm/sglang/core.py
@@ -41,6 +41,7 @@ from ..utils import (
     DEEPSEEK_TOOL_CALL_FAMILY,
     GEMMA_TOOL_CALL_FAMILY,
     GLM5_TOOL_CALL_FAMILY,
+    MINICPM5_TOOL_CALL_FAMILY,
     QWEN_TOOL_CALL_FAMILY,
     QWEN_TOOL_CALL_SYMBOLS,
     ChatModelMixin,
@@ -1019,6 +1020,7 @@ class SGLANGChatModel(SGLANGModel, ChatModelMixin):
                 or model_family in GEMMA_TOOL_CALL_FAMILY
                 or model_family in DEEPSEEK_TOOL_CALL_FAMILY
                 or model_family in GLM5_TOOL_CALL_FAMILY
+                or model_family in MINICPM5_TOOL_CALL_FAMILY
             ):
                 full_context_kwargs["tools"] = tools
         full_prompt = self.get_full_context(

--- a/xinference/model/llm/tests/test_llm_family.py
+++ b/xinference/model/llm/tests/test_llm_family.py
@@ -788,6 +788,11 @@ def test_match_llm():
             "MiniMaxM3SparseForConditionalGeneration",
             {"pytorch": {"none"}},
         ),
+        (
+            "minicpm5-2b",
+            "LlamaForCausalLM",
+            {"pytorch": {"none"}, "awq": {"Int4"}},
+        ),
     ],
 )
 def test_recent_sglang_engine_registration(
@@ -847,6 +852,7 @@ def test_recent_sglang_engine_registration(
             {"pytorch", "bnb", "awq", "gptq"},
         ),
         ("MiniMax-M3", "0.24.0", {"pytorch"}),
+        ("minicpm5-2b", "0.21.0", {"pytorch", "awq", "ggufv2"}),
     ],
 )
 def test_recent_vllm_engine_registration(
@@ -899,6 +905,8 @@ def test_recent_vllm_engine_registration(
         ("MiniCPM-V-4.6-Thinking", "sglang", "0.5.12"),
         ("MiniMax-M3", "vllm", "0.24.0"),
         ("MiniMax-M3", "sglang", "0.5.16"),
+        ("minicpm5-2b", "vllm", "0.21.0"),
+        ("minicpm5-2b", "sglang", "0.5.16"),
     ],
 )
 def test_recent_model_engine_minimum_versions(model_name, engine_name, minimum_version):
@@ -915,6 +923,40 @@ def test_recent_model_engine_minimum_versions(model_name, engine_name, minimum_v
         for requirement in [Requirement(package.split(";", 1)[0].strip())]
     }
     assert requirements[engine_name].specifier.contains(minimum_version)
+
+
+def test_minicpm5_2b_builtin_family_has_all_published_formats():
+    from ..llm_family import BUILTIN_LLM_FAMILIES
+
+    family = next(
+        family
+        for family in BUILTIN_LLM_FAMILIES
+        if family.model_name == "minicpm5-2b"
+    )
+    specs = {
+        spec.model_format: {
+            (candidate.quantization, candidate.model_id)
+            for candidate in family.model_specs
+            if candidate.model_hub == "huggingface"
+            and candidate.model_format == spec.model_format
+        }
+        for spec in family.model_specs
+        if spec.model_hub == "huggingface"
+    }
+
+    assert specs == {
+        "pytorch": {("none", "openbmb/MiniCPM5-2B")},
+        "ggufv2": {
+            ("F16", "openbmb/MiniCPM5-2B-GGUF"),
+            ("Q4_K_M", "openbmb/MiniCPM5-2B-GGUF"),
+            ("Q8_0", "openbmb/MiniCPM5-2B-GGUF"),
+        },
+        "mlx": {("4bit", "openbmb/MiniCPM5-2B-MLX")},
+        # Despite repository name, config.json declares AWQ GEMM packing.
+        "awq": {("Int4", "openbmb/MiniCPM5-2B-GPTQ")},
+    }
+    assert family.tool_parser == "minicpm5"
+    assert "<think>\\n\\n</think>" in family.chat_template
 
 
 def test_match_deepseek_v4_flash_0731():

--- a/xinference/model/llm/tests/test_llm_family.py
+++ b/xinference/model/llm/tests/test_llm_family.py
@@ -929,9 +929,7 @@ def test_minicpm5_2b_builtin_family_has_all_published_formats():
     from ..llm_family import BUILTIN_LLM_FAMILIES
 
     family = next(
-        family
-        for family in BUILTIN_LLM_FAMILIES
-        if family.model_name == "minicpm5-2b"
+        family for family in BUILTIN_LLM_FAMILIES if family.model_name == "minicpm5-2b"
     )
     specs = {
         spec.model_format: {

--- a/xinference/model/llm/tests/test_utils.py
+++ b/xinference/model/llm/tests/test_utils.py
@@ -2830,3 +2830,50 @@ def test_qwen3_family_get_full_context_handles_string_arguments():
         assert base_messages[2]["tool_calls"][0]["function"]["arguments"] == (
             '{"city":"北京"}'
         ), f"{name}: _normalize_tool_call_arguments_to_dict mutated input"
+
+
+def test_minicpm5_get_full_context_handles_string_arguments():
+    from .. import BUILTIN_LLM_FAMILIES
+
+    family = next(
+        family for family in BUILTIN_LLM_FAMILIES if family.model_name == "minicpm5-2b"
+    )
+    messages = [
+        {"role": "user", "content": "What is the weather in Beijing?"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call-1",
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "arguments": '{"city":"Beijing"}',
+                    },
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call-1", "content": "Sunny"},
+    ]
+    mixin = ChatModelMixin()
+    mixin.model_family = SimpleNamespace(
+        model_name=family.model_name,
+        model_ability=family.model_ability,
+        chat_template=family.chat_template,
+    )
+
+    prompt = mixin.get_full_context(
+        messages,
+        chat_template=family.chat_template,
+        tokenizer=None,
+    )
+
+    assert (
+        '<function name="get_weather"><param name="city">Beijing</param></function>'
+        in prompt
+    )
+    assert "<tool_response>\nSunny\n</tool_response>" in prompt
+    assert messages[1]["tool_calls"][0]["function"]["arguments"] == (
+        '{"city":"Beijing"}'
+    )

--- a/xinference/model/llm/tool_parsers/__init__.py
+++ b/xinference/model/llm/tool_parsers/__init__.py
@@ -60,6 +60,7 @@ from . import (
     glm5_tool_parser,
     kimi_k3_tool_parser,
     llama3_tool_parser,
+    minicpm5_tool_parser,
     minimax_m3_tool_parser,
     minimax_tool_parser,
     qwen_tool_parser,

--- a/xinference/model/llm/tool_parsers/minicpm5_tool_parser.py
+++ b/xinference/model/llm/tool_parsers/minicpm5_tool_parser.py
@@ -1,0 +1,114 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import re
+from typing import Any, Dict, List, Optional, Tuple
+
+from . import register_tool_parser
+from .abstract_tool_parser import ToolParser
+
+
+@register_tool_parser("minicpm5")
+class MiniCPM5ToolParser(ToolParser):
+    """Parse MiniCPM5 XML-style function calls."""
+
+    _FUNCTION_START = "<function"
+    _FUNCTION_END = "</function>"
+    _FUNCTION_RE = re.compile(
+        r"<function\s+name=['\"]([^'\"]+)['\"]\s*>(.*?)</function>", re.DOTALL
+    )
+    _PARAM_RE = re.compile(
+        r"<param\s+name=['\"]([^'\"]+)['\"]\s*>(.*?)</param>", re.DOTALL
+    )
+
+    @staticmethod
+    def _parse_value(value: str) -> Any:
+        value = value.strip()
+        if value.startswith("<![CDATA[") and value.endswith("]]>"):
+            value = value[9:-3]
+        try:
+            return json.loads(value)
+        except (TypeError, ValueError):
+            return value
+
+    @classmethod
+    def _parse_calls(
+        cls, model_output: str
+    ) -> List[Tuple[Optional[str], Optional[str], Optional[Dict[str, Any]]]]:
+        results = []
+        position = 0
+        for match in cls._FUNCTION_RE.finditer(model_output):
+            if match.start() > position:
+                results.append((model_output[position : match.start()], None, None))
+            arguments = {
+                name: cls._parse_value(value)
+                for name, value in cls._PARAM_RE.findall(match.group(2))
+            }
+            results.append((None, match.group(1), arguments))
+            position = match.end()
+        if position < len(model_output):
+            results.append((model_output[position:], None, None))
+        return results
+
+    def extract_tool_calls(
+        self, model_output: str
+    ) -> List[Tuple[Optional[str], Optional[str], Optional[Dict[str, Any]]]]:
+        if (
+            not isinstance(model_output, str)
+            or self._FUNCTION_START not in model_output
+        ):
+            return [(str(model_output), None, None)]
+        return self._parse_calls(model_output)
+
+    @classmethod
+    def _completed_output(cls, text: str) -> str:
+        for length in range(len(cls._FUNCTION_START) - 1, 0, -1):
+            if text.endswith(cls._FUNCTION_START[:length]):
+                text = text[:-length]
+                break
+        last_start = text.rfind(cls._FUNCTION_START)
+        if last_start != -1 and text.find(cls._FUNCTION_END, last_start) == -1:
+            return text[:last_start]
+        return text
+
+    def extract_tool_calls_streaming(
+        self, previous_text: List[str], current_text: str, delta_text: str
+    ):
+        previous = self._completed_output(previous_text[-1] if previous_text else "")
+        current = self._completed_output(current_text)
+        previous_results = self._parse_calls(previous)
+        current_results = self._parse_calls(current)
+        previous_call_count = sum(name is not None for _, name, _ in previous_results)
+        previous_content_length = sum(
+            len(content or "")
+            for content, name, _ in previous_results
+            if name is None
+        )
+        events = []
+        call_count = 0
+        current_content_length = 0
+        for content, name, arguments in current_results:
+            if name is not None:
+                if call_count >= previous_call_count:
+                    events.append((None, name, arguments, call_count))
+                call_count += 1
+            elif content:
+                start = max(0, previous_content_length - current_content_length)
+                if start < len(content):
+                    events.append((content[start:], None, None))
+                current_content_length += len(content)
+        if not events:
+            return None
+        return events[0] if len(events) == 1 else events

--- a/xinference/model/llm/tool_parsers/minicpm5_tool_parser.py
+++ b/xinference/model/llm/tool_parsers/minicpm5_tool_parser.py
@@ -26,12 +26,10 @@ class MiniCPM5ToolParser(ToolParser):
 
     _FUNCTION_START = "<function"
     _FUNCTION_END = "</function>"
-    _FUNCTION_RE = re.compile(
-        r"<function\s+name=['\"]([^'\"]+)['\"]\s*>(.*?)</function>", re.DOTALL
-    )
-    _PARAM_RE = re.compile(
-        r"<param\s+name=['\"]([^'\"]+)['\"]\s*>(.*?)</param>", re.DOTALL
-    )
+    _CDATA_START = "<![CDATA["
+    _CDATA_END = "]]>"
+    _FUNCTION_OPEN_RE = re.compile(r"<function\s+name=['\"]([^'\"]+)['\"]\s*>")
+    _PARAM_OPEN_RE = re.compile(r"<param\s+name=['\"]([^'\"]+)['\"]\s*>")
 
     @staticmethod
     def _parse_value(value: str) -> Any:
@@ -44,6 +42,24 @@ class MiniCPM5ToolParser(ToolParser):
             return value
 
     @classmethod
+    def _find_closing_tag(cls, text: str, tag: str, start: int) -> Optional[int]:
+        closing_tag = f"</{tag}>"
+        position = start
+        while True:
+            closing_position = text.find(closing_tag, position)
+            cdata_position = text.find(cls._CDATA_START, position)
+            if closing_position == -1:
+                return None
+            if cdata_position == -1 or closing_position < cdata_position:
+                return closing_position
+            cdata_end = text.find(
+                cls._CDATA_END, cdata_position + len(cls._CDATA_START)
+            )
+            if cdata_end == -1:
+                return None
+            position = cdata_end + len(cls._CDATA_END)
+
+    @classmethod
     def _parse_calls(
         cls, model_output: str
     ) -> List[Tuple[Optional[str], Optional[str], Optional[Dict[str, Any]]]]:
@@ -51,15 +67,28 @@ class MiniCPM5ToolParser(ToolParser):
             []
         )
         position = 0
-        for match in cls._FUNCTION_RE.finditer(model_output):
+        while match := cls._FUNCTION_OPEN_RE.search(model_output, position):
+            function_end = cls._find_closing_tag(model_output, "function", match.end())
+            if function_end is None:
+                break
             if match.start() > position:
                 results.append((model_output[position : match.start()], None, None))
-            arguments = {
-                name: cls._parse_value(value)
-                for name, value in cls._PARAM_RE.findall(match.group(2))
-            }
+            arguments: Dict[str, Any] = {}
+            param_position = match.end()
+            while param_match := cls._PARAM_OPEN_RE.search(
+                model_output, param_position, function_end
+            ):
+                param_end = cls._find_closing_tag(
+                    model_output, "param", param_match.end()
+                )
+                if param_end is None or param_end > function_end:
+                    break
+                arguments[param_match.group(1)] = cls._parse_value(
+                    model_output[param_match.end() : param_end]
+                )
+                param_position = param_end + len("</param>")
             results.append((None, match.group(1), arguments))
-            position = match.end()
+            position = function_end + len(cls._FUNCTION_END)
         if position < len(model_output):
             results.append((model_output[position:], None, None))
         return results
@@ -80,9 +109,12 @@ class MiniCPM5ToolParser(ToolParser):
             if text.endswith(cls._FUNCTION_START[:length]):
                 text = text[:-length]
                 break
-        last_start = text.rfind(cls._FUNCTION_START)
-        if last_start != -1 and text.find(cls._FUNCTION_END, last_start) == -1:
-            return text[:last_start]
+        position = 0
+        while match := cls._FUNCTION_OPEN_RE.search(text, position):
+            function_end = cls._find_closing_tag(text, "function", match.end())
+            if function_end is None:
+                return text[: match.start()]
+            position = function_end + len(cls._FUNCTION_END)
         return text
 
     def extract_tool_calls_streaming(

--- a/xinference/model/llm/tool_parsers/minicpm5_tool_parser.py
+++ b/xinference/model/llm/tool_parsers/minicpm5_tool_parser.py
@@ -110,7 +110,17 @@ class MiniCPM5ToolParser(ToolParser):
                 text = text[:-length]
                 break
         position = 0
-        while match := cls._FUNCTION_OPEN_RE.search(text, position):
+        while True:
+            function_start = text.find(cls._FUNCTION_START, position)
+            if function_start == -1:
+                break
+            opening_end = text.find(">", function_start + len(cls._FUNCTION_START))
+            if opening_end == -1:
+                return text[:function_start]
+            match = cls._FUNCTION_OPEN_RE.match(text, function_start)
+            if match is None:
+                position = opening_end + 1
+                continue
             function_end = cls._find_closing_tag(text, "function", match.end())
             if function_end is None:
                 return text[: match.start()]

--- a/xinference/model/llm/tool_parsers/minicpm5_tool_parser.py
+++ b/xinference/model/llm/tool_parsers/minicpm5_tool_parser.py
@@ -47,7 +47,9 @@ class MiniCPM5ToolParser(ToolParser):
     def _parse_calls(
         cls, model_output: str
     ) -> List[Tuple[Optional[str], Optional[str], Optional[Dict[str, Any]]]]:
-        results = []
+        results: List[Tuple[Optional[str], Optional[str], Optional[Dict[str, Any]]]] = (
+            []
+        )
         position = 0
         for match in cls._FUNCTION_RE.finditer(model_output):
             if match.start() > position:
@@ -92,11 +94,9 @@ class MiniCPM5ToolParser(ToolParser):
         current_results = self._parse_calls(current)
         previous_call_count = sum(name is not None for _, name, _ in previous_results)
         previous_content_length = sum(
-            len(content or "")
-            for content, name, _ in previous_results
-            if name is None
+            len(content or "") for content, name, _ in previous_results if name is None
         )
-        events = []
+        events: List[Any] = []
         call_count = 0
         current_content_length = 0
         for content, name, arguments in current_results:

--- a/xinference/model/llm/tool_parsers/tests/test_minicpm5_tool_parser.py
+++ b/xinference/model/llm/tool_parsers/tests/test_minicpm5_tool_parser.py
@@ -7,7 +7,7 @@ def test_extracts_minicpm5_xml_tool_calls():
     result = parser.extract_tool_calls(
         'Before <function name="weather"><param name="city">"Beijing"</param>'
         '<param name="days">3</param><param name="note"><![CDATA[a < b & c]]>'
-        '</param></function> after'
+        "</param></function> after"
     )
 
     assert result == [

--- a/xinference/model/llm/tool_parsers/tests/test_minicpm5_tool_parser.py
+++ b/xinference/model/llm/tool_parsers/tests/test_minicpm5_tool_parser.py
@@ -35,3 +35,43 @@ def test_waits_for_a_complete_minicpm5_tool_call_when_streaming():
         {"city": "Beijing"},
         0,
     )
+
+
+def test_preserves_cdata_with_literal_closing_tags():
+    parser = MiniCPM5ToolParser()
+    output = (
+        '<function name="write_file"><param name="content"><![CDATA['
+        "example </param> and </function> end]]></param></function>"
+    )
+
+    assert parser.extract_tool_calls(output) == [
+        (None, "write_file", {"content": "example </param> and </function> end"})
+    ]
+
+
+def test_streaming_waits_for_cdata_with_literal_closing_tags():
+    parser = MiniCPM5ToolParser()
+    complete = (
+        '<function name="write_file"><param name="content"><![CDATA['
+        "example </param> and </function> end]]></param></function>"
+    )
+    split_param = complete.index("</param>") + len("</par")
+    split_function = complete.index("</function>") + len("</func")
+    partial_param = complete[:split_param]
+    partial_function = complete[:split_function]
+
+    assert parser.extract_tool_calls_streaming([], partial_param, partial_param) is None
+    assert (
+        parser.extract_tool_calls_streaming(
+            [partial_param], partial_function, partial_function[len(partial_param) :]
+        )
+        is None
+    )
+    assert parser.extract_tool_calls_streaming(
+        [partial_function], complete, complete[len(partial_function) :]
+    ) == (
+        None,
+        "write_file",
+        {"content": "example </param> and </function> end"},
+        0,
+    )

--- a/xinference/model/llm/tool_parsers/tests/test_minicpm5_tool_parser.py
+++ b/xinference/model/llm/tool_parsers/tests/test_minicpm5_tool_parser.py
@@ -75,3 +75,73 @@ def test_streaming_waits_for_cdata_with_literal_closing_tags():
         {"content": "example </param> and </function> end"},
         0,
     )
+
+
+def test_streaming_buffers_every_function_opening_tag_split():
+    parser = MiniCPM5ToolParser()
+    prefix = "Before "
+    opening_tag = '<function name="weather">'
+    output = (
+        prefix + opening_tag + '<param name="city">"Beijing"</param></function> After'
+    )
+
+    for split in range(1, len(opening_tag) + 1):
+        partial = prefix + opening_tag[:split]
+        assert parser.extract_tool_calls_streaming([], partial, partial) == (
+            prefix,
+            None,
+            None,
+        )
+        assert parser.extract_tool_calls_streaming(
+            [partial], output, output[len(partial) :]
+        ) == [
+            (None, "weather", {"city": "Beijing"}, 0),
+            (" After", None, None),
+        ]
+
+
+def test_character_streaming_matches_complete_tool_calls_with_text():
+    parser = MiniCPM5ToolParser()
+    output = (
+        'Before <function name="first"><param name="value">1</param></function>'
+        ' between <function name="second"><param name="value">2</param></function>'
+        " After"
+    )
+    events = []
+    previous_text = []
+
+    for index, _ in enumerate(output, start=1):
+        current_text = output[:index]
+        result = parser.extract_tool_calls_streaming(
+            previous_text, current_text, output[index - 1 : index]
+        )
+        previous_text.append(current_text)
+        if result is None:
+            continue
+        events.extend(result if isinstance(result, list) else [result])
+
+    normalized_events = []
+    call_index = 0
+    for event in events:
+        content, name, arguments = event[:3]
+        if name is not None:
+            assert event[3] == call_index
+            call_index += 1
+            normalized_events.append((content, name, arguments))
+        elif normalized_events and normalized_events[-1][1] is None:
+            normalized_events[-1] = (
+                normalized_events[-1][0] + content,
+                None,
+                None,
+            )
+        else:
+            normalized_events.append((content, name, arguments))
+
+    assert normalized_events == [
+        ("Before ", None, None),
+        (None, "first", {"value": 1}),
+        (" between ", None, None),
+        (None, "second", {"value": 2}),
+        (" After", None, None),
+    ]
+    assert normalized_events == parser.extract_tool_calls(output)

--- a/xinference/model/llm/tool_parsers/tests/test_minicpm5_tool_parser.py
+++ b/xinference/model/llm/tool_parsers/tests/test_minicpm5_tool_parser.py
@@ -1,0 +1,37 @@
+from ..minicpm5_tool_parser import MiniCPM5ToolParser
+
+
+def test_extracts_minicpm5_xml_tool_calls():
+    parser = MiniCPM5ToolParser()
+
+    result = parser.extract_tool_calls(
+        'Before <function name="weather"><param name="city">"Beijing"</param>'
+        '<param name="days">3</param><param name="note"><![CDATA[a < b & c]]>'
+        '</param></function> after'
+    )
+
+    assert result == [
+        ("Before ", None, None),
+        (None, "weather", {"city": "Beijing", "days": 3, "note": "a < b & c"}),
+        (" after", None, None),
+    ]
+
+
+def test_waits_for_a_complete_minicpm5_tool_call_when_streaming():
+    parser = MiniCPM5ToolParser()
+    partial = 'before <function name="weather"><param name="city">Beijing'
+    complete = partial + "</param></function>"
+
+    assert parser.extract_tool_calls_streaming([], partial, partial) == (
+        "before ",
+        None,
+        None,
+    )
+    assert parser.extract_tool_calls_streaming(
+        [partial], complete, "</param></function>"
+    ) == (
+        None,
+        "weather",
+        {"city": "Beijing"},
+        0,
+    )

--- a/xinference/model/llm/transformers/core.py
+++ b/xinference/model/llm/transformers/core.py
@@ -44,6 +44,7 @@ from ..utils import (
     GEMMA_TOOL_CALL_FAMILY,
     GLM5_TOOL_CALL_FAMILY,
     LLAMA3_TOOL_CALL_FAMILY,
+    MINICPM5_TOOL_CALL_FAMILY,
     QWEN_TOOL_CALL_FAMILY,
     ChatModelMixin,
 )
@@ -1156,6 +1157,7 @@ class PytorchChatModel(PytorchModel, ChatModelMixin):
             or model_family in LLAMA3_TOOL_CALL_FAMILY
             or model_family in DEEPSEEK_TOOL_CALL_FAMILY
             or model_family in GLM5_TOOL_CALL_FAMILY
+            or model_family in MINICPM5_TOOL_CALL_FAMILY
         ):
             full_context_kwargs["tools"] = tools
         assert self.model_family.chat_template is not None

--- a/xinference/model/llm/utils.py
+++ b/xinference/model/llm/utils.py
@@ -212,6 +212,7 @@ LLAMA3_TOOL_CALL_FAMILY: Set[str] = set()
 QWEN_TOOL_CALL_FAMILY: Set[str] = set()
 GLM5_TOOL_CALL_FAMILY: Set[str] = set()
 KIMI_K3_TOOL_CALL_FAMILY: Set[str] = set()
+MINICPM5_TOOL_CALL_FAMILY: Set[str] = set()
 
 QWEN_TOOL_CALL_SYMBOLS = ["<tool_call>", "</tool_call>"]
 

--- a/xinference/model/llm/utils.py
+++ b/xinference/model/llm/utils.py
@@ -256,11 +256,15 @@ class ChatModelMixin:
     @staticmethod
     @functools.lru_cache(maxsize=64)
     def _chat_template_needs_dict_arguments(chat_template: Optional[str]) -> bool:
-        # Detect Coder-style templates that iterate `tool_call.arguments|items`.
+        # Detect templates that iterate tool-call arguments as a mapping.
         # Content-driven (not name-driven) so future models copying this
         # template style are covered automatically.
         return chat_template is not None and (
             "tool_call.arguments|items" in chat_template
+            or (
+                "args_dict = tool_call.arguments" in chat_template
+                and "args_dict.items()" in chat_template
+            )
         )
 
     @staticmethod

--- a/xinference/model/llm/vllm/core.py
+++ b/xinference/model/llm/vllm/core.py
@@ -67,6 +67,7 @@ from ..utils import (
     GEMMA_TOOL_CALL_FAMILY,
     GLM5_TOOL_CALL_FAMILY,
     KIMI_K3_TOOL_CALL_FAMILY,
+    MINICPM5_TOOL_CALL_FAMILY,
     QWEN_TOOL_CALL_FAMILY,
     QWEN_TOOL_CALL_SYMBOLS,
     ChatModelMixin,
@@ -2285,6 +2286,7 @@ class VLLMChatModel(VLLMModel, ChatModelMixin):
                 or model_family in DEEPSEEK_TOOL_CALL_FAMILY
                 or model_family in GLM5_TOOL_CALL_FAMILY
                 or model_family in KIMI_K3_TOOL_CALL_FAMILY
+                or model_family in MINICPM5_TOOL_CALL_FAMILY
             ):
                 full_context_kwargs["tools"] = tools
         assert self.model_family.chat_template is not None
@@ -2666,6 +2668,7 @@ class VLLMMultiModel(VLLMModel, ChatModelMixin):
                     or model_family in GEMMA_TOOL_CALL_FAMILY
                     or model_family in GLM5_TOOL_CALL_FAMILY
                     or model_family in KIMI_K3_TOOL_CALL_FAMILY
+                    or model_family in MINICPM5_TOOL_CALL_FAMILY
                 ):
                     full_context_kwargs["tools"] = tools
                 assert self.model_family.chat_template is not None


### PR DESCRIPTION
## Summary

Add built-in support for `openbmb/MiniCPM5-2B`.

- Register PyTorch, GGUF, MLX, and AWQ model specifications.
- Add Transformers, vLLM, SGLang, and MLX backend support.
- Add the MiniCPM5 XML tool-call parser.
- Add model registration and tool parser tests.
