### PR TITLE
FIX: avoid implicit event loop in async client cleanup

### DIFF
--- a/xinference/client/restful/async_restful_client.py
+++ b/xinference/client/restful/async_restful_client.py
@@ -73,12 +73,20 @@ async def _release_response(response: aiohttp.ClientResponse):
 def _schedule_session_close(client: Any) -> None:
     if not getattr(client, "session", None):
         return
-    try:
-        loop = asyncio.get_running_loop()
-    except RuntimeError:
-        # Async cleanup cannot run after the owning event loop has stopped.
+    loop = getattr(client, "_session_loop", None)
+    if loop is None or loop.is_closed():
         return
-    loop.create_task(client.close())
+
+    def close_on_owner_loop():
+        loop.create_task(client.close())
+
+    try:
+        # Also queues cleanup while a manually driven loop is paused, and when
+        # the last reference is released by another thread.
+        loop.call_soon_threadsafe(close_on_owner_loop)
+    except RuntimeError:
+        # The owning loop may have closed since the check above.
+        pass
 
 
 class AsyncRESTfulModelHandle:
@@ -92,6 +100,7 @@ class AsyncRESTfulModelHandle:
         self._base_url = base_url
         self.auth_headers = auth_headers
         self.timeout = aiohttp.ClientTimeout(total=1800)
+        self._session_loop = asyncio.get_running_loop()
         self.session = aiohttp.ClientSession(
             connector=aiohttp.TCPConnector(force_close=True)
         )
@@ -1286,6 +1295,7 @@ class AsyncClient:
         self._headers: Dict[str, str] = {}
         self._cluster_authed = False
         self.timeout = aiohttp.ClientTimeout(total=1800)
+        self._session_loop = asyncio.get_running_loop()
         self.session = aiohttp.ClientSession(
             connector=aiohttp.TCPConnector(force_close=True), timeout=self.timeout
         )

--- a/xinference/client/restful/async_restful_client.py
+++ b/xinference/client/restful/async_restful_client.py
@@ -70,6 +70,17 @@ async def _release_response(response: aiohttp.ClientResponse):
     await response.wait_for_close()
 
 
+def _schedule_session_close(client: Any) -> None:
+    if not getattr(client, "session", None):
+        return
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        # Async cleanup cannot run after the owning event loop has stopped.
+        return
+    loop.create_task(client.close())
+
+
 class AsyncRESTfulModelHandle:
     """
     A sync model interface (for RESTful client) which provides type hints that makes it much easier to use xinference
@@ -92,9 +103,7 @@ class AsyncRESTfulModelHandle:
             self.session = None
 
     def __del__(self):
-        if self.session:
-            loop = asyncio.get_event_loop()
-            loop.create_task(self.close())
+        _schedule_session_close(self)
 
 
 class AsyncRESTfulEmbeddingModelHandle(AsyncRESTfulModelHandle):
@@ -1291,9 +1300,7 @@ class AsyncClient:
             self.session = None
 
     def __del__(self):
-        if self.session:
-            loop = asyncio.get_event_loop()
-            loop.create_task(self.close())
+        _schedule_session_close(self)
 
     def _set_token(self, token: Optional[str]):
         if not self._cluster_authed or token is None:

--- a/xinference/client/tests/test_async_client_cleanup.py
+++ b/xinference/client/tests/test_async_client_cleanup.py
@@ -15,7 +15,6 @@
 import asyncio
 import gc
 import threading
-from unittest.mock import MagicMock
 
 import pytest
 
@@ -26,16 +25,11 @@ from ..restful import async_restful_client as client_module
     "client_class",
     [client_module.AsyncRESTfulModelHandle, client_module.AsyncClient],
 )
-def test_destructor_does_not_require_an_event_loop(client_class, monkeypatch):
+def test_destructor_without_initialized_owner_loop(client_class, monkeypatch):
     def fail_get_event_loop():
         raise AssertionError("destructor must not request an implicit event loop")
 
     monkeypatch.setattr(client_module.asyncio, "get_event_loop", fail_get_event_loop)
-    monkeypatch.setattr(
-        client_module.asyncio,
-        "get_running_loop",
-        MagicMock(side_effect=RuntimeError("no running event loop")),
-    )
     client = client_class.__new__(client_class)
     client.session = object()
 

--- a/xinference/client/tests/test_async_client_cleanup.py
+++ b/xinference/client/tests/test_async_client_cleanup.py
@@ -1,0 +1,64 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+from ..restful import async_restful_client as client_module
+
+
+@pytest.mark.parametrize(
+    "client_class",
+    [client_module.AsyncRESTfulModelHandle, client_module.AsyncClient],
+)
+def test_destructor_does_not_require_an_event_loop(client_class, monkeypatch):
+    def fail_get_event_loop():
+        raise AssertionError("destructor must not request an implicit event loop")
+
+    monkeypatch.setattr(client_module.asyncio, "get_event_loop", fail_get_event_loop)
+    monkeypatch.setattr(
+        client_module.asyncio,
+        "get_running_loop",
+        MagicMock(side_effect=RuntimeError("no running event loop")),
+    )
+    client = client_class.__new__(client_class)
+    client.session = object()
+
+    client.__del__()
+
+    client.session = None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "client_class",
+    [client_module.AsyncRESTfulModelHandle, client_module.AsyncClient],
+)
+async def test_destructor_schedules_close_on_running_loop(client_class):
+    client = client_class.__new__(client_class)
+    client.session = object()
+    closed = asyncio.Event()
+
+    async def close():
+        client.session = None
+        closed.set()
+
+    client.close = close
+
+    client.__del__()
+
+    await asyncio.wait_for(closed.wait(), timeout=1)
+    assert client.session is None

--- a/xinference/client/tests/test_async_client_cleanup.py
+++ b/xinference/client/tests/test_async_client_cleanup.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 import asyncio
+import gc
+import threading
 from unittest.mock import MagicMock
 
 import pytest
@@ -42,6 +44,19 @@ def test_destructor_does_not_require_an_event_loop(client_class, monkeypatch):
     client.session = None
 
 
+@pytest.mark.parametrize(
+    "client_class",
+    [client_module.AsyncRESTfulModelHandle, client_module.AsyncClient],
+)
+def test_destructor_after_owner_loop_closed(client_class):
+    client = client_class.__new__(client_class)
+    client.session = object()
+    client._session_loop = asyncio.new_event_loop()
+    client._session_loop.close()
+    client.__del__()
+    client.session = None
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "client_class",
@@ -49,6 +64,7 @@ def test_destructor_does_not_require_an_event_loop(client_class, monkeypatch):
 )
 async def test_destructor_schedules_close_on_running_loop(client_class):
     client = client_class.__new__(client_class)
+    client._session_loop = asyncio.get_running_loop()
     client.session = object()
     closed = asyncio.Event()
 
@@ -62,3 +78,55 @@ async def test_destructor_schedules_close_on_running_loop(client_class):
 
     await asyncio.wait_for(closed.wait(), timeout=1)
     assert client.session is None
+
+
+@pytest.mark.parametrize(
+    "client_class",
+    [client_module.AsyncRESTfulModelHandle, client_module.AsyncClient],
+)
+@pytest.mark.parametrize("other_thread", [False, True])
+def test_real_session_cleanup_on_paused_owner_loop(
+    client_class, other_thread, monkeypatch
+):
+    monkeypatch.setattr(
+        client_module.AsyncClient, "_check_cluster_authenticated", lambda self: None
+    )
+    loop = asyncio.new_event_loop()
+    loop.set_debug(True)
+
+    async def create():
+        if client_class is client_module.AsyncClient:
+            return client_class("http://localhost:9997")
+        return client_class("model", "http://localhost:9997", {})
+
+    clients = [loop.run_until_complete(create())]
+    session = clients[0].session
+    closed_on = []
+    original_close = session.close
+
+    async def close():
+        closed_on.append(asyncio.get_running_loop())
+        await original_close()
+
+    monkeypatch.setattr(session, "close", close)
+
+    async def drop():
+        clients.clear()
+        gc.collect()
+        await asyncio.sleep(0)
+
+    try:
+        if other_thread:
+            thread = threading.Thread(target=lambda: asyncio.run(drop()))
+            thread.start()
+            thread.join()
+        else:
+            clients.clear()
+            gc.collect()
+        assert not session.closed
+        loop.run_until_complete(asyncio.sleep(0))
+        assert session.closed
+        assert closed_on == [loop]
+    finally:
+        loop.run_until_complete(original_close())
+        loop.close()


### PR DESCRIPTION
Async client finalizers could raise an unraisable RuntimeError when no event loop was available, including after asyncio.run() returned.

Record the session creation loop and queue best-effort cleanup on it using call_soon_threadsafe. Paused loops execute cleanup when resumed; collection in another thread still targets the owner loop. Missing or closed owner loops are skipped. Callers should continue to explicitly await close() before shutting down their loop.

Validation: 10 cleanup tests passed on Python 3.11 and 3.14, including real aiohttp sessions on paused loops and cross-thread collection with asyncio debug mode enabled. Pre-commit passed.
