### PR TITLE
fix(security): reject local media paths and bound server-side media fetches

### DIFF
--- a/xinference/constants.py
+++ b/xinference/constants.py
@@ -624,3 +624,21 @@ _http_limit_concurrency = int(os.environ.get("XINFERENCE_HTTP_LIMIT_CONCURRENCY"
 XINFERENCE_HTTP_LIMIT_CONCURRENCY = (
     _http_limit_concurrency if _http_limit_concurrency > 0 else None
 )
+
+# Media references (image/video/audio URLs) supplied in chat requests are
+# fetched server-side. Unrestricted, that is an SSRF and local-file-read
+# primitive, so local paths are rejected unless explicitly allowed.
+XINFERENCE_MEDIA_ALLOW_LOCAL_PATH = os.environ.get(
+    "XINFERENCE_MEDIA_ALLOW_LOCAL_PATH", "false"
+).lower() in ("1", "true", "yes")
+# Opt-in: also refuse URLs resolving to loopback/private/link-local addresses.
+# Off by default because serving media from an intranet host is a legitimate
+# and common deployment.
+XINFERENCE_MEDIA_BLOCK_PRIVATE_ADDRESS = os.environ.get(
+    "XINFERENCE_MEDIA_BLOCK_PRIVATE_ADDRESS", "false"
+).lower() in ("1", "true", "yes")
+# Seconds allowed for a server-side media fetch. Without it requests hang on
+# the model actor lock until the OS gives up.
+XINFERENCE_MEDIA_FETCH_TIMEOUT = float(
+    os.environ.get("XINFERENCE_MEDIA_FETCH_TIMEOUT", "30")
+)

--- a/xinference/constants.py
+++ b/xinference/constants.py
@@ -628,15 +628,15 @@ XINFERENCE_HTTP_LIMIT_CONCURRENCY = (
 # Media references (image/video/audio URLs) supplied in chat requests are
 # fetched server-side. Unrestricted, that is an SSRF and local-file-read
 # primitive, so local paths are rejected unless explicitly allowed.
-XINFERENCE_MEDIA_ALLOW_LOCAL_PATH = os.environ.get(
-    "XINFERENCE_MEDIA_ALLOW_LOCAL_PATH", "false"
-).lower() in ("1", "true", "yes")
+XINFERENCE_MEDIA_ALLOW_LOCAL_PATH = parse_env_bool(
+    "XINFERENCE_MEDIA_ALLOW_LOCAL_PATH", False
+)
 # Opt-in: also refuse URLs resolving to loopback/private/link-local addresses.
 # Off by default because serving media from an intranet host is a legitimate
 # and common deployment.
-XINFERENCE_MEDIA_BLOCK_PRIVATE_ADDRESS = os.environ.get(
-    "XINFERENCE_MEDIA_BLOCK_PRIVATE_ADDRESS", "false"
-).lower() in ("1", "true", "yes")
+XINFERENCE_MEDIA_BLOCK_PRIVATE_ADDRESS = parse_env_bool(
+    "XINFERENCE_MEDIA_BLOCK_PRIVATE_ADDRESS", False
+)
 # Seconds allowed for a server-side media fetch. Without it requests hang on
 # the model actor lock until the OS gives up.
 XINFERENCE_MEDIA_FETCH_TIMEOUT = float(

--- a/xinference/model/llm/sglang/core.py
+++ b/xinference/model/llm/sglang/core.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import asyncio
 import json
 import logging
 import multiprocessing
@@ -1136,7 +1137,9 @@ class SGLANGVisionModel(SGLANGModel, ChatModelMixin):
             messages, chat_template, tokenizer=tokenizer, **full_context_kwargs
         )
 
-        images, video_inputs = process_vision_info(messages)
+        # Blocking downloads: keep them off the actor's event loop, otherwise a
+        # slow media URL stalls every other request served by this model.
+        images, video_inputs = await asyncio.to_thread(process_vision_info, messages)
         if video_inputs:
             raise ValueError("Not support video input now.")
 

--- a/xinference/model/llm/sglang/core.py
+++ b/xinference/model/llm/sglang/core.py
@@ -1111,7 +1111,9 @@ class SGLANGVisionModel(SGLANGModel, ChatModelMixin):
         from PIL import Image
         from qwen_vl_utils import process_vision_info
 
-        messages = self._transform_messages(messages)
+        # Validates client-supplied media references; the private-address
+        # check resolves hostnames, and getaddrinfo blocks the event loop.
+        messages = await asyncio.to_thread(self._transform_messages, messages)
 
         tools = list(generate_config.pop("tools", [])) if generate_config else None
         # Handle empty chat_template by falling back to tokenizer's chat_template

--- a/xinference/model/llm/utils.py
+++ b/xinference/model/llm/utils.py
@@ -40,6 +40,7 @@ from typing import (
 import requests
 from PIL import Image
 
+from ...constants import XINFERENCE_MEDIA_FETCH_TIMEOUT
 from ...types import (
     ChatCompletion,
     ChatCompletionChoice,
@@ -57,6 +58,7 @@ from ...types import (
     CompletionUsage,
     ToolCallDelta,
 )
+from ..media_source import validate_media_source, validate_messages_media
 from .core import chat_context_var
 from .reasoning_parser import ReasoningParser
 from .tool_parsers.glm4_tool_parser import Glm4ToolParser
@@ -1166,6 +1168,9 @@ class ChatModelMixin:
         self,
         messages: Union[List[ChatCompletionMessage], List[dict]],
     ):
+        # Every engine's multimodal path funnels through here, so this is the
+        # one place that sees client-supplied media before something fetches it.
+        validate_messages_media(messages)
         transformed_messages = []
         for msg in messages:
             new_content = []
@@ -1423,25 +1428,12 @@ def get_model_version(
 
 
 def _decode_image(_url):
-    if _url.startswith("data:"):
-        logging.info("Parse url by base64 decoder.")
-        # https://platform.openai.com/docs/guides/vision/uploading-base-64-encoded-images
-        # e.g. f"data:image/jpeg;base64,{base64_image}"
-        _type, data = _url.split(";")
-        _, ext = _type.split("/")
-        data = data[len("base64,") :]
-        data = base64.b64decode(data.encode("utf-8"))
-        return Image.open(BytesIO(data)).convert("RGB")
-    else:
-        try:
-            response = requests.get(_url)
-        except requests.exceptions.MissingSchema:
-            return Image.open(_url).convert("RGB")
-        else:
-            return Image.open(BytesIO(response.content)).convert("RGB")
+    image = _decode_image_without_rgb(_url)
+    return image.convert("RGB")
 
 
 def _decode_image_without_rgb(_url):
+    validate_media_source(_url)
     if _url.startswith("data:"):
         logging.info("Parse url by base64 decoder.")
         # https://platform.openai.com/docs/guides/vision/uploading-base-64-encoded-images
@@ -1453,10 +1445,15 @@ def _decode_image_without_rgb(_url):
         return Image.open(BytesIO(data))
     else:
         try:
-            response = requests.get(_url)
+            # Without a timeout a dead host pins the model actor until the OS
+            # gives up, which stalls every other request on that model.
+            response = requests.get(_url, timeout=XINFERENCE_MEDIA_FETCH_TIMEOUT)
         except requests.exceptions.MissingSchema:
+            # validate_media_source already rejected local paths unless they are
+            # explicitly allowed.
             return Image.open(_url)
         else:
+            response.raise_for_status()
             return Image.open(BytesIO(response.content))
 
 

--- a/xinference/model/llm/vllm/core.py
+++ b/xinference/model/llm/vllm/core.py
@@ -2654,7 +2654,10 @@ class VLLMMultiModel(VLLMModel, ChatModelMixin):
                     temp_dir = tempfile.TemporaryDirectory(prefix="xinference-vllm-")
                     self._handle_base64_media(messages, temp_dir.name)
 
-                messages = self._transform_messages(messages)
+                # Validates client-supplied media references, which resolves
+                # hostnames when private-address blocking is on. getaddrinfo
+                # blocks, so keep it off the actor's event loop too.
+                messages = await asyncio.to_thread(self._transform_messages, messages)
 
                 chat_template_kwargs = (
                     self._get_chat_template_kwargs_from_generate_config(

--- a/xinference/model/llm/vllm/core.py
+++ b/xinference/model/llm/vllm/core.py
@@ -2680,15 +2680,24 @@ class VLLMMultiModel(VLLMModel, ChatModelMixin):
                     model_family
                 )
 
+                # These helpers download every referenced image/audio/video
+                # with blocking IO. Run off the event loop: this coroutine is
+                # awaited directly by the model actor, so a slow fetch here
+                # stalls every other request that actor is serving.
                 if "omni" in self.model_family.model_ability:
-                    audios, images, videos, video_kwargs = process_mm_info(
-                        messages, use_audio_in_video=True, return_video_kwargs=True
+                    audios, images, videos, video_kwargs = await asyncio.to_thread(
+                        process_mm_info,
+                        messages,
+                        use_audio_in_video=True,
+                        return_video_kwargs=True,
                     )
                 elif "audio" in self.model_family.model_ability:
-                    audios = process_audio_info(messages, use_audio_in_video=False)
+                    audios = await asyncio.to_thread(
+                        process_audio_info, messages, use_audio_in_video=False
+                    )
                 elif "vision" in self.model_family.model_ability:
-                    images, videos, video_kwargs = process_vision_info(  # type: ignore
-                        messages, return_video_kwargs=True
+                    images, videos, video_kwargs = await asyncio.to_thread(  # type: ignore
+                        process_vision_info, messages, return_video_kwargs=True
                     )
 
                 prompt = self.get_full_context(

--- a/xinference/model/media_source.py
+++ b/xinference/model/media_source.py
@@ -1,0 +1,148 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Validation for client-supplied media references.
+
+Chat requests can carry ``image_url`` / ``video_url`` / ``audio_url`` values
+that the server fetches itself. Whatever accepts them is therefore a
+server-side fetcher driven by untrusted input, which without limits is both an
+SSRF primitive and a local-file-read primitive.
+"""
+
+import ipaddress
+import logging
+import socket
+from typing import Any, Dict, List, Optional, Union
+from urllib.parse import urlparse
+
+from ..constants import (
+    XINFERENCE_MEDIA_ALLOW_LOCAL_PATH,
+    XINFERENCE_MEDIA_BLOCK_PRIVATE_ADDRESS,
+)
+
+logger = logging.getLogger(__name__)
+
+REMOTE_SCHEMES = ("http://", "https://")
+DATA_URI_PREFIX = "data:"
+FILE_URI_PREFIX = "file://"
+
+
+class MediaSourceError(ValueError):
+    """Raised when a client-supplied media reference must not be fetched."""
+
+
+def _resolved_addresses(host: str) -> List[str]:
+    try:
+        infos = socket.getaddrinfo(host, None)
+    except socket.gaierror:
+        # Let the fetcher surface the resolution failure with its own error.
+        return []
+    return [str(info[4][0]) for info in infos]
+
+
+def _is_blocked_address(host: str) -> bool:
+    for address in _resolved_addresses(host):
+        try:
+            ip = ipaddress.ip_address(address)
+        except ValueError:
+            continue
+        if (
+            ip.is_loopback
+            or ip.is_private
+            or ip.is_link_local
+            or ip.is_reserved
+            or ip.is_multicast
+            or ip.is_unspecified
+        ):
+            return True
+    return False
+
+
+def validate_media_source(
+    source: Any,
+    *,
+    allow_local_path: Optional[bool] = None,
+    block_private_address: Optional[bool] = None,
+) -> None:
+    """Raise :class:`MediaSourceError` if ``source`` must not be fetched.
+
+    Non-string sources (already-decoded ``PIL.Image``, numpy arrays, ...) are
+    passed through: they carry no fetch.
+    """
+    if not isinstance(source, str):
+        return
+    if allow_local_path is None:
+        allow_local_path = XINFERENCE_MEDIA_ALLOW_LOCAL_PATH
+    if block_private_address is None:
+        block_private_address = XINFERENCE_MEDIA_BLOCK_PRIVATE_ADDRESS
+
+    reference = source.strip()
+    if reference.startswith(DATA_URI_PREFIX):
+        return
+
+    if reference.startswith(REMOTE_SCHEMES):
+        if not block_private_address:
+            return
+        host = urlparse(reference).hostname
+        # Resolution here is advisory: the fetcher resolves again, so a rebinding
+        # DNS entry can still slip through. Network policy remains the real control.
+        if host and _is_blocked_address(host):
+            raise MediaSourceError(
+                "Refusing to fetch media from a private or loopback address. "
+                "Unset XINFERENCE_MEDIA_BLOCK_PRIVATE_ADDRESS to allow it."
+            )
+        return
+
+    # Anything else is read off the server's filesystem: an explicit file://
+    # URI, or a bare path, which is what a permissive fetcher falls back to.
+    if allow_local_path:
+        return
+    raise MediaSourceError(
+        "Refusing to read media from the server filesystem. Send the media as a "
+        "data: URI or an http(s) URL, or set XINFERENCE_MEDIA_ALLOW_LOCAL_PATH=1 "
+        "to allow local paths."
+    )
+
+
+_MEDIA_CONTENT_KEYS = ("image_url", "video_url", "audio_url")
+_TRANSFORMED_MEDIA_KEYS = ("image", "video", "audio")
+
+
+def validate_messages_media(
+    messages: Union[List[Dict], List[Any]],
+) -> None:
+    """Validate every media reference carried by OpenAI-style chat messages.
+
+    Accepts both the raw OpenAI shape (``{"image_url": {"url": ...}}``) and the
+    transformed shape (``{"type": "image", "image": ...}``) so it can guard the
+    message list before or after normalisation.
+    """
+    for message in messages or []:
+        if not isinstance(message, dict):
+            continue
+        content = message.get("content")
+        if not isinstance(content, list):
+            continue
+        for item in content:
+            if not isinstance(item, dict):
+                continue
+            for key in _MEDIA_CONTENT_KEYS:
+                value = item.get(key)
+                if isinstance(value, dict):
+                    validate_media_source(value.get("url"))
+                elif value is not None:
+                    validate_media_source(value)
+            for key in _TRANSFORMED_MEDIA_KEYS:
+                if key in item:
+                    validate_media_source(item[key])

--- a/xinference/model/media_source.py
+++ b/xinference/model/media_source.py
@@ -94,7 +94,11 @@ def validate_media_source(
     if reference.startswith(REMOTE_SCHEMES):
         if not block_private_address:
             return
-        host = urlparse(reference).hostname
+        try:
+            host = urlparse(reference).hostname
+        except ValueError as e:
+            # Malformed URLs (bad IPv6 brackets, ...) raise instead of parsing.
+            raise MediaSourceError(f"Invalid media URL: {e}") from e
         # Resolution here is advisory: the fetcher resolves again, so a rebinding
         # DNS entry can still slip through. Network policy remains the real control.
         if host and _is_blocked_address(host):

--- a/xinference/model/tests/test_media_source.py
+++ b/xinference/model/tests/test_media_source.py
@@ -117,9 +117,17 @@ def _engine_source(relative_path: str) -> str:
     [
         (
             "llm/vllm/core.py",
-            ("process_mm_info", "process_audio_info", "process_vision_info"),
+            (
+                "process_mm_info",
+                "process_audio_info",
+                "process_vision_info",
+                "self._transform_messages",
+            ),
         ),
-        ("llm/sglang/core.py", ("process_vision_info",)),
+        (
+            "llm/sglang/core.py",
+            ("process_vision_info", "self._transform_messages"),
+        ),
     ],
 )
 def test_media_helpers_are_not_called_on_the_event_loop(module, helpers):

--- a/xinference/model/tests/test_media_source.py
+++ b/xinference/model/tests/test_media_source.py
@@ -1,0 +1,144 @@
+# Copyright 2022-2026 Xinference Holdings Pte. Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from ..media_source import (
+    MediaSourceError,
+    validate_media_source,
+    validate_messages_media,
+)
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "data:image/jpeg;base64,AAAA",
+        "https://example.com/cat.png",
+        "http://example.com/cat.png",
+    ],
+)
+def test_remote_and_inline_sources_allowed(source):
+    validate_media_source(source)
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        # Observed in production: a scanner probing for local file reads.
+        "/etc/hostname",
+        "/etc/os-release",
+        "/root/.xinference/config.json",
+        "/root/.xinference/",
+        "file:///etc/passwd",
+        "relative/path.png",
+    ],
+)
+def test_local_paths_rejected_by_default(source):
+    with pytest.raises(MediaSourceError):
+        validate_media_source(source)
+
+
+def test_local_paths_allowed_when_opted_in():
+    validate_media_source("/etc/hostname", allow_local_path=True)
+
+
+def test_private_addresses_rejected_only_when_opted_in():
+    # Default keeps intranet media hosts working.
+    validate_media_source("http://127.0.0.1:8080/a.png")
+    with pytest.raises(MediaSourceError):
+        validate_media_source("http://127.0.0.1:8080/a.png", block_private_address=True)
+
+
+def test_non_string_sources_pass_through():
+    # Already-decoded images carry no fetch.
+    validate_media_source(object())
+
+
+def test_validate_messages_media_checks_openai_shape():
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "what is this"},
+                {"type": "image_url", "image_url": {"url": "/etc/hostname"}},
+            ],
+        }
+    ]
+    with pytest.raises(MediaSourceError):
+        validate_messages_media(messages)
+
+
+def test_validate_messages_media_checks_transformed_shape():
+    messages = [
+        {"role": "user", "content": [{"type": "image", "image": "file:///etc/passwd"}]}
+    ]
+    with pytest.raises(MediaSourceError):
+        validate_messages_media(messages)
+
+
+@pytest.mark.parametrize("key", ["video_url", "audio_url"])
+def test_validate_messages_media_covers_video_and_audio(key):
+    messages = [{"role": "user", "content": [{key: {"url": "/etc/hostname"}}]}]
+    with pytest.raises(MediaSourceError):
+        validate_messages_media(messages)
+
+
+def test_validate_messages_media_tolerates_plain_content():
+    validate_messages_media([{"role": "user", "content": "hello"}])
+    validate_messages_media([])
+
+
+def _engine_source(relative_path: str) -> str:
+    """Return an engine module's text.
+
+    Read as text rather than imported: these modules pull in vllm / sglang,
+    which are not installed in the base test environment.
+    """
+    import pathlib
+
+    path = pathlib.Path(__file__).resolve().parents[1] / relative_path
+    return path.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize(
+    "module, helpers",
+    [
+        (
+            "llm/vllm/core.py",
+            ("process_mm_info", "process_audio_info", "process_vision_info"),
+        ),
+        ("llm/sglang/core.py", ("process_vision_info",)),
+    ],
+)
+def test_media_helpers_are_not_called_on_the_event_loop(module, helpers):
+    # async_chat is awaited directly by the model actor, so a blocking download
+    # inside it freezes every other request that actor serves -- including
+    # terminate_model. Each helper must be dispatched through to_thread, which
+    # takes the callable by name rather than calling it inline.
+    lines = _engine_source(module).splitlines()
+    for helper in helpers:
+        called_inline = [
+            line.strip()
+            for line in lines
+            # A bare "helper(" is an inline call; "to_thread(helper," is not.
+            if f"{helper}(" in line and "import" not in line
+        ]
+        assert called_inline == [], (
+            f"{module} calls {helper} inline, blocking the event loop: "
+            f"{called_inline}"
+        )
+        assert any(
+            f"asyncio.to_thread(" in line or f"{helper}," in line for line in lines
+        ), f"{module} no longer dispatches {helper}"


### PR DESCRIPTION
Chat requests can carry `image_url` / `video_url` / `audio_url` values that the server fetches itself. Today nothing constrains what those values may point at, and nothing bounds how long a fetch may take.

### What a client can currently do

`qwen_omni_utils.fetch_image` (and `qwen_vl_utils`) dispatch on the string prefix:

```python
elif image.startswith("http://") or image.startswith("https://"):
    with requests.get(image, stream=True) as response:   # no timeout
...
elif image.startswith("file://"):
    image_obj = Image.open(image[7:])
else:
    image_obj = Image.open(image)                        # bare path -> local file
```

The `else` branch means any string that is not a recognised URI is opened off the server's filesystem. Xinference's own `_decode_image` / `_decode_image_without_rgb` in `model/llm/utils.py` have the same two problems: `requests.get(_url)` without a timeout, and a `MissingSchema` fallback to `Image.open(_url)`.

I observed all three of these being exercised against a deployment:

- `http://<attacker-host>:28012/ssrf-http` — an out-of-band SSRF probe; the server connected out.
- `/etc/hostname`, `/etc/os-release`, `/root/.xinference/config.json`, `/root/.xinference/` — the errors differ per path (`Is a directory` vs `No such file or directory` vs `cannot identify image file`), which is a working file-existence oracle. A path pointing at a readable *image* would have been read and fed to the model.
- Each probe pinned the model for ~130s (`Leave chat, error: ... elapsed time: 131 s`).

### Why the stall is worse than one slow request

`async_chat` is a coroutine, so `ModelActor._call_wrapper` awaits it directly on the actor's event loop:

```python
if inspect.iscoroutinefunction(fn):
    return await fn(*args, **kwargs)      # on the event loop
return await asyncio.to_thread(fn, *args, **kwargs)
```

`process_vision_info` / `process_audio_info` / `process_mm_info` were called inline inside that coroutine, so their blocking downloads froze the whole event loop for that actor — not just the offending request. In the incident that included `terminate_model`, which logged `Enter terminate_model` and never completed: the model could not even be shut down. Note this is independent of `allow_batch`: vLLM sets `allow_batch = True` so `self._lock is None` and there is no lock contention, yet the actor was still wedged.

### Changes

1. **`xinference/model/media_source.py`** (new) — `validate_media_source()` / `validate_messages_media()`. `data:` URIs and `http(s)://` URLs pass; everything else (a `file://` URI or a bare path) is refused. The point is that the default is deny, rather than falling through to the filesystem.

2. **`ChatModelMixin._transform_messages`** — one validation call. Every engine's multimodal path funnels through it, so this covers vLLM, SGLang and all Transformers multimodal models at once; I checked each of the five `process_vision_info` call sites and they are all downstream of it (`ovis2` reaches it via `build_inputs_from_messages` -> `_generate_chat_data`).

3. **`_decode_image` / `_decode_image_without_rgb`** — validate first, pass `timeout=`, and `raise_for_status()`. `_decode_image` now delegates to `_decode_image_without_rgb` instead of duplicating the body.

4. **vLLM / SGLang `async_chat`** — the media helpers are dispatched through `asyncio.to_thread`, so a slow fetch no longer blocks the actor's event loop.

### Configuration

| Variable | Default | Effect |
| --- | --- | --- |
| `XINFERENCE_MEDIA_ALLOW_LOCAL_PATH` | `false` | Restores reading media off the server filesystem |
| `XINFERENCE_MEDIA_BLOCK_PRIVATE_ADDRESS` | `false` | Also refuse URLs resolving to loopback/private/link-local |
| `XINFERENCE_MEDIA_FETCH_TIMEOUT` | `30` | Seconds allowed for a fetch |

Two deliberate defaults, both arguable:

- Rejecting local paths **is** a behaviour change for anyone passing a server-side path today. I judged that worth it since it is the actual file-read primitive, and `XINFERENCE_MEDIA_ALLOW_LOCAL_PATH=1` restores it. Happy to flip the default if you would rather deprecate it over a release.
- Private-address blocking is **opt-in**, because serving media from an intranet host is a normal deployment and defaulting it on would break those users. That does mean SSRF to internal addresses is still reachable out of the box.

### Limitations

- The private-address check resolves the hostname once and the fetcher resolves again, so DNS rebinding defeats it. Noted in a comment; network policy remains the real control.
- `qwen_omni_utils` / `qwen_vl_utils` are unchanged — this relies on every media path passing through `_transform_messages`. That holds for all current call sites, but a future path calling those helpers directly would bypass it.
- The fetch is now off the event loop but still unpaginated/unbounded in size; a very large remote file is still a resource concern.

### Verification

- 19 new tests. The rejection cases use the exact payloads from the incident (`/etc/hostname`, `/etc/os-release`, `/root/.xinference/config.json`).
- Integration-checked against the real `ChatModelMixin._transform_messages`: the payload raises, a normal `https://` URL still transforms to `{'type': 'image', 'image': ...}`.
- The event-loop regression test fails if either engine goes back to calling the helpers inline (verified by reverting both files).
- `pre-commit run --files` clean on every touched file.

Not run: a live multimodal generation against real weights (no GPU available here), so the `to_thread` change is verified by tests and inspection rather than an end-to-end image request.
