### PR TITLE
ENH: Report disk usage in cache management

### DIFF
--- a/frontend/src/components/pages/cache-management/index.tsx
+++ b/frontend/src/components/pages/cache-management/index.tsx
@@ -50,7 +50,7 @@ import { useI18n } from '@/contexts/i18n-context';
 import { useMenuAuth } from '@/hooks/use-menu-auth';
 import { ModelType } from '@/constants';
 import request from '@/lib/request';
-import { cn, copyToClipboard } from '@/lib/utils';
+import { cn, copyToClipboard, formatFileSize } from '@/lib/utils';
 import type { ModelCachedItem, ModelDownloadItem, ModelEnvItem } from '@/types/services';
 
 type TabValue = 'models' | 'environments';
@@ -114,6 +114,12 @@ function includesQuery(query: string, ...values: unknown[]): boolean {
       .toLowerCase()
       .includes(query)
   );
+}
+
+function formatDiskUsage(sizeBytes?: number): string {
+  return typeof sizeBytes === 'number' && Number.isFinite(sizeBytes)
+    ? formatFileSize(Math.max(0, sizeBytes))
+    : '-';
 }
 
 function SummaryCard({ icon, label, value }: { icon: ReactNode; label: string; value: number }) {
@@ -532,6 +538,7 @@ export default function CacheManagement() {
                   <col className="w-[15%]" />
                   <col className="w-[6%]" />
                   <col className="w-[5%]" />
+                  <col className="w-[7%]" />
                   <col className="w-[4%]" />
                   <col className="w-[15%]" />
                   <col className="w-[12%]" />
@@ -545,6 +552,7 @@ export default function CacheManagement() {
                     <TableHead>{t('cacheManagement.modelVersion')}</TableHead>
                     <TableHead>{t('cacheManagement.format')}</TableHead>
                     <TableHead>{t('cacheManagement.size')}</TableHead>
+                    <TableHead>{t('cacheManagement.diskUsage')}</TableHead>
                     <TableHead>{t('cacheManagement.quantization')}</TableHead>
                     <TableHead>{t('cacheManagement.statusAndProgress')}</TableHead>
                     <TableHead>{t('cacheManagement.path')}</TableHead>
@@ -645,6 +653,7 @@ export default function CacheManagement() {
                           <TableCell className="font-semibold tabular-nums">
                             {download.model_size_in_billions ?? '-'}
                           </TableCell>
+                          <TableCell>-</TableCell>
                           <TableCell>{download.quantization || '-'}</TableCell>
                           <TableCell>
                             <div className="w-full space-y-2">
@@ -741,7 +750,7 @@ export default function CacheManagement() {
                             className={cn('hover:bg-transparent', !isDetailsExpanded && 'border-0')}
                             aria-hidden={!isDetailsExpanded}
                           >
-                            <TableCell colSpan={10} className="p-0">
+                            <TableCell colSpan={11} className="p-0">
                               <Collapsible open={isDetailsExpanded}>
                                 <CollapsibleContent forceMount>
                                   <div className="space-y-3 bg-muted/10 px-4 py-3">
@@ -784,6 +793,9 @@ export default function CacheManagement() {
                       <TableCell>{item.model_format || '-'}</TableCell>
                       <TableCell className="font-semibold tabular-nums">
                         {item.model_size_in_billions ?? '-'}
+                      </TableCell>
+                      <TableCell className="tabular-nums">
+                        {formatDiskUsage(item.size_bytes)}
                       </TableCell>
                       <TableCell>{item.quantization || '-'}</TableCell>
                       <TableCell>
@@ -842,7 +854,7 @@ export default function CacheManagement() {
 
                   {filteredDownloads.length === 0 && filteredCachedModels.length === 0 && (
                     <TableRow>
-                      <TableCell colSpan={10} className="h-64 text-center text-muted-foreground">
+                      <TableCell colSpan={11} className="h-64 text-center text-muted-foreground">
                         {t('cacheManagement.noModelCacheItems')}
                       </TableCell>
                     </TableRow>
@@ -859,6 +871,7 @@ export default function CacheManagement() {
                   <col className="w-[14%]" />
                   <col className="w-[12%]" />
                   <col className="w-[10%]" />
+                  <col className="w-[10%]" />
                   <col className="w-[21%]" />
                   <col className="w-[21%]" />
                   <col className="w-[11%]" />
@@ -869,6 +882,7 @@ export default function CacheManagement() {
                     <TableHead>{t('cacheManagement.modelName')}</TableHead>
                     <TableHead>{t('cacheManagement.engine')}</TableHead>
                     <TableHead>{t('cacheManagement.pythonVersion')}</TableHead>
+                    <TableHead>{t('cacheManagement.diskUsage')}</TableHead>
                     <TableHead>{t('cacheManagement.path')}</TableHead>
                     <TableHead>{t('cacheManagement.realPath')}</TableHead>
                     <TableHead>{t('cacheManagement.worker')}</TableHead>
@@ -884,6 +898,9 @@ export default function CacheManagement() {
                         <TableCell className="break-words font-medium">{item.model_name}</TableCell>
                         <TableCell className="break-words">{item.model_engine}</TableCell>
                         <TableCell>{item.python_version}</TableCell>
+                        <TableCell className="tabular-nums">
+                          {formatDiskUsage(item.size_bytes)}
+                        </TableCell>
                         <TableCell>
                           <PathCell path={item.path} copyLabel={t('cacheManagement.copyPath')} />
                         </TableCell>
@@ -917,7 +934,7 @@ export default function CacheManagement() {
                     ))
                   ) : (
                     <TableRow>
-                      <TableCell colSpan={7} className="h-64 text-center text-muted-foreground">
+                      <TableCell colSpan={8} className="h-64 text-center text-muted-foreground">
                         {t('cacheManagement.noVirtualEnvironments')}
                       </TableCell>
                     </TableRow>

--- a/frontend/src/components/pages/launch-model/cache-management.dialog.tsx
+++ b/frontend/src/components/pages/launch-model/cache-management.dialog.tsx
@@ -23,7 +23,7 @@ import {
   TableRow,
 } from '@/components/ui/table';
 import { useI18n } from '@/contexts/i18n-context';
-import { copyToClipboard } from '@/lib/utils';
+import { copyToClipboard, formatFileSize } from '@/lib/utils';
 import type { ModelCachedItem } from '@/types/services';
 import type { CatalogModel } from './types';
 
@@ -113,6 +113,7 @@ const CacheManagementDialog: FC<CacheManagementDialogProps> = ({ modelDetail, on
               <TableRow>
                 <TableHead>{t('launchModel.model_format')}</TableHead>
                 <TableHead>{t('launchModel.model_size_in_billions')}</TableHead>
+                <TableHead>{t('cacheManagement.diskUsage')}</TableHead>
                 <TableHead>{t('launchModel.quantizations')}</TableHead>
                 <TableHead>{t('launchModel.path')}</TableHead>
                 <TableHead>{t('launchModel.real_path')}</TableHead>
@@ -126,6 +127,9 @@ const CacheManagementDialog: FC<CacheManagementDialogProps> = ({ modelDetail, on
                   <TableRow key={`${item.model_version}:${item.actor_ip_address}`}>
                     <TableCell>{item.model_format || '-'}</TableCell>
                     <TableCell>{item.model_size_in_billions || '-'}</TableCell>
+                    <TableCell>
+                      {typeof item.size_bytes === 'number' ? formatFileSize(item.size_bytes) : '-'}
+                    </TableCell>
                     <TableCell>{item.quantization || '-'}</TableCell>
                     <TableCell className="max-w-[220px]">
                       <div className="flex items-center gap-2">
@@ -172,7 +176,7 @@ const CacheManagementDialog: FC<CacheManagementDialogProps> = ({ modelDetail, on
                 ))
               ) : (
                 <TableRow>
-                  <TableCell colSpan={7} className="h-40 text-center text-muted-foreground">
+                  <TableCell colSpan={8} className="h-40 text-center text-muted-foreground">
                     No cache for now.
                   </TableCell>
                 </TableRow>

--- a/frontend/src/components/pages/launch-model/env-management-dialog.tsx
+++ b/frontend/src/components/pages/launch-model/env-management-dialog.tsx
@@ -23,7 +23,7 @@ import {
   TableRow,
 } from '@/components/ui/table';
 import { useI18n } from '@/contexts/i18n-context';
-import { copyToClipboard } from '@/lib/utils';
+import { copyToClipboard, formatFileSize } from '@/lib/utils';
 import type { ModelEnvItem } from '@/types/services';
 import type { CatalogModel } from './types';
 
@@ -106,6 +106,7 @@ const EnvManagementDialog: FC<EnvManagementDialogProps> = ({ modelDetail, onEnvD
                 <TableHead>{t('launchModel.modelName')}</TableHead>
                 <TableHead>{t('launchModel.envPath')}</TableHead>
                 <TableHead>{t('launchModel.pythonVersion')}</TableHead>
+                <TableHead>{t('cacheManagement.diskUsage')}</TableHead>
                 <TableHead>{t('launchModel.ipAddress')}</TableHead>
                 <TableHead>{t('common.operation')}</TableHead>
               </TableRow>
@@ -131,6 +132,9 @@ const EnvManagementDialog: FC<EnvManagementDialogProps> = ({ modelDetail, onEnvD
                     </TableCell>
 
                     <TableCell>{item.python_version}</TableCell>
+                    <TableCell>
+                      {typeof item.size_bytes === 'number' ? formatFileSize(item.size_bytes) : '-'}
+                    </TableCell>
                     <TableCell>{item.actor_ip_address}</TableCell>
                     <TableCell>
                       <Button
@@ -146,7 +150,7 @@ const EnvManagementDialog: FC<EnvManagementDialogProps> = ({ modelDetail, onEnvD
                 ))
               ) : (
                 <TableRow>
-                  <TableCell colSpan={7} className="h-40 text-center text-muted-foreground">
+                  <TableCell colSpan={6} className="h-40 text-center text-muted-foreground">
                     No virtual environments for now.
                   </TableCell>
                 </TableRow>

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -43,6 +43,7 @@ const en = {
     modelVersion: 'Model Version',
     format: 'Format',
     size: 'Parameter Size (B)',
+    diskUsage: 'Disk Usage',
     quantization: 'Quantization',
     statusAndProgress: 'Status / Progress',
     path: 'Cache Path',

--- a/frontend/src/i18n/locales/ja.ts
+++ b/frontend/src/i18n/locales/ja.ts
@@ -43,6 +43,7 @@ const ja = {
     modelVersion: 'モデルバージョン',
     format: '形式',
     size: 'パラメーター規模（B）',
+    diskUsage: 'ディスク使用量',
     quantization: '量子化',
     statusAndProgress: 'ステータス / 進捗',
     path: 'キャッシュパス',

--- a/frontend/src/i18n/locales/ko.ts
+++ b/frontend/src/i18n/locales/ko.ts
@@ -43,6 +43,7 @@ const ko = {
     modelVersion: '모델 버전',
     format: '형식',
     size: '파라미터 규모(B)',
+    diskUsage: '디스크 사용량',
     quantization: '양자화',
     statusAndProgress: '상태 / 진행률',
     path: '캐시 경로',

--- a/frontend/src/i18n/locales/zh-TW.ts
+++ b/frontend/src/i18n/locales/zh-TW.ts
@@ -55,6 +55,7 @@ const zhTW = {
     modelVersion: '模型版本',
     format: '格式',
     size: '參數規模（B）',
+    diskUsage: '磁碟用量',
     quantization: '量化',
     statusAndProgress: '狀態 / 進度',
     path: '快取路徑',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -43,6 +43,7 @@ const zh = {
     modelVersion: '模型版本',
     format: '格式',
     size: '参数规模（B）',
+    diskUsage: '磁盘占用',
     quantization: '量化',
     statusAndProgress: '状态 / 进度',
     path: '缓存路径',

--- a/frontend/src/types/services.ts
+++ b/frontend/src/types/services.ts
@@ -73,6 +73,7 @@ export interface ModelCachedItem {
   model_version: string;
   path: string;
   real_path?: string;
+  size_bytes?: number;
   actor_ip_address: string;
 }
 
@@ -81,6 +82,7 @@ export interface ModelEnvItem {
   model_engine: string;
   path: string;
   real_path: string;
+  size_bytes?: number;
   python_version: string;
   actor_ip_address: string;
 }

--- a/xinference/api/tests/test_admin.py
+++ b/xinference/api/tests/test_admin.py
@@ -377,6 +377,7 @@ async def test_list_virtual_envs_returns_list(mock_api, mock_supervisor):
     )
     assert response.status_code == 200
     assert _json_body(response) == {"list": [{"name": "venv1"}]}
+    mock_supervisor.list_virtual_envs.assert_called_once_with("qwen", "vllm", None)
 
 
 @pytest.mark.asyncio

--- a/xinference/core/tests/test_utils.py
+++ b/xinference/core/tests/test_utils.py
@@ -20,6 +20,7 @@ from ..utils import (
     build_replica_model_uid,
     build_subpool_envs_for_virtual_env,
     filter_virtualenv_packages_by_markers,
+    get_path_size,
     is_valid_model_uid,
     iter_replica_model_uid,
     merge_virtual_env_packages,
@@ -46,6 +47,30 @@ def test_normalize_n_worker(value, expected):
 def test_normalize_n_worker_rejects_non_positive_or_non_integral_values(value):
     with pytest.raises(ValueError, match="n_worker must be a positive integer"):
         normalize_n_worker(value)
+
+
+def test_get_path_size_handles_file_symlinks_without_double_counting(tmp_path):
+    payload = tmp_path / "payload.bin"
+    payload.write_bytes(b"x" * 4096)
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    (cache_dir / "first.bin").symlink_to(payload)
+    (cache_dir / "second.bin").symlink_to(payload)
+
+    expected = get_path_size(str(payload))
+    assert get_path_size(str(cache_dir)) == 0
+    assert get_path_size(str(cache_dir), follow_file_symlinks=True) == expected
+
+
+def test_get_path_size_never_traverses_directory_symlinks(tmp_path):
+    payload_dir = tmp_path / "payload"
+    payload_dir.mkdir()
+    (payload_dir / "payload.bin").write_bytes(b"x" * 4096)
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    (cache_dir / "linked-directory").symlink_to(payload_dir, target_is_directory=True)
+
+    assert get_path_size(str(cache_dir), follow_file_symlinks=True) == 0
 
 
 def test_replica_model_uid():

--- a/xinference/core/tests/test_utils.py
+++ b/xinference/core/tests/test_utils.py
@@ -73,6 +73,16 @@ def test_get_path_size_never_traverses_directory_symlinks(tmp_path):
     assert get_path_size(str(cache_dir), follow_file_symlinks=True) == 0
 
 
+def test_get_path_size_follows_root_directory_symlink(tmp_path):
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    (cache_dir / "payload.bin").write_bytes(b"x" * 4096)
+    cache_link = tmp_path / "cache-link"
+    cache_link.symlink_to(cache_dir, target_is_directory=True)
+
+    assert get_path_size(str(cache_link)) == get_path_size(str(cache_dir))
+
+
 def test_replica_model_uid():
     all_gen_ids = []
     for replica_model_uid in iter_replica_model_uid("abc", 5):

--- a/xinference/core/utils.py
+++ b/xinference/core/utils.py
@@ -65,6 +65,47 @@ def normalize_n_worker(value: Any) -> int:
     return n_worker
 
 
+def get_path_size(path: str, follow_file_symlinks: bool = False) -> int:
+    """Return disk space allocated to files under *path*.
+
+    Directory symlinks are never traversed. File symlinks may be followed for
+    model caches, whose payload files commonly link to Hub-managed blobs.
+    """
+
+    if not path or os.path.islink(path):
+        return 0
+
+    seen_inodes: Set[Tuple[int, int]] = set()
+
+    def get_file_size(file_path: str) -> int:
+        if os.path.islink(file_path) and not follow_file_symlinks:
+            return 0
+        try:
+            file_stat = os.stat(file_path)
+        except OSError:
+            return 0
+
+        inode = (file_stat.st_dev, file_stat.st_ino)
+        if inode in seen_inodes:
+            return 0
+        seen_inodes.add(inode)
+
+        blocks = getattr(file_stat, "st_blocks", 0)
+        return blocks * 512 if blocks else file_stat.st_size
+
+    if os.path.isfile(path):
+        return get_file_size(path)
+
+    total = 0
+    for root, dirs, files in os.walk(path, followlinks=False):
+        dirs[:] = [
+            name for name in dirs if not os.path.islink(os.path.join(root, name))
+        ]
+        for name in files:
+            total += get_file_size(os.path.join(root, name))
+    return total
+
+
 def log_async(
     logger,
     level=logging.DEBUG,

--- a/xinference/core/utils.py
+++ b/xinference/core/utils.py
@@ -72,8 +72,13 @@ def get_path_size(path: str, follow_file_symlinks: bool = False) -> int:
     model caches, whose payload files commonly link to Hub-managed blobs.
     """
 
-    if not path or os.path.islink(path):
+    if not path:
         return 0
+    if os.path.islink(path):
+        if os.path.isdir(path) or (follow_file_symlinks and os.path.isfile(path)):
+            path = os.path.realpath(path)
+        else:
+            return 0
 
     seen_inodes: Set[Tuple[int, int]] = set()
 

--- a/xinference/core/worker.py
+++ b/xinference/core/worker.py
@@ -106,6 +106,7 @@ from .utils import (
     filter_virtualenv_packages_by_markers,
     find_direct_reference_packages,
     find_remote_direct_reference_packages,
+    get_path_size,
     log_async,
     log_sync,
     merge_virtual_env_packages,
@@ -5772,6 +5773,18 @@ class WorkerActor(xo.StatelessActor):
                 cached_model["real_path"] = real_path
             cached_model["actor_ip_address"] = self.address
             cached_models.append(cached_model)
+        sizes = await asyncio.gather(
+            *[
+                asyncio.to_thread(
+                    get_path_size,
+                    cached_model["path"],
+                    follow_file_symlinks=True,
+                )
+                for cached_model in cached_models
+            ]
+        )
+        for cached_model, size in zip(cached_models, sizes):
+            cached_model["size_bytes"] = size
         return cached_models
 
     @staticmethod
@@ -6194,6 +6207,15 @@ class WorkerActor(xo.StatelessActor):
                     "actor_ip_address": self.address,
                 }
                 virtual_envs.append(virtual_env)
+
+            sizes = await asyncio.gather(
+                *[
+                    asyncio.to_thread(get_path_size, virtual_env["path"])
+                    for virtual_env in virtual_envs
+                ]
+            )
+            for virtual_env, size in zip(virtual_envs, sizes):
+                virtual_env["size_bytes"] = size
 
             return virtual_envs
         except Exception as e:


### PR DESCRIPTION
## Summary

- Display allocated disk usage for cached models and virtual environments.
- Calculate sizes asynchronously, deduplicate hard links, and avoid traversing directory symlinks.
- Add cache-management and launch-dialog columns, type fields, and i18n translations.